### PR TITLE
docs(readme): replace build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://travis-ci.org/neherlab/treetime.svg?branch=master)](https://travis-ci.org/neherlab/treetime)
+[![CI](https://github.com/neherlab/treetime/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/neherlab/treetime/actions/workflows/ci.yml)
 [![anaconda](https://anaconda.org/bioconda/treetime/badges/installer/conda.svg)](https://anaconda.org/bioconda/treetime)
-
 [![readthedocs](https://readthedocs.org/projects/treetime/badge/)](https://treetime.readthedocs.io/en/latest/)
 
 ## TreeTime: maximum likelihood dating and ancestral sequence inference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,8 @@
 TreeTime: time-tree and ancestral sequence inference
 ====================================================
 
-.. image:: https://travis-ci.org/neherlab/treetime.svg?branch=master
-   :target: https://travis-ci.org/neherlab/treetime
+.. image:: https://github.com/neherlab/treetime/actions/workflows/ci.yml/badge.svg?branch=master
+   :target: https://github.com/neherlab/treetime/actions/workflows/ci.yml
 
 .. image:: https://anaconda.org/bioconda/treetime/badges/installer/conda.svg
    :target: https://anaconda.org/bioconda/treetime


### PR DESCRIPTION
This removes Travis CI badge and places GitHub Actions badge in:
 - readme
 - index file of the docs