### PR TITLE
Fix/delta function error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
+# 0.9.6: bug fixes
+ * in cases when very large polytomies are resolved, the multiplication of the discretized message results in messages/distributions of length 1. This resulted in an error, since interpolation objects require at least two points. This is now caught and a small discrete grid created.
+ * increase recursion limit to 10000 by default. The recursion limit can now also be set via the environment variable `TREETIME_RECURSION_LIMIT`.
+ * removed unused imports, fixed typos
+
 # 0.9.5: load custom GTR via CLI
+
  * fix bug that omitted the inferred state of the root in the nexus export of the migration command
  * add CLI flag and functionality to load sequence evolution models inferred and saved by TreeTime as human-readable text files. The flag is `--custom-gtr <filename>` and overwrites any arguments passed under the `--gtr` flag.
  * explicitly specify the optimization method, brackets, bounds, and tolerances in calls of `scipy.optimize.minimize` to suppress scipy warning. Scipy had previously silently ignored bounds when the method wasn't explicitly set to `bounded`.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import setup
 
 def get_version():

--- a/treetime/__init__.py
+++ b/treetime/__init__.py
@@ -1,4 +1,4 @@
-version="0.9.5"
+version="0.9.6"
 ## Here we define an error class for TreeTime errors, MissingData, UnknownMethod and NotReady errors
 ## are all due to incorrect calling of TreeTime functions or input data that does not fit our base assumptions.
 ## Errors marked as TreeTimeUnknownErrors might be due to data not fulfilling base assumptions or due
@@ -28,6 +28,12 @@ class TreeTimeUnknownError(Exception):
     """TreeTimeUnknownError class raised when TreeTime fails during inference due to an unknown reason. This might be due to data not fulfilling base assumptions or due  to bugs in TreeTime. Please report them to the developers if they persist."""
     pass
 
+import os, sys
+recursion_limit = os.environ.get("TREETIME_RECURSION_LIMIT")
+if recursion_limit:
+    sys.setrecursionlimit(int(recursion_limit))
+else:
+    sys.setrecursionlimit(max(sys.getrecursionlimit(), 10000))
 
 from .treeanc import TreeAnc
 from .treetime import TreeTime, plot_vs_years

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -703,6 +703,9 @@ class ClockTree(TreeAnc):
 
                     if hasattr(self, 'merger_model') and self.merger_model:
                         time_points = parent.marginal_pos_LH.x
+                        if len(time_points)<5:
+                            time_points = np.linspace(np.min([x.xmin for x in complementary_msgs]),
+                                                      np.max([x.xmax for x in complementary_msgs]), 10)
                         # As Lx do not include the node contribution this must be added on
                         complementary_msgs.append(self.merger_model.node_contribution(parent, time_points))
 

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -4,9 +4,7 @@ try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
-from copy import deepcopy as make_copy
-from scipy.ndimage import binary_dilation
-from .config import BIG_NUMBER, MIN_LOG, MIN_INTEGRATION_PEAK, TINY_NUMBER, SUPERTINY_NUMBER
+from .config import BIG_NUMBER, MIN_INTEGRATION_PEAK, TINY_NUMBER
 from .utils import clip
 
 class Distribution(object):
@@ -313,7 +311,6 @@ class Distribution(object):
         Assess the interval on which the value of self is higher than cutoff
         relative to its peak
         """
-        from scipy.optimize import brentq
         log_cutoff = -np.log(cutoff)
         vals = log_cutoff - self.__call__(self.x) + self.peak_val
         above = vals > 0

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -1,4 +1,5 @@
 import numpy as np
+from . import TreeTimeUnknownError
 from scipy.interpolate import interp1d
 try:
     from collections.abc import Iterable
@@ -112,22 +113,18 @@ class Distribution(object):
             try:
                 peak = y_vals.min()
             except:
-                print("WARNING: Unexpected behavior detected in multiply function,"
-                        "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues")
-                x_vals = [0,1]
-                y_vals = [BIG_NUMBER,BIG_NUMBER]
-                res = Distribution(x_vals, y_vals, is_log=True,
-                                    min_width=min_width, kind='linear')
-                return res
+                TreeTimeUnknownError("Error: Unexpected behavior detected in multiply function"
+                        " when determining peak of function with y-values '"+ str(y_vals) + "'.\n\n"
+                        "If you see this error please let us know by filling an issue at: \n"
+                        "https://github.com/neherlab/treetime/issues")
+
             ind = (y_vals-peak)<BIG_NUMBER/1000
             n_points = ind.sum()
             if n_points == 0:
-                print("WARNING: Unexpected behavior detected in multiply function,"
-                        "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues")
-                x_vals = [0,1]
-                y_vals = [BIG_NUMBER,BIG_NUMBER]
-                res = Distribution(x_vals, y_vals, is_log=True,
-                                   min_width=min_width, kind='linear')
+                TreeTimeUnknownError("Error: Unexpected behavior detected in multiply function. "
+                                     "No valid points left after reducing to plausible region.\n\n"
+                        "If you see this error please let us know by filling an issue at:\n"
+                        "https://github.com/neherlab/treetime/issues")
             elif n_points == 1:
                 res = Distribution.delta_function(x_vals[0])
             else:
@@ -431,6 +428,7 @@ class Distribution(object):
 
     def fft(self, T, n=None, inverse_time=True):
         if self.is_delta:
+            raise
             import ipdb; ipdb.set_trace()
         from numpy.fft import rfft
         if n is None:

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -124,7 +124,7 @@ class Distribution(object):
             ind = (y_vals-peak)<BIG_NUMBER/1000
             n_points = ind.sum()
             if n_points == 0:
-                print("WARNING: Unexpected behavior detected in multipy function,"
+                print("WARNING: Unexpected behavior detected in multiply function,"
                         "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues")
                 x_vals = [0,1]
                 y_vals = [BIG_NUMBER,BIG_NUMBER]
@@ -159,7 +159,7 @@ class Distribution(object):
         ind = (y_vals-peak)<BIG_NUMBER/1000
         n_points = ind.sum()
         if n_points == 0:
-            print("WARNING: Unexpected behavior detected in multipy function,"
+            print("WARNING: Unexpected behavior detected in multiply function,"
                     "if you see this error \n please let us know by filling an issue at: https://github.com/neherlab/treetime/issues")
             x_vals = [0,1]
             y_vals = [BIG_NUMBER,BIG_NUMBER]
@@ -271,7 +271,7 @@ class Distribution(object):
     @property
     def y(self):
         if self.is_delta:
-            print("THIS SHOULDN'T BE CALLED ON A DELTA FUNCTION")
+            print("Warning: evaluating log probability of a delta distribution.")
             return [self.weight]
         else:
             return self._peak_val + self._func.y

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -3,7 +3,6 @@ import gc
 import numpy as np
 from Bio import Phylo
 from Bio.Phylo.BaseTree import Clade
-from Bio import AlignIO
 from . import config as ttconf
 from . import MissingDataError,UnknownMethodError
 from .seq_utils import seq2prof, prof2seq, normalize_profile, extend_profile


### PR DESCRIPTION
In cases with very large polytomies, repeated convolutions resulted in delta-like function which wasn't caught and led to crashes. In such cases, we now generate a small grid to evaluate the merger model. In addition, we set the recursion limit by default to 10000 and allow setting via an environment variable similar to `augur`.