### PR TITLE
refactor: simplify upsert operation

### DIFF
--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -178,13 +178,7 @@ fn fitch_backwards(graph: &SparseGraph, sparse_partitions: &[PartitionParsimony]
               *parent_state = child_state;
             } else {
               // otherwise set or update the variable state
-              if seq_dis.variable.contains_key(&pos) {
-                let new_state = seq_dis.variable[&pos] + child_state;
-                seq_dis.variable.insert(pos, new_state);
-              } else {
-                let new_state = stateset! {*parent_state, child_state};
-                seq_dis.variable.insert(pos, new_state);
-              }
+              *seq_dis.variable.entry(pos).or_insert(stateset! {*parent_state}) += child_state;
               *parent_state = VARIABLE_CHAR;
             }
           }


### PR DESCRIPTION
This uses the rust-y `.entry().or_insert*()` [pattern](https://www.knowbe4.com/careers/blogs/engineering/on-rusts-map-entry-pattern) as an alternative to `.contains()` + `.insert()`,  to express the "upsert" (insert or update) operation of a `BTreeMap` more concisely.

I believe it preserves the original behavior.