### PR TITLE
Fix for vcf_new VCF constant site parsing

### DIFF
--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -554,9 +554,11 @@ class TreeAnc(object):
         alignment_patterns_const = {}
         for base in states:
             p = base*nseq
-            alignment_patterns_const[p] = [len(reduced_alignment_const),
-                                           list(np.where(refMod==base)[0])]
-            reduced_alignment_const.append(list(p))
+            #if the alignment doesn't have a const site of this base, don't add! (ex: no '----' site!)
+            if len(np.where(refMod==base)[0]):
+                alignment_patterns_const[p] = [len(reduced_alignment_const),
+                                               list(np.where(refMod==base)[0])]
+                reduced_alignment_const.append(list(p))
 
 
         return reduced_alignment_const, alignment_patterns_const, variable_pos

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -554,10 +554,10 @@ class TreeAnc(object):
         alignment_patterns_const = {}
         for base in states:
             p = base*nseq
+            pos = list(np.where(refMod==base)[0])
             #if the alignment doesn't have a const site of this base, don't add! (ex: no '----' site!)
-            if len(np.where(refMod==base)[0]):
-                alignment_patterns_const[p] = [len(reduced_alignment_const),
-                                               list(np.where(refMod==base)[0])]
+            if len(pos):
+                alignment_patterns_const[p] = [len(reduced_alignment_const), pos]
                 reduced_alignment_const.append(list(p))
 
 


### PR DESCRIPTION
At the end of `process_alignment_dict` a constant site for every `base` in `states` is added to the alignment patterns and reduced alignment. However, some alignments may not have a constant site for that base. The most likely case is that the alignment doesn't have a site that's all gaps ('-').

Under the current code, this is added to the alignment anyway, but with the 'locations where this pattern is found in the real alignment' as an empty array (`[]`) - this then causes an error when creating a map to compress a sequence in `make_reduced_alignment`.