### PR TITLE
Inference speedups

### DIFF
--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -148,8 +148,8 @@ class Distribution(object):
             self._peak_pos = xvals[self._peak_idx]
             yvals -= self._peak_val
             self._ymax = yvals.max()
-            # store the interpolation object
             self.xvals, self.yvals = xvals, yvals
+            # store the interpolation object
             self._func= interp1d(xvals, yvals, kind=kind, fill_value=BIG_NUMBER,
                                  bounds_error=False, assume_sorted=True)
             self._fwhm = Distribution.calc_fwhm(self)
@@ -225,18 +225,14 @@ class Distribution(object):
 
 
     def __call__(self, x):
-        #if isinstance(x, Iterable):
-        if type(x) == np.ndarray:
+        if isinstance(x, Iterable):
             valid_idxs = (x > self._xmin-TINY_NUMBER) & (x < self._xmax+TINY_NUMBER)
             res = np.full(np.shape(x), BIG_NUMBER+self.peak_val, dtype=float)
-            #tmp_x = np.copy(x[valid_idxs])
             tmp_x = x[valid_idxs]
             np.clip(tmp_x, self._xmin+TINY_NUMBER, self._xmax-TINY_NUMBER)
-            #tmp_x[tmp_x<self._xmin+TINY_NUMBER] = self._xmin+TINY_NUMBER
-            #tmp_x[tmp_x>self._xmax-TINY_NUMBER] = self._xmax-TINY_NUMBER
-            #res[valid_idxs] = self._peak_val + self._func(tmp_x)
             res[valid_idxs] = self._peak_val + np.interp(tmp_x, self.xvals, self.yvals)
             return res
+
         elif np.isreal(x):
             if x < self._xmin or x > self._xmax:
                 return BIG_NUMBER+self.peak_val
@@ -245,9 +241,9 @@ class Distribution(object):
                 return self._peak_val
             else:
                 return self._peak_val + self._func(x)
-                #return self._peak_val + np.interp(x, self.xvals, self.yvals)
         else:
             raise TypeError("Wrong type: should be float or array")
+
 
     def __mul__(self, other):
         return Distribution.multiply((self, other))

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -228,7 +228,7 @@ class Distribution(object):
         #if isinstance(x, Iterable):
         if type(x) == np.ndarray:
             valid_idxs = (x > self._xmin-TINY_NUMBER) & (x < self._xmax+TINY_NUMBER)
-            res = np.ones_like (x, dtype=float) * (BIG_NUMBER+self.peak_val)
+            res = np.full(np.shape(x), BIG_NUMBER+self.peak_val, dtype=float)
             #tmp_x = np.copy(x[valid_idxs])
             tmp_x = x[valid_idxs]
             np.clip(tmp_x, self._xmin+TINY_NUMBER, self._xmax-TINY_NUMBER)

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -672,9 +672,12 @@ class GTR(object):
             logP = -ttconf.BIG_NUMBER
         else:
             tmp_eQT = self.expQt(t)
-            bad_indices=(tmp_eQT==0)
-            logQt = np.log(tmp_eQT + ttconf.TINY_NUMBER*(bad_indices))
-            logQt[np.isnan(logQt) | np.isinf(logQt) | bad_indices] = -ttconf.BIG_NUMBER
+            #bad_indices=(tmp_eQT==0)
+            #logQt = np.log(tmp_eQT + ttconf.TINY_NUMBER*(bad_indices))
+            logQt = np.log(tmp_eQT)
+            #logQt[np.isnan(logQt) | np.isinf(logQt) | bad_indices] = -ttconf.BIG_NUMBER
+            #logQt[np.isnan(logQt) | np.isinf(logQt)] = -ttconf.BIG_NUMBER
+            logQt[~np.isfinite(logQt)] = -ttconf.BIG_NUMBER
             logP = np.sum(logQt[seq_pair[:,1], seq_pair[:,0]]*multiplicity)
 
         return logP if return_log else np.exp(logP)

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -672,11 +672,7 @@ class GTR(object):
             logP = -ttconf.BIG_NUMBER
         else:
             tmp_eQT = self.expQt(t)
-            #bad_indices=(tmp_eQT==0)
-            #logQt = np.log(tmp_eQT + ttconf.TINY_NUMBER*(bad_indices))
             logQt = np.log(tmp_eQT)
