### PR TITLE
Improve Error Handling in TreeTime

### DIFF
--- a/treetime/__init__.py
+++ b/treetime/__init__.py
@@ -24,7 +24,7 @@ class NotReadyError(TreeTimeError):
     """NotReadyError class raised when results are requested before inference"""
     pass
 
-class TreeTimeOtherError(TreeTimeError):
+class TreeTimeOtherError(Exception):
     """TreeTimeOtherError class raised when TreeTime fails during inference due to an unknown reason. This might be due to data not fulfilling base assumptions or due  to bugs in TreeTime. Please report them to the developers if they persist."""
     pass
 

--- a/treetime/__init__.py
+++ b/treetime/__init__.py
@@ -1,5 +1,8 @@
 version="0.9.2"
-
+## Here we define an error class for TreeTime errors, MissingData, UnknownMethod and NotReady errors
+## are all due to incorrect calling of TreeTime functions or input data that does not fit our base assumptions.
+## Errors marked as TreeTimeOtherErrors might be due to data not fulfilling base assumptions or due 
+## to bugs in TreeTime. Please report them to the developers if they persist. 
 class TreeTimeError(Exception):
     """TreeTimeError class"""
     pass
@@ -9,11 +12,15 @@ class MissingDataError(TreeTimeError):
     pass
 
 class UnknownMethodError(TreeTimeError):
-    """MissingDataError class raised when tree or alignment are missing"""
+    """MissingDataError class raised when an unknown method is called"""
     pass
 
 class NotReadyError(TreeTimeError):
     """NotReadyError class raised when results are requested before inference"""
+    pass
+
+class TreeTimeOtherError(TreeTimeError):
+    """TreeTimeOtherError class raised when TreeTime fails during inference due to an unknown reason. This might be due to data not fulfilling base assumptions or due  to bugs in TreeTime. Please report them to the developers if they persist."""
     pass
 
 

--- a/treetime/__init__.py
+++ b/treetime/__init__.py
@@ -4,7 +4,12 @@ version="0.9.2"
 ## Errors marked as TreeTimeOtherErrors might be due to data not fulfilling base assumptions or due 
 ## to bugs in TreeTime. Please report them to the developers if they persist. 
 class TreeTimeError(Exception):
-    """TreeTimeError class"""
+    """
+    TreeTimeError class
+    Parent class for more specific errors
+    Raised when treetime is used incorrectly in contrast with `TreeTimeOtherError`
+    `TreeTimeOtherError` is raised when the reason of the error is unknown, could indicate bug     
+    """
     pass
 
 class MissingDataError(TreeTimeError):

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -1,6 +1,6 @@
 import numpy as np
 from . import config as ttconf
-from . import MissingDataError
+from . import MissingDataError, UnknownMethodError
 from .treeanc import TreeAnc
 from .utils import numeric_date, DateConversion, datestring_from_numeric
 from .distribution import Distribution
@@ -77,7 +77,7 @@ class ClockTree(TreeAnc):
         """
         super(ClockTree, self).__init__(*args, **kwargs)
         if dates is None:
-            raise ValueError("ClockTree requires date constraints!")
+            raise MissingDataError("ClockTree requires date constraints!")
 
         self.debug=debug
         self.real_dates = real_dates
@@ -203,7 +203,7 @@ class ClockTree(TreeAnc):
                         " fft_grid_points=%.3e"%(precision_fft), 2)
                 self.fft_grid_size = precision_fft
             elif precision_fft!='auto':
-                raise ValueError(f"ClockTree: precision_fft needs to be either 'auto' or an integer, got '{precision_fft}'.")
+                raise UnknownMethodError(f"ClockTree: precision_fft needs to be either 'auto' or an integer, got '{precision_fft}'.")
             else:
                 self.fft_grid_size = ttconf.FFT_FWHM_GRID_SIZE
             if type(precision_branch) is int:

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -50,9 +50,8 @@ class Distribution(object):
         # the minimum is subtracted
         tmp = np.where(log_prob < 0.693147)[0]
         if len(tmp)==0:
-            raise Exception("Error in computing the FWHM for the distribution. This is "
-                    "most likely caused by \n incorrect input data. If this error persists "
-                    "please let us know by filing an issue at: \n https://github.com/neherlab/treetime/issues")
+            raise ValueError("Error in computing the FWHM for the distribution. This is "
+                    "most likely caused by incorrect input data.")
 
         x_l, x_u = tmp[0], tmp[-1]
         if L < 2:

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import numpy as np
-from . import config as ttconf
+from . import config as ttconf, TreeTimeError, MissingDataError
 from .seq_utils import alphabets, profile_maps, alphabet_synonyms
 
 def avg_transition(W,pi, gap_index=None):
@@ -953,9 +953,8 @@ class GTR(object):
         """
         log_val = self.mu * t * self.eigenvals
         if any(i > 10 for i in log_val):
