### PR TITLE
Convert VCF ref to uppercase when read in

### DIFF
--- a/treetime/vcf_utils.py
+++ b/treetime/vcf_utils.py
@@ -258,6 +258,7 @@ def read_vcf(vcf_file, ref_file):
             sequences[s] = {}
 
     refSeq = SeqIO.read(ref_file, format='fasta')
+    refSeq = refSeq.upper() #convert to uppercase to avoid unknown chars later
     refSeqStr = str(refSeq.seq)
 
     compress_seq = {'reference':refSeqStr,


### PR DESCRIPTION
Prevents errors when VCF reference FASTA is in lowercase. FASTA input is already converted to uppercase when read in.

Should resolve issue #82 