### PR TITLE
Fix/export and polytomies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
   workflow_dispatch:
-    
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           - '3.9'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Have a look at our repository with [example data](https://github.com/neherlab/tr
 
 ### Installation and prerequisites
 
-TreeTime is compatible with Python 3.6 upwards and is tested on 3.6, 3.7, and 3.8.  It depends on several Python libraries:
+TreeTime is compatible with Python 3.7 upwards and is tested on 3.7 to 3.10.  It depends on several Python libraries:
 
 * numpy, scipy, pandas: for all kind of mathematical operations as matrix
   operations, numerical integration, interpolation, minimization, etc.

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,8 @@
 
  * the output directory now contains a json file that is compatible with auspice.us. Both time scaled phylogenies and ancestral inferences can now be visualized and explored using auspice. Available colorings are "Date", "genotype", "Branch support", and Excluded. See [PR #232](https://github.com/neherlab/treetime/pull/232) for details.
  * move most function related to IO of the command line wrappers into a separate file.
- * make TreeTime own its random number generator and add `--rgn-seed` to control state in CLI
- * add flag `--greedy-resolve` as inverse to `--stochastic-resolve` with the aim of switching the two
+ * make TreeTime own its random number generator and add `--rgn-seed` to control state in CLI. See [PR #234](https://github.com/neherlab/treetime/pull/234)
+ * add flag `--greedy-resolve` as inverse to `--stochastic-resolve` with the aim of switching the two.
 
 # 0.9.6: bug fixes and new mode of polytomy resolution
  * in cases when very large polytomies are resolved, the multiplication of the discretized message results in messages/distributions of length 1. This resulted in an error, since interpolation objects require at least two points. This is now caught and a small discrete grid created.

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
  * the output directory now contains a json file that is compatible with auspice.us. Both time scaled phylogenies and ancestral inferences can now be visualized and explored using auspice. Available colorings are "Date", "genotype", "Branch support", and Excluded. See [PR #232](https://github.com/neherlab/treetime/pull/232) for details.
  * move most function related to IO of the command line wrappers into a separate file.
+ * make TreeTime own its random number generator and add `--rgn-seed` to control state in CLI
+ * add flag `--greedy-resolve` as inverse to `--stochastic-resolve` with the aim of switching the two
 
 # 0.9.6: bug fixes and new mode of polytomy resolution
  * in cases when very large polytomies are resolved, the multiplication of the discretized message results in messages/distributions of length 1. This resulted in an error, since interpolation objects require at least two points. This is now caught and a small discrete grid created.

--- a/test/test_treetime.py
+++ b/test/test_treetime.py
@@ -26,7 +26,7 @@ def test_assign_gamma(root_dir=None):
     tt_kwargs = {'clock_rate': 0.0001,
                     'time_marginal':'assign'}
     myTree = TreeTime(gtr='Jukes-Cantor', tree = nwk, use_fft=False,
-                    aln = fasta, verbose = 1, dates = dates, precision=3, debug=True)
+                    aln = fasta, verbose = 1, dates = dates, precision=3, debug=True, rng_seed=1234)
     def assign_gamma(tree):
         return tree
     success = myTree.run(infer_gtr=False, assign_gamma=assign_gamma, max_iter=1, verbose=3, **seq_kwargs, **tt_kwargs)
@@ -105,7 +105,7 @@ def test_ancestral(root_dir=None):
 
     for marginal in [True, False]:
         print('loading flu example')
-        t = TreeAnc(gtr='Jukes-Cantor', tree=nwk, aln=fasta)
+        t = TreeAnc(gtr='Jukes-Cantor', tree=nwk, aln=fasta, rng_seed=1234)
         print('ancestral reconstruction' + ("marginal" if marginal else "joint"))
         t.reconstruct_anc(method='ml', marginal=marginal)
         assert t.data.compressed_to_full_sequence(t.tree.root.cseq, as_string=True) == 'ATGAATCCAAATCAAAAGATAATAACGATTGGCTCTGTTTCTCTCACCATTTCCACAATATGCTTCTTCATGCAAATTGCCATCTTGATAACTACTGTAACATTGCATTTCAAGCAATATGAATTCAACTCCCCCCCAAACAACCAAGTGATGCTGTGTGAACCAACAATAATAGAAAGAAACATAACAGAGATAGTGTATCTGACCAACACCACCATAGAGAAGGAAATATGCCCCAAACCAGCAGAATACAGAAATTGGTCAAAACCGCAATGTGGCATTACAGGATTTGCACCTTTCTCTAAGGACAATTCGATTAGGCTTTCCGCTGGTGGGGACATCTGGGTGACAAGAGAACCTTATGTGTCATGCGATCCTGACAAGTGTTATCAATTTGCCCTTGGACAGGGAACAACACTAAACAACGTGCATTCAAATAACACAGTACGTGATAGGACCCCTTATCGGACTCTATTGATGAATGAGTTGGGTGTTCCTTTTCATCTGGGGACCAAGCAAGTGTGCATAGCATGGTCCAGCTCAAGTTGTCACGATGGAAAAGCATGGCTGCATGTTTGTATAACGGGGGATGATAAAAATGCAACTGCTAGCTTCATTTACAATGGGAGGCTTGTAGATAGTGTTGTTTCATGGTCCAAAGAAATTCTCAGGACCCAGGAGTCAGAATGCGTTTGTATCAATGGAACTTGTACAGTAGTAATGACTGATGGAAGTGCTTCAGGAAAAGCTGATACTAAAATACTATTCATTGAGGAGGGGAAAATCGTTCATACTAGCACATTGTCAGGAAGTGCTCAGCATGTCGAAGAGTGCTCTTGCTATCCTCGATATCCTGGTGTCAGATGTGTCTGCAGAGACAACTGGAAAGGCTCCAATCGGCCCATCGTAGATATAAACATAAAGGATCATAGCATTGTTTCCAGTTATGTGTGTTCAGGACTTGTTGGAGACACACCCAGAAAAAACGACAGCTCCAGCAGTAGCCATTGTTTGGATCCTAACAATGAAGAAGGTGGTCATGGAGTGAAAGGCTGGGCCTTTGATGATGGAAATGACGTGTGGATGGGAAGAACAATCAACGAGACGTCACGCTTAGGGTATGAAACCTTCAAAGTCATTGAAGGCTGGTCCAACCCTAAGTCCAAATTGCAGATAAATAGGCAAGTCATAGTTGACAGAGGTGATAGGTCCGGTTATTCTGGTATTTTCTCTGTTGAAGGCAAAAGCTGCATCAATCGGTGCTTTTATGTGGAGTTGATTAGGGGAAGAAAAGAGGAAACTGAAGTCTTGTGGACCTCAAACAGTATTGTTGTGTTTTGTGGCACCTCAGGTACATATGGAACAGGCTCATGGCCTGATGGGGCGGACCTCAATCTCATGCCTATA'
@@ -118,7 +118,7 @@ def test_ancestral(root_dir=None):
                                      ">C\nACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT\n"), 'fasta')
 
     mygtr = GTR.custom(alphabet = np.array(['A', 'C', 'G', 'T']), pi = np.array([0.9, 0.06, 0.02, 0.02]), W=np.ones((4,4)))
-    t = TreeAnc(gtr=mygtr, tree=tiny_tree, aln=tiny_aln)
+    t = TreeAnc(gtr=mygtr, tree=tiny_tree, aln=tiny_aln, rng_seed=1234)
     t.reconstruct_anc('ml', marginal=True, debug=True)
     lhsum =  np.exp(t.sequence_LH(pos=np.arange(4**3))).sum()
     print (lhsum)
@@ -152,15 +152,14 @@ def test_seq_joint_reconstruction_correct():
     mygtr = GTR.custom(alphabet = np.array(['A', 'C', 'G', 'T']),
                        pi = np.array([0.15, 0.95, 0.05, 0.3]),
                        W=np.ones((4,4)))
-    seq = np.random.choice(mygtr.alphabet, p=mygtr.Pi, size=400)
 
 
-    myTree = TreeAnc(gtr=mygtr, tree=tiny_tree, aln=None, verbose=4)
+    myTree = TreeAnc(gtr=mygtr, tree=tiny_tree, aln=None, verbose=4, rng_seed=1234)
 
     # simulate evolution, set resulting sequence as ref_seq
     tree = myTree.tree
     seq_len = 400
-    tree.root.ref_seq = np.random.choice(mygtr.alphabet, p=mygtr.Pi, size=seq_len)
+    tree.root.ref_seq = myTree.rng.choice(mygtr.alphabet, p=mygtr.Pi, size=seq_len)
     print ("Root sequence: " + ''.join(tree.root.ref_seq.astype('U')))
     mutation_list = defaultdict(list)
     for node in tree.find_clades():
@@ -173,7 +172,7 @@ def test_seq_joint_reconstruction_correct():
         # normalize profile
         p=(p.T/p.sum(axis=1)).T
         # sample mutations randomly
-        ref_seq_idxs = np.array([int(np.random.choice(np.arange(p.shape[1]), p=p[k])) for k in np.arange(p.shape[0])])
+        ref_seq_idxs = np.array([int(myTree.rng.choice(np.arange(p.shape[1]), p=p[k])) for k in np.arange(p.shape[0])])
 
         node.ref_seq = np.array([mygtr.alphabet[k] for k in ref_seq_idxs])
 
@@ -257,7 +256,7 @@ def test_seq_joint_lh_is_max():
                                          ">E\nACGTACGTACGTACGT\n"), 'fasta')
 
         myTree = TreeAnc(gtr=mygtr, tree = tiny_tree,
-                         aln =tiny_aln, verbose = 4)
+                         aln =tiny_aln, verbose = 4, rng_seed=1234)
 
         logLH_ref = myTree.ancestral_likelihood()
 