-            raise ValueError("Error in computing exp(Q * t): Q has positive eigenvalues or the branch length t \n"
-                    "is too large. This is most likely caused by incorrect input data. If this error persists \n"
-                    "please let us know by filing an issue at: https://github.com/neherlab/treetime/issues")
+            raise ValueError("Error in computing exp(Q * t): Q has positive eigenvalues or the branch length t is too large. "
+                    "This is most likely caused by incorrect input data.")
 
         return np.exp(log_val)
 

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -147,7 +147,7 @@ class TreeAnc(object):
         self._tree = None
         self.tree = tree
         if tree is None:
-            raise ValueError("TreeAnc: tree loading failed! exiting")
+            raise MissingDataError("TreeAnc: tree loading failed! exiting")
 
         # set up GTR model
         self._gtr = None
@@ -311,12 +311,12 @@ class TreeAnc(object):
                 if fmt in ['nexus', 'nex']:
                     self._tree=Phylo.read(in_tree, 'nexus')
                 else:
-                    raise ValueError('TreeAnc: could not load tree, format needs to be nexus or newick! input was '+str(in_tree))
+                    raise MissingDataError('TreeAnc: could not load tree, format needs to be nexus or newick! input was '+str(in_tree))
         else:
-            raise ValueError('TreeAnc: could not load tree! input was '+str(in_tree))
+            raise MissingDataError('TreeAnc: could not load tree! input was '+str(in_tree))
 
         if self._tree.count_terminals()<3:
-            raise ValueError('TreeAnc: tree in %s as only %d tips. Please check your tree!'%(str(in_tree), self._tree.count_terminals()))
+            raise MissingDataError('TreeAnc: tree in %s as only %d tips. Please check your tree!'%(str(in_tree), self._tree.count_terminals()))
 
         # remove all existing sequence attributes
         branch_length_warning = False
@@ -528,7 +528,7 @@ class TreeAnc(object):
         elif method.lower() in ['fitch', 'parsimony']:
             _ml_anc = self._fitch_anc
         else:
-            raise ValueError("Reconstruction method needs to be in ['ml', 'probabilistic', 'fitch', 'parsimony'], got '{}'".format(method))
+            raise UnknownMethodError("Reconstruction method needs to be in ['ml', 'probabilistic', 'fitch', 'parsimony'], got '{}'".format(method))
 
         if infer_gtr:
             self.infer_gtr(marginal=marginal, **kwargs)

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -54,7 +54,7 @@ class TreeTime(ClockTree):
     def run(self, augur=False, **kwargs):
         import sys
         try:
-            self._run(**kwargs)
+            return self._run(**kwargs)
         except TreeTimeError as err:
             print(f"ERROR: {err} \n", file=sys.stderr)
             if augur:

--- a/treetime/utils.py
+++ b/treetime/utils.py
@@ -2,7 +2,7 @@ import os,sys
 import datetime
 import pandas as pd
 import numpy as np
