### PR TITLE
fix: explicitly specify minimization method and tolerance in case of …

### DIFF
--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -1030,8 +1030,8 @@ class ClockTree(TreeAnc):
                     interval = np.array([left(x), right(x)]).squeeze()
                     return (thres - np.diff(node.marginal_cdf(np.array(interval))))**2
 
-                # minimza and determine success
-                sol = minimize(func, bracket=[0,10], args=(fraction,))
+                # minimze and determine success
+                sol = minimize(func, bracket=[0,10], args=(fraction,), method='brent')
                 if sol['success']:
                     mutation_contribution = self.date2dist.to_numdate(np.array([right(sol['x']), left(sol['x'])]).squeeze())
                 else: # on failure, return standard confidence interval

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -803,8 +803,8 @@ class GTR(object):
         try:
             from scipy.optimize import minimize_scalar
             opt = minimize_scalar(_neg_prob,
-                    bounds=[-np.sqrt(ttconf.MAX_BRANCH_LENGTH),np.sqrt(ttconf.MAX_BRANCH_LENGTH)],
-                    args=(seq_pair, multiplicity), tol=tol)
+                    bracket=[-np.sqrt(ttconf.MAX_BRANCH_LENGTH),np.sqrt(ttconf.MAX_BRANCH_LENGTH)],
+                    args=(seq_pair, multiplicity), tol=tol, method='brent')
             new_len = opt["x"]**2
             if 'success' not in opt:
                 opt['success'] = True

--- a/treetime/merger_models.py
+++ b/treetime/merger_models.py
@@ -255,11 +255,11 @@ class Coalescent(object):
         '''
         from scipy.optimize import minimize_scalar
         initial_Tc = self.Tc
-        def cost(Tc):
-            self.set_Tc(Tc)
+        def cost(logTc):
+            self.set_Tc(np.exp(logTc))
             return -self.total_LH()
 
-        sol = minimize_scalar(cost, bounds=[ttconf.TINY_NUMBER,10.0])
+        sol = minimize_scalar(cost, bracket=[-20.0, 2.0], method='brent')
         if "success" in sol and sol["success"]:
             self.set_Tc(sol['x'])
         else:

--- a/treetime/merger_models.py
+++ b/treetime/merger_models.py
@@ -261,7 +261,7 @@ class Coalescent(object):
 
         sol = minimize_scalar(cost, bracket=[-20.0, 2.0], method='brent')
         if "success" in sol and sol["success"]:
-            self.set_Tc(sol['x'])
+            self.set_Tc(np.exp(sol['x']))
         else:
             self.logger("merger_models:optimize_Tc: optimization of coalescent time scale failed: " + str(sol), 0, warn=True)
             self.set_Tc(initial_Tc.y, T=initial_Tc.x)

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -1571,7 +1571,7 @@ class TreeAnc(object):
 
         old_mu = self.gtr.mu
         try:
-            sol = minimize_scalar(cost_func,bracket=[0.01*np.sqrt(old_mu), np.sqrt(old_mu),100*np.sqrt(old_mu)])
+            sol = minimize_scalar(cost_func, bracket=[0.01*np.sqrt(old_mu), np.sqrt(old_mu),100*np.sqrt(old_mu)], method='brent')
         except:
             self.gtr.mu=old_mu
             self.logger('treeanc:optimize_gtr_rate: optimization failed, continuing with previous mu',1,warn=True)

--- a/treetime/treeregression.py
+++ b/treetime/treeregression.py
@@ -402,7 +402,7 @@ class TreeRegression(object):
         else:
             ii = np.argmin(chisq_grid)
             bounds = (0 if ii==0 else grid[ii-1], 1.0 if ii==len(grid)-1 else grid[ii+1])
-            sol = minimize_scalar(chisq, bounds=bounds, method="bounded", tol=1e-6)
+            sol = minimize_scalar(chisq, bounds=bounds, method="bounded", options={'xatol':1e-6})
             if sol["success"]:
                 return sol['x'], sol['fun']
             else:
@@ -611,6 +611,4 @@ if __name__ == '__main__':
     rtt = np.array(rtt)
     plt.plot(ti, rtt)
     plt.plot(ti, reg["slope"]*ti + reg["intercept"])
-    plt.show()
-
     Phylo.draw(T)

--- a/treetime/treeregression.py
+++ b/treetime/treeregression.py
@@ -402,7 +402,7 @@ class TreeRegression(object):
         else:
             ii = np.argmin(chisq_grid)
             bounds = (0 if ii==0 else grid[ii-1], 1.0 if ii==len(grid)-1 else grid[ii+1])
-            sol = minimize_scalar(chisq, bounds=bounds, method="bounded")
+            sol = minimize_scalar(chisq, bounds=bounds, method="bounded", tol=1e-6)
             if sol["success"]:
                 return sol['x'], sol['fun']
             else:

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -645,7 +645,7 @@ class TreeTime(ClockTree):
             try:
                 cg = sciopt.minimize_scalar(_c_gain,
                     bounds=[max(n1.time_before_present,n2.time_before_present), parent.time_before_present],
-                    method='Bounded',args=(n1,n2, parent))
+                    method='bounded',args=(n1,n2, parent), tol=1e-4*self.one_mutation)
                 return cg['x'], - cg['fun']
             except:
                 self.logger("TreeTime._poly.cost_gain: optimization of gain failed", 3, warn=True)

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -645,7 +645,7 @@ class TreeTime(ClockTree):
             try:
                 cg = sciopt.minimize_scalar(_c_gain,
                     bounds=[max(n1.time_before_present,n2.time_before_present), parent.time_before_present],
-                    method='bounded',args=(n1,n2, parent), tol=1e-4*self.one_mutation)
+                    method='bounded',args=(n1,n2, parent), options={'xatol':1e-4*self.one_mutation})
                 return cg['x'], - cg['fun']
             except:
                 self.logger("TreeTime._poly.cost_gain: optimization of gain failed", 3, warn=True)


### PR DESCRIPTION
…bounded optimization

@victorlin discovered that a recent change in scipy triggers warnings (this fixes previous behavior in scipy were tjhe `bounds` arguments to `minimize_scalar` was silently ignored when the method wasn't specified). 

https://github.com/neherlab/treetime/issues/223

This PR add an explicit choice of method to each call, changes one optimization to the logarithm (to ensure positivity) and specifies tolerance for the remaining bounded optimizations. 