### PR TITLE
Reduce memory required for ancestral sequence inference

### DIFF
--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -917,7 +917,7 @@ class TreeAnc(object):
             # get the best state of the current node
             # and compute the likelihood of this state
             # preallocate storage
-            node.joint_Lx = np.zeros((L, n_states), dtype=np.float32) # likelihood array
+            node.joint_Lx = np.zeros((L, n_states)) # likelihood array
             node.joint_Cx = np.zeros((L, n_states), dtype=np.uint16)  # max LH indices
             for char_i, char in enumerate(self.gtr.alphabet):
                 # Pij(i) * L_ch(i) for given parent state j

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -906,12 +906,19 @@ class TreeAnc(object):
                 # this is prod_ch L_x(i)
                 msg_from_children = np.sum(np.stack([c.joint_Lx for c in node.clades], axis=0), axis=0)
 
+                if not debug:
+                    # Now that we have calculated the current node's likelihood
+                    # from its children, clean up likelihood matrices attached
+                    # to children to save memory.
+                    for c in node.clades:
+                        del c.joint_Lx
+
             # for every possible state of the parent node,
             # get the best state of the current node
             # and compute the likelihood of this state
             # preallocate storage
-            node.joint_Lx = np.zeros((L, n_states))             # likelihood array
-            node.joint_Cx = np.zeros((L, n_states), dtype=int)  # max LH indices
+            node.joint_Lx = np.zeros((L, n_states), dtype=np.float32) # likelihood array
+            node.joint_Cx = np.zeros((L, n_states), dtype=np.uint16)  # max LH indices
             for char_i, char in enumerate(self.gtr.alphabet):
                 # Pij(i) * L_ch(i) for given parent state j
                 msg_to_parent = (log_transitions[:,char_i].T + msg_from_children)
@@ -973,7 +980,10 @@ class TreeAnc(object):
         # do clean-up
         if not debug:
             for node in self.tree.find_clades(order='preorder'):
-                del node.joint_Lx
+                # Check for the likelihood matrix, since we might have cleaned
+                # it up earlier.
+                if hasattr(node, "joint_Lx"):
+                    del node.joint_Lx
                 del node.joint_Cx
                 if hasattr(node, 'seq_idx'):
                     del node.seq_idx


### PR DESCRIPTION
The joint likelihood function for ancestral sequence reconstruction stores two matrices per node in a given tree including a) the likelihood per state and site in the alignment (`joint_Lx`) and b) the indices of optimal states per parent state and site in the alignment (`joint_Cx`). The current implementation stores the likelihoods as double precision floats (`float64`) and the state indices as 64-bit signed integers. With larger trees (~6,000 tips and ~12,000 total nodes), the size of these annotations on the tree causes memory usage to spike to 12 GB during ancestral sequence reconstruction. These memory spikes can cause augur refine jobs to be killed when multiple are running at once (e.g., on AWS Batch).

This PR makes three minor modifications to the joint likelihood function to reduce the overall memory usage:

1. Store indices of optimal states as unsigned 16-bit integers. In the most common use case of nucleotide states, we only have 5 states, so the current range of possible values (-9223372036854775808 to 9223372036854775807) is overkill. An unsigned 16-bit int stores values in the range of 0 to 65535, which should be sufficient for all inputs.

2. ~Store likelihoods as single-precision floats (`float32`). For the likelihood calculations performed in TreeTime, the lower bound on precision depends on the log of `ttconf.TINY_NUMBER` and smallest value in the GTR model's transition matrices. Since we are operating in log space anyway, we should not need double-precision floats.~ It actually turns out that we need this level of precision, at least for the unit tests to pass. Commit 36d414e reverts the type change proposed here.

3. Remove likelihood matrices from child nodes after they have been processed by the current node. Since TreeTime maintains the indices of the optimal states already in the `joint_Cx` matrices, the likelihoods are never used again after the current node sums across its children. Removing these matrices after their initial use means memory usage no longer scales with the number of nodes in the tree but with the number of children being processed by the current node.

The last of these changes has the most substantial effect on memory, reducing peak usage from 12 GB in my large tree scenario to 2.5 GB. The reduced size of optimal state indices is important, since these annotations need to remain on all nodes for the duration of the function execution. The reduced size of the likelihood values themselves is not as critical here, given the major effect of removing likelihood matrices after their use. The single-precision float does require a little less
memory than double-precision, however.