### PR TITLE
TreeTime Error Log - add Victor's suggestions

### DIFF
--- a/treetime/__init__.py
+++ b/treetime/__init__.py
@@ -1,14 +1,14 @@
 version="0.9.2"
 ## Here we define an error class for TreeTime errors, MissingData, UnknownMethod and NotReady errors
 ## are all due to incorrect calling of TreeTime functions or input data that does not fit our base assumptions.
-## Errors marked as TreeTimeOtherErrors might be due to data not fulfilling base assumptions or due 
+## Errors marked as TreeTimeUnknownErrors might be due to data not fulfilling base assumptions or due 
 ## to bugs in TreeTime. Please report them to the developers if they persist. 
 class TreeTimeError(Exception):
     """
     TreeTimeError class
     Parent class for more specific errors
-    Raised when treetime is used incorrectly in contrast with `TreeTimeOtherError`
-    `TreeTimeOtherError` is raised when the reason of the error is unknown, could indicate bug     
+    Raised when treetime is used incorrectly in contrast with `TreeTimeUnknownError`
+    `TreeTimeUnknownError` is raised when the reason of the error is unknown, could indicate bug     
     """
     pass
 
@@ -24,8 +24,8 @@ class NotReadyError(TreeTimeError):
     """NotReadyError class raised when results are requested before inference"""
     pass
 
-class TreeTimeOtherError(Exception):
-    """TreeTimeOtherError class raised when TreeTime fails during inference due to an unknown reason. This might be due to data not fulfilling base assumptions or due  to bugs in TreeTime. Please report them to the developers if they persist."""
+class TreeTimeUnknownError(Exception):
+    """TreeTimeUnknownError class raised when TreeTime fails during inference due to an unknown reason. This might be due to data not fulfilling base assumptions or due  to bugs in TreeTime. Please report them to the developers if they persist."""
     pass
 
 

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import optimize as sciopt
 from Bio import Phylo
 from . import config as ttconf
-from . import MissingDataError,UnknownMethodError,NotReadyError,TreeTimeError, TreeTimeOtherError
+from . import MissingDataError,UnknownMethodError,NotReadyError,TreeTimeError, TreeTimeUnknownError
 from .utils import tree_layout
 from .clock_tree import ClockTree
 
@@ -51,24 +51,24 @@ class TreeTime(ClockTree):
         super(TreeTime, self).__init__(*args, **kwargs)
 
 
-    def run(self, augur=False, **kwargs):
+    def run(self, raise_uncaught_exceptions=False, **kwargs):
         import sys
         try:
             return self._run(**kwargs)
         except TreeTimeError as err:
-            print(f"ERROR: {err} \n", file=sys.stderr)
-            if augur:
+            if raise_uncaught_exceptions:
                 raise err
             else:
+                print(f"ERROR: {err} \n", file=sys.stderr)
                 sys.exit(2)
         except BaseException as err:
             import traceback
-            print(traceback.format_exc())
+            print(traceback.format_exc(), file=sys.stderr)
             print(f"ERROR: {err} \n ", file=sys.stderr)
-            print("ERROR in TreeTime.run: An error has occurred which is not properly handled in TreeTime. If this error persists, please let us know "
+            print("ERROR in TreeTime.run: An error occurred which was not properly handled in TreeTime. If this error persists, please let us know "
                     "by filing a new issue including the original command and the error above at: https://github.com/neherlab/treetime/issues \n", file=sys.stderr)
-            if augur:
-                raise TreeTimeOtherError() from err
+            if raise_uncaught_exceptions:
+                raise TreeTimeUnknownError() from err
             else:
                 sys.exit(2)
 


### PR DESCRIPTION
Building on https://github.com/neherlab/treetime/pull/206 I added some suggestions that Victor made

- change the name of `TreeTimeOtherError` to `TreeTimeUnknownerror` to be more clear for users
- change argument in `run` function to `raise_uncaught_exceptions` from `augur` so more clear and can be used with other programs
- some minor fixes regarding print statement location 

This can now be used from augur and will work with: https://github.com/nextstrain/augur/pull/1033