### PR TITLE
Ambiguous Base Recovery for Fasta

### DIFF
--- a/test/test_treetime.py
+++ b/test/test_treetime.py
@@ -109,7 +109,7 @@ def test_seq_joint_reconstruction_correct():
         if hasattr(node, 'ref_seq'):
             continue
         t = node.branch_length
-        p = mygtr.propagate_profile( seq_utils.seq2prof(node.up.ref_seq, mygtr.profile_map), t)
+        p = mygtr.evolve( seq_utils.seq2prof(node.up.ref_seq, mygtr.profile_map), t)
         # normalie profile
         p=(p.T/p.sum(axis=1)).T
         # sample mutations randomly
@@ -120,7 +120,6 @@ def test_seq_joint_reconstruction_correct():
         node.ref_mutations = [(anc, pos, der) for pos, (anc, der) in
                             enumerate(izip(node.up.ref_seq, node.ref_seq)) if anc!=der]
         for anc, pos, der in node.ref_mutations:
-            print(pos)
             mutation_list[pos].append((node.name, anc, der))
         print (node.name, len(node.ref_mutations), node.ref_mutations)
 

--- a/treetime/__init__.py
+++ b/treetime/__init__.py
@@ -6,4 +6,4 @@ from .treetime import ttconf as treetime_conf
 from .gtr import GTR
 from .merger_models import Coalescent
 from .treeregression import TreeRegression
-version="0.5.5"
+version="0.5.6"

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -591,10 +591,14 @@ class TreeAnc(object):
             # if the column contains only one state and ambiguous nucleotides, replace
             # those with the state in other strains right away
             unique_letters = list(np.unique(pattern))
+            #create a copy so we don't modify aln_transpose
+            fixed_pattern = np.copy(pattern)
             if hasattr(self.gtr, "ambiguous"):
                 if len(unique_letters)==2 and self.gtr.ambiguous in unique_letters:
                     other = [c for c in unique_letters if c!=self.gtr.ambiguous][0]
                     str_pat = str_pat.replace(self.gtr.ambiguous, other)
+                    #also replace in original pattern!
+                    fixed_pattern[fixed_pattern == self.gtr.ambiguous] = other
                     unique_letters = [other]
             # if there is a mutation in this column, give it its private pattern
             # this is required when sampling mutations from reconstructed profiles.
@@ -607,7 +611,7 @@ class TreeAnc(object):
                 # bind the index in the reduced aln, index in sequence to the pattern string
                 alignment_patterns[str_pat] = (len(tmp_reduced_aln), [pi])
                 # append this pattern to the reduced alignment
-                tmp_reduced_aln.append(pattern)
+                tmp_reduced_aln.append(fixed_pattern)
             else:
                 # if the pattern is already seen, append the position in the real
                 # sequence to the reduced aln<->sequence_pos_indexes map

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -976,6 +976,7 @@ class TreeAnc(object):
         """
         Recalculates mutations using the original compressed sequence for terminal nodes
         which will recover ambiguous bases at variable sites. (See 'get_mutations')
+        For fasta input, also regenerates 'sequence' with original ambig sites
 
         Once this has been run, infer_gtr and other functions which depend on self.gtr.alphabet
         will not work, as ambiguous bases are not part of that alphabet (only A, C, G, T, -).
@@ -983,6 +984,9 @@ class TreeAnc(object):
         """
         for node in self.tree.get_terminals():
             node.mutations = self.get_mutations(node, keep_var_ambigs=True)
+            # If fasta, replace 'sequence' as this is what will be accessed later
+            if not self.is_vcf and hasattr(node, "original_cseq"):
+                node.sequence = self.expanded_sequence(node, keep_var_ambigs=True)
 
 
     def get_mutations(self, node, keep_var_ambigs=False):
@@ -1065,7 +1069,7 @@ class TreeAnc(object):
             return mut_matrix_stack
 
 
-    def expanded_sequence(self, node, include_additional_constant_sites=False):
+    def expanded_sequence(self, node, include_additional_constant_sites=False, keep_var_ambigs=False):
         """
         Expand a nodes compressed sequence into the real sequence
 
@@ -1084,7 +1088,12 @@ class TreeAnc(object):
         else:
             L = self.seq_len - self.additional_constant_sites
 
-        return node.cseq[self.full_to_reduced_sequence_map[:L]]
+        if keep_var_ambigs and hasattr(node, 'original_cseq'):
+            compress_seq = node.original_cseq
+        else:
+            compress_seq = node.cseq
+
+        return compress_seq[self.full_to_reduced_sequence_map[:L]] 
 
 
     def dict_sequence(self, node, keep_var_ambigs=False):


### PR DESCRIPTION
This PR is part bug-fix and part adding functionality to allow recovery of ambiguous bases for Fasta input (previously only available for VCF input).

**Bug Fix**
When a column has only two unique states and one is ambiguous ('AAAANNA'), the ambig sites are replaced by the other base (so 'AAAANNA' is processed as if it is 'AAAAAAA'). However, ambig sites are only replaced in `str_pat` (line [597](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L597) of treeanc.py), the string of the column, and not in `pattern`, the array of the column.

`str_pat` is then used check if the pattern has been seen before (line [606](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L606)) and add it to `alignment_patterns` if it has or hasn't (line [608](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L608)and [614](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L614)). But `pattern` is what's used to add it to `tmp_reduced_aln` (line [610](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L610)) which later becomes `self.reduced_alignment` (line [647](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L647)) and is used to generate `cseq` and `original_cseq` (line [668](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L668) and below). 

The consequence of this is that if the first 'constant' site seen is actually a mix of ambig + some base, it's identifying pattern (`str_pat`) will be a constant site ('AAAAAAA'), but the pattern stored in `tmp_reduced_aln` is the mix (`pattern`) ('AAAANNA'). When reconstructing the original sequence, this means in a sequence that an an ambig base at this position, will have an ambig base at EVERY position where that constant site is reported. Ex: here, all sites that should be constant 'A' sites will be 'N' in a sequence that had 'N' in the original column. The result is a huge number of Ns in the reconstructed sequence that were not originally there. 

This never was an issue with VCF as VCF files are pre-processed when they arrive as  their own form of compressed dicts (line [557](https://github.com/neherlab/treetime/blob/d9448934525e66413c851b7aa11690054ea397a8/treetime/treeanc.py#L557)). As part of this, the 'constant' sites will be added to `tmp_reduced_aln` before any sites with any variation. Thus, the constant site that is referenced later (for 'true' constant and converted ambig-mix columns) is always correct, unlike the above. 

As reconstruction of ambiguous sites has never been available to formats other than VCF, this bug is not expected to have ever caused deleterious effects. Though it will have been 'present' in Fasta-input reconstructions, as affected sites are always otherwise constant, all ambig sites are reconstructed as the constant base, and this does not appear to affect branch length estimates.


**Enabling Recovery of Ambig Sites for Fasta-Input**
`recover_var_ambigs()` function has added functionality so that when called it not only recalculates the mutations, but also replaces `node.sequence` with a reconstructed sequence that includes ambiguous bases present in the original. 
This means that Fasta-input now has the same option available as only VCF-input did previously.

**Version Bump**
The accompanying version bump is to allow other programs (like `augur`) to check the version to determine if ambiguous base recovery should be allowed for Fasta-input. (Without the bug-fix, it will produce nonsense!)