### PR TITLE
fix: set clock deviation to 0 for terminals without date constraint

### DIFF
--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -1071,7 +1071,7 @@ def estimate_clock_model(params):
                     tmp_str = ''
                 ofile.write("%s, %s, %f, %f\n"%(n.name, tmp_str, n.dist2root, clock_deviation))
             else:
-                ofile.write("%s, %f, %f, %f\n"%(n.name, d2d.numdate_from_dist2root(n.dist2root), n.dist2root, clock_deviation))
+                ofile.write("%s, %f, %f, 0.0\n"%(n.name, d2d.numdate_from_dist2root(n.dist2root), n.dist2root))
         for n in myTree.tree.get_nonterminals(order='preorder'):
             ofile.write("%s, %f, %f, 0.0\n"%(n.name, d2d.numdate_from_dist2root(n.dist2root), n.dist2root))
         print("--- wrote dates and root-to-tip distances to \n\t%s\n"%table_fname)


### PR DESCRIPTION
The `clock_deviation` had undefined value on this line
https://github.com/neherlab/treetime/blob/a76ac2b9f1d04374d98cce2b00d837f5867b150d/treetime/wrappers.py#L1074

After a short Slack discussion we decided that it should be `0.0`, for consistency with the non-terminals and also taking into consideration the comment just above the loop:

```
Dates of nodes that didn't have a specified date are inferred from the root-to-tip regression
```