### PR TITLE
limit number of grid points when multiplying distributions

### DIFF
--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -641,7 +641,7 @@ class ClockTree(TreeAnc):
                     ## for k branches, but due to the fact that inner branches overlap at time t one can be removed
                     ## resulting in the exponent (k-1))
                     if hasattr(self, 'merger_model') and self.merger_model:
-                        time_points = np.unique(np.concatenate([msg.x for msg in msgs_to_multiply]))
+                        time_points = node.product_of_child_messages.x
                         # set multiplicity of node to number of good child branches
                         if node.is_terminal():
                             merger_contribution = Distribution(time_points, -self.merger_model.integral_merger_rate(time_points), is_log=True)
@@ -690,7 +690,7 @@ class ClockTree(TreeAnc):
 
                 msg_parent_to_node =None
                 if node.marginal_pos_Lx is not None:
-                    if len(parent.clades)<5:
+                    if len(parent.clades)<3:
                         # messages from the complementary subtree (iterate over all sister nodes)
                         complementary_msgs = [parent.date_constraint] if parent.date_constraint is not None else []
                         complementary_msgs.extend([sister.marginal_pos_Lx for sister in parent.clades
@@ -702,7 +702,7 @@ class ClockTree(TreeAnc):
                         complementary_msgs.append(parent.msg_from_parent)
 
                     if hasattr(self, 'merger_model') and self.merger_model:
-                        time_points = np.unique(np.concatenate([msg.x for msg in complementary_msgs]))
+                        time_points = parent.marginal_pos_LH.x
                         # As Lx do not include the node contribution this must be added on
                         complementary_msgs.append(self.merger_model.node_contribution(parent, time_points))
 

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -256,7 +256,7 @@ class ClockTree(TreeAnc):
 
 
     def get_clock_model(self, covariation=True, slope=None):
-        self.logger(f'ClockTree.get_clock_model: estimating clock model with {covariation=}',3)
+        self.logger(f'ClockTree.get_clock_model: estimating clock model with covariation={covariation}',3)
         Treg = self.setup_TreeRegression(covariation=covariation)
         self.clock_model = Treg.regression(slope=slope)
         if not np.isfinite(self.clock_model['slope']):

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -102,6 +102,14 @@ class Distribution(object):
 
             x_vals = np.unique(np.concatenate([k.x for k in dists]))
             x_vals = x_vals[(x_vals> new_xmin-TINY_NUMBER)&(x_vals< new_xmax+TINY_NUMBER)]
+            n_dists = len(dists)
+            if len(x_vals)>100*n_dists and n_dists>3:
+                n_bins = len(x_vals)//n_dists - 6
+                lower_cut_off = n_dists*3
+                upper_cut_off = n_dists*(n_bins + 3)
+                x_vals = np.concatenate((x_vals[:lower_cut_off],
+                                         x_vals[lower_cut_off:upper_cut_off].reshape((-1,n_dists)).mean(axis=1),
+                                         x_vals[upper_cut_off:]))
             y_vals = np.sum([k.__call__(x_vals) for k in dists], axis=0)
             try:
                 peak = y_vals.min()

--- a/treetime/treeregression.py
+++ b/treetime/treeregression.py
@@ -347,7 +347,7 @@ class TreeRegression(object):
                     best_root.update(reg)
 
         if 'node' not in best_root:
-            print(f"TreeRegression.find_best_root: No valid root found! {force_positive=}")
+            print(f"TreeRegression.find_best_root: No valid root found! force_positive={force_positive}")
             return None
 
         if 'hessian' in best_root:


### PR DESCRIPTION
this should address the curious slow down of the marginal time tree calculation. it was due to an explosion in the number of grid points when a large number of distributions were multiplied (taking the union of all grid points). This is now fixed by using a running average of the union of the grid points with the same number of points and the average distribution. 