### PR TITLE
Fix reconstruction of discrete traits with missing data

### DIFF
--- a/test/test_treetime.py
+++ b/test/test_treetime.py
@@ -48,6 +48,35 @@ def test_GTR():
         assert np.abs(myGTR.v.sum()) > 1e-10 # **and** v is not zero
 
 
+def test_reconstruct_discrete_traits():
+    from Bio import Phylo
+    from treetime.wrappers import reconstruct_discrete_traits
+
+    # Create a minimal tree with traits to reconstruct.
+    tiny_tree = Phylo.read(StringIO("((A:0.60100000009,B:0.3010000009):0.1,C:0.2):0.001;"), 'newick')
+    traits = {
+        "A": "?",
+        "B": "North America",
+        "C": "West Asia",
+    }
+
+    # Reconstruct traits with "?" as missing data.
+    mugration, letter_to_state, reverse_alphabet = reconstruct_discrete_traits(
+        tiny_tree,
+        traits,
+        missing_data="?",
+    )
+
+    # With two known states, the letters "A" and "B" should be in the alphabet
+    # mapping to those states.
+    assert "A" in letter_to_state
+    assert "B" in letter_to_state
+
+    # The letter for missing data should be the next letter in the alphabet,
+    # following the two known state letters.
+    assert letter_to_state["C"] == "?"
+
+
 def test_ancestral(root_dir=None):
     import os
     from Bio import AlignIO

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -768,7 +768,10 @@ def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling
     ### make a single character alphabet that maps to discrete states
     ###########################################################################
 
-    unique_states = set(traits.values())
+    # Find all unique states to reconstruct, excluding the missing data state.
+    # This missing state will get its own letter assigned after we enumerate the
+    # known states.
+    unique_states = set(traits.values()) - {missing_data}
     n_observed_states = len(unique_states)
 
     # load weights from file and convert to dict if supplied as string


### PR DESCRIPTION
Fixes an issue that emerged when running `augur traits` with flu data where strains with known states in their metadata were getting states inferred as if they were unknown. For example, the screenshot below shows a specific strain from Oman that had "West Asia" in its `region` column of the metadata, but the traits node data included an inferred region of "North America".

![image](https://user-images.githubusercontent.com/85372/198748789-6fe7000a-2e8d-4082-b747-8f9ceb03f546.png)

To debug this issue, I added an ipdb checkpoint to the `augur traits` module locally [just after the `reconstruct_discrete_traits` function was called and traits assigned to nodes](https://github.com/nextstrain/augur/blob/7f968ce7a0ebf1226bf1a5e99717f0175ae55159/augur/traits.py#L83). I ran the following commands to recreate the logic of that function in the ipdb REPL:

```python
>>> unique_states = set(traits.values())
>>> n_observed_states = len(unique_states)
>>> unique_states=sorted(unique_states)
>>> unique_states
['?', 'Africa', 'China', 'Europe', 'Japan Korea', 'North America', 'Oceania', 'South America', 'South Asia', 'Southeast Asia', 'West Asia']
>>> {state:chr(65+i) for i,state in enumerate(unique_states) if state!="?"}
{'Africa': 'B', 'China': 'C', 'Europe': 'D', 'Japan Korea': 'E', 'North America': 'F', 'Oceania': 'G', 'South America': 'H', 'South Asia': 'I', 'Southeast Asia': 'J', 'West Asia': 'K'}
>>> reverse_alphabet = {state:chr(65+i) for i,state in enumerate(unique_states) if state!="?"}
>>> reverse_alphabet
{'Africa': 'B', 'China': 'C', 'Europe': 'D', 'Japan Korea': 'E', 'North America': 'F', 'Oceania': 'G', 'South America': 'H', 'South Asia': 'I', 'Southeast Asia': 'J', 'West Asia': 'K'}
>>> alphabet = list(reverse_alphabet.values())
>>> alphabet
['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K']
>>> letter_to_state = {v:k for k,v in reverse_alphabet.items()}
>>> letter_to_state
{'B': 'Africa', 'C': 'China', 'D': 'Europe', 'E': 'Japan Korea', 'F': 'North America', 'G': 'Oceania', 'H': 'South America', 'I': 'South Asia', 'J': 'Southeast Asia', 'K': 'West Asia'}
>>> n_states = len(alphabet)
>>> n_states
10
>>> missing_char = chr(65+n_states)
>>> missing_char
'K'
```

This testing shows that the sorted list of unique states starts with the missing data character "?" but the enumerated alphabet for unique states skips this character. As a result, the letter "A" gets dropped from the alphabet. Then, the character for the missing state, "K", overwrites the character associated with "West Asia". As a result, all samples from "West Asia" get treated as if they were missing data. 

This PR adds a "unit test" for the `reconstruct_discrete_traits` function with missing data that recreates the specific error. The test fails with the code in `master`, as expected. The second commit in this PR adds logic to resolve the issue and make the test pass.

Notably, this issue does not impact the `treetime mugration` CLI in the same way that it affected the `augur traits` CLI. The TreeTime `mugration` function [drops the missing data value from traits](https://github.com/neherlab/treetime/blob/9b6ec821b85d45a324a23a1ec283543f0d090b4b/treetime/wrappers.py#L916-L917) before calling `reconstruct_discrete_traits`. This means past users of the `treetime` CLI should not have experienced this issue. However, this issue will have affected Augur users [since the beginning of the pandemic](https://github.com/nextstrain/augur/commit/324666e6ff67b6d1e567d2d15e3986ee91eae9e7).