### PR TITLE
Perf/loop over kids first

### DIFF
--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -1,7 +1,4 @@
 #![allow(dead_code)]
-
-use std::collections::BTreeMap;
-
 use crate::alphabet::alphabet::{FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
 use crate::graph::breadth_first::GraphTraversalContinuation;
 use crate::io::fasta::FastaRecord;
@@ -9,7 +6,7 @@ use crate::representation::graph_sparse::{
   Deletion, ParsimonySeqDis, SparseGraph, SparseNode, SparseSeqDis, SparseSeqEdge, SparseSeqInfo, SparseSeqNode,
 };
 use crate::representation::partitions_parsimony::{PartitionParsimony, PartitionParsimonyWithAln};
-use crate::representation::state_set::{BitSet128, StateSet, StateSetStatus};
+use crate::representation::state_set::{StateSet, StateSetStatus};
 use crate::seq::composition::Composition;
 use crate::seq::indel::InDel;
 use crate::seq::mutation::Sub;
@@ -167,60 +164,33 @@ fn fitch_backwards(graph: &SparseGraph, sparse_partitions: &[PartitionParsimony]
         }
       }
 
+      // // Process all positions where the children are fixed or completely unknown in some children.
+      // loop over all children
       for &(child, _) in &children {
         for (pos, parent_state) in sequence.iter_mut().enumerate() {
           let cstate = child.sequence[pos];
-          if *parent_state==cstate || *parent_state==NON_CHAR {
-            continue;
+          if *parent_state == cstate || *parent_state == NON_CHAR {
+            continue; // if parent is equal to child state or we know its a non-char, skip
           }
           if alphabet.is_canonical(cstate) {
-            if *parent_state==FILL_CHAR {
-              *parent_state=cstate;
-            } else{
+            if *parent_state == FILL_CHAR { // if cstate is canonical and parent is still FILL_STATE, set parent_state
+              *parent_state = cstate;
+            } else { // otherwise set or update the variable state
               if seq_dis.variable.contains_key(&pos) {
-                seq_dis.variable.insert(pos, StateSet::from_union(&[seq_dis.variable[&pos], StateSet::from_char(cstate)]));
+                seq_dis.variable.insert(
+                  pos,
+                  StateSet::from_union(&[seq_dis.variable[&pos], StateSet::from_char(cstate)]),
+                );
               } else {
-                seq_dis.variable.insert(pos,  StateSet::from_slice(&[*parent_state, cstate]));
+                seq_dis
+                  .variable
+                  .insert(pos, StateSet::from_slice(&[*parent_state, cstate]));
               }
               *parent_state = VARIABLE_CHAR;
             }
           }
         }
       }
-
-      // // Process all positions where the children are fixed or completely unknown in some children.
-      // for (pos, parent_state) in sequence.iter_mut().enumerate() {
-      //   if *parent_state != FILL_CHAR {
-      //     continue;
-      //   }
-
-      //   let mut determined_states = Vec::with_capacity(alphabet.n_chars());
-      //   for &(child, _) in &children {
-      //     let state = child.sequence[pos];
-      //     if !determined_states.contains(&state) && alphabet.is_canonical(state) {
-      //       determined_states.push(state);
-      //     }
-      //   }
-
-      //   // Find the state of the current node at this position
-      //   *parent_state = match determined_states.as_slice() {
-      //     [state] => {
-      //       // All children have the same state, that will be the state of the current node
-      //       *state
-      //     }
-      //     [] => {
-      //       // No child states. Impossible
-      //       unreachable!("No child states. This is impossible");
-      //     }
-      //     states => {
-      //       // Child states differ. This is variable state.
-      //       // Save child states and postpone the decision until forward pass.
-      //       let dis = states.iter().collect();
-      //       seq_dis.variable.insert(pos, dis);
-      //       VARIABLE_CHAR
-      //     }
-      //   };
-      // }
 
       // Process insertions and deletions.
 

--- a/packages/treetime/src/commands/clock/minimize_scalar.rs
+++ b/packages/treetime/src/commands/clock/minimize_scalar.rs
@@ -1,0 +1,57 @@
+use argmin::core::observers::{ObserverMode, SlogLogger};
+use argmin::core::{CostFunction, Error, Executor, State};
+use argmin::solver::brent::BrentOpt;
+use eyre::{eyre, Report};
+use log::log_enabled;
+use log::Level::Trace;
+
+struct CostFunctionWrapper<F>
+where
+  F: Fn(f64) -> f64,
+{
+  problem: F,
+}
+
+impl<F> CostFunctionWrapper<F>
+where
+  F: Fn(f64) -> f64,
+{
+  pub const fn new(problem: F) -> Self {
+    Self { problem }
+  }
+}
+
+impl<F> CostFunction for CostFunctionWrapper<F>
+where
+  F: Fn(f64) -> f64,
+{
+  type Param = f64;
+  type Output = f64;
+
+  fn cost(&self, x: &Self::Param) -> Result<Self::Output, Error> {
+    let problem = &self.problem;
+    Ok(problem(*x))
+  }
+}
+
+pub fn minimize_scalar_brent_bounded(problem: impl Fn(f64) -> f64, bounds: (f64, f64)) -> Result<(f64, f64), Report> {
+  let problem = CostFunctionWrapper::new(problem);
+  let solver = BrentOpt::new(bounds.0, bounds.1);
+
+  let mut executor = Executor::new(problem, solver).configure(|state| state.max_iters(1000));
+
+  if log_enabled!(Trace) {
+    executor = executor.add_observer(SlogLogger::term_noblock(), ObserverMode::NewBest);
+  }
+
+  let result = executor.run().map_err(|err| eyre!("{err}"))?;
+
+  let param = *result
+    .state()
+    .get_best_param()
+    .ok_or_else(|| eyre!("Unable to get the best param"))?;
+
+  let cost = result.state().get_best_cost();
+
+  Ok((param, cost))
+}

--- a/packages/treetime/src/representation/mod.rs
+++ b/packages/treetime/src/representation/mod.rs
@@ -1,7 +1,7 @@
+pub mod bitset128;
 pub mod graph_dense;
 pub mod graph_sparse;
 pub mod infer_dense;
 pub mod partitions_likelihood;
 pub mod partitions_parsimony;
 pub mod state_set;
-pub mod bitset128;

--- a/packages/treetime/src/utils/mod.rs
+++ b/packages/treetime/src/utils/mod.rs
@@ -1,5 +1,4 @@
 pub mod assert;
-pub mod openblas;
 pub mod container;
 pub mod datetime;
 pub mod error;
@@ -8,6 +7,7 @@ pub mod global_init;
 pub mod interval;
 pub mod manyzip;
 pub mod ndarray;
+pub mod openblas;
 pub mod random;
 pub mod string;
 pub mod vec;


### PR DESCRIPTION
small experiment: this is a bit faster for me
```
richard@X1-2024:~/Projects_GitHub/TreeTime/treetime_rs$ hyperfine --warmup 1 --show-output 'target/release/treetime ancestral --method-anc=parsimony --dense=false --tree=data/mpox/clade-ii/500/tree.nwk --outdir=
tmp/smoke-tests/ancestral/marginal/mpox/clade-ii/500 data/mpox/clade-ii/500/aln.fasta.xz'                
Benchmark 1: target/release/treetime ancestral --method-anc=parsimony --dense=false --tree=data/mpox/clade-ii/500/tree.nwk --outdir=tmp/smoke-tests/ancestral/marginal/mpox/clade-ii/500 data/mpox/clade-ii/500/aln
.fasta.xz                                                                                                                                                                                                          
  Time (mean ± σ):      1.016 s ±  0.025 s    [User: 2.100 s, System: 2.086 s]                                                                                                                                     
  Range (min … max):    0.980 s …  1.064 s    10 runs                                                                                                                                                              
```

vs

```
richard@X1-2024:~/Projects_GitHub/TreeTime/treetime_rs$ hyperfine --warmup 1 --show-output 'target/release/treetime ancestral --method-anc=parsimony --dense=false --tree=data/mpox/clade-ii/500/tree.nwk --outdir=
tmp/smoke-tests/ancestral/marginal/mpox/clade-ii/500 data/mpox/clade-ii/500/aln.fasta.xz'                
Benchmark 1: target/release/treetime ancestral --method-anc=parsimony --dense=false --tree=data/mpox/clade-ii/500/tree.nwk --outdir=tmp/smoke-tests/ancestral/marginal/mpox/clade-ii/500 data/mpox/clade-ii/500/aln
.fasta.xz                                                                                                
  Time (mean ± σ):      1.157 s ±  0.027 s    [User: 3.124 s, System: 2.120 s]                           
  Range (min … max):    1.124 s …  1.198 s    10 runs                                                    
```

not really worth the trouble unless you feel it is cleaner...