@@ -274,7 +273,7 @@ def test_seq_joint_lh_is_max():
                                            ">D\n"+D_char+"\n"), 'fasta')
 
         myTree_1 = TreeAnc(gtr=mygtr, tree = tiny_tree,
-                            aln=tiny_aln_1, verbose = 4)
+                            aln=tiny_aln_1, verbose = 4, rng_seed=1234)
 
         myTree_1.reconstruct_anc(method='ml', marginal=False, debug=True)
         logLH = myTree_1.tree.sequence_LH

--- a/treetime/CLI_io.py
+++ b/treetime/CLI_io.py
@@ -3,6 +3,7 @@ from Bio import AlignIO, Phylo
 from .vcf_utils import read_vcf, write_vcf
 from .seq_utils import alphabets
 from Bio import __version__ as bioversion
+from . import version as treetime_version
 import numpy as np
 
 def get_outdir(params, suffix='_treetime'):
@@ -227,9 +228,12 @@ def print_save_plot_skyline(tt, n_std=2.0, screen=True, save='', plot='', gen=50
 
 def create_auspice_json(tt, timetree=False, confidence=False):
     # mock up meta data for auspice json
+    from datetime import datetime
     meta = {
-        "title": "Auspice visualization of TreeTime analysis",
+        "title": f"Auspice visualization of TreeTime (v{treetime_version}) analysis",
         "build_url": "https://github.com/neherlab/treetime",
+        "last_updated": datetime.now().strftime("%Y-%m-%d"),
+        "treetime_version": treetime_version,
         "genome_annotations": {
             "nuc":{"start":1, "end":int(tt.data.full_length), "type":"source", "strand":"+:"}
         },
@@ -238,12 +242,12 @@ def create_auspice_json(tt, timetree=False, confidence=False):
             {
                 "title": "Date",
                 "type": "continuous",
-                "key": "gt",
+                "key": "num_date",
             },
             {
                 "title": "Genotype",
                 "type": "categorical",
-                "key": "num_date",
+                "key": "gt",
             },
             {
                 "title": "Excluded",

--- a/treetime/CLI_io.py
+++ b/treetime/CLI_io.py
@@ -259,7 +259,9 @@ def create_auspice_json(tt, timetree=False, confidence=False):
                 "type": "continuous",
                 "key": "confidence"
             }
-        ]
+        ],
+        "display_defaults": {"color_by":"bad_branch"},
+        "filters": ["bad_branch"]
     }
 
     def node_to_json(n, pdiv=0.0):

