### PR TITLE
add pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,62 @@
+[MASTER]
+ignore=.git .idea .input .output .temp .venv .vscode
+
+[MESSAGES CONTROL]
+disable=
+  bad-continuation,
+  bad-whitespace,
+  bare-except,
+  chained-comparison,
+  consider-using-in,
+  fixme,
+  invalid-name,
+  len-as-condition,
+  line-too-long,
+  missing-docstring,
+  multiple-imports,
+  no-else-continue,
+  no-else-raise,
+  no-else-return,
+  no-self-use,
+  protected-access,
+  too-many-arguments,
+  too-many-branches,
+  too-many-branches,
+  too-many-instance-attributes,
+  too-many-lines,
+  too-many-locals,
+  too-many-nested-blocks,
+  too-many-public-methods,
+  too-many-statements,
+  trailing-newlines,
+  unidiomatic-typecheck,
+  unnecessary-comprehension,
+  unnecessary-pass,
+  useless-object-inheritance,
+
+  duplicate-code,
+
+  unused-argument,
+  unused-import,
+  unused-variable,
+
+  simplifiable-if-expression,
+  simplifiable-if-statement,
+  singleton-comparison,
+
+  attribute-defined-outside-init,
+  multiple-statements,
+  redefined-outer-name,
+
+  cyclic-import,
+  import-error,
+  import-outside-toplevel,
+  reimported,
+  wrong-import-order,
+  wrong-import-position,
+
+[BASIC]
+bad-names=foo,baz,toto,tutu,tata,let,const,nil,null,define
+good-names=a,b,c,e,f,g,i,j,k,x,y,z,ex,Run,_,__,___
+
+extension-pkg-whitelist=numpy


### PR DESCRIPTION
Adds pylint configuration.

I excluded most of the stylistic and opinionated rules and only left something that looks dangerous or is simple to fix. And there is still quite a few things being reported.

### How to run

Install `pylint`:
```
pip3 install --user --upgrade pylint
```

Run on `treetime/` directory:
```
reset; pylint treetime/**/*.py
```
(`reset` cuts off the terminals' scrolling history)

If necessary, a rule can be silenced by adding it to the list in `.pylintrc`:

https://github.com/neherlab/treetime/blob/ba2be021a120851833921f1a78acc38fbb4fab62/.pylintrc#L5-L56


Or disabled and then enabled in a block:

```
# pylint: disable=unused-argument, unused-variable
...
# pylint: enable=unused-argument, unused-variable

```

