### PR TITLE
convolve_fft: convert to delta function if distributions too narrow 

### DIFF
--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -598,6 +598,7 @@ class ClockTree(TreeAnc):
 
         method = 'FFT' if self.use_fft else 'explicit'
         self.logger(f"ClockTree - Marginal reconstruction using {method} convolution:  Propagating leaves -> root...", 2)
+        from scipy.interpolate import interp1d
         # go through the nodes from leaves towards the root:
         for node in self.tree.find_clades(order='postorder'):  # children first, msg to parents
             if node.bad_branch:
@@ -660,6 +661,12 @@ class ClockTree(TreeAnc):
                                                     self.merger_model.integral_merger_rate(node.subtree_distribution.x), is_log=True)])
                         else:
                             node.marginal_pos_LH = node.subtree_distribution
+                        dt = np.diff(node.marginal_pos_LH.x)
+                        y = node.marginal_pos_LH.prob_relative(node.marginal_pos_LH.x)
+                        int_y = np.concatenate(([0], np.cumsum(dt*(y[1:]+y[:-1])/2.0)))
+                        int_y/=int_y[-1]
+                        node.marginal_inverse_cdf = interp1d(int_y, node.marginal_pos_LH.x, kind="linear")
+                        node.marginal_cdf = interp1d(node.marginal_pos_LH.x, int_y, kind="linear")
                     else: # otherwise propagate to parent
                         if self.use_fft:
                             res, res_t = NodeInterpolator.convolve_fft(node.subtree_distribution,
@@ -675,13 +682,13 @@ class ClockTree(TreeAnc):
                         node.marginal_pos_Lx = res
 
         self.logger("ClockTree - Marginal reconstruction:  Propagating root -> leaves...", 2)
-        from scipy.interpolate import interp1d
         for node in self.tree.find_clades(order='preorder'):
 
             ## If a delta constraint in known no further work required
             if (node.date_constraint is not None) and (not node.bad_branch) and node.date_constraint.is_delta:
                 node.marginal_pos_LH = node.date_constraint
                 node.msg_from_parent = None #if internal node has a delta constraint no previous information is passed on
+                node.marginal_inverse_cdf = "delta"
             elif node.up is None:
                 node.msg_from_parent = None # nothing beyond the root
             # all other cases (All internal nodes + unconstrained terminals)

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -163,20 +163,18 @@ class NodeInterpolator (Distribution):
 
         dt = max(branch_interp.one_mutation*0.005, min(node_interp.fwhm, branch_interp.fwhm)/fft_grid_size)
         ratio = node_interp.fwhm/branch_interp.fwhm
-        if ratio < 1/100 and dt > 4*node_interp.fwhm/fft_grid_size:
-            print("convolve_fft: entering delta function mode")
+        if ratio < 1/250 and dt > 4*node_interp.fwhm/fft_grid_size:
             ## node distribution is much narrower than the branch distribution, proceed as if node distribution is
             ## a delta distribution
-            bl = branch_interp.x
-            x = bl + node_interp._peak_pos
-            return Distribution(x, branch_interp(bl), min_width=min(node_interp.min_width, branch_interp.min_width), is_log=True)
-        elif ratio >100 and dt > 4*branch_interp.fwhm/fft_grid_size:
+            x = branch_interp.x + node_interp._peak_pos
+            x = np.concatenate((np.logspace(-10,0,6)[:5]*x[0], x)) # avoid numerical issues if peak pos is slightly inaccurate
+            return Distribution(x, branch_interp(x - node_interp._peak_pos), min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)
+        elif ratio >250 and dt > 4*branch_interp.fwhm/fft_grid_size:
             ## branch distribution is much narrower than the node distribution, proceed as if branch distribution is
             ## a delta distribution
-            print("convolve_fft: entering delta function mode")
-            bl = node_interp.x
-            x = bl + branch_interp._peak_pos
-            return  Distribution(x, node_interp(bl), min_width=min(node_interp.min_width, branch_interp.min_width), is_log=True)
+            x = node_interp.x + branch_interp._peak_pos
+            x = np.concatenate((np.logspace(-10,0,6)[:5]*x[0], x))
+            return  Distribution(x, node_interp(x - branch_interp._peak_pos), min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)
         else:
             b_effsupport = branch_interp.effective_support
             n_effsupport = node_interp.effective_support

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -171,7 +171,7 @@ class NodeInterpolator (Distribution):
             else:
                 x = - branch_interp.x + node_interp._peak_pos
             log_scale_node_interp = node_interp.integrate(return_log=True, a=node_interp.xmin,b=node_interp.xmax,n=max(100, len(node_interp.x))) #probability of node distribution 
-            dist = Distribution(x, branch_interp(x - node_interp._peak_pos) + log_scale_node_interp, min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)
+            dist = Distribution(x, branch_interp(x - node_interp._peak_pos) - log_scale_node_interp, min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)
             return dist
         elif ratio > fft_grid_size and 4*dt > branch_interp.fwhm:
             raise ValueError("ERROR: Unexpected behavior: branch distribution is much narrower than the node distribution.")

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -166,12 +166,13 @@ class NodeInterpolator (Distribution):
         if ratio < 1/fft_grid_size and 4*dt > node_interp.fwhm:
             ## node distribution is much narrower than the branch distribution, proceed as if node distribution is
             ## a delta distribution
+            log_scale_node_interp = node_interp.integrate(return_log=True, a=node_interp.xmin,b=node_interp.xmax,n=max(100, len(node_interp.x))) #probability of node distribution 
             if inverse_time:
                 x = branch_interp.x + node_interp._peak_pos
+                dist = Distribution(x, branch_interp(x - node_interp._peak_pos) - log_scale_node_interp, min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)  
             else:
                 x = - branch_interp.x + node_interp._peak_pos
-            log_scale_node_interp = node_interp.integrate(return_log=True, a=node_interp.xmin,b=node_interp.xmax,n=max(100, len(node_interp.x))) #probability of node distribution 
-            dist = Distribution(x, branch_interp(x - node_interp._peak_pos) - log_scale_node_interp, min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)
+                dist = Distribution(x, branch_interp(branch_interp.x) - log_scale_node_interp, min_width=max(node_interp.min_width, branch_interp.min_width), is_log=True)
             return dist
         elif ratio > fft_grid_size and 4*dt > branch_interp.fwhm:
             raise ValueError("ERROR: Unexpected behavior: branch distribution is much narrower than the node distribution.")


### PR DESCRIPTION
## Issue

https://github.com/nextstrain/augur/issues/1057 The monkey pox build has branches where the node distributions are much smaller than the branch distributions and the fft fails as the grid is not coarse enough. 

## Changes 

- In these cases where the node distributions are much smaller than the branch distributions we should treat the node distribution as a delta function at the peak pos $T_n$ of that distribution and instead of using the fft to convolve the two distributions return the result of the branch length interpolator convolved with a delta function (this is for the inverse time case). 
 $$C(t) = \int b(\tau) H(t- \tau) d\tau = C(t) = \int b(\tau) \delta([t - \tau] - T_n) d\tau =b(t - T_n)$$
we can also add the case if the branch length interpolator distribution is too small 
$$C(t) = \int b(\tau) H(t- \tau) d\tau = C(t) = \int \delta([\tau] - T_n)  H(t- \tau) d\tau =H(t - T_n).$$

- However, after implementing this I realized that the `multiply` function was continuously hitting the Warning: 
```WARNING: Unexpected behavior detected in multipy function,"
                         "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues"
```
~~This happens when multiply receives two distributions as input which do not overlap. From closer analysis this seems to be due to the fact that branch length interpolators have x values starting from 0 and adding $T_n$ to the x values would result in the distributions only starting at $T_n$ exactly which is often too imprecise and leads to this error. Thus I add an exponential tail at the start of the convolution output whenever we convolve with a delta function.~~

This was due to the forward time case not being properly handled. For forward time the convolution becomes: 
 $$C(t) = \int b(\tau) H(t+ \tau) d\tau = C(t) = \int b(\tau) \delta([t + \tau] - T_n) d\tau =b(T_n -t )$$

- ~~I am also not sure if this should be in a different PR: the `get_max_posterior_region` function was failing because  `marginal_inverse_cdf` was not calculated for all nodes (which is strange as I thought this was fixed) so I have added this in a separate commit.~~ I have added a check if `marginal_inverse_cdf` throws an error to handle delta functions.

## Testing

I tested this on the monkeypox build that failed (output trees provided by Richard over slack), running the command: 
```
augur refine             --tree results/hmpxv1_big/tree_fixed.nwk             --alignment results/hmpxv1_big/masked.fasta             --metadata results/hmpxv1_big/metadata.tsv             --output-tree results/hmpxv1_big/tree.nwk             --timetree             --use-fft             --root MK783032 MK783030             --precision 3             --keep-polytomies             --clock-rate 5.7e-05             --clock-std-dev 2e-5             --use-fft             --output-node-data results/hmpxv1_big/branch_lengths.json             --coalescent opt             --date-inference marginal             --date-confidence             --clock-filter-iqd 0
```
on augur master branch with the fix/narrow_peak_as_delta` branch installed for TreeTime. I used Cornelius' suggestion in the TreeTime run function and pickled `self` for speedy debugging. i.e. I added the statement 
```
 if os.path.exists('self.pickle'):
            with open('self.pickle', 'rb') as handle:
                self = pickle.load(handle)
            # determine how to reconstruct and sample sequences
            seq_kwargs = {"marginal_sequences":sequence_marginal or (self.branch_length_mode=='marginal'),
                        "branch_length_mode": self.branch_length_mode,
                        "sample_from_profile": "root",
                        "prune_short":kwargs.get("prune_short", True),
                        "reconstruct_tip_states":kwargs.get("reconstruct_tip_states", False)}
            time_marginal_method = reduce_time_marginal_argument(time_marginal) ## for backward compatibility
            tt_kwargs = {'clock_rate':fixed_clock_rate,
                        'time_marginal':False if time_marginal_method in ['never', 'only-final', 'confidence-only'] else True}
            tt_kwargs.update(kwargs)
        else:
             ##lines up to self.logger("###TreeTime.run: INITIAL ROUND",0)
              with open('self.pickle', 'wb') as handle:
                self.logger("###TreeTime.run: pickling",0)
                pickle.dump(self, handle, protocol=pickle.HIGHEST_PROTOCOL)
 ```
  to the `run()` function in TreeTime.             