--- a/treetime/argument_parser.py
+++ b/treetime/argument_parser.py
@@ -227,6 +227,7 @@ def make_parser():
     else:
         t_parser = parser
     t_parser.add_argument('--tree', type=str, help=tree_description)
+    t_parser.add_argument('--rng-seed', type=int, help="random number generator seed for treetime")
     add_seq_len_aln_group(t_parser)
     add_time_arguments(t_parser)
     add_timetree_args(t_parser)
@@ -250,6 +251,7 @@ def make_parser():
     h_parser = subparsers.add_parser('homoplasy', description=homoplasy_description)
     add_aln_group(h_parser)
     h_parser.add_argument('--tree', type = str,  help=tree_description)
+    h_parser.add_argument('--rng-seed', type=int, help="random number generator seed for treetime")
     h_parser.add_argument('--const', type = int, default=0, help ="number of constant sites not included in alignment")
     h_parser.add_argument('--rescale', type = float, default=1.0, help ="rescale branch lengths")
     h_parser.add_argument('--detailed', required = False, action="store_true",  help ="generate a more detailed report")
@@ -264,6 +266,7 @@ def make_parser():
     a_parser = subparsers.add_parser('ancestral', description=ancestral_description)
     add_aln_group(a_parser)
     a_parser.add_argument('--tree', type=str,  help=tree_description)
+    a_parser.add_argument('--rng-seed', type=int, help="random number generator seed for treetime")
     add_gtr_arguments(a_parser)
     a_parser.add_argument('--marginal', default=False, action="store_true", help ="marginal reconstruction of ancestral sequences")
     add_anc_arguments(a_parser)
@@ -273,6 +276,7 @@ def make_parser():
     ## MUGRATION
     m_parser = subparsers.add_parser('mugration', description=mugration_description)
     m_parser.add_argument('--tree', required = True, type=str, help=tree_description)
+    m_parser.add_argument('--rng-seed', type=int, help="random number generator seed for treetime")
     m_parser.add_argument('--name-column', type=str, help="label of the column to be used as taxon name")
     m_parser.add_argument('--attribute', type=str, help ="attribute to reconstruct, e.g. country")
     m_parser.add_argument('--states', required = True, type=str, help ="csv or tsv file with discrete characters."
@@ -299,6 +303,7 @@ def make_parser():
                         "It will reroot the tree to maximize the clock-like "
                         "signal and recalculate branch length unless run with --keep-root.")
     c_parser.add_argument('--tree', required=True, type=str,  help=tree_description)
+    c_parser.add_argument('--rng-seed', type=int, help="random number generator seed for treetime")
     add_time_arguments(c_parser)
     add_seq_len_aln_group(c_parser)
 
@@ -317,6 +322,7 @@ def make_parser():
             description="Calculates the root-to-tip regression and quantifies the 'clock-i-ness' of the tree. "
                         "It will reroot the tree to maximize the clock-like "
                         "signal and recalculate branch length unless run with --keep_root.")
