### PR TITLE
perf: speedup parsimony sequence reconstruction and fasta writer

### DIFF
--- a/packages/treetime/src/commands/ancestral/run_ancestral.rs
+++ b/packages/treetime/src/commands/ancestral/run_ancestral.rs
@@ -17,7 +17,6 @@ use crate::representation::infer_dense::infer_dense;
 use crate::representation::partitions_likelihood::{PartitionLikelihood, PartitionLikelihoodWithAln};
 use crate::representation::partitions_parsimony::PartitionParsimonyWithAln;
 use crate::utils::random::get_random_number_generator;
-use crate::utils::string::vec_to_string;
 use eyre::Report;
 use itertools::Itertools;
 use serde::Serialize;
@@ -89,8 +88,7 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
       ancestral_reconstruction_fitch(&graph, *reconstruct_tip_states, &partitions, |node, seq| {
         let name = node.name.as_deref().unwrap_or("");
         let desc = &node.desc;
-        // TODO: avoid converting vec to string, write vec chars directly
-        output_fasta.write(name, desc, vec_to_string(seq)).unwrap();
+        output_fasta.write(name, desc, seq).unwrap();
       })?;
 
       write_graph(outdir, &graph)?;
@@ -112,8 +110,7 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
         ancestral_reconstruction_marginal_sparse(&graph, *reconstruct_tip_states, &partitions, |node, seq| {
           let name = node.name.as_deref().unwrap_or("");
           let desc = &node.desc;
-          // TODO: avoid converting vec to string, write vec chars directly
-          output_fasta.write(name, desc, vec_to_string(seq)).unwrap();
+          output_fasta.write(name, desc, &seq).unwrap();
         })?;
 
         write_graph(outdir, &graph)?;
@@ -127,8 +124,7 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
         ancestral_reconstruction_marginal_dense(&graph, *reconstruct_tip_states, |node, seq| {
           let name = node.name.as_deref().unwrap_or("");
           let desc = &node.desc;
-          // TODO: avoid converting vec to string, write vec chars directly
-          output_fasta.write(name, desc, vec_to_string(seq)).unwrap();
+          output_fasta.write(name, desc, &seq).unwrap();
         })?;
 
         write_graph(outdir, &graph)?;

--- a/packages/treetime/src/graph/graph.rs
+++ b/packages/treetime/src/graph/graph.rs
@@ -87,8 +87,10 @@ where
     }
   }
 
-  pub fn get_exactly_one_parent(&self) -> Result<&NodeEdgePayloadPair<N, E>, Report> {
-    get_exactly_one(&self.parents).wrap_err("Nodes with multiple parents are not yet supported")
+  pub fn get_exactly_one_parent(&self) -> Result<NodeEdgePayloadPair<N, E>, Report> {
+    get_exactly_one(&self.parents)
+      .cloned()
+      .wrap_err("Nodes with multiple parents are not yet supported")
   }
 }
 


### PR DESCRIPTION
This removes unnecessary heap allocations and copies in the reconstruction step (reconstruction from copressed representation - `ancestral_reconstruction_fitch()`) and in the fasta writer code.

Speedup: ~16% on mpox-500 dataset.

Command:
```
$ cargo -q build --release --target-dir=/workdir/.build/docker --bin=treetime
$ hyperfine --warmup 1 --show-output '/workdir/.build/docker/release/treetime ancestral --method-anc=parsimony --dense=false --tree=data/mpox/clade-ii/500/tree.nwk --outdir=tmp/smoke-tests/ancestral/marginal/mpox/clade-ii/500 data/mpox/clade-ii/500/aln.fasta.xz'
```

Before (branch: rust, commit f676392):
```
  Time (mean ± σ):      1.866 s ±  0.113 s    [User: 4.547 s, System: 0.576 s]
  Range (min … max):    1.768 s …  2.041 s    10 runs
```

After:
```
  Time (mean ± σ):      1.582 s ±  0.014 s    [User: 4.358 s, System: 0.505 s]
  Range (min … max):    1.558 s …  1.599 s    10 runs
```

According to profiler, on the same data, `ancestral_reconstruction_fitch()` is now 6% of the running time, down from 16%.