### PR TITLE
add counter suffix if outdirectory already exist

### DIFF
--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -83,7 +83,7 @@ def get_outdir(params, suffix='_treetime'):
     outdir = outdir_stem + suffix.rstrip('/')+'/'
     count = 1
     while os.path.exists(outdir):
-        outdir = outdir_stem '-%04d'%count + suffix.rstrip('/')+'/'
+        outdir = outdir_stem + '-%04d'%count + suffix.rstrip('/')+'/'
         count += 1
 
     os.makedirs(outdir)

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -79,9 +79,14 @@ def get_outdir(params, suffix='_treetime'):
             return params.outdir.rstrip('/') + '/'
 
     from datetime import datetime
-    outdir = datetime.now().date().isoformat()+suffix.rstrip('/') + '/'
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
+    outdir_stem = datetime.now().date().isoformat()
+    outdir = outdir_stem + suffix.rstrip('/')+'/'
+    count = 1
+    while os.path.exists(outdir):
+        outdir = outdir_stem '-%04d'%count + suffix.rstrip('/')+'/'
+        count += 1
+
+    os.makedirs(outdir)
     return outdir
 
 def get_basename(params, outdir):


### PR DESCRIPTION
This PR avoid overwriting the content of the automatically generated output directories by adding a '-0001' style counter to the date. This should address issue #95 