### PR TITLE
Include OS files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,9 +74,20 @@ target/
 # proportion of contributors will probably not be using SublimeText
 *.sublime-project
 # sftp configuration file
-sftp-config.json 
+sftp-config.json
 
 #data files other resources
 *.svg
 
 !data/
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
@rneher ---

Mac OS continually creates a `.DS_Store` file in the `treetime/` submodule within `augur/`. This then causes issues with the repo looking like it has unstaged changes. This PR fixes the small issue.