### PR TITLE
feat: add division functionality 

### DIFF
--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -102,7 +102,7 @@ class Distribution(object):
             try:
                 peak = y_vals.min()
             except:
-                print("WARNING: Unexpected behavior detected in multipy function,"
+                print("WARNING: Unexpected behavior detected in multiply function,"
                         "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues")
                 x_vals = [0,1]
                 y_vals = [BIG_NUMBER,BIG_NUMBER]
@@ -126,6 +126,39 @@ class Distribution(object):
 
         return res
 
+    @staticmethod
+    def divide(numerator, denominator):
+        '''
+        divides one distribution object by another. Note that this is in general an ill-defined procedure.
+        this is implemented here for the special case where the numerator is a product that contains the denominator
+        to produce a reduced product without the denominator.
+        '''
+        if numerator.is_delta or denominator.is_delta:
+            raise(ArithmeticError("Can not divide delta functions"))
+        dists = [numerator, denominator]
+        min_width = np.max([k.min_width for k in dists])
+        new_xmin = np.max([k.xmin for k in dists])
+        new_xmax = np.min([k.xmax for k in dists])
+        x_vals = np.unique(np.concatenate([k.x for k in dists]))
+        x_vals = x_vals[(x_vals> new_xmin-TINY_NUMBER)&(x_vals< new_xmax+TINY_NUMBER)]
+        y_vals = numerator.__call__(x_vals) - denominator.__call__(x_vals)
+
+        peak = y_vals.min()
+        ind = (y_vals-peak)<BIG_NUMBER/1000
+        n_points = ind.sum()
+        if n_points == 0:
+            print("WARNING: Unexpected behavior detected in multipy function,"
+                    "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues")
+            x_vals = [0,1]
+            y_vals = [BIG_NUMBER,BIG_NUMBER]
+            res = Distribution(x_vals, y_vals, is_log=True,
+                                min_width=min_width, kind='linear')
+        elif n_points == 1:
+            res = Distribution.delta_function(x_vals[0])
+        else:
+            res = Distribution(x_vals[ind], y_vals[ind], is_log=True,
+                                min_width=min_width, kind='linear', assume_sorted=True)
+        return res
 
     def __init__(self, x, y, is_log=True, min_width = MIN_INTEGRATION_PEAK,
                  kind='linear', assume_sorted=False):

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -167,8 +167,7 @@ class TreeTime(ClockTree):
                       "reconstruct_tip_states":kwargs.get("reconstruct_tip_states", False)}
         time_marginal_method = reduce_time_marginal_argument(time_marginal) ## for backward compatibility
         tt_kwargs = {'clock_rate':fixed_clock_rate,
-                     'time_marginal':False if time_marginal_method in ['never', 'only-final', 'confidence-only'] else True,
-                     'assign_dates': True}
+                     'time_marginal':False if time_marginal_method in ['never', 'only-final', 'confidence-only'] else True}
         tt_kwargs.update(kwargs)
 
         seq_LH = 0


### PR DESCRIPTION
I noticed that the pre-order traversal of the marginal time tree inference is very slow when there are large polytomy. the reason is that the `complementary_msgs` need to be calculated for every child, which involves summing messages from every sibling, which ends up being quadratic in the size of the polytomy. This problem is greatly reduced when implementing division. 

Here, I added another field that during the post-order iteration that contains all messages other than the coalescent contribution. This can then be used to divide (log-subtract) the contribution of a particular child. 

