### PR TITLE
Include safety checks in _calc_dist2root for missing branch lengths

### DIFF
--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -840,12 +840,10 @@ class TreeAnc(object):
         self.tree.root.dist2root = 0.0
         for clade in self.tree.get_nonterminals(order='preorder'): # parents first
             for c in clade.clades:
+                if c.branch_length is None:
+                    c.branch_length = 0.0
                 if not hasattr(c, 'mutation_length'):
                     c.mutation_length = c.branch_length
-                if c.branch_length == None:
-                    c.branch_length = 0.0
-                if c.mutation_length == None:
-                    c.mutation_length = 0.0
                 c.dist2root = c.up.dist2root + c.mutation_length
 
 

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -841,7 +841,11 @@ class TreeAnc(object):
         for clade in self.tree.get_nonterminals(order='preorder'): # parents first
             for c in clade.clades:
                 if not hasattr(c, 'mutation_length'):
-                    c.mutation_length=c.branch_length
+                    c.mutation_length = c.branch_length
+                if c.branch_length == None:
+                    c.branch_length = 0.0
+                if c.mutation_length == None:
+                    c.mutation_length = 0.0
                 c.dist2root = c.up.dist2root + c.mutation_length
 
 
@@ -2121,4 +2125,3 @@ class TreeAnc(object):
             return tree_dict
         else:
             raise TypeError("A dict can only be returned for trees created with VCF-input!")
-


### PR DESCRIPTION
If TreeTime is handed a Newick tree with just a topology, the `_calc_dist2root` function will fail reporting:
`TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'`
This resulted from the branch_length attr existing but being set to None. With this fix TreeTime now works with just an input topology.

You can reproduce the original error by running https://github.com/nextstrain/zika-tutorial, but modifying the intermediate `tree_raw.nwk` to remove all branch lengths `:0.303`, etc...