### PR TITLE
Fixing always convert to uppercase bug

### DIFF
--- a/treetime/seq_utils.py
+++ b/treetime/seq_utils.py
@@ -120,7 +120,7 @@ profile_maps = {
 def seq2array(seq, fill_overhangs=True, ambiguous_character='N'):
     """
     Take the raw sequence, substitute the "overhanging" gaps with 'N' (missequenced)
-    convert the sequence to the numpy array of uppercase chars.
+    convert the sequence to the numpy array of chars.
 
     Parameters
     ----------
@@ -142,7 +142,6 @@ def seq2array(seq, fill_overhangs=True, ambiguous_character='N'):
         sequence = ''.join(seq)
     except TypeError:
         sequence = seq
-    sequence = sequence.upper()
 
     sequence = np.array(list(sequence))
     # substitute overhanging unsequenced tails

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -23,7 +23,8 @@ class TreeAnc(object):
     """
 
     def __init__(self, tree=None, aln=None, gtr=None, fill_overhangs=True,
-                 verbose = ttconf.VERBOSE, ignore_gaps=True,  **kwargs):
+                 verbose = ttconf.VERBOSE, ignore_gaps=True,  convert_upper=True,
+                 **kwargs):
         """
         TreeAnc constructor. It prepares tree, attach sequences to the leaf nodes,
         and sets some configuration parameters.
@@ -86,6 +87,7 @@ class TreeAnc(object):
         else:
             self.tree = tree
 
+        self.convert_upper = convert_upper
         # set alignment and attach sequences to tree.
         self.aln = aln
 
@@ -249,6 +251,17 @@ class TreeAnc(object):
         else:
             self._aln = None
             return
+
+        #Convert to uppercase here, rather than in _attach_sequences_to_nodes
+        #(which used to do it through seq2array in seq_utils.py)
+        #so that it is controlled by param convert_upper. This way for
+        #mugration (ancestral reconstruction of non-sequences), you can
+        #NOT convert to uppercase!
+        if self.convert_upper:
+            temp_aln = [] #MultSeqAlign aren't modifiable, so this not so neat.
+            for seq in self._aln:
+                temp_aln.append(seq.upper())
+            self._aln = MultipleSeqAlignment(temp_aln)
 
         if hasattr(self, '_tree'):
             self._attach_sequences_to_nodes()


### PR DESCRIPTION
In `seq_utils.py` `seq2array` the alignment is always converted to uppercase. For sequences this good, as prevents mismatches between upper- and lower-case base. However for ancestral reconstruction of other traits like location, these are given 1-char 'codes' and passed as an alignment. Both upper- and lower-case characters are used to code different locations. Currently, converting to uppercase remaps any country that was mapped to a lower-case char to some other country.

This fix allows the user to specify in `TreeAnc` (and all inheriting classes) `convert_upper` (True or False, default=True). When used for ancestral state reconstruction ('mugration' in Augur/Augurlinos), this should be set to False. 

Only datasets with >32 countries would be affected (I think), as the char-mapping goes through a few special characters before moving to lowercase. 