### PR TITLE
Add new output file to ancestral containing branch mutations

### DIFF
--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -188,6 +188,8 @@ def export_sequences_and_tree(tt, basename, is_vcf=False, zero_based=False,
             fh_dates.write('#node\tdate\tnumeric date\tlower bound\tupper bound\n')
         else:
             fh_dates.write('#node\tdate\tnumeric date\n')
+    mutations_out = open(basename + "branch_mutations.txt", "w")
+    mutations_out.write("node\tstate1\tpos\tstate2\n")
     for n in tt.tree.find_clades():
         if timetree:
             if confidence:
@@ -215,9 +217,13 @@ def export_sequences_and_tree(tt, basename, is_vcf=False, zero_based=False,
             else:
                 n.comment= '&mutations="' + ','.join([a+str(pos + offset)+d for (a,pos, d) in n.mutations
                                                       if tt.gtr.ambiguous not in [a,d]])+'"'
+                for (a, pos, d) in n.mutations:
+                    if tt.gtr.ambiguous not in [a,d]:
+                        mutations_out.write("%s\t%s\t%s\t%s\n" %(n.name, a, pos + 1, d))
         if timetree:
             n.comment+=(',' if n.comment else '&') + 'date=%1.2f'%n.numdate
-
+    mutations_out.close()
+    
     # write tree to file
     fmt_bl = "%1.6f" if tt.data.full_length<1e6 else "%1.8e"
     if timetree:


### PR DESCRIPTION
Pull request to add a branch_mutations.txt output file to treetime ancestral. We've found this to be useful when we have large trees with lots of mutations as the annotated_tree.nexus file becomes very large to read in. The proposed new output file contains each inferred mutation and the branch it occurred on as a text file