### PR TITLE
refactor: introduce `AsciiChar` wrapper over `u8`

### DIFF
--- a/packages/treetime/benches/find_letter_ranges_benchmark.rs
+++ b/packages/treetime/benches/find_letter_ranges_benchmark.rs
@@ -1,5 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use treetime::representation::seq::Seq;
+use treetime::representation::seq_char::AsciiChar;
 use treetime::seq::find_char_ranges::find_letter_ranges_by;
 
 const SEQ: &str = "\
@@ -27,8 +28,8 @@ const SEQ: &str = "\
   ACACTGTCTTCATGTTGTCGGCCCAAATGTTAACAAAGGTGAAGACATTCAACTTCTTAA\
 ";
 
-fn pred(c: u8) -> bool {
-  c == b'N' || c == b'-'
+fn pred(c: AsciiChar) -> bool {
+  c == AsciiChar(b'N') || c == AsciiChar(b'-')
 }
 
 pub fn bench_1(c: &mut Criterion) {

--- a/packages/treetime/src/commands/ancestral/marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/marginal_sparse.rs
@@ -6,6 +6,7 @@ use crate::make_internal_error;
 use crate::representation::graph_sparse::{SparseGraph, SparseNode, SparseSeqDis, VarPos};
 use crate::representation::partitions_likelihood::PartitionLikelihood;
 use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 use crate::seq::composition;
 use crate::utils::container::get_exactly_one_mut;
 use crate::utils::interval::range::range_contains;
@@ -54,7 +55,7 @@ fn ingroup_profiles_sparse(graph: &SparseGraph, partitions: &[PartitionLikelihoo
         // for internal nodes, combine the messages from the children
         // to do so, we need to loop over incoming edges, collect variable positions and the child states at them
         let mut variable_pos = btreemap! {};
-        let mut child_states: Vec<BTreeMap<usize, u8>> = vec![];
+        let mut child_states = vec![];
         let mut child_messages: Vec<SparseSeqDis> = vec![];
         for (ci, (_, edge)) in node.children.iter().enumerate() {
           // go over all mutations and get reference and child state
@@ -161,8 +162,8 @@ fn propagate_raw(
 fn combine_messages(
   composition: &composition::Composition,
   messages: &[SparseSeqDis],
-  variable_pos: &BTreeMap<usize, u8>,
-  reference_states: &[BTreeMap<usize, u8>],
+  variable_pos: &BTreeMap<usize, AsciiChar>,
+  reference_states: &[BTreeMap<usize, AsciiChar>],
   alphabet: &Alphabet,
   gtr_weight: Option<&Array1<f64>>,
 ) -> Result<SparseSeqDis, Report> {
@@ -267,12 +268,12 @@ fn outgroup_profiles_sparse(graph: &SparseGraph, partitions: &[PartitionLikeliho
       if !node.is_root {
         // the root has no input from parents, profile is already calculated
         let mut variable_pos = btreemap! {};
-        let mut ref_states: Vec<BTreeMap<usize, u8>> = vec![];
+        let mut ref_states: Vec<BTreeMap<usize, AsciiChar>> = vec![];
         let mut msgs_to_combine: Vec<SparseSeqDis> = vec![];
         for (_, edge) in &node.parents {
           // go over all mutations and get reference state
-          let mut parent_state: BTreeMap<usize, u8> = btreemap! {};
-          let mut child_state: BTreeMap<usize, u8> = btreemap! {};
+          let mut parent_state: BTreeMap<usize, AsciiChar> = btreemap! {};
+          let mut child_state: BTreeMap<usize, AsciiChar> = btreemap! {};
           // go over parent variable position and get reference state
           for (pos, p) in &edge.read_arc().sparse_partitions[si].msg_to_child.variable {
             if !range_contains(&seq_info.seq.gaps, *pos) {
@@ -330,8 +331,8 @@ fn outgroup_profiles_sparse(graph: &SparseGraph, partitions: &[PartitionLikeliho
         };
 
         let child_dis = &child_edge.sparse_partitions[si].msg_from_child;
-        let mut parent_states: BTreeMap<usize, u8> = btreemap! {};
-        let mut child_states: BTreeMap<usize, u8> = btreemap! {};
+        let mut parent_states: BTreeMap<usize, AsciiChar> = btreemap! {};
+        let mut child_states: BTreeMap<usize, AsciiChar> = btreemap! {};
         for (pos, p) in &seq_info.profile.variable {
           child_states.insert(*pos, p.state);
           parent_states.insert(*pos, p.state);

--- a/packages/treetime/src/io/fasta.rs
+++ b/packages/treetime/src/io/fasta.rs
@@ -4,6 +4,7 @@ use crate::io::concat::Concat;
 use crate::io::file::{create_file_or_stdout, open_file_or_stdin, open_stdin};
 use crate::make_error;
 use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 use crate::utils::string::quote_single;
 use eyre::{Context, Report};
 use itertools::Itertools;
@@ -158,13 +159,13 @@ impl<'a, 'b> FastaReader<'a, 'b> {
 
       record.seq.reserve(trimmed.len());
       for c in trimmed.chars() {
-        let uc = c.to_ascii_uppercase() as u8;
+        let uc = AsciiChar::from(c.to_ascii_uppercase());
         if self.alphabet.contains(uc) {
           record.seq.push(uc);
         } else {
           return make_error!(
             "FASTA input is incorrect: character \"{c}\" is not in the alphabet. Expected characters: {}",
-            self.alphabet.chars().map(|c| c as char).map(quote_single).join(", ")
+            self.alphabet.chars().map(char::from).map(quote_single).join(", ")
           )
           .wrap_err_with(|| format!("When processing sequence #{}: \"{}\"", self.index, record.header()));
         }
@@ -248,7 +249,7 @@ impl FastaWriter {
     }
 
     self.writer.write_all(b"\n")?;
-    self.writer.write_all(seq)?;
+    self.writer.write_all(seq.as_ref())?;
     self.writer.write_all(b"\n")?;
     Ok(())
   }

--- a/packages/treetime/src/representation/graph_sparse.rs
+++ b/packages/treetime/src/representation/graph_sparse.rs
@@ -6,6 +6,7 @@ use crate::io::graphviz::{EdgeToGraphViz, NodeToGraphviz};
 use crate::io::nwk::{format_weight, EdgeFromNwk, EdgeToNwk, NodeFromNwk, NodeToNwk, NwkWriteOptions};
 use crate::o;
 use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 use crate::representation::state_set::StateSet;
 use crate::seq::composition::Composition;
 use crate::seq::find_char_ranges::find_letter_ranges;
@@ -184,11 +185,11 @@ pub struct SparseSeqEdge {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VarPos {
   pub dis: Array1<f64>, // array of floats of size 'alphabet'
-  pub state: u8,
+  pub state: AsciiChar,
 }
 
 impl VarPos {
-  pub fn new(dis: Array1<f64>, state: u8) -> Self {
+  pub fn new(dis: Array1<f64>, state: AsciiChar) -> Self {
     Self { dis, state }
   }
 }
@@ -207,7 +208,7 @@ pub struct SparseSeqDis {
   pub variable_indel: BTreeMap<(usize, usize), Deletion>,
 
   /// probability vector for the state of fixed positions based on information from children
-  pub fixed: BTreeMap<u8, Array1<f64>>,
+  pub fixed: BTreeMap<AsciiChar, Array1<f64>>,
 
   pub fixed_counts: Composition,
 

--- a/packages/treetime/src/representation/mod.rs
+++ b/packages/treetime/src/representation/mod.rs
@@ -5,4 +5,5 @@ pub mod infer_dense;
 pub mod partitions_likelihood;
 pub mod partitions_parsimony;
 pub mod seq;
+pub mod seq_char;
 pub mod state_set;

--- a/packages/treetime/src/representation/seq.rs
+++ b/packages/treetime/src/representation/seq.rs
@@ -1,8 +1,10 @@
+use crate::representation::seq_char::AsciiChar;
+
 /// Represents genetic sequence (ASCII characters only)
 #[must_use]
 #[derive(Clone, PartialOrd, Ord, Default)]
 pub struct Seq {
-  data: Vec<u8>,
+  data: Vec<AsciiChar>,
 }
 
 impl Seq {
@@ -18,28 +20,27 @@ impl Seq {
 
   pub fn from_elem<T: Into<u8>>(elem: T, n: usize) -> Self {
     Self {
-      data: vec![elem.into(); n],
+      data: vec![AsciiChar::from(elem.into()); n],
     }
-  }
-
-  pub fn from_string(s: String) -> Self {
-    debug_assert!(s.is_ascii());
-    Self { data: s.into_bytes() }
   }
 
   pub fn from_str(s: &str) -> Self {
     debug_assert!(s.is_ascii());
     Self {
-      data: s.as_bytes().to_vec(),
+      data: s.as_bytes().iter().copied().map(AsciiChar::from).collect(),
     }
   }
 
   pub fn from_vec(vec: Vec<u8>) -> Self {
-    Self { data: vec }
+    Self {
+      data: vec.into_iter().map(AsciiChar::from).collect(),
+    }
   }
 
   pub fn from_slice(slice: &[u8]) -> Self {
-    Self { data: slice.to_vec() }
+    Self {
+      data: slice.iter().copied().map(AsciiChar::from).collect(),
+    }
   }
 
   pub fn len(&self) -> usize {
@@ -58,12 +59,12 @@ impl Seq {
     self.data.truncate(len);
   }
 
-  pub fn push(&mut self, byte: u8) {
+  pub fn push(&mut self, byte: AsciiChar) {
     self.data.push(byte);
   }
 
-  pub fn pop(&mut self) -> Option<u8> {
-    self.data.pop()
+  pub fn pop(&mut self) -> Option<AsciiChar> {
+    self.data.pop().map(Into::into)
   }
 
   pub fn capacity(&self) -> usize {
@@ -80,35 +81,42 @@ impl Seq {
 
   #[allow(unsafe_code)]
   pub fn as_str(&self) -> &str {
-    // SAFETY: safe if `data` consists of ASCII-characters
-    unsafe { core::str::from_utf8_unchecked(&self.data) }
+    // SAFETY: `self.data.as_ptr()` is guaranteed to be valid for reads and properly aligned
+    // because `data` is a `Vec<AsciiChar>`. The `AsciiChar` type ensures that each element is a valid
+    // single-byte ASCII character, making the conversion to a `u8` pointer valid.
+    let byte_slice = unsafe { std::slice::from_raw_parts(self.data.as_ptr().cast::<u8>(), self.data.len()) };
+
+    // SAFETY: `from_utf8_unchecked` is safe here because `byte_slice` is guaranteed to contain only
+    // valid UTF-8 data. This is ensured by the invariant that `AsciiChar` can only hold valid ASCII characters,
+    // which are a subset of UTF-8.
+    unsafe { std::str::from_utf8_unchecked(byte_slice) }
   }
 
-  pub fn as_slice(&self) -> &[u8] {
+  pub fn as_slice(&self) -> &[AsciiChar] {
     &self.data
   }
 
-  pub fn as_mut_slice(&mut self) -> &mut [u8] {
+  pub fn as_mut_slice(&mut self) -> &mut [AsciiChar] {
     &mut self.data
   }
 
   pub fn insert(&mut self, index: usize, byte: u8) {
-    self.data.insert(index, byte);
+    self.data.insert(index, AsciiChar::from(byte));
   }
 
   pub fn remove(&mut self, index: usize) -> u8 {
-    self.data.remove(index)
+    self.data.remove(index).into()
   }
 
   pub fn append(&mut self, other: &mut Vec<u8>) {
-    self.data.append(other);
+    self.data.extend(other.drain(..).map(AsciiChar::from));
   }
 
   pub fn push_str(&mut self, s: &str) {
-    self.data.extend_from_slice(s.as_bytes());
+    self.data.extend(s.as_bytes().iter().copied().map(AsciiChar::from));
   }
 
-  pub fn contains(&self, s: &str) -> bool {
+  pub fn contains_str(&self, s: &str) -> bool {
     self.as_str().contains(s)
   }
 
@@ -130,7 +138,7 @@ impl Seq {
 
   pub fn replace(&mut self, from: &str, to: &str) -> &mut Self {
     let replaced = self.as_str().replace(from, to);
-    self.data = replaced.into_bytes();
+    self.data = replaced.into_bytes().into_iter().map(AsciiChar::from).collect();
     self
   }
 
@@ -140,16 +148,16 @@ impl Seq {
     }
   }
 
-  pub fn splice<I>(
-    &mut self,
-    range: core::ops::Range<usize>,
-    replace_with: I,
-  ) -> std::vec::Splice<'_, <I as IntoIterator>::IntoIter>
-  where
-    I: IntoIterator<Item = u8>,
-  {
-    self.data.splice(range, replace_with)
-  }
+  // pub fn splice<I>(
+  //   &mut self,
+  //   range: core::ops::Range<usize>,
+  //   replace_with: I,
+  // ) -> std::vec::Splice<'_, <I as IntoIterator>::IntoIter>
+  // where
+  //   I: IntoIterator<Item = u8>,
+  // {
+  //   self.data.splice(range, replace_with.into_iter().map(AsciiChar::from))
+  // }
 }
 
 impl PartialEq for Seq {
@@ -160,44 +168,50 @@ impl PartialEq for Seq {
 
 impl PartialEq<Vec<u8>> for Seq {
   fn eq(&self, other: &Vec<u8>) -> bool {
-    self.data == *other
+    if self.data.len() != other.len() {
+      return false;
+    }
+    self.data.iter().zip(other).all(|(&AsciiChar(c), &b)| c == b)
   }
 }
 
 impl PartialEq<str> for Seq {
   fn eq(&self, other: &str) -> bool {
-    self.data == other.as_bytes()
+    if self.data.len() != other.len() {
+      return false;
+    }
+    self.data.iter().zip(other.as_bytes()).all(|(&AsciiChar(c), &b)| c == b)
   }
 }
 
 impl PartialEq<String> for Seq {
   fn eq(&self, other: &String) -> bool {
-    self.data == other.as_bytes()
+    self == other.as_str()
   }
 }
 
 impl PartialEq<&str> for Seq {
   fn eq(&self, other: &&str) -> bool {
-    self.data == other.as_bytes()
+    self == *other
   }
 }
 
 impl PartialEq<Seq> for str {
   fn eq(&self, other: &Seq) -> bool {
-    self.as_bytes() == other.data
+    other == self
   }
 }
 
 impl PartialEq<Seq> for String {
   fn eq(&self, other: &Seq) -> bool {
-    self.as_bytes() == other.data
+    other == self.as_str()
   }
 }
 
 impl Eq for Seq {}
 
 impl core::ops::Deref for Seq {
-  type Target = [u8];
+  type Target = [AsciiChar];
   fn deref(&self) -> &Self::Target {
     &self.data
   }
@@ -217,33 +231,47 @@ impl From<&str> for Seq {
 
 impl From<&[u8]> for Seq {
   fn from(slice: &[u8]) -> Self {
-    Self { data: slice.to_vec() }
+    Self::from_slice(slice)
+  }
+}
+
+impl From<&[AsciiChar]> for Seq {
+  fn from(slice: &[AsciiChar]) -> Self {
+    slice.iter().copied().collect()
   }
 }
 
 impl Extend<u8> for Seq {
   fn extend<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
-    self.data.extend(iter);
+    self.data.extend(iter.into_iter().map(AsciiChar::from));
   }
 }
 
 impl FromIterator<u8> for Seq {
   fn from_iter<I: IntoIterator<Item = u8>>(iter: I) -> Self {
     Self {
+      data: iter.into_iter().map(AsciiChar::from).collect(),
+    }
+  }
+}
+
+impl FromIterator<AsciiChar> for Seq {
+  fn from_iter<I: IntoIterator<Item = AsciiChar>>(iter: I) -> Self {
+    Self {
       data: Vec::from_iter(iter),
     }
   }
 }
 
-impl AsRef<[u8]> for Seq {
-  fn as_ref(&self) -> &[u8] {
+impl AsRef<[AsciiChar]> for Seq {
+  fn as_ref(&self) -> &[AsciiChar] {
     &self.data
   }
 }
 
-impl AsRef<str> for Seq {
-  fn as_ref(&self) -> &str {
-    self.as_str()
+impl AsRef<[u8]> for Seq {
+  fn as_ref(&self) -> &[u8] {
+    self.as_str().as_bytes()
   }
 }
 
@@ -260,7 +288,7 @@ impl core::fmt::Debug for Seq {
 }
 
 impl core::ops::Index<usize> for Seq {
-  type Output = u8;
+  type Output = AsciiChar;
 
   fn index(&self, index: usize) -> &Self::Output {
     &self.data[index]
@@ -274,7 +302,7 @@ impl core::ops::IndexMut<usize> for Seq {
 }
 
 impl core::ops::Index<core::ops::Range<usize>> for Seq {
-  type Output = [u8];
+  type Output = [AsciiChar];
 
   fn index(&self, index: core::ops::Range<usize>) -> &Self::Output {
     &self.data[index]
@@ -309,8 +337,8 @@ impl std::ops::Mul<usize> for Seq {
 }
 
 impl<'a> IntoIterator for &'a Seq {
-  type Item = &'a u8;
-  type IntoIter = core::slice::Iter<'a, u8>;
+  type Item = &'a AsciiChar;
+  type IntoIter = core::slice::Iter<'a, AsciiChar>;
 
   fn into_iter(self) -> Self::IntoIter {
     self.data.iter()
@@ -318,8 +346,8 @@ impl<'a> IntoIterator for &'a Seq {
 }
 
 impl<'a> IntoIterator for &'a mut Seq {
-  type Item = &'a mut u8;
-  type IntoIter = core::slice::IterMut<'a, u8>;
+  type Item = &'a mut AsciiChar;
+  type IntoIter = core::slice::IterMut<'a, AsciiChar>;
 
   fn into_iter(self) -> Self::IntoIter {
     self.data.iter_mut()
@@ -327,17 +355,35 @@ impl<'a> IntoIterator for &'a mut Seq {
 }
 
 impl IntoIterator for Seq {
-  type Item = u8;
-  type IntoIter = std::vec::IntoIter<u8>;
+  type Item = AsciiChar;
+  type IntoIter = std::vec::IntoIter<AsciiChar>;
 
   fn into_iter(self) -> Self::IntoIter {
     self.data.into_iter()
   }
 }
 
+#[allow(unsafe_code)]
+impl std::io::Read for Seq {
+  fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    let len = std::cmp::min(buf.len(), self.len());
+    // SAFETY:
+    // 1. `self.data` is guaranteed to hold only ASCII characters because `Seq` enforces this invariant via `AsciiChar`.
+    // 2. The length `len` is calculated as the minimum of `buf.len()` and `self.len()`, ensuring no out-of-bounds access for either slice.
+    // 3. `std::ptr::copy_nonoverlapping` is safe to use here because:
+    //    a. Both `self.data` and `buf` are valid, properly aligned, and non-overlapping.
+    //    b. The memory regions are guaranteed to be accessible for `len` bytes.
+    unsafe {
+      std::ptr::copy_nonoverlapping(self.data.as_ptr().cast::<u8>(), buf.as_mut_ptr(), len);
+    }
+    self.data.drain(..len);
+    Ok(len)
+  }
+}
+
 impl std::io::Write for Seq {
   fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-    self.data.extend_from_slice(buf);
+    self.extend(buf.iter().copied());
     Ok(buf.len())
   }
 
@@ -363,7 +409,7 @@ impl<'de> serde::Deserialize<'de> for Seq {
     D: serde::Deserializer<'de>,
   {
     let s = String::deserialize(deserializer)?;
-    Ok(Seq::from_string(s))
+    Ok(Seq::from_str(&s))
   }
 }
 

--- a/packages/treetime/src/representation/seq_char.rs
+++ b/packages/treetime/src/representation/seq_char.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Serialize};
+use std::fmt::Write as StdFmtWrite;
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AsciiChar(pub u8);
+
+impl AsciiChar {
+  pub const fn new(value: u8) -> Self {
+    Self(value)
+  }
+
+  pub const fn inner(&self) -> u8 {
+    self.0
+  }
+}
+
+impl core::fmt::Display for AsciiChar {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_char(self.0 as char)
+  }
+}
+
+impl core::fmt::Debug for AsciiChar {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    core::fmt::Display::fmt(self, f)
+  }
+}
+
+impl From<u8> for AsciiChar {
+  fn from(item: u8) -> Self {
+    AsciiChar(item)
+  }
+}
+
+impl From<u16> for AsciiChar {
+  fn from(item: u16) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<u32> for AsciiChar {
+  fn from(item: u32) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<u64> for AsciiChar {
+  fn from(item: u64) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<usize> for AsciiChar {
+  fn from(item: usize) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<char> for AsciiChar {
+  fn from(item: char) -> Self {
+    AsciiChar(item as u8)
+  }
+}
+
+impl From<AsciiChar> for u8 {
+  fn from(item: AsciiChar) -> Self {
+    item.0
+  }
+}
+
+impl From<AsciiChar> for u16 {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as u16
+  }
+}
+
+impl From<AsciiChar> for u32 {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as u32
+  }
+}
+
+impl From<AsciiChar> for u64 {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as u64
+  }
+}
+
+impl From<AsciiChar> for usize {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as usize
+  }
+}
+
+impl From<AsciiChar> for char {
+  fn from(item: AsciiChar) -> Self {
+    item.0 as char
+  }
+}

--- a/packages/treetime/src/seq/find_char_ranges.rs
+++ b/packages/treetime/src/seq/find_char_ranges.rs
@@ -1,4 +1,5 @@
 use crate::representation::seq::Seq;
+use crate::representation::seq_char::AsciiChar;
 
 // Finds contiguous ranges (segments) in the sequence, such that for every character inside every range,
 // the predicate function returns true and every range contains only the same letter.
@@ -8,7 +9,10 @@ use crate::representation::seq::Seq;
 // For example if predicate returns `true` for characters A and C, this function will find ranges `AAAA`, `CCCCC`, `ACCCACAAA`
 // but not `ZZZZZ`.
 #[inline]
-pub fn find_letter_ranges_by(seq: &Seq, pred: impl Fn(u8) -> bool + Copy) -> Vec<(usize, usize)> {
+pub fn find_letter_ranges_by<F>(seq: &Seq, pred: F) -> Vec<(usize, usize)>
+where
+  F: Fn(AsciiChar) -> bool + Copy,
+{
   let mut result = Vec::with_capacity(31);
   let mut i = 0;
   while i < seq.len() {
@@ -69,8 +73,8 @@ pub mod old {
 
 /// Finds contiguous ranges (segments) consisting of a given letter in the sequence.
 #[inline]
-pub fn find_letter_ranges(seq: &Seq, letter: u8) -> Vec<(usize, usize)> {
-  find_letter_ranges_by(seq, |candidate| candidate == letter)
+pub fn find_letter_ranges(seq: &Seq, letter: impl Into<AsciiChar> + Copy) -> Vec<(usize, usize)> {
+  find_letter_ranges_by(seq, |candidate: AsciiChar| candidate == letter.into())
 }
 
 #[cfg(test)]
@@ -131,7 +135,7 @@ mod tests {
   #[case("ATGNNNTTTT---",    vec![(3, 6), (10, 13)])]
   #[case("ATG---TTTTNNN",    vec![(3, 6), (10, 13)])]
   fn test_find_undetermined_ranges(#[case] seq: &str, #[case] expected: Vec<(usize, usize)>) {
-    let actual = find_letter_ranges_by(&seq.into(), |c| c == b'N' || c == b'-');
+    let actual = find_letter_ranges_by(&seq.into(), |c| c == AsciiChar(b'N') || c == AsciiChar(b'-'));
     assert_eq!(expected, actual);
   }
 }

--- a/packages/treetime/src/seq/mutation.rs
+++ b/packages/treetime/src/seq/mutation.rs
@@ -1,4 +1,5 @@
 use crate::make_error;
+use crate::representation::seq_char::AsciiChar;
 use crate::utils::error::to_eyre_error;
 use eyre::{Report, WrapErr};
 use lazy_static::lazy_static;
@@ -10,9 +11,9 @@ use std::str::FromStr;
 #[derive(Clone, Debug, Serialize, Deserialize, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Sub {
   pub pos: usize,
-  pub qry: u8,
+  pub qry: AsciiChar,
   #[serde(rename = "ref")]
-  pub reff: u8,
+  pub reff: AsciiChar,
 }
 
 impl FromStr for Sub {
@@ -29,9 +30,9 @@ impl FromStr for Sub {
     if let Some(captures) = RE.captures(s) {
       return match (captures.name("ref"), captures.name("pos"), captures.name("qry")) {
         (Some(reff), Some(pos), Some(qry)) => {
-          let reff = reff.as_str().bytes().next().unwrap();
+          let reff = AsciiChar(reff.as_str().bytes().next().unwrap());
           let pos = parse_pos(pos.as_str()).wrap_err_with(|| format!("When parsing mutation position in '{s}'"))?;
-          let qry = qry.as_str().bytes().next().unwrap();
+          let qry = AsciiChar(qry.as_str().bytes().next().unwrap());
           Ok(Self { pos, qry, reff })
         }
         _ => make_error!("Unable to parse nucleotide mutation: '{s}'"),
@@ -55,6 +56,6 @@ pub fn parse_pos(s: &str) -> Result<usize, Report> {
 
 impl fmt::Display for Sub {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{}{}{}", self.reff as char, self.pos + 1, self.qry as char)
+    write!(f, "{}{}{}", self.reff, self.pos + 1, self.qry)
   }
 }


### PR DESCRIPTION
Followup of https://github.com/neherlab/treetime/pull/301

The `AsciiChar` wrapper type allows:
 * better debugging, as we can control how `AsciiChar` is printed, as opposed to the integer-like `u8` type - this is mostly a dev convenience thing - for debug-printing sequences, various maps etc., but it boosts development significantly
 * provide valid outputs wherever we need to display or write to file any characters - this is actually needed for correctness

I measured no significant slowdown:

Command:
```
$ cargo -q build --release --target-dir=/workdir/.build/docker --bin=treetime
$ hyperfine --warmup 1 --show-output '/workdir/.build/docker/release/treetime ancestral --method-anc=parsimony --dense=false --tree=data/mpox/clade-ii/500/tree.nwk --outdir=tmp/smoke-tests/ancestral/marginal/mpox/clade-ii/500 data/mpox/clade-ii/500/aln.fasta.xz'
```

Before (branch: rust, commit 67ba54a):
```
  Time (mean ± σ):     655.4 ms ±  25.7 ms    [User: 2258.9 ms, System: 210.1 ms]
  Range (min … max):   635.3 ms … 717.6 ms    10 runs
```

After:
```
  Time (mean ± σ):     650.3 ms ±  26.9 ms    [User: 2231.2 ms, System: 218.7 ms]
  Range (min … max):   630.9 ms … 716.2 ms    10 runs
```