### PR TITLE
Cleaning up & standardizing autodoc

### DIFF
--- a/doc/source/gtr.rst
+++ b/doc/source/gtr.rst
@@ -17,7 +17,7 @@ GTR class documentation
 .. automethod:: treetime.GTR.assign_rates
 
 .. Note::
-    GTR object can be modified in-place by calling :func:`assign_rates`
+    GTR object can be modified in-place by calling :py:func:`treetime.GTR.assign_rates`
 
 
 Sequence manipulation

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,6 +17,7 @@ TreeTime is organized as a hierarchy of classes. The GTR class implements sequen
    clock_tree
    treetime
    vcf_utils
+   seq_utils
 
 
 .. automodule:: treetime
@@ -41,6 +42,9 @@ Utility code
 :doc:`VCF tools<vcf_utils>`
 -------------------------------
 
+:doc:`Seq tools<seq_utils>`
+-------------------------------
+
 
 Command-line functions
 ======================
@@ -50,19 +54,33 @@ regular linux programs.
 
 homoplasy_scanner
 -----------------
+Reconstructs ancestral sequences and maps mutations to the tree.
+The tree is then scanned for homoplasies. An excess number of homoplasies
+might suggest contamination, recombination, culture adaptation or similar.
+Results are printed to stdout.
 
 ancestral_reconstruction
 ------------------------
+Reconstructs ancestral sequences and maps mutations to the tree.
+Produces an alignment file containing inferred ancestral sequences and a tree file
+with mutations included as comments. The inferred GTR model is written to stdout.
 
 temporal_signal
 ---------------
+Calculates the root-to-tip regression and quantifies the 'clock-i-ness' of the tree.
+It will reroot the tree to maximize the clock-like
+signal and recalculate branch length unless run with --keep_root.
 
 timetree_inference
 ------------------
+Reconstructs ancestral sequences and infers a molecular clock tree. Produces
+an alignment file containing inferred ancestral sequences and a tree file with
+mutations included as comments, and prints the molecular clock and inferred
+GTR model.
 
 mugration
 ---------
-
+Reconstructs discrete ancestral states, for example geographic location, host, or similar.
 
 
 Indices and tables

--- a/doc/source/seq_utils.rst
+++ b/doc/source/seq_utils.rst
@@ -1,0 +1,9 @@
+*******************
+Sequence Utilities
+*******************
+
+.. autofunction:: treetime.seq_utils.seq2array
+
+.. autofunction:: treetime.seq_utils.seq2prof
+
+.. autofunction:: treetime.seq_utils.prof2seq

--- a/doc/source/treeanc.rst
+++ b/doc/source/treeanc.rst
@@ -9,8 +9,7 @@ The tree is stored as Bio.Phylo object. In order to facilitate the tree operatio
 The main purpose of the TreeAnc class is to implement standard algorithms for ancestral sequence reconstruction.
 Both marginal and joint maximum likelihood reconstructions are possible. The marginal reconstructions computes the entire distribution of the states at a given node after tracing out states at all other nodes.
 
-The `example scripts <https://github.com/neherlab/treetime/blob/master/examples/ancestral_inference.py>`_
-illustrate how to instantiate TreeAnc objects.
+The `example scripts <https://github.com/neherlab/treetime/blob/master/examples/ancestral_inference.py>`_ illustrate how to instantiate TreeAnc objects.
 
 
 TreeAnc Constructor
@@ -33,17 +32,17 @@ Basic functions, utilities, properties
 
 .. automethod:: treetime.TreeAnc.logger
 
-.. automethod:: treetime.TreeAnc.aln
+.. automethod:: treetime.TreeAnc.aln()
 
-.. automethod:: treetime.TreeAnc.gtr
+.. automethod:: treetime.TreeAnc.gtr()
 
-.. automethod:: treetime.TreeAnc.tree
+.. automethod:: treetime.TreeAnc.tree()
 
-.. automethod:: treetime.TreeAnc.leaves_lookup
+.. automethod:: treetime.TreeAnc.leaves_lookup()
 
 
 Sequence and profile manipulation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------
 
 .. automethod:: treetime.TreeAnc.get_mutations
 
@@ -53,9 +52,11 @@ Sequence and profile manipulation
 
 .. automethod:: treetime.TreeAnc.expanded_sequence
 
+.. automethod:: treetime.TreeAnc.dict_sequence
+
 
 Ancestral reconstruction and tree optimization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------------
 
 .. automethod:: treetime.TreeAnc.reconstruct_anc
 

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -32,12 +32,12 @@ class ClockTree(TreeAnc):
         Parameters
         ----------
 
-         dates : dic, None
-            {leaf_name:leaf_date} dictionary
+         dates : dict
+            :code:`{leaf_name:leaf_date}` dictionary
 
          debug : bool
             If True, the debug mode is ON, which means no or less clean-up of
-            obsolete parameters to control program  execution in intermediate
+            obsolete parameters to control program execution in intermediate
             states. In debug mode, the python debugger is also allowed to interrupt
             program execution with intercative shell if an error occurs.
 
@@ -46,15 +46,14 @@ class ClockTree(TreeAnc):
             performed.
 
          precision : int
-            precision can be 0 (rough), 1 (default), 2 (fine), or 3 (ultra fine)
-            this parameter determines the number of grid points that are used
+            Precision can be 0 (rough), 1 (default), 2 (fine), or 3 (ultra fine).
+            This parameter determines the number of grid points that are used
             for the evaluation of the branch length interpolation objects.
             When not specified, this will default to 1 for short sequences and 2
             for long sequences with L>1e4
 
