### PR TITLE
The new stochastic_resolve function didn't properly check

### DIFF
--- a/treetime/treetime.py
+++ b/treetime/treetime.py
@@ -815,7 +815,7 @@ class TreeTime(ClockTree):
 
             # branches without mutations are ready to coalesce -- others have to mutate first
             ready_to_coalesce = [b for b in branches_alive if mutations_per_branch.get(b.name,0)==0]
-            if self.merger_model is None:
+            if hasattr(self, 'merger_model') and (self.merger_model is not None):
                 coalescent_rate = 0.5*len(ready_to_coalesce)*dummy_coalescent_rate + mutation_rate
             else:
                 coalescent_rate = self.merger_model.branch_merger_rate(t) + mutation_rate


### PR DESCRIPTION
for presence of the merger_model. Now it explicitly checks for the attribute to be present and not None.