### PR TITLE
Feature: input generation per year via CLI for skyline and N_e calculations

### DIFF
--- a/test/command_line_tests.sh
+++ b/test/command_line_tests.sh
@@ -54,6 +54,14 @@ else
 	echo "timetree_inference on vcf data failed $retval"
 fi
 
+treetime --tree treetime_examples/data/ebola/ebola.nwk --dates treetime_examples/data/ebola/ebola.metadata.csv --aln treetime_examples/data/ebola/ebola.fasta  --coalescent skyline --gen-per-year 100
+retval="$?"
+if [ "$retval" == 0 ]; then
+	echo "skyline approximation ok"
+else
+	((all_tests++))
+	echo "skyline approximation failed $retval"
+fi
 
 if [ "$all_tests" == 0 ];then
 	echo "All tests passed"

--- a/treetime/argument_parser.py
+++ b/treetime/argument_parser.py
@@ -193,6 +193,8 @@ def add_timetree_args(parser):
                           help=coalescent_description)
     parser.add_argument('--n-skyline', default="20", type=int,
                           help="number of grid points in skyline coalescent model")
+    parser.add_argument('--gen-per-year', default="50.0", type=float,
+                          help="number of generations per year - used for estimating N_e in coalescent models")
     parser.add_argument('--n-branches-posterior', default=False, action='store_true',
                           help= "add posterior LH to coalescent model: use the posterior probability distributions of "
                                 "divergence times for estimating the number of branches when calculating the coalescent merger"

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -248,13 +248,13 @@ def export_sequences_and_tree(tt, basename, is_vcf=False, zero_based=False,
         print("--- divergence tree saved in nexus format as  \n\t %s\n"%outtree_name)
 
 
-def print_save_plot_skyline(tt, n_std=2.0, screen=True, save='', plot=''):
+def print_save_plot_skyline(tt, n_std=2.0, screen=True, save='', plot='', gen=50):
     if plot:
         import matplotlib.pyplot as plt
 
-    skyline, conf = tt.merger_model.skyline_inferred(gen=50, confidence=n_std)
+    skyline, conf = tt.merger_model.skyline_inferred(gen=gen, confidence=n_std)
     if save: fh = open(save, 'w', encoding='utf-8')
-    header1 = "Skyline assuming 50 gen/year and approximate confidence bounds (+/- %f standard deviations of the LH)\n"%n_std
+    header1 = "Skyline assuming "+ str(gen)+" gen/year and approximate confidence bounds (+/- %f standard deviations of the LH)\n"%n_std
     header2 = "date \tN_e \tlower \tupper"
     if screen: print('\t'+header1+'\t'+header2)
     if save: fh.write("#"+ header1+'#'+header2+'\n')
@@ -638,12 +638,12 @@ def run_timetree(myTree, params, outdir, tree_suffix='', prune_short=True, metho
     if coalescent in ['skyline', 'opt', 'const']:
         print("Inferred coalescent model")
         if coalescent=='skyline':
-            print_save_plot_skyline(myTree, plot=basename+'skyline.pdf', save=basename+'skyline.tsv', screen=True)
+            print_save_plot_skyline(myTree, plot=basename+'skyline.pdf', save=basename+'skyline.tsv', screen=True, gen=params.gen_per_year)
         else:
             Tc = myTree.merger_model.Tc.y[0]
             print(" --T_c: \t %1.2e \toptimized inverse merger rate in units of substitutions"%Tc)
             print(" --T_c: \t %1.2e \toptimized inverse merger rate in years"%(Tc/myTree.date2dist.clock_rate))
-            print(" --N_e: \t %1.2e \tcorresponding 'effective population size' assuming 50 gen/year\n"%(Tc/myTree.date2dist.clock_rate*50))
+            print(" --N_e: \t %1.2e \tcorresponding 'effective population size' assuming %1.2e gen/year\n"%(params.gen_per_year, Tc/myTree.date2dist.clock_rate*params.gen_per_year))
 
     # plot
     ##IMPORTANT: after this point the functions not only plot the tree but also modify the branch length

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -643,7 +643,7 @@ def run_timetree(myTree, params, outdir, tree_suffix='', prune_short=True, metho
             Tc = myTree.merger_model.Tc.y[0]
             print(" --T_c: \t %1.2e \toptimized inverse merger rate in units of substitutions"%Tc)
             print(" --T_c: \t %1.2e \toptimized inverse merger rate in years"%(Tc/myTree.date2dist.clock_rate))
-            print(" --N_e: \t %1.2e \tcorresponding 'effective population size' assuming %1.2e gen/year\n"%(params.gen_per_year, Tc/myTree.date2dist.clock_rate*params.gen_per_year))
+            print(" --N_e: \t %1.2e \tcorresponding 'effective population size' assuming %1.2e gen/year\n"%(Tc/myTree.date2dist.clock_rate*params.gen_per_year, params.gen_per_year))
 
     # plot
     ##IMPORTANT: after this point the functions not only plot the tree but also modify the branch length


### PR DESCRIPTION
Currently we use the value 50 as the default number of generations per year when estimating merger rate trajectories via the CLI. However, as different organisms have a different generation per year rate it would be nice to add this as a parameter, especially when the output is a desired skyline plot of the inverse rate of coalesence scaled by the number of generations per year. 

### Issues:
https://github.com/neherlab/treetime/issues/210

### Tests:
A CLI test has been added to the `command_line_tests.sh` file.