+    arg_parser.add_argument('--rng-seed', type=int, help="random number generator seed for treetime")
     arg_parser.add_argument('--trees', nargs=2, required=True, type=str)
     arg_parser.add_argument('--alignments', nargs=2, required=True, type=str)
     arg_parser.add_argument('--mccs', required=True, type=str)

--- a/treetime/argument_parser.py
+++ b/treetime/argument_parser.py
@@ -182,6 +182,9 @@ def add_timetree_args(parser):
                         help="Don't resolve polytomies using temporal information.")
     parser.add_argument('--stochastic-resolve', default=False, action='store_true',
                         help="Resolve polytomies using a random coalescent tree.")
+    parser.add_argument('--greedy-resolve', action='store_false', dest='stochastic_resolve',
+                        help="Resolve polytomies greedily. Currently default, but will "
+                             "switched to `stochastic-resolve` in future versions.")
     # parser.add_argument('--keep-node-order', default=False, action='store_true',
     #                     help="Don't ladderize the tree.")
     parser.add_argument('--relax',nargs=2, type=float,

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -24,7 +24,7 @@ class ClockTree(TreeAnc):
 
     def __init__(self, *args, dates=None, debug=False, real_dates=True, precision_fft = 'auto',
                 precision='auto', precision_branch='auto', branch_length_mode='joint', use_covariation=False,
-                use_fft=True,**kwargs):
+                use_fft=True, **kwargs):
 
         """
         ClockTree constructor
@@ -32,20 +32,20 @@ class ClockTree(TreeAnc):
         Parameters
         ----------
 
-         dates : dict
+        dates : dict
             :code:`{leaf_name:leaf_date}` dictionary
 
-         debug : bool
+        debug : bool
             If True, the debug mode is ON, which means no or less clean-up of
             obsolete parameters to control program execution in intermediate
             states. In debug mode, the python debugger is also allowed to interrupt
             program execution with intercative shell if an error occurs.
 
-         real_dates : bool
+        real_dates : bool
             If True, some additional checks for the input dates sanity will be
             performed.
 
-         precision : int
+        precision : int
             Precision can be 0 (rough), 1 (default), 2 (fine), or 3 (ultra fine).
             This parameter determines the number of grid points that are used
             for the evaluation of the branch length interpolation objects.
@@ -59,11 +59,11 @@ class ClockTree(TreeAnc):
             The number of points desired to span the width of the FWHM of a distribution
             can be specified explicitly by precision_fft (default is 200).
 
-         branch_length_mode : str
+        branch_length_mode : str
             determines whether branch length are calculated using the 'joint' ML,
             'marginal' ML, or branch length of the input tree ('input').
 
-         use_covariation : bool
+        use_covariation : bool
             determines whether root-to-tip regression accounts for covariance
             introduced by shared ancestry.
 

--- a/treetime/clock_tree.py
+++ b/treetime/clock_tree.py
@@ -702,11 +702,12 @@ class ClockTree(TreeAnc):
                         complementary_msgs.append(parent.msg_from_parent)
 
                     if hasattr(self, 'merger_model') and self.merger_model:
-                        time_points = np.unique(np.concatenate(parent.msg_from_parent.x, node.subtree_distribution.x))
+                        time_points = parent.marginal_pos_LH.x
                         if len(time_points)<5:
                             time_points = np.linspace(np.min([x.xmin for x in complementary_msgs]),
                                                       np.max([x.xmax for x in complementary_msgs]), 50)
-                        # As Lx do not include the node contribution this must be added on
+                        # As Lx (the product of child messages) does not include the node contribution this must
+                        # be added to recover the full distribution of the parent node w/o contribution of the focal node.
                         complementary_msgs.append(self.merger_model.node_contribution(parent, time_points))
 
                         # Removed merger rate must be added back if no msgs from parent (equivalent to root node case)
@@ -741,6 +742,7 @@ class ClockTree(TreeAnc):
                 if node.marginal_pos_Lx is None:
                     node.marginal_pos_LH = node.msg_from_parent
                 else:
+                    #node.subtree_distribution contains merger model contribution of this node
                     node.marginal_pos_LH = NodeInterpolator.multiply((node.msg_from_parent, node.subtree_distribution))
 
                 self.logger('ClockTree._ml_t_root_to_leaves: computed convolution'

--- a/treetime/distribution.py
+++ b/treetime/distribution.py
@@ -100,15 +100,19 @@ class Distribution(object):
             new_xmax = np.min([k.xmax for k in dists])
 
             x_vals = np.unique(np.concatenate([k.x for k in dists]))
-            x_vals = x_vals[(x_vals> new_xmin-TINY_NUMBER)&(x_vals< new_xmax+TINY_NUMBER)]
+            x_vals = x_vals[(x_vals > new_xmin - TINY_NUMBER)&(x_vals < new_xmax + TINY_NUMBER)]
             n_dists = len(dists)
+            # for reduce number of points if there are many distributions
             if len(x_vals)>100*n_dists and n_dists>3:
+                # make sure there are at least 3 points per distribution on average
                 n_bins = len(x_vals)//n_dists - 6
                 lower_cut_off = n_dists*3
                 upper_cut_off = n_dists*(n_bins + 3)
+                # use peripheral points from the original array, average the center
                 x_vals = np.concatenate((x_vals[:lower_cut_off],
                                          x_vals[lower_cut_off:upper_cut_off].reshape((-1,n_dists)).mean(axis=1),
                                          x_vals[upper_cut_off:]))
+            # evaluate the function at the consolidated lists of x-values
             y_vals = np.sum([k.__call__(x_vals) for k in dists], axis=0)
             try:
                 peak = y_vals.min()
@@ -118,6 +122,7 @@ class Distribution(object):
                         "If you see this error please let us know by filling an issue at: \n"
                         "https://github.com/neherlab/treetime/issues")
 
+            # remove data points exp(-1000) less likely than the peak
             ind = (y_vals-peak)<BIG_NUMBER/1000
             n_points = ind.sum()
             if n_points == 0:

--- a/treetime/gtr.py
+++ b/treetime/gtr.py
@@ -455,7 +455,7 @@ class GTR(object):
 
 
     @classmethod
-    def random(cls, mu=1.0, alphabet='nuc'):
+    def random(cls, mu=1.0, alphabet='nuc', rng=None):
         """
         Creates a random GTR model
 
