### PR TITLE
Use relative imports

### DIFF
--- a/treetime/argument_parser.py
+++ b/treetime/argument_parser.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function, division, absolute_import
 import sys, argparse, os
-from treetime.wrappers import ancestral_reconstruction, mugration, scan_homoplasies, timetree, estimate_clock_model
-from treetime import version
+from .wrappers import ancestral_reconstruction, mugration, scan_homoplasies, timetree, estimate_clock_model
+from . import version
 
 py2 = sys.version_info.major==2
 

--- a/treetime/branch_len_interpolator.py
+++ b/treetime/branch_len_interpolator.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
-from treetime import config as ttconf
+from . import config as ttconf
 from .distribution import Distribution
 
 class BranchLenInterpolator (Distribution):

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
-from treetime import config as ttconf
-from treetime import MissingDataError
+from . import config as ttconf
+from . import MissingDataError
 from .treeanc import TreeAnc
 from .utils import numeric_date, DateConversion, datestring_from_numeric
 from .distribution import Distribution

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 from collections import defaultdict
 import numpy as np
-from treetime import config as ttconf
+from . import config as ttconf
 from .seq_utils import alphabets, profile_maps, alphabet_synonyms
 
 def avg_transition(W,pi, gap_index=None):

--- a/treetime/gtr_site_specific.py
+++ b/treetime/gtr_site_specific.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 from collections import defaultdict
 import numpy as np
-from treetime import config as ttconf
+from . import config as ttconf
 from .seq_utils import alphabets, profile_maps, alphabet_synonyms
 from .gtr import GTR
 

--- a/treetime/merger_models.py
+++ b/treetime/merger_models.py
@@ -10,7 +10,7 @@ try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
-from treetime import config as ttconf
+from . import config as ttconf
 
 
 class Coalescent(object):

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
-from treetime import config as ttconf
+from . import config as ttconf
 from .distribution import Distribution
 
 def _create_initial_grid(node_dist, branch_dist):

--- a/treetime/seqgen.py
+++ b/treetime/seqgen.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 from collections import defaultdict
 import numpy as np
-from treetime import config as ttconf
+from . import config as ttconf
 from .seq_utils import alphabets, profile_maps, alphabet_synonyms, seq2array, seq2prof
 from .gtr import GTR
 from .treeanc import TreeAnc

--- a/treetime/sequence_data.py
+++ b/treetime/sequence_data.py
@@ -4,8 +4,8 @@ from os.path import isfile
 from collections import defaultdict
 import numpy as np
 from Bio import SeqRecord, Seq, AlignIO, SeqIO
-from treetime import config as ttconf
-from treetime import MissingDataError
+from . import config as ttconf
+from . import MissingDataError
 from .seq_utils import seq2array, guess_alphabet, alphabets
 
 string_types = [str] if sys.version_info[0]==3 else [str, unicode]

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -6,8 +6,8 @@ import numpy as np
 from Bio import Phylo
 from Bio.Phylo.BaseTree import Clade
 from Bio import AlignIO
-from treetime import config as ttconf
-from treetime import MissingDataError,UnknownMethodError
+from . import config as ttconf
+from . import MissingDataError,UnknownMethodError
 from .seq_utils import seq2prof, seq2array, prof2seq, normalize_profile, extend_profile
 from .gtr import GTR
 from .gtr_site_specific import GTR_site_specific

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -2,8 +2,8 @@ from __future__ import print_function, division, absolute_import
 import numpy as np
 from scipy import optimize as sciopt
 from Bio import Phylo
-from treetime import config as ttconf
-from treetime import MissingDataError,UnknownMethodError,NotReadyError
+from . import config as ttconf
+from . import MissingDataError,UnknownMethodError,NotReadyError
 from .utils import tree_layout
 from .clock_tree import ClockTree
 

--- a/treetime/utils.py
+++ b/treetime/utils.py
@@ -7,7 +7,7 @@ from scipy.interpolate import interp1d
 from scipy.integrate import quad
 from scipy import stats
 from scipy.ndimage import binary_dilation
-from treetime import TreeTimeError
+from . import TreeTimeError
 
 class DateConversion(object):
     """

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -8,12 +8,12 @@ from Bio.Seq import Seq
 from Bio.Align import MultipleSeqAlignment
 from Bio import Phylo, AlignIO
 from Bio import __version__ as bioversion
-from treetime import TreeAnc, GTR, TreeTime
-from treetime import config as ttconf
-from treetime import utils
+from . import TreeAnc, GTR, TreeTime
+from . import config as ttconf
+from . import utils
 from .vcf_utils import read_vcf, write_vcf
 from .seq_utils import alphabets
-from treetime import TreeTimeError, MissingDataError
+from . import TreeTimeError, MissingDataError
 
 def assure_tree(params, tmp_dir='treetime_tmp'):
     """


### PR DESCRIPTION
This PR changes all absolute imports from treetime to relative imports.

I wanted to mess around with some stuff to try to understand the bottlenecks of running treetime on very large datasets, and found that the absolute imports made it harder to e.g. just make a prototype copy of the package called `treetime2` to tinker with.

I'm very unfamiliar with the codebase, and not an expert on Python either, so it is definitely possible that this messes something up. I am hoping that Travis might catch that for me.

I completely understand if you don't have bandwidth to consider this PR.