### PR TITLE
fix for minor file name issue

### DIFF
--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -162,7 +162,7 @@ def plot_rtt(tt, fname):
 
 def export_sequences_and_tree(tt, basename, is_vcf=False, zero_based=False,
                               report_ambiguous=False, timetree=False, confidence=False,
-                              reconstruct_tip_states=False, tree_suffix={}):
+                              reconstruct_tip_states=False, tree_suffix=''):
     seq_info = is_vcf or tt.aln
     if is_vcf:
         outaln_name = basename + f'ancestral_sequences{tree_suffix}.vcf'


### PR DESCRIPTION
When running `treetime ancestral` the file output names have `{}` inserted.
This leads to the output file names `ancestral_sequences{}.fasta` and `annotated_tree{}.nexus`.
This pull request modifies the default tree suffix of the `export_sequences_and_tree` function to remove the braces.