@@ -470,12 +470,14 @@ class GTR(object):
 
 
         """
+        if rng is None:
+            rng = np.random.default_rng()
 
         alphabet=alphabets[alphabet]
         gtr = cls(alphabet)
         n = gtr.alphabet.shape[0]
-        pi = 1.0*np.random.randint(0,100,size=(n))
-        W = 1.0*np.random.randint(0,100,size=(n,n)) # with gaps
+        pi = 1.0*rng.randint(0,100,size=(n))
+        W = 1.0*rng.randint(0,100,size=(n,n)) # with gaps
 
         gtr.assign_rates(mu=mu, pi=pi, W=W)
         return gtr

--- a/treetime/gtr_site_specific.py
+++ b/treetime/gtr_site_specific.py
@@ -105,7 +105,7 @@ class GTR_site_specific(GTR):
 
     @classmethod
     def random(cls, L=1, avg_mu=1.0, alphabet='nuc', pi_dirichlet_alpha=1,
-               W_dirichlet_alpha=3.0, mu_gamma_alpha=3.0):
+               W_dirichlet_alpha=3.0, mu_gamma_alpha=3.0, rng=None):
         """
         Creates a random GTR model
 
@@ -129,28 +129,29 @@ class GTR_site_specific(GTR):
         GTR_site_specific
             model with randomly sampled frequencies
         """
+        if rng is None:
+            rng = np.random.default_rng()
 
-        from scipy.stats import gamma
         alphabet=alphabets[alphabet]
         gtr = cls(alphabet=alphabet, seq_len=L)
         n = gtr.alphabet.shape[0]
 
         # Dirichlet distribution == l_1 normalized vector of samples of the Gamma distribution
         if pi_dirichlet_alpha:
-            pi = 1.0*gamma.rvs(pi_dirichlet_alpha, size=(n,L))
+            pi = 1.0*rng.gamma(pi_dirichlet_alpha, size=(n,L))
         else:
             pi = np.ones((n,L))
 
         pi /= pi.sum(axis=0)
         if W_dirichlet_alpha:
-            tmp = 1.0*gamma.rvs(W_dirichlet_alpha, size=(n,n))
+            tmp = 1.0*rng.gamma(W_dirichlet_alpha, size=(n,n))
         else:
             tmp = np.ones((n,n))
         tmp = np.tril(tmp,k=-1)
         W = tmp + tmp.T
 
         if mu_gamma_alpha:
-            mu = gamma.rvs(mu_gamma_alpha, size=(L,))
+            mu = rng.gamma(mu_gamma_alpha, size=(L,))
         else:
             mu = np.ones(L)
 

--- a/treetime/node_interpolator.py
+++ b/treetime/node_interpolator.py
@@ -163,7 +163,13 @@ class NodeInterpolator (Distribution):
     def convolve_fft(cls, node_interp, branch_interp, fft_grid_size=FFT_FWHM_GRID_SIZE, inverse_time=True):
 
         dt = max(branch_interp.one_mutation*0.005, min(node_interp.fwhm, branch_interp.fwhm)/fft_grid_size)
+        b_effsupport = branch_interp.effective_support
+        n_effsupport = node_interp.effective_support
+        b_support_range = b_effsupport[1]-b_effsupport[0]
+        n_support_range = n_effsupport[1]-n_effsupport[0]
+        #ratio = n_support_range/b_support_range
         ratio = node_interp.fwhm/branch_interp.fwhm
+
         if ratio < 1/fft_grid_size and 4*dt > node_interp.fwhm:
             ## node distribution is much narrower than the branch distribution, proceed as if node distribution is
             ## a delta distribution
@@ -178,10 +184,7 @@ class NodeInterpolator (Distribution):
         elif ratio > fft_grid_size and 4*dt > branch_interp.fwhm:
             raise ValueError("ERROR: Unexpected behavior: branch distribution is much narrower than the node distribution.")
         else:
-            b_effsupport = branch_interp.effective_support
-            n_effsupport = node_interp.effective_support
-
-            tmax = 2*max(b_effsupport[1]-b_effsupport[0], n_effsupport[1]-n_effsupport[0])
+            tmax = 2*max(b_support_range, n_support_range)
 
             Tb = np.arange(b_effsupport[0], b_effsupport[0] + tmax + dt, dt)
             if inverse_time:

--- a/treetime/seq_utils.py
+++ b/treetime/seq_utils.py
@@ -223,7 +223,7 @@ def seq2prof(seq, profile_map):
     return np.array([profile_map[k] for k in seq])
 
 
-def prof2seq(profile, gtr, sample_from_prof=False, normalize=True):
+def prof2seq(profile, gtr, sample_from_prof=False, normalize=True, rng=None):
     """
     Convert profile to sequence and normalize profile across sites.
 
