### PR TITLE
fix: preserve sparse exact states for ambiguous sites

### DIFF
--- a/docs/port-known-issues/M-ancestral-dense-sparse-divergence.md
+++ b/docs/port-known-issues/M-ancestral-dense-sparse-divergence.md
@@ -25,3 +25,7 @@ Candidates for root cause (from test file comments):
 
 The bimodal distribution (clean separation between populations 1 and 2)
 suggests a discrete trigger rather than continuous numerical drift.
+
+## Excluded cause
+
+Partial-IUPAC sparse reference-state fallback is covered separately by [`test_marginal_dense_sparse_ambiguous_r_reference_state_consistency`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs#L317) and the `flu/h3n2/500` site-451 regression. The remaining issue in this file is not the fixed ambiguous-`R` exact-state bug.

--- a/docs/port-test-inventory/ancestral.md
+++ b/docs/port-test-inventory/ancestral.md
@@ -6,7 +6,7 @@
 
 | Category                 | Files  | Tests   | Type            |
 | ------------------------ | ------ | ------- | --------------- |
-| Fitch parsimony          | 1      | 6       | Unit            |
+| Fitch parsimony          | 1      | 7       | Unit            |
 | Marginal ML dense        | 1      | 5       | Unit            |
 | Marginal ML sparse       | 1      | 6       | Unit            |
 | Dense/sparse equivalence | 2      | 2       | Unit + Property |
@@ -14,14 +14,14 @@
 | Normalization            | 2      | 6       | Unit + Property |
 | Root invariance          | 1      | 4       | Property + Unit |
 | Python parity            | 1      | 8       | Unit            |
-| Consistency              | 1      | 4       | Unit            |
+| Consistency              | 1      | 5       | Unit            |
 | Branch length            | 2      | 12      | Unit            |
 | Topology                 | 3      | 13      | Unit            |
 | Stability                | 3      | 16      | Unit            |
 | Analytical               | 3      | 10      | Golden-master   |
 | Sparse composition       | 1      | 12      | Unit            |
 | Generator validation     | 4      | 15      | Property        |
-| **Total**                | **28** | **123** | Mixed           |
+| **Total**                | **28** | **125** | Mixed           |
 
 Support files (helpers only, no tests): `prop_marginal_support.rs`, `test_marginal_analytical_support.rs`, `test_marginal_stability_support.rs`
 
@@ -35,6 +35,7 @@ Support files (helpers only, no tests): `prop_marginal_support.rs`, `test_margin
 | ------------------------------------------------- | -------------------------------------------------- |
 | `test_ancestral_reconstruction_fitch`             | MAP sequences at internal nodes                    |
 | `test_ancestral_reconstruction_fitch_with_leaves` | Same with leaf sequences included                  |
+| `test_compress_sequences_retains_internal_exact_sequences` | Internal exact sequences remain available after compression |
 | `test_fitch_internals`                            | Substitution and indel mutations on edges          |
 | `test_fitch_complex_gaps`                         | Overlapping deletions and variable insertions      |
 | `test_fitch_polytomy`                             | Multifurcation with 3 children                     |
@@ -164,6 +165,7 @@ Support files (helpers only, no tests): `prop_marginal_support.rs`, `test_margin
 | `test_marginal_dense_sparse_log_lh_consistency_gap_free`                 | Dense and sparse log-likelihoods match (gap-free, JC69)   |
 | `test_marginal_sparse_varpos_matches_dense_profile_gap_free`             | Sparse variable-position distributions match dense rows   |
 | `test_marginal_dense_sparse_ambiguous_character_expectations_documented` | Log-likelihood agreement with ambiguity codes             |
+| `test_marginal_dense_sparse_ambiguous_r_reference_state_consistency`     | Dense and sparse reconstruct the same exact state for partial ambiguity |
 | `test_marginal_posteriors_sum_to_one_skewed_gtr`                         | Normalization under extreme GTR (pi=[0.9,0.06,0.02,0.02]) |
 
 ---

--- a/docs/port-test-inventory/optimization.md
+++ b/docs/port-test-inventory/optimization.md
@@ -15,12 +15,13 @@
 | Optimization metrics             | 1      | 7       | 0             | Unit     |
 | Zero branch optimal              | 1      | 13      | 0             | Unit     |
 | Initial guess GTR messages       | 1      | 2       | 0             | Unit     |
+| Initial guess formula            | 1      | 4       | 0             | Unit     |
 | Initial guess soft Hamming       | 1      | 10      | 0             | Unit     |
 | Topology cleanup in loop         | 1      | 15      | 0             | Unit     |
 | Indel contribution (inline)      | 1      | 8       | 0             | Unit     |
 | Indel contribution (integration) | 1      | 11      | 0             | Unit     |
 | Indel contribution (property)    | 1      | 3       | 0             | Property |
-| **Total**                        | **32** | **130** | **5**         |          |
+| **Total**                        | **33** | **134** | **5**         |          |
 
 ---
 
@@ -421,6 +422,21 @@ Regression tests verifying that `initial_guess_mixed()` reads edge messages comp
 | ------------------------------------------------ | ------------------------------------------------------------- |
 | `test_stale_jc69_messages_bias_initial_guess`    | Stale JC69 messages produce different branch lengths than F81 |
 | `test_initial_guess_idempotent_after_gtr_update` | Identical initialization sequences produce identical results  |
+
+---
+
+## Initial Guess Formula
+
+**File:** [`test_initial_guess_formula.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs)
+
+Tests that `initial_guess_mixed()` still follows the edge substitution formula after marginal reconstruction, and that dense and sparse stay aligned on ambiguity-sensitive sparse reference-state paths.
+
+| Test                                                                          | Purpose                                                           |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `test_initial_guess_formula_sparse`                                           | Sparse branch length equals substitution count over effective length |
+| `test_initial_guess_formula_dense`                                            | Dense branch length equals substitution count over effective length |
+| `test_initial_guess_dense_sparse_ambiguous_r_reference_state_consistency`     | Dense and sparse initial branch lengths match on partial ambiguity |
+| `test_optimize_contribution_dense_sparse_ambiguous_r_value_and_gradient_consistency` | Dense and sparse optimize contributions agree in value and gradient on partial ambiguity |
 
 ---
 

--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
@@ -122,6 +122,19 @@ mod tests {
     partition.nodes[&root_key].seq.sequence.as_str().to_owned()
   }
 
+  fn get_internal_sequences(graph: &GraphAncestral, partition: &PartitionFitch) -> BTreeMap<String, String> {
+    graph
+      .get_internal_nodes()
+      .iter()
+      .map(|node| {
+        let node = node.read_arc();
+        let node_name = node.payload().read_arc().name.clone().unwrap();
+        let sequence = partition.nodes[&node.key()].seq.sequence.as_str().to_owned();
+        (node_name, sequence)
+      })
+      .collect()
+  }
+
   /// Collect insertion/deletion (indel) mutations on every edge, keyed by "parent->child" label.
   ///
   /// Each indel is formatted as a range with parent and child states (e.g. "12--13: T -> -"
@@ -294,6 +307,49 @@ mod tests {
       json_write_str(&actual, JsonPretty(false))?
     );
 
+    Ok(())
+  }
+
+  #[test]
+  fn test_compress_sequences_retains_internal_exact_sequences() -> Result<(), Report> {
+    drop(rayon::ThreadPoolBuilder::new().num_threads(1).build_global());
+
+    let aln = read_many_fasta_str(
+      indoc! {r#"
+        >A
+        RCGTACGT
+        >B
+        GCGTACGT
+        >C
+        GCGTACGT
+        >D
+        GCGTACGT
+      "#},
+      &*NUC_ALPHABET,
+    )?;
+
+    let graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
+    let alphabet = Alphabet::default();
+
+    let partitions = [Arc::new(RwLock::new(PartitionFitch {
+      index: 0,
+      alphabet,
+      length: get_common_length(&aln)?,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }))];
+
+    compress_sequences(&graph, &partitions, &aln)?;
+
+    let partition = partitions[0].read_arc();
+    let actual = get_internal_sequences(&graph, &partition);
+    let expected = btreemap! {
+      o!("AB") => o!("GCGTACGT"),
+      o!("CD") => o!("GCGTACGT"),
+      o!("root") => o!("GCGTACGT"),
+    };
+
+    assert_eq!(expected, actual);
     Ok(())
   }
 

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -361,10 +361,7 @@ mod tests {
     Ok(actual)
   }
 
-  fn edge_subs_by_edge_name<P>(
-    graph: &GraphAncestral,
-    partition: &P,
-  ) -> Result<BTreeMap<String, Vec<Sub>>, Report>
+  fn edge_subs_by_edge_name<P>(graph: &GraphAncestral, partition: &P) -> Result<BTreeMap<String, Vec<Sub>>, Report>
   where
     P: PartitionBranchOps,
   {

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -2,12 +2,14 @@
 mod tests {
   use crate::alphabet::alphabet::{Alphabet, AlphabetName};
   use crate::commands::ancestral::fitch::{compress_sequences, get_common_length};
-  use crate::commands::ancestral::marginal::{initialize_marginal, update_marginal};
+  use crate::commands::ancestral::marginal::{ancestral_reconstruction_marginal, initialize_marginal, update_marginal};
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::gtr::gtr::{GTR, GTRParams};
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+  use crate::representation::partition::traits::PartitionBranchOps;
   use crate::representation::payload::ancestral::GraphAncestral;
+  use crate::seq::mutation::Sub;
   use crate::test_utils::find_node_key_by_name;
   use approx::assert_ulps_eq;
   use eyre::Report;
@@ -15,7 +17,9 @@ mod tests {
   use maplit::btreemap;
   use ndarray::array;
   use parking_lot::RwLock;
+  use std::collections::BTreeMap;
   use std::sync::{Arc, LazyLock};
+  use treetime_graph::node::Named;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::make_report;
@@ -41,6 +45,28 @@ mod tests {
       ACGTACGTACGTACGG
       >D
       ACGTACGTACGTACGC
+    "#},
+      &*NUC_ALPHABET,
+    )
+  }
+
+  /// 4-taxon alignment shaped like the sparse ambiguity bug.
+  ///
+  /// At position 1, leaf A is `R = {A,G}` while all other leaves are canonical `G`.
+  /// Fitch forward can resolve the A leaf canonically to `G` from its parent context,
+  /// but sparse marginal leaf encoding must not rebuild a false canonical `A` from
+  /// the ambiguous state set.
+  fn ambiguous_r_in_g_clade_alignment() -> Result<Vec<FastaRecord>, Report> {
+    read_many_fasta_str(
+      indoc! {r#"
+      >A
+      RCGTACGT
+      >B
+      GCGTACGT
+      >C
+      GCGTACGT
+      >D
+      GCGTACGT
     "#},
       &*NUC_ALPHABET,
     )
@@ -285,6 +311,91 @@ mod tests {
     }
 
     Ok(())
+  }
+
+  #[test]
+  fn test_marginal_dense_sparse_ambiguous_r_reference_state_consistency() -> Result<(), Report> {
+    let aln = ambiguous_r_in_g_clade_alignment()?;
+    let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+
+    let gtr_dense = jc69(JC69Params {
+      alphabet: AlphabetName::Nuc,
+      ..JC69Params::default()
+    })?;
+    let gtr_sparse = jc69(JC69Params {
+      alphabet: AlphabetName::Nuc,
+      ..JC69Params::default()
+    })?;
+
+    let (log_lh_dense, dense_partition) = run_dense_marginal(&graph, &aln, gtr_dense)?;
+    let (log_lh_sparse, sparse_partition) = run_sparse_marginal(&graph, &aln, gtr_sparse)?;
+
+    assert_ulps_eq!(log_lh_dense, log_lh_sparse, epsilon = 1e-10);
+
+    let dense_sequences = reconstruct_named_sequences(&graph, std::slice::from_ref(&dense_partition))?;
+    let sparse_sequences = reconstruct_named_sequences(&graph, std::slice::from_ref(&sparse_partition))?;
+    assert_eq!(dense_sequences, sparse_sequences);
+
+    let dense_branch_subs = edge_subs_by_edge_name(&graph, &*dense_partition.read_arc())?;
+    let sparse_branch_subs = edge_subs_by_edge_name(&graph, &*sparse_partition.read_arc())?;
+    assert_eq!(dense_branch_subs, sparse_branch_subs);
+
+    Ok(())
+  }
+
+  fn reconstruct_named_sequences<P>(
+    graph: &GraphAncestral,
+    partitions: &[Arc<RwLock<P>>],
+  ) -> Result<BTreeMap<String, String>, Report>
+  where
+    P: crate::representation::partition::traits::PartitionMarginalOps<
+        crate::representation::payload::ancestral::NodeAncestral,
+        crate::representation::payload::ancestral::EdgeAncestral,
+      > + crate::representation::partition::traits::HasLogLh,
+  {
+    let mut actual = BTreeMap::new();
+    ancestral_reconstruction_marginal(graph, false, partitions, |node, seq| {
+      actual.insert(node.name.clone().expect("all test nodes are named"), seq.to_string());
+      Ok(())
+    })?;
+    Ok(actual)
+  }
+
+  fn edge_subs_by_edge_name<P>(
+    graph: &GraphAncestral,
+    partition: &P,
+  ) -> Result<BTreeMap<String, Vec<Sub>>, Report>
+  where
+    P: PartitionBranchOps,
+  {
+    graph
+      .get_edges()
+      .iter()
+      .map(|edge_ref| {
+        let edge = edge_ref.read_arc();
+        let parent_name = graph
+          .get_node(edge.source())
+          .expect("parent node exists")
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name()
+          .map(|name| name.as_ref().to_owned())
+          .expect("named parent");
+        let child_name = graph
+          .get_node(edge.target())
+          .expect("child node exists")
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name()
+          .map(|name| name.as_ref().to_owned())
+          .expect("named child");
+        let edge_name = format!("{parent_name}->{child_name}");
+        let subs = partition.edge_subs(graph, edge.key())?;
+        Ok((edge_name, subs))
+      })
+      .collect()
   }
 
   /// Verify marginal posterior normalization under a highly skewed GTR model.

--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -507,9 +507,9 @@ where
       }
     }
 
-    if !node.is_root {
-      seq.sequence = seq![];
-    }
+    // Keep the exact reconstructed sequence on every node. Sparse marginal
+    // passes need an authoritative reference state for fixed-site lookups at
+    // ambiguous-variable positions.
   }
 
   GraphTraversalContinuation::Continue

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
@@ -3,6 +3,7 @@ mod tests {
   use crate::alphabet::alphabet::{Alphabet, AlphabetName};
   use crate::commands::ancestral::fitch::{compress_sequences, get_common_length};
   use crate::commands::ancestral::marginal::{initialize_marginal, update_marginal};
+  use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
   use crate::commands::optimize::optimize_unified::initial_guess_mixed;
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
@@ -101,6 +102,31 @@ mod tests {
     Ok(())
   }
 
+  #[test]
+  fn test_optimize_contribution_dense_sparse_ambiguous_r_value_and_gradient_consistency() -> Result<(), Report> {
+    let aln = ambiguous_r_in_g_clade_alignment()?;
+
+    let graph_dense: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+    let graph_sparse: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+
+    let partitions_dense = setup_dense(&graph_dense, &aln)?;
+    let partitions_sparse = setup_sparse(&graph_sparse, &aln)?;
+
+    let dense_metrics = optimization_metrics_by_child_name(&graph_dense, &*partitions_dense[0].read_arc(), 0.1)?;
+    let sparse_metrics = optimization_metrics_by_child_name(&graph_sparse, &*partitions_sparse[0].read_arc(), 0.1)?;
+
+    assert_eq!(
+      dense_metrics.keys().cloned().collect::<Vec<_>>(),
+      sparse_metrics.keys().cloned().collect::<Vec<_>>()
+    );
+    for (edge_name, (dense_log_lh, dense_derivative, _dense_second_derivative)) in dense_metrics {
+      let (sparse_log_lh, sparse_derivative, _sparse_second_derivative) = sparse_metrics[&edge_name];
+      assert_abs_diff_eq!(dense_log_lh, sparse_log_lh, epsilon = 1e-12);
+      assert_abs_diff_eq!(dense_derivative, sparse_derivative, epsilon = 1e-12);
+    }
+    Ok(())
+  }
+
   fn divergent_alignment() -> Result<Vec<FastaRecord>, Report> {
     let alphabet = Alphabet::default();
     read_many_fasta_str(
@@ -194,6 +220,36 @@ mod tests {
           .to_owned();
         let branch_length = edge_ref.payload().read_arc().branch_length().unwrap_or(0.0);
         Ok((child_name, branch_length))
+      })
+      .collect()
+  }
+
+  fn optimization_metrics_by_child_name<P: PartitionOptimizeOps>(
+    graph: &GraphAncestral,
+    partition: &P,
+    branch_length: f64,
+  ) -> Result<BTreeMap<String, (f64, f64, f64)>, Report> {
+    graph
+      .get_edges()
+      .iter()
+      .map(|edge_ref| {
+        let edge_ref = edge_ref.read_arc();
+        let child_key = edge_ref.target();
+        let child_name = graph
+          .get_node(child_key)
+          .ok_or_eyre("Child node must exist")?
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name()
+          .unwrap()
+          .as_ref()
+          .to_owned();
+        let metrics = partition.create_edge_contribution(edge_ref.key())?.evaluate(branch_length);
+        Ok((
+          child_name,
+          (metrics.log_lh, metrics.derivative, metrics.second_derivative),
+        ))
       })
       .collect()
   }

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
@@ -10,12 +10,15 @@ mod tests {
   use crate::representation::partition::traits::PartitionBranchOps;
   use crate::representation::payload::ancestral::GraphAncestral;
   use approx::assert_abs_diff_eq;
-  use eyre::Report;
+  use eyre::{OptionExt, Report};
   use indoc::indoc;
   use maplit::btreemap;
   use parking_lot::RwLock;
+  use pretty_assertions::assert_eq;
+  use std::collections::BTreeMap;
   use std::sync::Arc;
   use treetime_graph::edge::HasBranchLength;
+  use treetime_graph::node::Named;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
 
@@ -78,6 +81,26 @@ mod tests {
     Ok(())
   }
 
+  #[test]
+  fn test_initial_guess_dense_sparse_ambiguous_r_reference_state_consistency() -> Result<(), Report> {
+    let aln = ambiguous_r_in_g_clade_alignment()?;
+
+    let graph_dense: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+    let graph_sparse: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+
+    let partitions_dense = setup_dense(&graph_dense, &aln)?;
+    let partitions_sparse = setup_sparse(&graph_sparse, &aln)?;
+
+    initial_guess_mixed(&graph_dense, &partitions_dense, true)?;
+    initial_guess_mixed(&graph_sparse, &partitions_sparse, true)?;
+
+    let dense_branch_lengths = branch_lengths_by_child_name(&graph_dense)?;
+    let sparse_branch_lengths = branch_lengths_by_child_name(&graph_sparse)?;
+
+    assert_eq!(dense_branch_lengths, sparse_branch_lengths);
+    Ok(())
+  }
+
   fn divergent_alignment() -> Result<Vec<FastaRecord>, Report> {
     let alphabet = Alphabet::default();
     read_many_fasta_str(
@@ -90,6 +113,23 @@ mod tests {
         GGGGTTTTAAAACCCC
         >D
         TTTTAAAACCCCGGGG
+      "#},
+      &alphabet,
+    )
+  }
+
+  fn ambiguous_r_in_g_clade_alignment() -> Result<Vec<FastaRecord>, Report> {
+    let alphabet = Alphabet::default();
+    read_many_fasta_str(
+      indoc! {r#"
+        >A
+        RCGTACGT
+        >B
+        GCGTACGT
+        >C
+        GCGTACGT
+        >D
+        GCGTACGT
       "#},
       &alphabet,
     )
@@ -133,5 +173,28 @@ mod tests {
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)
+  }
+
+  fn branch_lengths_by_child_name(graph: &GraphAncestral) -> Result<BTreeMap<String, f64>, Report> {
+    graph
+      .get_edges()
+      .iter()
+      .map(|edge_ref| {
+        let edge_ref = edge_ref.read_arc();
+        let child_key = edge_ref.target();
+        let child_name = graph
+          .get_node(child_key)
+          .ok_or_eyre("Child node must exist")?
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name()
+          .unwrap()
+          .as_ref()
+          .to_owned();
+        let branch_length = edge_ref.payload().read_arc().branch_length().unwrap_or(0.0);
+        Ok((child_name, branch_length))
+      })
+      .collect()
   }
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
@@ -3,8 +3,8 @@ mod tests {
   use crate::alphabet::alphabet::{Alphabet, AlphabetName};
   use crate::commands::ancestral::fitch::{compress_sequences, get_common_length};
   use crate::commands::ancestral::marginal::{initialize_marginal, update_marginal};
-  use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
   use crate::commands::optimize::optimize_unified::initial_guess_mixed;
+  use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
@@ -245,7 +245,9 @@ mod tests {
           .unwrap()
           .as_ref()
           .to_owned();
-        let metrics = partition.create_edge_contribution(edge_ref.key())?.evaluate(branch_length);
+        let metrics = partition
+          .create_edge_contribution(edge_ref.key())?
+          .evaluate(branch_length);
         Ok((
           child_name,
           (metrics.log_lh, metrics.derivative, metrics.second_derivative),

--- a/packages/treetime/src/representation/partition/marginal_passes.rs
+++ b/packages/treetime/src/representation/partition/marginal_passes.rs
@@ -26,7 +26,9 @@ fn node_reference_state_or(
   pos: usize,
   fallback: AsciiChar,
 ) -> AsciiChar {
-  node_reference_state(partition, node_key, pos).unwrap_or(fallback)
+  node_reference_state(partition, node_key, pos)
+    .filter(|state| partition.alphabet.is_canonical(*state))
+    .unwrap_or(fallback)
 }
 
 pub fn process_node_backward<N, E>(

--- a/packages/treetime/src/representation/partition/marginal_passes.rs
+++ b/packages/treetime/src/representation/partition/marginal_passes.rs
@@ -8,10 +8,26 @@ use std::collections::BTreeMap;
 use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
-use treetime_graph::node::{GraphNode, Named};
+use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_primitives::AsciiChar;
 use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::interval::range::range_contains;
+
+fn node_reference_state(partition: &PartitionMarginalSparse, node_key: GraphNodeKey, pos: usize) -> Option<AsciiChar> {
+  partition
+    .nodes
+    .get(&node_key)
+    .and_then(|node_data| node_data.seq.sequence.get(pos).copied())
+}
+
+fn node_reference_state_or(
+  partition: &PartitionMarginalSparse,
+  node_key: GraphNodeKey,
+  pos: usize,
+  fallback: AsciiChar,
+) -> AsciiChar {
+  node_reference_state(partition, node_key, pos).unwrap_or(fallback)
+}
 
 pub fn process_node_backward<N, E>(
   partition: &mut PartitionMarginalSparse,
@@ -40,7 +56,7 @@ where
       .iter()
       .map(|(pos, p)| {
         let dis = alphabet.construct_profile(p.chars()).unwrap();
-        let state = p.get_one();
+        let state = node_reference_state_or(partition, node.key, *pos, p.get_one());
         (*pos, VarPos { dis, state })
       })
       .collect();
@@ -65,7 +81,8 @@ where
         child_states[ci].insert(m.pos(), m.qry());
       }
       for (pos, p) in &edge_data.msg_from_child.variable {
-        variable_pos.entry(*pos).or_insert(p.state);
+        let state = node_reference_state_or(partition, node.key, *pos, p.state);
+        variable_pos.entry(*pos).or_insert(state);
       }
       child_messages.push(edge_data.msg_from_child.clone());
     }
@@ -75,12 +92,18 @@ where
       let states = &mut child_states[ci];
       let child_data = &partition.nodes[child_key];
       for pos in variable_pos.keys() {
-        if !states.contains_key(pos) && range_contains(&child_data.seq.non_char, *pos) {
-          if range_contains(&child_data.seq.gaps, *pos) {
-            states.insert(*pos, alphabet.gap());
+        if states.contains_key(pos) {
+          continue;
+        }
+        if let Some(state) = node_reference_state(partition, *child_key, *pos) {
+          states.insert(*pos, state);
+        } else if range_contains(&child_data.seq.non_char, *pos) {
+          let state = if range_contains(&child_data.seq.gaps, *pos) {
+            alphabet.gap()
           } else {
-            states.insert(*pos, alphabet.unknown());
-          }
+            alphabet.unknown()
+          };
+          states.insert(*pos, state);
         }
       }
     }
@@ -140,7 +163,7 @@ where
     let mut ref_states: Vec<BTreeMap<usize, AsciiChar>> = vec![];
     let mut msgs_to_combine: Vec<MarginalSparseSeqDistribution> = vec![];
     let mut removed_edges = vec![];
-    for (_, edge_key) in &node.parent_keys {
+    for (parent_key, edge_key) in &node.parent_keys {
       let mut parent_state: BTreeMap<usize, AsciiChar> = btreemap! {};
       let mut child_state: BTreeMap<usize, AsciiChar> = btreemap! {};
       let edge_data = partition.edges.remove(edge_key).unwrap();
@@ -149,18 +172,22 @@ where
       let node_data = &partition.nodes[&node.key];
       for (pos, p) in &edge_data.msg_to_child.variable {
         if !range_contains(&node_data.seq.gaps, *pos) {
-          variable_pos.entry(*pos).or_insert(p.state);
-          parent_state.insert(*pos, p.state);
+          let current_state = node_reference_state_or(partition, node.key, *pos, p.state);
+          let parent_ref_state = node_reference_state_or(partition, *parent_key, *pos, p.state);
+          variable_pos.entry(*pos).or_insert(current_state);
+          parent_state.insert(*pos, parent_ref_state);
         }
       }
       for m in &edge_data.subs {
-        variable_pos.insert(m.pos(), m.qry());
+        let current_state = node_reference_state_or(partition, node.key, m.pos(), m.qry());
+        variable_pos.insert(m.pos(), current_state);
         parent_state.entry(m.pos()).or_insert_with(|| m.reff());
-        child_state.entry(m.pos()).or_insert_with(|| m.qry());
+        child_state.entry(m.pos()).or_insert(current_state);
       }
       for (pos, p) in &edge_data.msg_to_parent.variable {
-        variable_pos.entry(*pos).or_insert(p.state);
-        child_state.entry(*pos).or_insert(p.state);
+        let current_state = node_reference_state_or(partition, node.key, *pos, p.state);
+        variable_pos.entry(*pos).or_insert(current_state);
+        child_state.entry(*pos).or_insert(current_state);
       }
 
       let edge_payload = graph.get_edge(*edge_key).unwrap().read_arc().payload().read_arc();
@@ -219,17 +246,23 @@ where
     let child_dis = child_edge_data.msg_from_child.clone();
     let mut parent_states: BTreeMap<usize, AsciiChar> = btreemap! {};
     let mut child_states: BTreeMap<usize, AsciiChar> = btreemap! {};
+    let child_key = graph.get_target_node_key(*child_edge_key)?;
     for (pos, p) in &seq_info.profile.variable {
-      child_states.insert(*pos, p.state);
-      parent_states.insert(*pos, p.state);
+      let current_state = node_reference_state_or(partition, node.key, *pos, p.state);
+      child_states.insert(*pos, current_state);
+      parent_states.insert(*pos, current_state);
     }
     for (pos, p) in &child_dis.variable {
-      child_states.insert(*pos, p.state);
-      parent_states.entry(*pos).or_insert(p.state);
+      let current_state = node_reference_state_or(partition, node.key, *pos, p.state);
+      let child_state = node_reference_state_or(partition, child_key, *pos, p.state);
+      child_states.insert(*pos, child_state);
+      parent_states.entry(*pos).or_insert(current_state);
     }
     for sub in &child_edge_data.subs {
-      child_states.insert(sub.pos(), sub.qry());
-      parent_states.insert(sub.pos(), sub.reff());
+      let current_state = node_reference_state_or(partition, node.key, sub.pos(), sub.reff());
+      let child_state = node_reference_state_or(partition, child_key, sub.pos(), sub.qry());
+      child_states.insert(sub.pos(), child_state);
+      parent_states.insert(sub.pos(), current_state);
     }
 
     let mut delta_ll = 0.0;

--- a/packages/treetime/src/representation/payload/sparse.rs
+++ b/packages/treetime/src/representation/payload/sparse.rs
@@ -146,7 +146,7 @@ pub struct FitchSeqDistribution {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VarPos {
   pub dis: Array1<f64>, // array of floats of size 'alphabet'
-  pub state: AsciiChar,
+  pub state: AsciiChar, // exact reference state for this sparse position
 }
 
 impl VarPos {


### PR DESCRIPTION
Sparse marginal reconstruction reused arbitrary representatives from ambiguous state sets as if they were exact canonical reference states. On `data/flu/h3n2/500`, that broke partly ambiguous `R` sites around position 451 and produced many spurious `G451A` mutations in sparse mode while dense reconstructed the same ancestral state as `G`.

This PR preserves an authoritative exact reconstructed state for sparse nodes and uses that state consistently in sparse backward and forward message combination instead of `get_one()` fallbacks [[src](https://github.com/neherlab/treetime/blob/dab337ca08188ac65e8c157994ecd121c3364b48/packages/treetime/src/commands/ancestral/fitch.rs#L476-L515)] [[src](https://github.com/neherlab/treetime/blob/dab337ca08188ac65e8c157994ecd121c3364b48/packages/treetime/src/representation/partition/marginal_passes.rs#L16-L32)]. It adds ancestral and optimize regressions for ambiguous `R` handling and updates the test inventory ledgers [[src](https://github.com/neherlab/treetime/blob/dab337ca08188ac65e8c157994ecd121c3364b48/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs#L177-L249)] [[src](https://github.com/neherlab/treetime/blob/dab337ca08188ac65e8c157994ecd121c3364b48/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs#L83-L274)].

The change is correct because sparse fixed-site lookups now use the same exact reconstructed reference state that Fitch already resolved, rather than an arbitrary member of an ambiguous set. That restores dense-sparse agreement for the reported ambiguity case without changing sparse posterior storage into dense per-site probability matrices.

### Verification

Reproduce the original report:

```bash
./dev/docker/run ./dev/dev r treetime -- ancestral -vv --tree data/flu/h3n2/500/tree.nwk --outdir tmp/ancestral/flu/h3n2/500/sparse --method-anc marginal --dense false data/flu/h3n2/500/aln.fasta.xz
./dev/docker/run ./dev/dev r treetime -- ancestral -vv --tree data/flu/h3n2/500/tree.nwk --outdir tmp/ancestral/flu/h3n2/500/dense --method-anc marginal --dense true data/flu/h3n2/500/aln.fasta.xz
```

Before this branch:

```text
sparse annotated_tree.nwk: 30 x G451A
dense  annotated_tree.nwk:  4 x G451A
```

On this branch:

```text
sparse annotated_tree.nwk: 4 x G451A
dense  annotated_tree.nwk: 4 x G451A
sparse ancestors site 451: A=0 G=441
dense  ancestors site 451: A=0 G=441
```

Project validation:

```bash
./dev/docker/run ./dev/dev q
```

```text
2155 passed, 18 skipped
```

### Work items

- [x] Preserve exact sparse reference states for ambiguous-variable sites
- [x] Keep sparse fixed-state lookups canonical
- [x] Add ancestral regressions for ambiguous `R` handling and internal exact-sequence retention
- [x] Add optimize regressions covering the shared sparse ambiguity path
- [x] Update port test inventory and known-issue ledger entries

### Possible improvements

- [ ] Replace persistent internal full sequences with a dedicated sparse exact-state oracle if memory reduction beyond this fix is needed
- [ ] Run an end-to-end `optimize` CLI reproduction on `data/flu/h3n2/500` in addition to the shared-code regressions already added
