### PR TITLE
Improve VCF parsing

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -19,5 +19,10 @@ if [ "$OUT" != 0 ]; then
   exit 1
 fi
 
+pytest test_vcf.py
+if [ "$OUT" != 0 ]; then
+  exit 1
+fi
+
 # Clean up, the 202* is to remove auto-generated output dirs
 rm -rf treetime_examples __pycache__ 202*

--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -43,3 +43,119 @@ class TestMalformedVcf:
                 ##fileformat=VCFv4.3
                 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample_A\tsample_B\tsample_C
             """))
+
+def zero_based(idx):
+    """Useful as a form of code commentary. Convert idx from 1-based to 0-based"""
+    return idx-1
+
+def write_data(tmp_path_factory, sample_names, data_lines, reference_seq, meta_lines=None, reference_name='reference_name'):
+    """helper function to create and write a VCF and FASTA file. Returns a tuple of filenames"""
+    if meta_lines:
+        vcf = "\n".join(meta_lines)
+    else:
+        vcf = dedent("""\
+            ##fileformat=VCFv4.3
+            ##contig=<ID=1,length=50>
+            ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+        """)
+    vcf += "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" + "\t".join(sample_names) + "\n"
+    for line in data_lines:
+        vcf += "\t".join(line) + "\n"
+    reference=dedent(f"""\
+        >{reference_name}
+        {reference_seq}
+    """)
+    dir = tmp_path_factory.mktemp("data")
+    vcf_fn = dir / "snps.vcf"
+    ref_fn = dir / "reference.fasta"
+    with open(vcf_fn, 'w') as fh:
+        print(vcf, file=fh)
+    with open(ref_fn, 'w') as fh:
+        print(reference, file=fh)
+    return (str(vcf_fn), str(ref_fn))
+
+
+class TestSimpleVcf:
+    @pytest.fixture(scope="class")
+    def data(self, tmp_path_factory):
+        """
+        Creates the VCF and reference files (in a temporary location) to be used by
+        the tests in this class.
+        Returns their filenames, as well as information about their contents which
+        we can use as comparisons in tests.
+        NOTE: this function is only run once - _not_ once per test.
+        """
+        sample_names = ["sample_A", "sample_B", "sample_C"]
+        data_lines = [
+            ["1", "5",  ".", "T", "C",   ".", ".", ".", "GT", "1", "1", "1"],
+            ["1", "7",  ".", "T", "G",   ".", ".", ".", "GT", "1", "1", "0"],
+            ["1", "14", ".", "C", "T",   ".", ".", ".", "GT", "1", "1", "0"],
+            ["1", "18", ".", "C", "T",   ".", ".", ".", "GT", "0", "0", "1"],
+            ["1", "28", ".", "A", "N",   ".", ".", ".", "GT", "0", "0", "1"],
+            ["1", "29", ".", "A", "N",   ".", ".", ".", "GT", "0", "0", "1"],
+            ["1", "30", ".", "A", "N",   ".", ".", ".", "GT", "0", "0", "1"],
+            ["1", "33", ".", "A", "C,G", ".", ".", ".", "GT", "1", "2", "0"],
+            ["1", "39", ".", "C", "T",   ".", ".", ".", "GT", "1", "0", "0"],
+            ["1", "42", ".", "G", "A",   ".", ".", ".", "GT", "0", "1", "0"],
+            ["1", "43", ".", "A", "T",   ".", ".", ".", "GT", "1", "1", "0"],
+        ]
+        positions = [int(line[1]) for line in data_lines]
+        reference_seq = 'AAAAAAAAAATGCCCTGCGGGTAAAAAAAAAAAAACTACTTGACCATAAA'
+        filenames = write_data(tmp_path_factory, sample_names, data_lines, reference_seq)
+        return {
+            "filenames": filenames,
+            "positions": positions,
+            "data_lines": data_lines,
+            "sample_names": sample_names,
+            "reference_seq": reference_seq,
+        }
+
+    def test_mutation_structure(self, data):
+        vcf_data = read_vcf(*data['filenames'])
+        # The structure of insertions & sequences is a dict a key for each sample, irregardless of whether
+        # any insertions/mutations are defined for that sample.
+        # samples = {'sample_A', 'sample_B', 'sample_C'}
+        assert(set(data['sample_names'])==set(vcf_data['sequences'].keys()))
+        assert(set(data['sample_names'])==set(vcf_data['insertions'].keys()))
+
+    def test_mutation_parsing(self, data):
+        """
+        Test that the correct SNPs (ALTs) are extracted from the VCF for the three samples defined in the VCF
+        """
+        vcf_data = read_vcf(*data['filenames'])
+        def summarise(sample):
+            # uses 1-based position so we can easily compare with the VCF file
+            return ",".join([f"{pos+1}{alt}" for pos,alt in vcf_data['sequences'][sample].items()])
+
+        assert("5C,7G,14T,33C,39T,43T"==summarise('sample_A'))
+        assert("5C,7G,14T,33G,42A,43T"==summarise('sample_B'))
+        assert("5C,18T,28N,29N,30N"==summarise('sample_C'))
+
+    def test_no_insertions_parsed(self, data):
+        vcf_data = read_vcf(*data['filenames'])
+        for sample, ins in vcf_data['insertions'].items():
+            assert(ins=={})
+
+    def test_reference_sequence(self, data):
+        vcf_data = read_vcf(*data['filenames'])
+        assert(data['reference_seq']==vcf_data['reference'])
+
+    def test_positions_with_mutations(self, data):
+        vcf_data = read_vcf(*data['filenames'])
+        assert(data['positions'] == [pos+1 for pos in vcf_data['positions']]) 
+
+
+class TestNoCallAllele:
+    @pytest.fixture(scope="class")
+    def data(self, tmp_path_factory):
+        sample_names = ["sample_A", "sample_B"]
+        data_lines = [
+            ["1", "2",  ".", "T", "A",   ".", ".", ".", "GT", ".", "1"], # No-call allele -> make a SNP of T2N in sample_A
+            ["1", "4",  ".", "C", "G",   ".", ".", ".", "GT", "1", "1"],
+        ]
+        filenames = write_data(tmp_path_factory, sample_names, data_lines, "ATGC")
+        return {"filenames": filenames}
+
+    def test_no_call_allele(self, data):
+        vcf_data = read_vcf(*data['filenames'])
+        assert(vcf_data['sequences']['sample_A'][zero_based(2)]=='N')

--- a/test/test_vcf.py
+++ b/test/test_vcf.py
@@ -1,0 +1,45 @@
+import pytest
+from textwrap import dedent
+from treetime.vcf_utils import read_vcf
+from treetime import TreeTimeError
+
+def create_vcf(dir, content):
+    d = dir / 'data'
+    d.mkdir()
+    fname = d / "no-header.vcf"
+    with open(fname, 'w') as fh:
+        print(dedent(content), file=fh)
+    return str(fname)
+
+class TestMalformedVcf:
+
+    def test_no_header(self, tmp_path):
+        with pytest.raises(TreeTimeError):
+            read_vcf(create_vcf(tmp_path, """\
+                ##fileformat=VCFv4.3
+                1\t5\t.\tT\tC\t.\t.\t.\tGT\t1\t1\t1
+            """))
+
+    def test_meta_info_after_header(self, tmp_path):
+        with pytest.raises(TreeTimeError):
+            read_vcf(create_vcf(tmp_path, """\
+                #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample_A\tsample_B\tsample_C
+                ##fileformat=VCFv4.3
+                1\t5\t.\tT\tC\t.\t.\t.\tGT\t1\t1\t1
+            """))
+    
+    def test_inconsistent_sample_numbers(self, tmp_path):
+        with pytest.raises(TreeTimeError):
+            read_vcf(create_vcf(tmp_path, """\
+                ##fileformat=VCFv4.3
+                #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample_A\tsample_B\tsample_C
+                1\t5\t.\tT\tC\t.\t.\t.\tGT\t1\t1\t1
+                1\t6\t.\tT\tC\t.\t.\t.\tGT\t1\t1
+            """))
+
+    def test_no_data_lines(self, tmp_path):
+        with pytest.raises(TreeTimeError):
+            read_vcf(create_vcf(tmp_path, """\
+                ##fileformat=VCFv4.3
+                #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample_A\tsample_B\tsample_C
+            """))

--- a/treetime/treeanc.py
+++ b/treetime/treeanc.py
@@ -1670,7 +1670,7 @@ class TreeAnc(object):
 
 
     def get_tree_dict(self, keep_var_ambigs=False):
-        return self.get_reconstructed_alignment()
+        return self.get_reconstructed_alignment(reconstruct_tip_states=not keep_var_ambigs)
 
 
     def recover_var_ambigs(self):

--- a/treetime/vcf_utils.py
+++ b/treetime/vcf_utils.py
@@ -76,7 +76,7 @@ def read_vcf(vcf_file, ref_file=None):
     #     Ex:
     #       REF     ALT
     #       A       ATT
-    #     First base always matches Ref.
+    #     First base _does not_ always match REF, so there may be a SNP as well
     # 'No indel'
     #     Ex:
     #       REF     ALT
@@ -137,9 +137,12 @@ def read_vcf(vcf_file, ref_file=None):
                 else:
                     if ref[i] != alt[i]:
                         snps[pos+i] = alt[i]
-        #Insertion
+        #Insertion + single-base ref
         elif len(alt) > 1:
             ins[pos] = alt
+            # If the first base of the allele doesn't match the ref then we _also_ have a mutation
+            if ref[0]!=alt[0]:
+                snps[pos] = alt[0]
         #No indel
         else:
             snps[pos] = alt

--- a/treetime/vcf_utils.py
+++ b/treetime/vcf_utils.py
@@ -482,7 +482,8 @@ def write_vcf(tree_dict, file_name, mask=None):#, compress=False):
 
     out_file.write( "##fileformat=VCFv4.2\n"+
                         "##source=NextStrain\n"+
-                        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n")
+                        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"+
+                        f"##contig=<ID={chrom_name}>\n")
     out_file.write("\t".join(header)+"\n")
 
     vcfWrite = []

--- a/treetime/vcf_utils.py
+++ b/treetime/vcf_utils.py
@@ -572,19 +572,19 @@ def write_vcf(tree_dict, file_name, mask=None):#, compress=False):
 
         #What if there's no variation at a variable site??
         #This can happen when sites are modified by TreeTime - see below.
-        printPos = True
-        if len(uniques)==0:
+        #We don't print to VCF (because no variation!)
+        any_variation = len(uniques)!=0
+        if not any_variation:
             #If we expect it (it was made constant by TreeTime), it's fine.
             if 'inferred_const_sites' in tree_dict and pi in tree_dict['inferred_const_sites']:
                 explainedErrors += 1
-                printPos = False #and don't output position to the VCF
             else:
                 #If we don't expect, raise an error
                 errorPositions.append(str(pi))
 
         #Write it out - Increment positions by 1 so it's in VCF numbering
         #If no longer variable, and explained, don't write it out
-        if printPos:
+        if any_variation:
             output = [chrom_name, str(pos), ".", refb, ",".join(uniques), ".", "PASS", ".", "GT"] + calls
             vcfWrite.append("\t".join(output))
 

--- a/treetime/vcf_utils.py
+++ b/treetime/vcf_utils.py
@@ -108,9 +108,11 @@ def read_vcf(vcf_file, ref_file=None):
     def parse_homozygous_call(snps, ins, pos, ref, alt):
         #Insertion where there are also deletions (special handling)
         if len(ref) > 1 and len(alt)>len(ref):
-            ## TODO XXX - the loop below contains a double-counting bug. Imagine the following
-            ## data: REF='TCG' ALT='TCAG' (Example 5.1.3 in the VCF 4.2 spec)
-            ## then when i=2, we'll add both snps[pos+2] = 'A' as well as ins[pos+2] = 'AG'
+            ## NOTE: the loop below contains a potential double-counting bug. For example,
+            ## REF='TCG' ALT='TCAG' (Example 5.1.3 in the VCF 4.2 spec), then when i=2
+            ## we'll add both snps[pos+2] = 'A' as well as ins[pos+2] = 'AG'. This has been 
+            ## detailed within `test_vcf.py`, as it may also be the expected way to encode
+            ## insertions within TreeTime
             for i in range(len(ref)):
                 #if the pos doesn't match, store in sequences
                 if ref[i] != alt[i]:


### PR DESCRIPTION
This isn't complete yet, but if people wanted to take a look and see if they are happy with the direction this is going in that'd be great!

I still want to take a close look at how insertions are being encoded in the "sequences" output, and is treetime/augur is ok with that (i.e. `data['sequences'][<sample>][<pos>]` is more than one character). And ideally I'd sort out the writing of VCFs as well to both preserve the ploidy representation of alleles and also use the correct chromosome name!