### PR TITLE
Improve error handling of missing terminal sequences

### DIFF
--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -1200,6 +1200,9 @@ class TreeAnc(object):
             return self.one_mutation
 
         if not hasattr(node, 'branch_state'):
+            if node.cseq is None and node.is_terminal():
+                raise MissingDataError("TreeAnc.optimal_branch_length: terminal node alignments required; sequence is missing for leaf: '%s'. "
+                        "Missing terminal sequences can be inferred from sister nodes by rerunning with `reconstruct_tip_states=True` or `--reconstruct-tip-states`" % node.name)
             self.add_branch_state(node)
         return self.gtr.optimal_t_compressed(node.branch_state['pair'],
                                     node.branch_state['multiplicity'])


### PR DESCRIPTION
## Issue
https://github.com/nextstrain/augur/issues/1062  - general bug that if a node sequence is not in the alignment treetime will print a warning and then crash instead of throwing an exception. In this issue there was an unnamed terminal node in the tree ('None') with no sequence data. 

## Testing 
Reproduce error either with large tree in the issue above or by removing a terminal sequence from the `treetime_examples/data/h3n2_na/h3n2_na_20.fasta` , the command 
```treetime --aln treetime_examples/data/h3n2_na/h3n2_na_20.fasta --tree treetime_examples/data/h3n2_na/h3n2_na_20.nwk --dates treetime_examples/data/h3n2_na/h3n2_na_20.metadata.csv --confidence --covariation ```
should throw a missing data error, the command 
```treetime --aln treetime_examples/data/h3n2_na/h3n2_na_20.fasta --tree treetime_examples/data/h3n2_na/h3n2_na_20.nwk --dates treetime_examples/data/h3n2_na/h3n2_na_20.metadata.csv --confidence --covariation --reconstruct-tip-states```
should still run without issues. 

## Output
Nice error msg: 
![image](https://user-images.githubusercontent.com/50943381/196197427-52f38f59-917b-4da4-bd80-18b6d6c9d216.png)