@@ -247,7 +247,8 @@ def prof2seq(profile, gtr, sample_from_prof=False, normalize=True):
      idx : numpy.array
         Indices chosen from profile as array of length L
     """
-
+    if rng is None:
+        rng = np.random.default_rng()
     # normalize profile such that probabilities at each site sum to one
     if normalize:
         tmp_profile, pre=normalize_profile(profile, return_offset=False)
@@ -258,7 +259,7 @@ def prof2seq(profile, gtr, sample_from_prof=False, normalize=True):
     # (sampling from cumulative distribution over the different states)
     if sample_from_prof:
         cumdis = tmp_profile.cumsum(axis=1).T
-        randnum = np.random.random(size=cumdis.shape[1])
+        randnum = rng.random(size=cumdis.shape[1])
         idx = np.argmax(cumdis>=randnum, axis=0)
     else:
         idx = tmp_profile.argmax(axis=1)

--- a/treetime/seqgen.py
+++ b/treetime/seqgen.py
@@ -33,7 +33,7 @@ class SeqGen(TreeAnc):
         """
         cum_p = p.cumsum(axis=1).T
 
-        prand = np.random.random(self.seq_len)
+        prand = self.rng.random(self.seq_len)
         seq = self.gtr.alphabet[np.argmax(cum_p>prand, axis=0)]
         return seq
 

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -512,13 +512,6 @@ class TreeAnc(object):
 
         self.logger("TreeAnc.infer_ancestral_sequences with method: %s, %s"%(method, 'marginal' if marginal else 'joint'), 1)
 
-        if not reconstruct_tip_states:
-            self.logger("WARNING: Previous versions of TreeTime (<0.7.0) RECONSTRUCTED sequences"
-                        " of tips at positions with AMBIGUOUS bases. This resulted in"
-                        " unexpected behavior is some cases and is no longer done by default."
-                        " If you want to replace those ambiguous sites with their most likely state,"
-                        " rerun with `reconstruct_tip_states=True` or `--reconstruct-tip-states`.", 0, warn=True, only_once=True)
-
         if method.lower() in ['ml', 'probabilistic']:
             if marginal:
                 _ml_anc = self._ml_anc_marginal

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -54,7 +54,7 @@ class TreeAnc(object):
                 ref=None, verbose = ttconf.VERBOSE, ignore_gaps=True,
                 convert_upper=True, seq_multiplicity=None, log=None,
                 compress=True, seq_len=None, ignore_missing_alns=False,
