### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 
 setup(
         name = "treetime",
-        version = "0.3.0",
+        version = "0.4.0",
         author = "Pavel Sagulenko and Richard Neher",
         author_email = "richard.neher@unibas.ch",
         description = ("Maximum-likelihood phylodynamic inference"),

--- a/treetime/version.py
+++ b/treetime/version.py
@@ -1,1 +1,1 @@
-tt_version="0.3.0"
+tt_version="0.4.0"


### PR DESCRIPTION
…so the Python 3 version on this branch, py3, is distinguishable from
the Python 2 version on master.  In particular this lets requirements in
other places use a specific version to distinguish the Python-compat
branches.

This is the most conservative version bump.  At some point it'd be nice
to switch to semantic versioning.