### PR TITLE
refactor: encapsulate `Sub` fields

### DIFF
--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -302,11 +302,7 @@ fn fitch_forward(graph: &SparseGraph, sparse_partitions: &[PartitionParsimony]) 
             } else {
               let cnuc = states.get_one();
               sequence[*pos] = cnuc;
-              let m = Sub {
-                pos: *pos,
-                qry: cnuc,
-                reff: pnuc,
-              };
+              let m = Sub::new(pnuc, *pos, cnuc).unwrap();
               composition.add_sub(&m);
               edge.subs.push(m);
             }
@@ -325,11 +321,7 @@ fn fitch_forward(graph: &SparseGraph, sparse_partitions: &[PartitionParsimony]) 
           // child state of variable positions in the backward pass
           let node_nuc = sequence[pos];
           if alphabet.is_canonical(node_nuc) && parent.sequence[pos] != node_nuc {
-            let m = Sub {
-              pos,
-              qry: node_nuc,
-              reff: parent.sequence[pos],
-            };
+            let m = Sub::new(parent.sequence[pos], pos, node_nuc).unwrap();
             composition.add_sub(&m);
             edge.subs.push(m);
           }
@@ -464,7 +456,7 @@ pub fn ancestral_reconstruction_fitch(
         node.payload.sparse_partitions[si].seq.sequence = parent_seq.clone();
 
         for sub in &edge_part.subs {
-          node.payload.sparse_partitions[si].seq.sequence[sub.pos] = sub.qry;
+          node.payload.sparse_partitions[si].seq.sequence[sub.pos()] = sub.qry();
         }
 
         for indel in &edge_part.indels {

--- a/packages/treetime/src/commands/ancestral/marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/marginal_sparse.rs
@@ -61,8 +61,8 @@ fn ingroup_profiles_sparse(graph: &SparseGraph, partitions: &[PartitionLikelihoo
           // go over all mutations and get reference and child state
           child_states.push(btreemap! {});
           for m in &edge.read_arc().sparse_partitions[si].subs {
-            variable_pos.insert(m.pos, m.reff); // this might be set multiple times, but the reference state should always be the same
-            child_states[ci].insert(m.pos, m.qry);
+            variable_pos.insert(m.pos(), m.reff()); // this might be set multiple times, but the reference state should always be the same
+            child_states[ci].insert(m.pos(), m.qry());
           }
           // go over child variable position and get reference state
           for (pos, p) in &edge.read_arc().sparse_partitions[si].msg_from_child.variable {
@@ -284,9 +284,9 @@ fn outgroup_profiles_sparse(graph: &SparseGraph, partitions: &[PartitionLikeliho
           }
           // record all states that involve a mutation
           for m in &edge.read_arc().sparse_partitions[si].subs {
-            variable_pos.insert(m.pos, m.qry);
-            parent_state.entry(m.pos).or_insert(m.reff);
-            child_state.entry(m.pos).or_insert(m.qry);
+            variable_pos.insert(m.pos(), m.qry());
+            parent_state.entry(m.pos()).or_insert_with(|| m.reff());
+            child_state.entry(m.pos()).or_insert_with(|| m.qry());
           }
           // go over variable position in children (info pushed to parent) and get reference state
           for (pos, p) in &edge.read_arc().sparse_partitions[si].msg_to_parent.variable {
@@ -342,8 +342,8 @@ fn outgroup_profiles_sparse(graph: &SparseGraph, partitions: &[PartitionLikeliho
           parent_states.entry(*pos).or_insert(p.state);
         }
         for sub in &child_edge.sparse_partitions[si].subs {
-          child_states.insert(sub.pos, sub.qry);
-          parent_states.insert(sub.pos, sub.reff);
+          child_states.insert(sub.pos(), sub.qry());
+          parent_states.insert(sub.pos(), sub.reff());
         }
 
         let mut delta_ll = 0.0;
@@ -430,7 +430,7 @@ pub fn ancestral_reconstruction_marginal_sparse(
 
           // Implant mutations
           for m in &edge.subs {
-            seq[m.pos] = m.qry;
+            seq[m.pos()] = m.qry();
           }
 
           // Implant most likely state of variable sites

--- a/packages/treetime/src/commands/optimize/optimize_sparse.rs
+++ b/packages/treetime/src/commands/optimize/optimize_sparse.rs
@@ -20,6 +20,7 @@
 //!
 //!   d^2logLh/dt^2 = sum_i sum_j \sum_c k_c \lambda_c*\lambda^i_c exp(\lambda^i_c t) / \sum_c k_c exp(\lambda^i_c t) - k_c \lambda_c*\exp(\lambda^i_c t) / \sum_c k_c exp(\lambda^i_c t)
 //!
+use crate::seq::mutation::Sub;
 use crate::{
   gtr::gtr::GTR,
   representation::{
@@ -50,7 +51,7 @@ fn get_coefficients(edge: &SparseSeqEdge, gtr: &GTR) -> Result<PartitionContribu
     .keys()
     .copied()
     .chain(edge.msg_to_parent.variable.keys().copied())
-    .chain(edge.subs.iter().map(|sub| sub.pos))
+    .chain(edge.subs.iter().map(Sub::pos))
     .unique()
     .collect();
 
@@ -58,8 +59,8 @@ fn get_coefficients(edge: &SparseSeqEdge, gtr: &GTR) -> Result<PartitionContribu
     .iter()
     .map(|pos| {
       // Check whether the position is in substitutions
-      let state_pair = if let Some(sub) = edge.subs.iter().find(|m| m.pos == *pos) {
-        (sub.reff, sub.qry)
+      let state_pair = if let Some(sub) = edge.subs.iter().find(|m| m.pos() == *pos) {
+        (sub.reff(), sub.qry())
       } else {
         let parent = edge
           .msg_to_child

--- a/packages/treetime/src/gtr/infer_gtr.rs
+++ b/packages/treetime/src/gtr/infer_gtr.rs
@@ -157,8 +157,8 @@ pub fn get_mutation_counts(graph: &SparseGraph, alphabet: &Alphabet) -> Result<M
     }
 
     for m in &edge.sparse_partitions[0].subs {
-      let i = alphabet.index(m.qry);
-      let j = alphabet.index(m.reff);
+      let i = alphabet.index(m.qry());
+      let j = alphabet.index(m.reff());
       nij[[i, j]] += 1.0;
       Ti[i] -= 0.5 * branch_length;
       Ti[j] += 0.5 * branch_length;

--- a/packages/treetime/src/seq/composition.rs
+++ b/packages/treetime/src/seq/composition.rs
@@ -66,8 +66,8 @@ impl Composition {
 
   /// Reflect sequence mutation in the composition counts
   pub fn add_sub(&mut self, sub: &Sub) {
-    self.adjust_count(sub.reff, -1);
-    self.adjust_count(sub.qry, 1);
+    self.adjust_count(sub.reff(), -1);
+    self.adjust_count(sub.qry(), 1);
   }
 
   /// Reflect sequence indel in the composition counts
@@ -87,6 +87,7 @@ impl Composition {
 
 #[cfg(test)]
 mod tests {
+  use std::str::FromStr;
   use super::*;
   use crate::alphabet::alphabet::{Alphabet, AlphabetName};
   use crate::representation::seq::Seq;
@@ -157,11 +158,7 @@ mod tests {
   #[test]
   fn test_composition_add_mutation() {
     let mut actual = Composition::with_sequence("AAAGCTTACGGGGTCAAGTCC".bytes(), "ACGT-".bytes(), b'-');
-    let mutation = Sub {
-      pos: 123,
-      reff: b'A'.into(),
-      qry: b'G'.into(),
-    };
+    let mutation = Sub::from_str("A123G").unwrap();
     actual.add_sub(&mutation);
     let expected = Composition::from(btreemap! { b'-' => 0, b'A' => 5, b'C' => 5, b'G' => 7, b'T' => 4}, b'-');
     assert_eq!(expected, actual);


### PR DESCRIPTION
This allows to validate correctness of substitution (e.g. whether it is from or to a gap), to catch bugs early, and overall is a good practice.