-                keep_node_order=False, **kwargs):
+                keep_node_order=False, rng_seed=None, **kwargs):
         """
         TreeAnc constructor. It prepares the tree, attaches sequences to the leaf nodes,
         and sets some configuration parameters.
@@ -142,7 +142,7 @@ class TreeAnc(object):
         self.sequence_reconstruction = None
         self.ignore_missing_alns = ignore_missing_alns
         self.keep_node_order = keep_node_order
-
+        self.rng = np.random.default_rng(seed=rng_seed)
         self._tree = None
         self.tree = tree
         if tree is None:
@@ -579,7 +579,7 @@ class TreeAnc(object):
                                     "in the position %d: %s, "
                                     "choosing %s" % (amb, str(self.tree.root.state[amb]),
                                                      self.tree.root.state[amb][0]), 4)
-        self.tree.root._cseq = np.array([k[np.random.randint(len(k)) if len(k)>1 else 0]
+        self.tree.root._cseq = np.array([k[self.rng.randint(len(k)) if len(k)>1 else 0]
                                            for k in self.tree.root.state])
 
 
@@ -801,7 +801,8 @@ class TreeAnc(object):
         self.tree.sequence_marginal_LH = self.tree.total_sequence_LH
         if assign_sequence:
             seq, prof_vals, idxs = prof2seq(self.tree.root.marginal_profile,
-                                        self.gtr, sample_from_prof=sample_from_profile, normalize=False)
+                                        self.gtr, sample_from_prof=sample_from_profile,
+                                        normalize=False, rng=self.rng)
             self.tree.root._cseq = seq
 
 
@@ -870,7 +871,8 @@ class TreeAnc(object):
             # choose sequence based maximal marginal LH.
             if assign_sequence:
                 seq, prof_vals, idxs = prof2seq(node.marginal_profile, self.gtr,
-                                                sample_from_prof=sample_from_profile, normalize=False)
+                                                sample_from_prof=sample_from_profile,
+                                                normalize=False, rng=self.rng)
 
                 if self.sequence_reconstruction:
                     N_diff += (seq!=node.cseq).sum()
@@ -975,8 +977,9 @@ class TreeAnc(object):
         elif isinstance(sample_from_profile, bool):
             root_sample_from_profile = sample_from_profile
 
-        seq, anc_lh_vals, idxs = prof2seq(np.exp(normalized_profile),
-                                    self.gtr, sample_from_prof = root_sample_from_profile)
+        seq, anc_lh_vals, idxs = prof2seq(np.exp(normalized_profile), self.gtr,
+                                          sample_from_prof = root_sample_from_profile,
+                                          rng=self.rng)
 
         # compute the likelihood of the most probable root sequence
         self.tree.sequence_LH = np.choose(idxs, self.tree.root.joint_Lx.T)

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -290,6 +290,7 @@ class TreeTime(ClockTree):
                     if self.branch_length_mode!='input': # otherwise reoptimize branch length while preserving branches without mutations
                         self.optimize_tree(max_iter=0, method_anc = method_anc,**seq_kwargs)
                     need_new_time_tree = True
+
             if assign_gamma and callable(assign_gamma):
                 self.logger("### assigning gamma",1)
                 assign_gamma(self.tree)
@@ -571,7 +572,8 @@ class TreeTime(ClockTree):
         return new_root
 
 
-    def resolve_polytomies(self, merge_compressed=False, resolution_threshold=0.05, stochastic_resolve=False):
+    def resolve_polytomies(self, merge_compressed=False, resolution_threshold=0.05,
+                           stochastic_resolve=False):
         """
         Resolve the polytomies on the tree.
 
@@ -612,7 +614,8 @@ class TreeTime(ClockTree):
 
                 poly_found+=prior_n_clades - len(n.clades)
 
-        obsolete_nodes = [n for n in self.tree.find_clades() if len(n.clades)==1 and n.up is not None]
+        obsolete_nodes = [n for n in self.tree.find_clades()
+                          if len(n.clades)==1 and n.up is not None]
         for node in obsolete_nodes:
             self.logger('TreeTime.resolve_polytomies: remove obsolete node '+node.name,4)
             if node.up is not None:
@@ -773,7 +776,9 @@ class TreeTime(ClockTree):
 
 
     def generate_subtree(self, parent):
-        from numpy.random import exponential as exp_dis
+        # use the random number generator of TreeTime
+        exp_dis = self.rng.exponential
+
         L = self.data.full_length
         mutation_rate = self.gtr.mu*L
 
@@ -833,7 +838,7 @@ class TreeTime(ClockTree):
             # else mutate or coalesce
             else:
                 # determine whether to mutate or coalesce
-                p = np.random.random()
+                p = self.rng.random()
                 mut_or_coal = p<total_mut_rate*total_rate_inv
                 if mut_or_coal:
                     # transform p to be on a scale of 0 to total mutation
@@ -846,7 +851,7 @@ class TreeTime(ClockTree):
                     mutations_per_branch[b.name] -= 1
                 else:
                     # pick a pair to coalesce, make a new node.
-                    picks = np.random.choice(len(ready_to_coalesce), size=2, replace=False)
+                    picks = self.rng.choice(len(ready_to_coalesce), size=2, replace=False)
                     new_node = Phylo.BaseTree.Clade()
                     new_node.time_before_present = t
                     n1, n2 = ready_to_coalesce[picks[0]], ready_to_coalesce[picks[1]]

--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -603,6 +603,12 @@ class TreeTime(ClockTree):
         """
         self.logger("TreeTime.resolve_polytomies: resolving multiple mergers...",1)
         poly_found=0
+        if stochastic_resolve is False:
+            self.logger("DEPRECATION WARNING. TreeTime.resolve_polytomies: You are "
+                        "resolving polytomies using the old 'greedy' mode. This is not "
+                        "well suited for large polytomies. Stochastic resolution will "
+                        "become the default in future versions. To switch now, rerun "
+                        "with the flag `--stochastic-resolve`.", 0, warn=True, only_once=True)
 
         for n in self.tree.find_clades():
             if len(n.clades) > 2:

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -537,7 +537,7 @@ def ancestral_reconstruction(params):
     return 0
 
 def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling_bias_correction=None,
-                                weights=None, verbose=0, iterations=5):
+                                weights=None, verbose=0, iterations=5, rng_seed=None):
     """take a set of discrete states associated with tips of a tree
     and reconstruct their ancestral states along with a GTR model that
     approximately maximizes the likelihood of the states on the tree.
@@ -648,7 +648,7 @@ def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling
     ### set up treeanc
     ###########################################################################
     treeanc = TreeAnc(tree, gtr=mugration_GTR, verbose=verbose, ref='A',
-                      convert_upper=False, one_mutation=0.001, rng_seed=params.rng_seed)
+                      convert_upper=False, one_mutation=0.001, rng_seed=rng_seed)
     treeanc.use_mutation_length = False
     pseudo_seqs = {n.name: {0:reverse_alphabet[traits[n.name]] if n.name in traits else missing_char}
                    for n in treeanc.tree.get_terminals()}
