### PR TITLE
fix: reconstruction of ambiguous nucs in ancestral parsimony mode

### DIFF
--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -509,8 +509,7 @@ pub fn ancestral_reconstruction_fitch(
         }
 
         for (&pos, &states) in &node.fitch.variable {
-          seq[pos] = states.first().unwrap();
-          // seq[pos] = alphabet.ambiguate(states).first().unwrap();
+          seq[pos] = alphabet.set_to_char(states);
         }
 
         node.sequence = seq.clone();

--- a/packages/treetime/src/representation/graph_sparse.rs
+++ b/packages/treetime/src/representation/graph_sparse.rs
@@ -94,7 +94,7 @@ impl SparseSeqNode {
       .iter()
       .enumerate()
       .filter(|(_, &c)| alphabet.is_ambiguous(c))
-      .map(|(pos, &c)| (pos, alphabet.disambiguate(c)))
+      .map(|(pos, &c)| (pos, alphabet.char_to_set(c)))
       .collect();
 
     let seq_dis = ParsimonySeqDis {


### PR DESCRIPTION
Followup of: https://github.com/neherlab/treetime/pull/292

The transition from character sets to bit sets introduced some confusion in handling of ambiguous characters. Ambiguous characters correspond to multiple canonical characters, so they needed explicit disambiguation and disambiguation when using sets. With profile maps (arrays of floats) and with bitsets (~arrays of bits) this happens transparently: multiple "enabled" bits denote canonical components of an ambiguous character.

Here I introduce precalculated `char_to_set` and `set_to_char` maps, which allow to resolve particular combinations of bits from and to characters. This is similar to how profile maps operate, but with bits (0s and 1s) rather than floating point values.

This allows the remaining test for parsimony reconstruction to pass.