-        Keyword Args
-        ------------
-            Kwargs needed to construct parent class (TreeAnc)
+         **kwargs:
+            Key word argments needed to construct parent class (TreeAnc)
 
         """
         super(ClockTree, self).__init__(*args, **kwargs)
@@ -160,21 +159,22 @@ class ClockTree(TreeAnc):
         lengths as they are used in ML computations. The conversion formula is
         assumed to be 'length = k*numdate + b'. For convenience, these
         coefficients as well as regression parameters are stored in the
-        dates2dist object.
+        'dates2dist' object.
 
-        ..Note:: that tree must have dates set to all nodes before calling this
-        function.
+        .. Note::
+            The tree must have dates set to all nodes before calling this
+            function.
 
         Parameters
         ----------
 
          ancestral_inference: bool
-            Whether or not to reinfer ancestral sequences
-            done by default when ancestral sequences are missing
+            If True, reinfer ancestral sequences
+            when ancestral sequences are missing
 
-         clock_rate: float, None
-            if specified, timetree optimization will be done assuming a
-            fixed clock rate
+         clock_rate: float
+            If specified, timetree optimization will be done assuming a
+            fixed clock rate as specified
 
         """
         self.logger("ClockTree.init_date_constraints...",2)
@@ -239,12 +239,10 @@ class ClockTree(TreeAnc):
         ----------
 
          time_marginal : bool
-            Whether use marginal reconstruction for node positions or not
+            If true, use marginal reconstruction for node positions
 
-        Keyword Args
-        ------------
-
-         Kwargs needed to initialize dates constraints
+         **kwargs
+            Key word arguments to initialize dates constraints
 
         '''
         self.logger("ClockTree: Maximum likelihood tree optimization with temporal constraints:",1)
@@ -567,10 +565,9 @@ class ClockTree(TreeAnc):
 
     def convert_dates(self):
         '''
-        this fucntion converts the estimated "time_before_present" properties of all nodes
+        This function converts the estimated "time_before_present" properties of all nodes
         to numerical dates stored in the "numdate" attribute. This date is further converted
-        into a human readable date string in format %Y-%m-%d assuming the usual calendar
-
+        into a human readable date string in format %Y-%m-%d assuming the usual calendar.
 
         Returns
         -------
@@ -608,7 +605,7 @@ class ClockTree(TreeAnc):
     def branch_length_to_years(self):
         '''
         This function sets branch length to reflect the date differences between parent and child
-        nodes measured in years. Should only be called after convert_dates has been called
+        nodes measured in years. Should only be called after :py:meth:`timetree.ClockTree.convert_dates` has been called.
 
         Returns
         -------
@@ -628,8 +625,8 @@ class ClockTree(TreeAnc):
     def get_confidence_interval(self, node, interval = (0.05, 0.95)):
         '''
         If temporal reconstruction was done using the marginal ML mode, the entire distribution of
-        times is available. this function here determines the 90%( or other) confidence interval defines as the
-        range where 5% of probability are below and above. Note that this does not necessarily contain
+        times is available. This function determines the 90% (or other) confidence interval, defined as the
+        range where 5% of probability is below and above. Note that this does not necessarily contain
         the highest probability position.
 
         Parameters
@@ -638,8 +635,8 @@ class ClockTree(TreeAnc):
          node : PhyloTree.Clade
             The node for which the confidence interval is to be calculated
 
-         interval : tuple, list default=(0.05, 0.95)
-            Array like of length two defining the bounds of the confidence interval
+         interval : tuple, list
+            Array of length two, or tuple, defining the bounds of the confidence interval
 
         Returns
         -------