@@ -722,8 +722,10 @@ def mugration(params):
     leaf_to_attr = {x[taxon_name]:str(x[attr]) for xi, x in states.iterrows()
                     if x[attr]!=params.missing_data and x[attr]}
 
-    mug, letter_to_state, reverse_alphabet = reconstruct_discrete_traits(params.tree, leaf_to_attr, missing_data=params.missing_data,
-            pc=params.pc, sampling_bias_correction=params.sampling_bias_correction, verbose=params.verbose, weights=params.weights)
+    mug, letter_to_state, reverse_alphabet = reconstruct_discrete_traits(params.tree, leaf_to_attr,
+                missing_data=params.missing_data, pc=params.pc,
+                sampling_bias_correction=params.sampling_bias_correction,
+                verbose=params.verbose, weights=params.weights, rng_seed=params.rng_seed)
 
     if mug is None:
         print("Mugration inference failed, check error messages above and your input data.")

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -675,11 +675,6 @@ def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling
                                  marginal=True, normalized_rate=False,
                                  reconstruct_tip_states=True)
 
-    print(fill("NOTE: previous versions (<0.7.0) of this command made a 'short-branch length assumption. "
-          "TreeTime now optimizes the overall rate numerically and thus allows for long branches "
-          "along which multiple changes accumulated. This is expected to affect estimates of the "
-          "overall rate while leaving the relative rates mostly unchanged."))
-
     return treeanc, letter_to_state, reverse_alphabet
 
 

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -554,7 +554,7 @@ def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling
     sampling_bias_correction : float, optional
         factor to inflate overall switching rate by to counteract sampling bias
     weights : str, optional
-        name of file with equilibirum frequencies
+        name of file with equilibrium frequencies
     verbose : int, optional
         level of verbosity in output
     iterations : int, optional

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -94,7 +94,7 @@ def scan_homoplasies(params):
     ### ANCESTRAL RECONSTRUCTION
     ###########################################################################
     treeanc = TreeAnc(params.tree, aln=aln, ref=ref, gtr=gtr, verbose=1,
-                      fill_overhangs=True)
+                      fill_overhangs=True, rng_seed=params.rng_seed)
     if treeanc.aln is None: # if alignment didn't load, exit
         return 1
 
@@ -325,10 +325,11 @@ def timetree(params):
     if params.aln is None and params.sequence_length is None:
         print("one of arguments '--aln' and '--sequence-length' is required.", file=sys.stderr)
         return 1
+    print(f"rng_seed: {params.rng_seed}")
     myTree = TreeTime(dates=dates, tree=params.tree, ref=ref,
                       aln=aln, gtr=gtr, seq_len=params.sequence_length,
                       verbose=params.verbose, fill_overhangs=not params.keep_overhangs,
-                      branch_length_mode = params.branch_length_mode)
+                      branch_length_mode = params.branch_length_mode, rng_seed=params.rng_seed)
 
     return run_timetree(myTree, params, outdir)
 
@@ -509,7 +510,7 @@ def ancestral_reconstruction(params):
     is_vcf = True if ref is not None else False
 
     treeanc = TreeAnc(params.tree, aln=aln, ref=ref, gtr=gtr, verbose=1,
-                      fill_overhangs=not params.keep_overhangs)
+                      fill_overhangs=not params.keep_overhangs, rng_seed=params.rng_seed)
 
     try:
         ndiff = treeanc.infer_ancestral_sequences('ml', infer_gtr=params.gtr=='infer',
@@ -647,7 +648,7 @@ def reconstruct_discrete_traits(tree, traits, missing_data='?', pc=1.0, sampling
     ### set up treeanc
     ###########################################################################
     treeanc = TreeAnc(tree, gtr=mugration_GTR, verbose=verbose, ref='A',
-                      convert_upper=False, one_mutation=0.001)
+                      convert_upper=False, one_mutation=0.001, rng_seed=params.rng_seed)
     treeanc.use_mutation_length = False
     pseudo_seqs = {n.name: {0:reverse_alphabet[traits[n.name]] if n.name in traits else missing_char}
                    for n in treeanc.tree.get_terminals()}
@@ -806,7 +807,7 @@ def estimate_clock_model(params):
     try:
         myTree = TreeTime(dates=dates, tree=params.tree, aln=aln, gtr='JC69',
                       verbose=params.verbose, seq_len=params.sequence_length,
-                      ref=ref)
+                      ref=ref, rng_seed=params.rng_seed)
     except TreeTimeError as e:
         print("\nTreeTime setup failed. Please see above for error messages and/or rerun with --verbose 4\n")
         raise e


### PR DESCRIPTION
The main part of this PR is a reorganization of how random number generator states are handled in TreeTime.
This was previously scattered around and used the default numpy or scipy states. Now, the class TreeAnc owns its own RNG instance that can be seeded explicitly in the constructor and the command line. 

Otherwise, this PR implements a few fixes and clean ups