-            #logQt[np.isnan(logQt) | np.isinf(logQt) | bad_indices] = -ttconf.BIG_NUMBER
-            #logQt[np.isnan(logQt) | np.isinf(logQt)] = -ttconf.BIG_NUMBER
             logQt[~np.isfinite(logQt)] = -ttconf.BIG_NUMBER
             logP = np.sum(logQt[seq_pair[:,1], seq_pair[:,0]]*multiplicity)
 

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -68,7 +68,6 @@ def _convolution_integrand(t_val, f, g,
             tau = np.unique(np.concatenate((g.x, t_val-f.x,[tau_min,tau_max])))
         else:
             tau = np.unique(np.concatenate((g.x, f.x-t_val,[tau_min,tau_max])))
-        #tau = tau[(tau>tau_min-ttconf.TINY_NUMBER)&(tau<tau_max+ttconf.TINY_NUMBER)]
         np.clip(tau, tau_min-ttconf.TINY_NUMBER, tau_max+ttconf.TINY_NUMBER)
         if len(tau)<10:
             tau = np.linspace(tau_min, tau_max, 10)

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -68,7 +68,8 @@ def _convolution_integrand(t_val, f, g,
             tau = np.unique(np.concatenate((g.x, t_val-f.x,[tau_min,tau_max])))
         else:
             tau = np.unique(np.concatenate((g.x, f.x-t_val,[tau_min,tau_max])))
-        tau = tau[(tau>tau_min-ttconf.TINY_NUMBER)&(tau<tau_max+ttconf.TINY_NUMBER)]
+        #tau = tau[(tau>tau_min-ttconf.TINY_NUMBER)&(tau<tau_max+ttconf.TINY_NUMBER)]
+        np.clip(tau, tau_min-ttconf.TINY_NUMBER, tau_max+ttconf.TINY_NUMBER)
         if len(tau)<10:
             tau = np.linspace(tau_min, tau_max, 10)
 

--- a/treetime/sequence_data.py
+++ b/treetime/sequence_data.py
@@ -453,13 +453,19 @@ class SequenceData(object):
         if self.ref is None:
             raise TypeError("SequenceData: sparse sequences can only be constructed when a reference sequence is defined")
         sparse_seq = {}
-        for pos in self.nonref_positions:
-            cseqLoc = self.full_to_compressed_sequence_map[pos]
-            base = sequence[cseqLoc]
-            if self.ref[pos] != base:
-                sparse_seq[pos] = base
 
-        return sparse_seq
+        compressed_nonref_positions = self.full_to_compressed_sequence_map[self.nonref_positions]
+        compressed_nonref_values = sequence[compressed_nonref_positions]
+        mismatches = (compressed_nonref_values != self.ref[self.nonref_positions])
+        return dict(zip(self.nonref_positions[mismatches], compressed_nonref_values[mismatches]))
+
+        #for pos in self.nonref_positions:
+        #    cseqLoc = self.full_to_compressed_sequence_map[pos]
+        #    base = sequence[cseqLoc]
+        #    if self.ref[pos] != base:
+        #        sparse_seq[pos] = base
+
+        #return sparse_seq
 
 
     def compressed_to_full_sequence(self, sequence, include_additional_constant_sites=False, as_string=False):

--- a/treetime/sequence_data.py
+++ b/treetime/sequence_data.py
@@ -459,14 +459,6 @@ class SequenceData(object):
         mismatches = (compressed_nonref_values != self.ref[self.nonref_positions])
         return dict(zip(self.nonref_positions[mismatches], compressed_nonref_values[mismatches]))
 
-        #for pos in self.nonref_positions:
-        #    cseqLoc = self.full_to_compressed_sequence_map[pos]
-        #    base = sequence[cseqLoc]
-        #    if self.ref[pos] != base:
-        #        sparse_seq[pos] = base
-
-        #return sparse_seq
-
 
     def compressed_to_full_sequence(self, sequence, include_additional_constant_sites=False, as_string=False):
         """expand a compressed sequence


### PR DESCRIPTION
This is an initial naive attempt to speed up the inference step by moving as much work as possible into numpy and otherwise vectorizing work where possible. The hotspots to work on were determined by profiling the following command, adapted from test/command_line_tests.sh:

`treetime --aln treetime_examples/data/tb/lee_2015.vcf.gz --vcf-reference treetime_examples/data/tb/tb_ref.fasta --tree treetime_examples/data/tb/lee_2015.nwk --clock-rate 1e-7 --dates treetime_examples/data/tb/lee_2015.metadata.tsv`

Profiling inormation was retrieved like this: `python3 -c'import pstats; p = pstats.Stats("treetime_tottime.cprofile"); p.strip_dirs().sort_stats("tottime").print_stats(42)'`

In my tests, this brings a modest (~10%) but stable speedup of the inference loop.

Relevant to https://github.com/neherlab/treetime/issues/110

cc @sidneymbell @ttung