### PR TITLE
Address Pytest warning

### DIFF
--- a/test/test_treetime.py
+++ b/test/test_treetime.py
@@ -209,8 +209,6 @@ def test_seq_joint_reconstruction_correct():
     print ("Difference between reference and inferred LH:", (LH - LH_p).sum())
     assert ((LH - LH_p).sum())<1e-9
 
-    return myTree
-
 
 def test_seq_joint_lh_is_max():
     """
@@ -280,4 +278,3 @@ def test_seq_joint_lh_is_max():
     print(abs(ref.max() - real) )
     # joint chooses the most likely realization of the tree
     assert(abs(ref.max() - real) < 1e-10)
-    return ref, real

--- a/test/test_treetime.py
+++ b/test/test_treetime.py
@@ -142,11 +142,6 @@ def test_seq_joint_reconstruction_correct():
     from Bio import Phylo, AlignIO
     import numpy as np
     from collections import defaultdict
-    def exclusion(a, b):
-        """
-        Intersection of two lists
-        """
-        return list(set(a) - set(b))
 
     tiny_tree = Phylo.read(StringIO("((A:.060,B:.01200)C:.020,D:.0050)E:.004;"), 'newick')
     mygtr = GTR.custom(alphabet = np.array(['A', 'C', 'G', 'T']),


### PR DESCRIPTION
Address Pytest warning:
```log

================================================================================================ warnings summary ================================================================================================
test/test_treetime.py::test_seq_joint_reconstruction_correct
  /opt/homebrew/Caskroom/miniforge/base/envs/treetime/lib/python3.11/site-packages/_pytest/python.py:198: PytestReturnNotNoneWarning: Expected None, but test/test_treetime.py::test_seq_joint_reconstruction_correct returned <treetime.treeanc.TreeAnc object at 0x168882dd0>, which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

test/test_treetime.py::test_seq_joint_lh_is_max
  /opt/homebrew/Caskroom/miniforge/base/envs/treetime/lib/python3.11/site-packages/_pytest/python.py:198: PytestReturnNotNoneWarning: Expected None, but test/test_treetime.py::test_seq_joint_lh_is_max returned (array([-12.27749988, -18.79208911, -11.89394655, -19.70837984,
         -19.94155598, -16.35420334, -15.94483502, -23.75926831,
         -24.9211463 , -27.8225679 , -13.52027303, -28.73885863,
         -24.9211463 , -27.8225679 , -20.92442534, -21.33470632]), array([-11.89394655])), which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================= 7 passed, 2 warnings in 3.46s ==========================================================================================

```