@@ -660,7 +657,7 @@ class ClockTree(TreeAnc):
     def get_max_posterior_region(self, node, fraction = 0.9):
         '''
         If temporal reconstruction was done using the marginal ML mode, the entire distribution of
-        times is available. this function here determines the 95% confidence interval defines as the
+        times is available. This function determines the 95% confidence interval defines as the
         range where 5% of probability are below and above. Note that this does not necessarily contain
         the highest probability position.
 
@@ -668,7 +665,7 @@ class ClockTree(TreeAnc):
         ----------
 
          node : PhyloTree.Clade
-            The node for which the confidence region is to be calculated
+            The node for which the posterior region is to be calculated
 
          interval : float
             Float specifying who much of the posterior probability is

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -18,24 +18,24 @@ class GTR(object):
         ----------
 
          alphabet : str, numpy.array
-            alphabet of the sequence. If string passed, it is understood as
-            alphabet name. In this case, the alphabet and its profile map pulled
-            from seq_utils.
+            Alphabet of the sequence. If a string is passed, it is understood as
+            an alphabet name. In this case, the alphabet and its profile map are pulled
+            from :py:obj:`treetime.seq_utils`.
 
-            If numpy array of characters passed, a new alphabet is constructed,
+            If a numpy array of characters is passed, a new alphabet is constructed,
             and the default profile map is atached to it.
 
          prof_map : dict
-            dictionary linking characters in the sequence to likelihood
-            of observing characters in the alphabt. This is used to
+            Dictionary linking characters in the sequence to the likelihood
+            of observing characters in the alphabet. This is used to
             implement ambiguous characters like 'N'=[1,1,1,1] which are
-            equally likely any of the 4 nucleotides. Standard profile_maps
-            are defined in file seq_utils.py. If none is provided, no ambigous
+            equally likely to be any of the 4 nucleotides. Standard profile_maps
+            are defined in file seq_utils.py. If None is provided, no ambigous
             characters are supported.
 
          logger : callable
-            custom logging function that should take arguments (msg, level, warn=False)
-            where msg is a string, level an integer to be compared against verbose.
+            Custom logging function that should take arguments (msg, level, warn=False),
+            where msg is a string and level an integer to be compared against verbose.
 
         """
         self.debug=False
@@ -186,12 +186,15 @@ class GTR(object):
          pi : n vector
             Equilibrium frequencies
 
+         **kwargs:
+            Key word arguments to be passed
+
         Keyword Args
         ------------
 
          alphabet : str
             Specify alphabet when applicable. If the alphabet specification is
-            required, but no alphabet specified, the nucleotide will be used as
+            required, but no alphabet is specified, the nucleotide alphabet will be used as
             default.
 
         """
@@ -208,13 +211,9 @@ class GTR(object):
         ----------
 
          model : str
-            Model to create. List of the available models is
-            (see description below)
-
-        Keyword Args
-        ------------
-
-         model arguments
+            Model to create. See list of available models below
+         **kwargs:
+            Key word arguments to be passed to the model
 
 
         **Available models**
@@ -347,7 +346,7 @@ class GTR(object):
     @classmethod
     def random(cls, mu=1.0, alphabet='nuc'):
         """
-        Create random GTR model
+        Creates a random GTR model
 
         Parameters
         ----------
@@ -376,7 +375,9 @@ class GTR(object):
         """
         Infer a GTR model by specifying the number of transitions and time spent in each
         character. The basic equation that is being solved is
-            :math:`n_{ij} = pi_i W_{ij} T_j`
+
+        :math:`n_{ij} = pi_i W_{ij} T_j`
+
         where :math:`n_{ij}` are the transitions, :math:`pi_i` are the equilibrium
         state frequencies, :math:`W_{ij}` is the "substitution attempt matrix",
         while :math:`T_i` is the time on the tree spent in character state
@@ -384,7 +385,7 @@ class GTR(object):
         to account for the fact that the root of the tree is in a particular
         state. the modified equation is
 
-            :math:`n_{ij} + pc = pi_i W_{ij} (T_j+pc+root\_state)`
+        :math:`n_{ij} + pc = pi_i W_{ij} (T_j+pc+root\_state)`
 
         Parameters
         ----------
@@ -404,12 +405,15 @@ class GTR(object):
             Pseudocounts, this determines the lower cutoff on the rate when
             no substitutions are observed
 
+         **kwargs:
+            Key word arguments to be passed
+
         Keyword Args
         ------------
 
          alphabet : str
             Specify alphabet when applicable. If the alphabet specification
-            is required, but no alphabet specified, the nucleotide will be used as default.
+            is required, but no alphabet is specified, the nucleotide alphabet will be used as default.
 
         """
         from scipy import linalg as LA
@@ -510,9 +514,9 @@ class GTR(object):
     def compress_sequence_pair(self, seq_p, seq_ch, pattern_multiplicity=None,
                                ignore_gaps=False):
         '''
-        make a compressed representation of a pair of sequences only counting
+        Make a compressed representation of a pair of sequences, only counting
         the number of times a particular pair of states (e.g. (A,T)) is observed
-        the the aligned sequences of parent and child
+        in the aligned sequences of parent and child.
 
         Parameters
         ----------
@@ -523,20 +527,20 @@ class GTR(object):
          seq_ch: numpy array
             Child sequence as numpy array of chars
 
-         pattern_multiplicity : numpy array, None
-            if sequences are reduced by combining identical alignment patterns,
+         pattern_multiplicity : numpy array
+            If sequences are reduced by combining identical alignment patterns,
             these multplicities need to be accounted for when counting the number
             of mutations across a branch. If None, all pattern are assumed to
             occur exactly once.
 
-         ignore_gap: bool, default False
+         ignore_gap: bool
             Whether or not to include gapped positions of the alignment
             in the multiplicity count
 
         Returns
         -------
           seq_pair : list
-            [(0,1), (2,2), (3,4)] list of parent_child state pairs
+            :code:`[(0,1), (2,2), (3,4)]` list of parent_child state pairs
             as indices in the alphabet
 
           multiplicity : numpy array
@@ -590,24 +594,25 @@ class GTR(object):
 ########################################################################
     def prob_t_compressed(self, seq_pair, multiplicity, t, return_log=False, derivative=0):
         '''
-        calculate the probability of observing a sequence pair at a distance t
+        Calculate the probability of observing a sequence pair at a distance t,
+        for compressed sequences
 
         Parameters
         ----------
 
           seq_pair : numpy array
-            np.array([(0,1), (2,2), ()..]) as indicies of
-            pairs of aligned positions. (e.g. 'A'==0, 'C'==1 etc)
-            this only lists all occuring parent-child state pairs, order is irrelevant
+            :code:`np.array([(0,1), (2,2), ()..])` as indicies of
+            pairs of aligned positions. (e.g. 'A'==0, 'C'==1 etc).
+            This only lists all occuring parent-child state pairs, order is irrelevant
 
           multiplicity : numpy array
-            The number of times a parent-child state pair is observed
-            this allows to compress the sequence representation
+            The number of times a parent-child state pair is observed.
+            This allows compression of the sequence representation
 
           t : float
             Length of the branch separating parent and child
 
-          return_log : bool, default False
+          return_log : bool
             Whether or not to exponentiate the result
 
         '''