-from . import TreeTimeError
+from . import TreeTimeError, MissingDataError
 
 class DateConversion(object):
     """
@@ -263,11 +263,11 @@ def parse_dates(date_file, name_col=None, date_col=None):
                 potential_index_columns.append((ci, col))
 
         if date_col and date_col not in df.columns:
-            raise TreeTimeError("ERROR: specified column for dates does not exist. \n\tAvailable columns are: "\
+            raise MissingDataError("ERROR: specified column for dates does not exist. \n\tAvailable columns are: "\
                                 +", ".join(df.columns)+"\n\tYou specified '%s'"%date_col)
 
         if name_col and name_col not in df.columns:
-            raise TreeTimeError("ERROR: specified column for the taxon name does not exist. \n\tAvailable columns are: "\
+            raise MissingDataError("ERROR: specified column for the taxon name does not exist. \n\tAvailable columns are: "\
                                 +", ".join(df.columns)+"\n\tYou specified '%s'"%name_col)
 
 
@@ -275,7 +275,7 @@ def parse_dates(date_file, name_col=None, date_col=None):
         # if a potential numeric date column was found, use it
         # (use the first, if there are more than one)
         if not (len(potential_index_columns) or name_col):
-            raise TreeTimeError("ERROR: Cannot read metadata: need at least one column that contains the taxon labels."
+            raise MissingDataError("ERROR: Cannot read metadata: need at least one column that contains the taxon labels."
                   " Looking for the first column that contains 'name', 'strain', or 'accession' in the header.")
         else:
             # use the first column that is either 'name', 'strain', 'accession'
@@ -320,10 +320,10 @@ def parse_dates(date_file, name_col=None, date_col=None):
                             dates[k] = [numeric_date(x) for x in [lower, upper]]
 
         else:
-            raise TreeTimeError("ERROR: Metadata file has no column which looks like a sampling date!")
+            raise MissingDataError("ERROR: Metadata file has no column which looks like a sampling date!")
 
         if all(v is None for v in dates.values()):
-            raise TreeTimeError("ERROR: Cannot parse dates correctly! Check date format.")
+            raise MissingDataError("ERROR: Cannot parse dates correctly! Check date format.")
         return dates
     except TreeTimeError as err:
         raise err

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -8,7 +8,7 @@ from . import TreeAnc, GTR, TreeTime
 from . import utils
 from .vcf_utils import read_vcf, write_vcf
 from .seq_utils import alphabets
-from . import TreeTimeError, MissingDataError
+from . import TreeTimeError, MissingDataError, UnknownMethodError
 from .treetime import reduce_time_marginal_argument
 
 def assure_tree(params, tmp_dir='treetime_tmp'):
@@ -794,7 +794,7 @@ def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling
         if len(missing_weights)>0.5*n_observed_states:
             print("More than half of discrete states missing from the weights file")
             print("Weights read from file are:", weights)
-            raise TreeTimeError("More than half of discrete states missing from the weights file")
+            raise MissingDataError("More than half of discrete states missing from the weights file")
 
     unique_states=sorted(unique_states)
     # make a map from states (excluding missing data) to characters in the alphabet
@@ -1022,7 +1022,7 @@ def estimate_clock_model(params):
         try:
             res = myTree.reroot(params.reroot,
                       force_positive=not params.allow_negative_rate)
-        except TreeTimeError as e:
+        except UnknownMethodError as e:
             print("ERROR: unknown root or rooting mechanism!")
             raise e
 


### PR DESCRIPTION
# Related Issue and PR:

https://github.com/nextstrain/augur/issues/1032
https://github.com/nextstrain/augur/pull/1033

Building on @victorlin's suggestions in : https://github.com/neherlab/treetime/compare/44e7c56a1d10baa3d4dcdf07b5c7cd55d6d651e9...2632d96144ada719a33f966cc11c5bc118c987a4 I have made a couple minor changes to TreeTime's error handling process: 
 - more consistent labeling of error classes: rename errors due to incorrect input data or incorrect use of treetime as one of the three predefined TreeTime error classes: `MissingDataError`, `UnknownMethodError` and `NotReadyError`
 - add new `TreeTimeError` class for errors that might be due to input data not matching with assumptions or unknown behavior (potential bug): `TreeTimeOtherError`. 
 - call `treetime.run` in a wrapper to catch all errors with notification on how to report issues. i.e. `ERROR in TreeTime.run: An error has occurred which is not properly handled in TreeTime. If this error persists, please let us know "
                    "by filing a new issue including the original command and the error above at: https://github.com/neherlab/treetime/issues `
 - when run from another application, such as `augur` return all errors as `TreeTimeError`s but with distinction between input/usage errors and potential treetime bugs (these are output as `TreeTimeOtherError`s). On standard run print traceback for unknown errors / potential bugs, print warning and then exit treetime (avoid double printing of traceback or traceback after final warning). 
 
 Example for unknown `ValueError`: 
 
![image](https://user-images.githubusercontent.com/50943381/188157285-e75b2f2a-dfb7-4958-bbff-5968d3974aa7.png)

Example for known `MissingDataError`: 

![image](https://user-images.githubusercontent.com/50943381/188158102-165d144a-d145-4b0a-8944-248e434ad361.png)


I used the same example as in the PR above to create an error. I made two test cases, one where the error is called a `ValueError` which should be handled as a `TreeTimeOtherError` and another where the error is called a `MissingDataError`. 

# Testing
- install augur and treetime in local environment
- cause an Exception in treetime (either call this a `ValueError` or a `TreeTimeError`), I added a line in `_exp_lt`
```
        """
        Parameters
        ----------

         t : float
            time to propagate

        Returns
        --------

         exp_lt : numpy.array
            Array of values exp(lambda(i) * t),
            where (i) - alphabet index (the eigenvalue number).
        """
        log_val = self.mu * t * self.eigenvals
        log_val = np.ones(len(log_val))*750 ##cause an exception
        if any(i > 10 for i in log_val):
            raise ValueError("Error in computing exp(Q * t): Q has positive eigenvalues or the branch length t \n"
                    "is too large. This is most likely caused by incorrect input data.")

        return np.exp(log_val)
```
- install modified treetime in local environment `(pip install .`)
- call `treetime.run()` in a test script where it is not in a `try` - `catch` statement, for example: run `python test/treetime_algorithms.py`