### PR TITLE
Rename confusingly named `gaps` variable

### DIFF
--- a/treetime/seq_utils.py
+++ b/treetime/seq_utils.py
@@ -188,9 +188,9 @@ def seq2array(seq, word_length=1, convert_upper=False, fill_overhangs=False, amb
 
     # substitute overhanging unsequenced tails
     if fill_overhangs:
-        gaps = np.where(seq_array != '-')[0]
-        seq_array[:gaps[0]] = ambiguous
-        seq_array[gaps[-1]+1:] = ambiguous
+        nongaps = np.where(seq_array != '-')[0]
+        seq_array[:nongaps[0]] = ambiguous
+        seq_array[nongaps[-1]+1:] = ambiguous
 
     return seq_array
 


### PR DESCRIPTION
This variable actually holds the position of non-gaps.

Do close if this is more trouble than it's worth.