@@ -626,35 +631,34 @@ class GTR(object):
 
     def prob_t(self, seq_p, seq_ch, t, pattern_multiplicity = None, return_log=False, ignore_gaps=True):
         """
-        Compute the probability to observe seq_ch after time t starting from seq_p.
+        Compute the probability to observe seq_ch (child sequence) after time t starting from seq_p
+        (parent sequence).
 
         Parameters
         ----------
 
-         profile_p : np.array
-            Parent profile of shape (L, a), where
-            L - length of the sequence, a - alphabet size.
+         seq_p : character array
+            Parent sequence
 
-         profile_ch : np.array
-            Child profile of shape (L, a), where
-            L - length of the sequence, a - alphabet size.
+         seq_c : character array
+            Child sequence
 
          t : double
-            Time (branch len), separating the profiles.
+            Time (branch len) separating the profiles.
 
-         pattern_multiplicity : numpy array, None
-            if sequences are reduced by combining identical alignment patterns,
+         pattern_multiplicity : numpy array
+            If sequences are reduced by combining identical alignment patterns,
             these multplicities need to be accounted for when counting the number
             of mutations across a branch. If None, all pattern are assumed to
             occur exactly once.
 
-         return_log : bool, default False
-            Whether return log-probability.
+         return_log : bool
+            It True, return log-probability.
 
         Returns
         -------
          prob : np.array
-            resulting probability.
+            Resulting probability
 
         """
         seq_pair, multiplicity = self.compress_sequence_pair(seq_p, seq_ch,
@@ -670,19 +674,19 @@ class GTR(object):
         ----------
 
          seq_p : character array
-            parent sequence
+            Parent sequence
 
          seq_c : character array
-            child sequence
+            Child sequence
 
-         pattern_multiplicity : numpy array, None
-            if sequences are reduced by combining identical alignment patterns,
+         pattern_multiplicity : numpy array
+            If sequences are reduced by combining identical alignment patterns,
             these multplicities need to be accounted for when counting the number
             of mutations across a branch. If None, all pattern are assumed to
             occur exactly once.
 
          ignore_gaps : bool
-            ignore gaps in distance calculations
+            If True, ignore gaps in distance calculations
 
         '''
         seq_pair, multiplicity = self.compress_sequence_pair(seq_p, seq_ch,
@@ -693,32 +697,33 @@ class GTR(object):
 
     def optimal_t_compressed(self, seq_pair, multiplicity, profiles=False):
         """
-        Find the optimal distance between the two sequences
+        Find the optimal distance between the two sequences, for compressed sequences
 
         Parameters
         ----------
 
          seq_pair : compressed_sequence_pair
-            compressed representation of sequences along a branch, either
+            Compressed representation of sequences along a branch, either
             as tuple of state pairs or as tuple of profiles.
 
          multiplicity : array
-            number of times each state pair in seq_pair appears (profile==False)
-            number of times an alignment pattern is observed (profiles==True)
+            Number of times each state pair in seq_pair appears (if profile==False)
+
+            Number of times an alignment pattern is observed (if profiles==True)
 
          profiles : bool, default False
-            the standard branch length optimization assumes fixed sequences at
+            The standard branch length optimization assumes fixed sequences at
             either end of the branch. With profiles==True, optimization is performed
             while summing over all possible states of the nodes at either end of the
             branch. Note that the meaning/format of seq_pair and multiplicity
-            depend on the value of profiles
+            depend on the value of profiles.
 
         """
 
         def _neg_prob(t, seq_pair, multiplicity):
             """
-            Probability to observe child given the the parent state, transition
-            matrix and the time of evolution (branch length).
+            Probability to observe a child given the the parent state, transition
+            matrix, and the time of evolution (branch length).
 
             Parameters
             ----------
@@ -778,25 +783,25 @@ class GTR(object):
 
     def prob_t_profiles(self, profile_pair, multiplicity, t, return_log=False, ignore_gaps=True):
         '''
-        calculate the probability of observing a node pair at a distance t
+        Calculate the probability of observing a node pair at a distance t
 
         Parameters
         ----------
 
           profile_pair: numpy arrays
-            probability distributions of the nucleotides at either
+            Probability distributions of the nucleotides at either
             end of the branch. pp[0] = parent, pp[1] = child
 
           multiplicity : numpy array
-            The number of times a an alignment pattern is observed
+            The number of times an alignment pattern is observed
 
           t : float
             Length of the branch separating parent and child
 
           ignore_gaps: bool
-            ignore mutations to and from gaps in distance calculations
+            If True, ignore mutations to and from gaps in distance calculations
 
-          return_log : bool, default False
+          return_log : bool
             Whether or not to exponentiate the result
 
         '''
@@ -835,8 +840,8 @@ class GTR(object):
          t : double
             Time to propagate
 
-         return_log: bool, default False
-            Whether to return log-probability
+         return_log: bool
+            If True, return log-probability
 
         Returns
         -------
@@ -879,13 +884,13 @@ class GTR(object):
         ----------
 
          t : float
-            time to propagate
+            Time to propagate
 
         Returns
         --------
 
          expQt : numpy.array
-            matrix exponential of exo(Qt)
+            Matrix exponential of exo(Qt)
         '''
         eLambdaT = np.diag(self._exp_lt(t)) # vector length = a
         Qs = self.v.dot(eLambdaT.dot(self.v_inv))   # This is P(nuc1 | given nuc_2)
@@ -926,16 +931,16 @@ class GTR(object):
 
     def sequence_logLH(self,seq, pattern_multiplicity=None):
         """
-        Returns the log-likelihood of sampling a sequence from equilibrium frequency
-        expects a sequence as numpy array
+        Returns the log-likelihood of sampling a sequence from equilibrium frequency.
+        Expects a sequence as numpy array
 
         Parameters
         ----------
 
          seq : numpy array
-            Compressed sequence as array of chars
+            Compressed sequence as an array of chars
 
-         pattern_multiplicity : numpy_array, None
+         pattern_multiplicity : numpy_array
             The number of times each position in sequence is observed in the
             initial alignment. If None, sequence is assumed to be not compressed
 

--- a/treetime/seq_utils.py
+++ b/treetime/seq_utils.py
@@ -119,24 +119,25 @@ profile_maps = {
 
 def seq2array(seq, fill_overhangs=True, ambiguous_character='N'):
     """
-    Take the raw sequence, substitute the "overhanging" gaps with 'N' (missequenced)
-    convert the sequence to the numpy array of chars.
+    Take the raw sequence, substitute the "overhanging" gaps with 'N' (missequenced),
+    and convert the sequence to the numpy array of chars.
 
     Parameters
     ----------
      seq : Biopython.SeqRecord, str, iterable
-        sequence as an object of SeqRecord, string or iterable
+        Sequence as an object of SeqRecord, string or iterable
 
      fill_overhangs : bool
-        should substitute the "overhanging" gaps with ambiguous character symbol?
+        If True, substitute the "overhanging" gaps with ambiguous character symbol
 
      ambiguous_character : char
-        Specify the caharcter for ambiguous state ('N' default for nucleotide)
+        Specify the character for ambiguous state ('N' default for nucleotide)
 
     Returns
     -------
      sequence : np.array
-        sequence as 1D numpy array of chars
+        Sequence as 1D numpy array of chars
+
     """
     try:
         sequence = ''.join(seq)
@@ -159,16 +160,16 @@ def seq2prof(seq, profile_map):
     ----------
 
      seq : numpy.array
-        sequence to be converted to the profile
+        Sequence to be converted to the profile
 
      profile_map : dic
-        mapping valid characters to profiles
+        Mapping valid characters to profiles
 
     Returns
     -------
 
      idx : numpy.array
-        profile for the character, zero array if the character not found
+        Profile for the character. Zero array if the character not found
 
     """
     plength = np.unique([len(x) for x in profile_map.values()])
@@ -192,25 +193,25 @@ def prof2seq(profile, gtr, sample_from_prof=False):
     ----------
 
      profile : numpy 2D array
-        profile. Shape of the profile should be (L x a), where L - sequence
+        Profile. Shape of the profile should be (L x a), where L - sequence
         length, a - alphabet size.
 
      gtr : gtr.GTR
-        instance of teh GTR class to supply the sequence alphabet
+        Instance of the GTR class to supply the sequence alphabet
 
-     collapse_prof : bool, default True
-        whether to convert the profile to the delta-function
+     collapse_prof : bool
+        Whether to convert the profile to the delta-function
 
     Returns
     -------
      seq : numpy.array
-        sequence as numpy array of length L
+        Sequence as numpy array of length L
 
      prof_values :  numpy.array
-        values of the profile for the chosen sequence characters (length L)
+        Values of the profile for the chosen sequence characters (length L)
 
      idx : numpy.array
-        inidces chosen form profile as array of length L
+        Indices chosen from profile as array of length L
     """
 
     # normalize profile such that probabilities at each site sum to one

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -22,7 +22,7 @@ class TreeAnc(object):
                 ref=None, verbose = ttconf.VERBOSE, ignore_gaps=True,
                 convert_upper=True, seq_multiplicity=None, log=None, **kwargs):
         """
-        TreeAnc constructor. It prepares tree, attach sequences to the leaf nodes,
+        TreeAnc constructor. It prepares the tree, attaches sequences to the leaf nodes,
         and sets some configuration parameters.
 
         Parameters
@@ -39,37 +39,41 @@ class TreeAnc(object):
             specifies for each sequence the differences from a reference
 
          gtr : str, GTR
-            gtr model object. If string passed, it is interpreted as the type of
+            GTR model object. If string passed, it is interpreted as the type of
             the GTR model. A new GTR instance will be created for this type.
-           **Note** some GTR types require additional configuration parameters.
-           If the new GTR is being instantiated, these parameters are expected
-           to be passed as kwargs. If nothing is passed, the default values are
-           used, which might cause unexpected results.
 
          fill_overhangs : bool
             In some cases, the missing data on both ends of the alignment is
-            filled with the gap sign('-'). As we suppose that the most
-            appropriate way to deal with the missing data is to assign it to the
-            "unknown" character ('N' for nucleotides, 'X' for aminoacids). If the
-            parameter is set to True, the end-gaps are converted to unknown
-            symbols. Otherwise, the alignment is treated as-is
+            filled with the gap sign('-'). If set to True, the end-gaps are converted to "unknown"
+            characters ('N' for nucleotides, 'X' for aminoacids). Otherwise, the alignment is treated as-is
 
          ignore_gaps: bool
-            ignore gaps in branch length calculations
+            Ignore gaps in branch length calculations
 
          verbose : int
-            verbosity level as number from 0 (lowest) to 10 (highest).
+            Verbosity level as number from 0 (lowest) to 10 (highest).
 
          seq_multiplicity: dict
-            if individual nodes in the tree correspond to multiple sampled sequences
+            If individual nodes in the tree correspond to multiple sampled sequences
             (i.e. read count in a deep sequencing experiment), these can be
             specified as a dictionary. This currently only affects rooting and
             can be used to weigh individual tips by abundance or important during root search.
 
-        Keyword Args
-        ------------
+         **kwargs
+            Keyword arguments to construct the GTR model
 
-          Keyword arguments to construct GTR model
+          .. Note::
+                Some GTR types require additional configuration parameters.
+                If the new GTR is being instantiated, these parameters are expected
+                to be passed as kwargs. If nothing is passed, the default values are
+                used, which might cause unexpected results.
+
+        Raises
+        ----------
+
+         TypeError
+            If a tree is not passed in
+
 
         """
         if tree is None:
@@ -115,14 +119,14 @@ class TreeAnc(object):
         -----------
 
          msg : str
-            string to print on the screen
+            String to print on the screen
 
          level : int
-            log-level. Only the messages with the level higher than the
+            Log-level. Only the messages with a level higher than the
             current verbose level will be shown.
 
          warn : bool
-            warning flag. If True, the message will be displayed
+            Warning flag. If True, the message will be displayed
             regardless of its log-level.
 
         """
@@ -145,7 +149,7 @@ class TreeAnc(object):
     @property
     def leaves_lookup(self):
         """
-        Leaves lookup is the {leaf-name:leaf-node} dictionary. It enables fast
+        The :code:`{leaf-name:leaf-node}` dictionary. It enables fast
         search of a tree leaf object by its name.
         """
         return self._leaves_lookup
@@ -153,7 +157,11 @@ class TreeAnc(object):
     @property
     def gtr(self):
         """
-        Get GTR object currently used.
+        The current GTR object.
+
+        :setter: Sets the GTR object passed in
+        :getter: Returns the current GTR object
+
         """
         return self._gtr
 
@@ -183,15 +191,13 @@ class TreeAnc(object):
 
          in_gtr : str, GTR
             The gtr model to be assigned. If string is passed,
-            it is understood as the name of the standard GTR model, and is
-            attempted to be created through GTR.standard() interface. In case
-            GTR instance is passed, it is directly set as the class attribute
+            it is taken as the name of a standard GTR model, and is
+            attempted to be created through :code:`GTR.standard()` interface. If a
+            GTR instance is passed, it is set directly .
 
-        Keyword Args
-        ------------
-
-         All parameters needed for the gtr creation. If none passed, defaults are assumed.
-           Refer to the particular GTR models for the exact parameter values
+         **kwargs
+            Keyword arguments to construct the GTR model. If none are passed, defaults
+            are assumed.
 
         """
         if type(in_gtr)==str:
@@ -213,7 +219,12 @@ class TreeAnc(object):
     @property
     def tree(self):
         """
-        Get reference to the phylogenetic tree currently used by the TreeAnc.
+        The phylogenetic tree currently used by the TreeAnc.
+
+        :setter: Sets the tree. Directly if passed as Phylo.Tree, or by reading from \
+        file if passed as a str.
+        :getter: Returns the tree as a Phylo.Tree object
+
         """
         return self._tree
 
@@ -256,12 +267,28 @@ class TreeAnc(object):
     @property
     def aln(self):
         """
-        Get the multiple sequence alignment currently used by the TreeAnc
+        The multiple sequence alignment currently used by the TreeAnc
+
+        :setter: Takes in alignment as MultipleSeqAlignment, str, or dict/defaultdict \
+        and attaches sequences to tree nodes.
+        :getter: Returns alignment as MultipleSeqAlignment or dict/defaultdict
+
         """
         return self._aln
 
     @aln.setter
     def aln(self,in_aln):
+        """
+        Reads in the alignment (from a dict, MultipleSeqAlignment, or file,
+        as necessary), sets tree-related parameters, and attaches sequences
+        to the tree nodes.
+
+        Parameters
+        ----------
+        in_aln : MultipleSeqAlignment, str, dict/defaultdict
+            The alignment to be read in
+
+        """
         # load alignment from file if necessary
         from os.path import isfile
         from Bio.Align import MultipleSeqAlignment
@@ -309,8 +336,12 @@ class TreeAnc(object):
     @property
     def ref(self):
         """
-        Get the str reference nucleotide sequence currently used by TreeAnc
-        When having read in from a VCF, this is what variants map to
+        Get the str reference nucleotide sequence currently used by TreeAnc.
+        When having read alignment in from a VCF, this is what variants map to.
+
+        :setter: Sets the string reference sequence
+        :getter: Returns the string reference sequence
+
         """
         return self._ref
 
@@ -374,6 +405,7 @@ class TreeAnc(object):
         unique patterns are present. The reduced alignment and the pattern multiplicity
         are sufficient for the GTR calculations and allow to save memory on profile
         instantiation.
+
         The maps from full sequence to reduced sequence and back are also stored to allow
         compressing and expanding the sequences.
 
@@ -381,20 +413,20 @@ class TreeAnc(object):
         -----
 
           full_to_reduced_sequence_map : (array)
-             map to reduce a sequence
+             Map to reduce a sequence
 
           reduced_to_full_sequence_map : (dict)
-             map to restore sequence from reduced alignment
+             Map to restore sequence from reduced alignment
 
           multiplicity : (array)
-            numpy array, which stores the pattern multiplicity for each position of the reduced alignment.
+            Numpy array, which stores the pattern multiplicity for each position of the reduced alignment.
 
           reduced_alignment : (2D numpy array)
-            representing the alignment. Shape is (N x L'), where N is number of
+            The reduced alignment. Shape is (N x L'), where N is number of
             sequences, L' - number of unique alignment patterns
 
           cseq : (array)
-            compressed sequence (corresponding row of the reduced alignment) is attached to each node
+            The compressed sequence (corresponding row of the reduced alignment) attached to each node
 
         """
 
@@ -639,39 +671,40 @@ class TreeAnc(object):
     def infer_gtr(self, print_raw=False, marginal=False, normalized_rate=True,
                   fixed_pi=None, pc=5.0, **kwargs):
         """
-        Calculates GTR model given the multiple sequence alignment and the tree.
-        It performs ancestral sequence inferrence (joint or marginal) followed by
+        Calculates a GTR model given the multiple sequence alignment and the tree.
+        It performs ancestral sequence inferrence (joint or marginal), followed by
         the branch lengths optimization. Then, the numbers of mutations are counted
         in the optimal tree and related to the time within the mutation happened.
-        From this statistics, the relative state transition probabilities are inferred,
+        From these statistics, the relative state transition probabilities are inferred,
         and the transition matrix is computed.
+
         The result is used to construct the new GTR model of type 'custom'.
-        The model is assigned to the TreeAnc and is used in the following analysis.
+        The model is assigned to the TreeAnc and is used in subsequent analysis.
 
         Parameters
         -----------
 
          print_raw : bool
-            Should print the inferred GTR model?
+            If True, print the inferred GTR model
 
          marginal : bool
-            Should use marginal sequence reconstruction?
+            If True, use marginal sequence reconstruction
 
          normalized_rate : bool
-            If True, will set the mutation rate prefactor to 1.0.
+            If True, sets the mutation rate prefactor to 1.0.
 
-         fixed_pi : np.array, None
+         fixed_pi : np.array
             Provide the equilibrium character concentrations.
-            If None is passed, the concentrations will be inferred from scratch.
+            If None is passed, the concentrations will be inferred from the alignment.
 
-         pc: float, 5.0
+         pc: float
             Number of pseudo counts to use in gtr inference
 
         Returns
         -------
 
          gtr : GTR
-            The inferred GTR model.
+            The inferred GTR model
         """
 
         # decide which type of the Maximum-likelihood reconstruction use
@@ -723,7 +756,7 @@ class TreeAnc(object):
 ### ancestral reconstruction
 ###################################################################
     def infer_ancestral_sequences(self,*args, **kwargs):
-        """Shortcut for :meth:`reconstruct_anc`
+        """Shortcut for :py:meth:`treetime.TreeAnc.reconstruct_anc`
         """
         return self.reconstruct_anc(*args,**kwargs)
 
@@ -739,10 +772,10 @@ class TreeAnc(object):
          method : str
             Method to use. Supported values are "fitch" and "ml"
 
-         infer_gtr : bool, default False
+         infer_gtr : bool
             Infer a GTR model before reconstructing the sequences
 
-         marginal : bool, default False
+         marginal : bool
             Assign sequences that are most likely after averaging over all other nodes
             instead of the jointly most likely sequences.
 
@@ -804,17 +837,17 @@ class TreeAnc(object):
             Tree node, which is the child node attached to the branch.
 
          keep_var_ambigs : boolean
-            If true, generates mutations based on the *original* _compressed_ sequence, which
+            If true, generates mutations based on the *original* compressed sequence, which
             may include ambiguities. Note sites that only have 1 unambiguous base and ambiguous
             bases ("AAAAANN") are stripped of ambiguous bases *before* compression, so ambiguous
-            bases will *not* be preserved.
+            bases will **not** be preserved.
 
         Returns
         -------
 
           muts : list
             List of mutations. Each mutation is represented as tuple of
-            (parent_state, position, child_state).
+            :code:`(parent_state, position, child_state)`.
         """
 
         # if ambiguous site are to be restored and node is terminal,
@@ -879,10 +912,10 @@ class TreeAnc(object):
     def dict_sequence(self, node, keep_var_ambigs=False):
         """
         For VCF-based TreeAnc objects, we do not want to store the entire
-        sequence on every node - not space efficient! Instead, return the dict
-        of mutation locations for this sequence. This is used in place of
-        'expanded_sequence' for VCF-based obj throughout TreeAnc. However, users
-        can still call 'expanded_sequence' if they do actually want the whole thing!
+        sequence on every node, as they could be large. Instead, this returns the dict
+        of variants & their positions for this sequence. This is used in place of
+        :py:meth:`treetime.TreeAnc.expanded_sequence` for VCF-based objects throughout TreeAnc. However, users can still
+        call :py:meth:`expanded_sequence` if they require the full sequence.
 
         Parameters
         ----------
@@ -892,9 +925,8 @@ class TreeAnc(object):
         Returns
         -------
          seq : dict
-            dict where keys are position and value is the mutation
+            dict where keys are the basepair position (numbering from 0) and value is the variant call
 
-        EBH 6 Dec 2017
         """
         seq = {}
 
@@ -1416,7 +1448,9 @@ class TreeAnc(object):
     def optimize_branch_length(self, mode='joint', **kwargs):
         """
         Perform optimization for the branch lengths of the whole tree or any
-        subtree. **Note** this method assumes that each node stores information
+        subtree.
+
+        **Note** this method assumes that each node stores information
         about its sequence as numpy.array object (node.sequence attribute).
         Therefore, before calling this method, sequence reconstruction with
         either of the available models must be performed.
@@ -1425,23 +1459,23 @@ class TreeAnc(object):
         ----------
 
          mode : str
-            optimize branch length assuming the joint ML sequence assignment
-            of both ends of the branch, or trace over all possible sequence
-            assignments on both ends of the branch (slower, experimental).
+            Optimize branch length assuming the joint ML sequence assignment
+            of both ends of the branch (:code:`joint`), or trace over all possible sequence
+            assignments on both ends of the branch (:code:`marginal`) (slower, experimental).
+
+         **kwargs :
+            Keyword arguments
 
         Keyword Args
         ------------
 
          verbose : int
-            Output detalization
+            Output level
 
          store_old : bool
-            If True, the old lenths will be saved in node._old_dist attribute.
+            If True, the old lengths will be saved in :code:`node._old_dist` attribute.
             Useful for testing, and special post-processing.
 
-        Returns
-        -------
-         None, the phylogenetic tree is modified in-place.
 
         """
 
@@ -1638,7 +1672,7 @@ class TreeAnc(object):
     def prune_short_branches(self):
         """
         If the branch length is less than the minimal value, remove the branch
-        from the tree. **Requires** the ancestral sequence reconstruction
+        from the tree. **Requires** ancestral sequence reconstruction
         """
         self.logger("TreeAnc.prune_short_branches: pruning short branches (max prob at zero)...", 1)
         for node in self.tree.find_clades():
@@ -1655,15 +1689,8 @@ class TreeAnc(object):
 
 
     def optimize_sequences_and_branch_length(self,*args, **kwargs):
-        """This method is a shortcut for :py:meth:`optimize_seq_and_branch_len`
+        """This method is a shortcut for :py:meth:`treetime.TreeAnc.optimize_seq_and_branch_len`
 
-        Iteratively set branch lengths and reconstruct ancestral sequences until
-        the values of either former or latter do not change. The algorithm assumes
-        knowing only the topology of the tree, and requires that sequences are assigned
-        to all leaves of the tree. The first step is to pre-reconstruct ancestral
-        states using Fitch reconstruction algorithm or ML using existing branch length
-        estimates. Then, optimize branch lengths and re-do reconstruction until
-        convergence using ML method.
         """
         self.optimize_seq_and_branch_len(*args,**kwargs)
 
@@ -1675,7 +1702,9 @@ class TreeAnc(object):
         Iteratively set branch lengths and reconstruct ancestral sequences until
         the values of either former or latter do not change. The algorithm assumes
         knowing only the topology of the tree, and requires that sequences are assigned
-        to all leaves of the tree. The first step is to pre-reconstruct ancestral
+        to all leaves of the tree.
+
+        The first step is to pre-reconstruct ancestral
         states using Fitch reconstruction algorithm or ML using existing branch length
         estimates. Then, optimize branch lengths and re-do reconstruction until
         convergence using ML method.
@@ -1683,19 +1712,19 @@ class TreeAnc(object):
         Parameters
         -----------
 
-         reuse_branch_len : bool, default True
-            If True, rely on the initial branch lenghts, and start with the
-            Maximum-likelihood ancestral sequence inference using existing branch
-            lengths. Otherwise, initial reconstruction of ancestral states with
+         reuse_branch_len : bool
+            If True, rely on the initial branch lengths, and start with the
+            maximum-likelihood ancestral sequence inference using existing branch
+            lengths. Otherwise, do initial reconstruction of ancestral states with
             Fitch algorithm, which uses only the tree topology.
 
-         prune_short : bool, default True
+         prune_short : bool
             If True, the branches with zero optimal length will be pruned from
-            the tree hence creating polytomies. The polytomies could be further
-            processed using resolve_polytomies from the TreeTime class.
+            the tree, creating polytomies. The polytomies could be further
+            processed using :py:meth:`treetime.TreeTime.resolve_polytomies` from the TreeTime class.
 
-         marginal_sequences : bool, default False
-            assign sequences to their marginally most likely value, rather than
+         marginal_sequences : bool
+            Assign sequences to their marginally most likely value, rather than
             the values that are jointly most likely across all nodes.
 
          branch_length_mode : str
@@ -1705,10 +1734,10 @@ class TreeAnc(object):
             internal sequence states.
 
          max_iter : int
-            maximal number of times sequence and branch length iteration are optimized
+            Maximal number of times sequence and branch length iteration are optimized
 
-         infer_gtr : bool, default False
-            infer a GTR model from the observed substitutions.
+         infer_gtr : bool
+            Infer a GTR model from the observed substitutions.
 
         """
         if branch_length_mode=='marginal':
@@ -1749,7 +1778,7 @@ class TreeAnc(object):
 ###############################################################################
     def get_reconstructed_alignment(self):
         """
-        Get the multiple sequence alignment including reconstructed sequences for
+        Get the multiple sequence alignment, including reconstructed sequences for
         the internal nodes.
 
         Returns
@@ -1775,35 +1804,42 @@ class TreeAnc(object):
 
     def get_tree_dict(self, keep_var_ambigs=False):
         """
-        For VCF-based objects, returns a nested dict with all information required to
+        For VCF-based objects, returns a nested dict with all the information required to
         reconstruct sequences for all nodes (terminal and internal).
 
         Parameters
         ----------
 
         keep_var_ambigs : boolean
-            If true, generates dict sequence based on the *original* _compressed_ sequence, which
+            If true, generates dict sequences based on the *original* compressed sequences, which
             may include ambiguities. Note sites that only have 1 unambiguous base and ambiguous
             bases ("AAAAANN") are stripped of ambiguous bases *before* compression, so ambiguous
-            bases will *not* be preserved.
+            bases at this sites will *not* be preserved.
 
 
         Returns
         -------
 
          tree_dict : dict
-            Format:
-            '{'reference':'AGCTCGA..A',
-            'sequences': { 'seq1':{4:'A', 7:'-'}, 'seq2':{100:'C'} },
-            'positions': [1,4,7,10,100...],
-            'inferred_const_sites': [7,100....]     <this is optional>}'
-            Reference being the reference sequence to which the variable sites are mapped;
-            sequence containing a dict for each sequence with the position and base of
-            mutations; and positions containing a list of all the variable positions.
-            If included, inferred_const_sites is positions that were constant except
-            ambiguous bases, which were converted into constant sites (ex: 'AAAN' -> 'AAAA')
+            Format: ::
 
-        EBH 7 Dec 2017
+                {
+                'reference':'AGCTCGA...A',
+                'sequences': { 'seq1':{4:'A', 7:'-'}, 'seq2':{100:'C'} },
+                'positions': [1,4,7,10,100...],
+                'inferred_const_sites': [7,100....]
+                }
+
+            reference: str
+                The reference sequence to which the variable sites are mapped
+            sequences: nested dict
+                A dict for each sequence with the position and alternative call for each variant
+            positions: list
+                All variable positions in the alignment
+            inferred_cost_sites: list
+                *(optional)* Positions that were constant except ambiguous bases, which were
+                converted into constant sites by TreeAnc (ex: 'AAAN' -> 'AAAA')
+
         """
         if self.is_vcf:
             tree_dict = {}


### PR DESCRIPTION
Should now run without errors and with decorated functions handled correctly. Added new vcf-specific functions, and did a quick sweep to correct typos, improve clarity, and vaguely standardise to numpy autodoc style. 
The command-line functions on the index were updated to include the description from their argparse.

No code is changed, only comments.