### PR TITLE
Properly raise numerical instability errors occurring due to problematic input trees

### DIFF
--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -49,6 +49,11 @@ class Distribution(object):
         # 0.69... is log(2), there is always one value for which this is true since
         # the minimum is subtracted
         tmp = np.where(log_prob < 0.693147)[0]
+        if len(tmp)==0:
+            raise Exception("Error in computing the FWHM for the distribution. This is "
+                    "most likely caused by \n incorrect input data. If this error persists "
+                    "please let us know by filing an issue at: \n https://github.com/neherlab/treetime/issues")
+
         x_l, x_u = tmp[0], tmp[-1]
         if L < 2:
             print ("Not enough points to compute FWHM: returning zero")

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -951,7 +951,13 @@ class GTR(object):
             Array of values exp(lambda(i) * t),
             where (i) - alphabet index (the eigenvalue number).
         """
-        return np.exp(self.mu * t * self.eigenvals)
+        log_val = self.mu * t * self.eigenvals
+        if any(i > 10 for i in log_val):
+            raise ValueError("Error in computing exp(Q * t): Q has positive eigenvalues or the branch length t \n"
+                    "is too large. This is most likely caused by incorrect input data. If this error persists \n"
+                    "please let us know by filing an issue at: https://github.com/neherlab/treetime/issues")
+
+        return np.exp(log_val)
 
 
     def expQt(self, t):


### PR DESCRIPTION
When trees with long branches are given as input to `treetime` overflow errors and other bugs can occur, these errors should be better handled with commentary. See: https://github.com/nextstrain/augur/issues/1013. 

Resolves https://github.com/nextstrain/augur/issues/1013

## Testing 
I tested these out by making `treetime` throw an error when running data, e.g. triggering the exception in `_exp_lt` by adding ```log_val = np.ones(len(log_val))*750```, or the exception in `calc_fwhm` by adding ```tmp = []```. I also ran it on data with long branches (https://github.com/nextstrain/augur/issues/1013)... but potentially there is a better way to do this...