### PR TITLE
Fix deprecation warning in python 3, but maintain python 2 compatibility

### DIFF
--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -1,7 +1,10 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
 from scipy.interpolate import interp1d
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError: # python < 3.3
+    from collections import Iterable
 from copy import deepcopy as make_copy
 from scipy.ndimage import binary_dilation
 from .config import BIG_NUMBER, MIN_LOG, MIN_INTEGRATION_PEAK, TINY_NUMBER

--- a/treetime/merger_models.py
+++ b/treetime/merger_models.py
@@ -7,7 +7,10 @@ import scipy.special as sf
 from scipy.interpolate import interp1d
 from Bio import AlignIO, Phylo
 from scipy.interpolate import interp1d
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError: # python < 3.3
+    from collections import Iterable
 from treetime import config as ttconf
 
 


### PR DESCRIPTION
This fixes the following deprecation warning that shows up in Python 3.8 (but apparently applies since Python 3.3).

> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working from collections import Iterable