### PR TITLE
Bug fix: vcf index error

### DIFF
--- a/treetime/vcf_utils.py
+++ b/treetime/vcf_utils.py
@@ -435,7 +435,10 @@ def write_vcf(tree_dict, file_name):#, compress=False):
             try:
                 pattern2.append(sequences[k][pi+1])
             except KeyError:
-                pattern2.append(ref[pi+1])
+                try:
+                    pattern2.append(ref[pi+1])
+                except IndexError:
+                    pass
 
         pattern = np.array(pattern).astype('U')
         pattern2 = np.array(pattern2).astype('U')


### PR DESCRIPTION
## Issue
https://github.com/neherlab/treetime/issues/218

## Solution
Thanks to @andreott for finding and fixing this bug!

## Testing
Error can be reproduced by adding the final index of the reference sequence to the positions vector in the `write_vcf` function, i..e `positions = np.append(positions, [len(ref)-1])` and running 
```treetime ancestral --aln data/tb/lee_2015.vcf.gz --vcf-reference data/tb/tb_ref.fasta --tree data/tb/lee_2015.nwk```
in the `treetime_examples` folder.