### PR TITLE
refactor: convert loop-over-cases to rstest in optimizer tests

### DIFF
--- a/docs/port-feature-inventory/_index.md
+++ b/docs/port-feature-inventory/_index.md
@@ -402,7 +402,7 @@ command and a reusable `PartitionOptimizeOps` trait system shared with timetree.
 - [x] `optimize` command with `--tree`, `--aln`, `--outdir`
 - [x] Mixed dense and sparse partition setup (one of each, from same alignment)
 - [x] Initial branch-length guess from observed mutation counts (excludes deletion and ambiguous positions)
-- [x] `--branch-length-initial-guess` flag: `auto` (selective fill), `always` (overwrite all), `never` (error on missing)
+- [x] `--branch-length-initial-guess` flag: `auto` (selective fill, treats zero BL as invalid when indels present), `always` (overwrite all), `never` (error on missing)
 - [x] Output annotated Newick and Nexus trees
 - [x] GTR parameters written to JSON
 
@@ -415,7 +415,7 @@ likelihood (`expQt = V diag(exp(lambda*t)) V_inv`).
 
 - [x] Eigenvalue-space coefficient caching (dense: `msg.dot(V) * msg.dot(V_inv.T)`, sparse: per-site with multiplicity)
 - [x] Analytical first and second derivatives (v1-only, v0 uses derivative-free Brent)
-- [x] Newton's method with clamped step (max 10 inner iterations, step in `[-1.0, bl]`)
+- [x] Newton's method with clamped step (max 10 inner iterations, step in `[-1.0, bl]`, absolute tolerance floor 1e-8 subs/site)
 - [x] Grid search fallback when second derivative >= 0 (100 points, log-spaced grid with 0.5 subs/site minimum upper bound)
 - [x] Zero branch length short-circuit (combined likelihood > 0.01 and derivative < 0 at zero)
 - [x] `compute_derivatives` flag to skip derivative computation for log-likelihood-only evaluation

--- a/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs
@@ -3,6 +3,7 @@ mod tests {
   use crate::commands::optimize::optimize_dense::{evaluate, get_coefficients};
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use ndarray::array;
+  use rstest::rstest;
 
   use super::super::test_coefficient_extraction_dense_support::tests::make_dense_seq_dis;
 
@@ -57,9 +58,14 @@ mod tests {
     );
   }
 
-  #[test]
-  fn test_coefficients_support_positive_branch_length() {
-    // Coefficients should produce valid metrics at positive branch lengths
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::tiny(    0.001)]
+  #[case::small(   0.01 )]
+  #[case::moderate( 0.1 )]
+  #[case::large(   1.0  )]
+  #[trace]
+  fn test_coefficients_support_positive_branch_length(#[case] branch_length: f64) {
     let gtr = jc69(JC69Params::default()).expect("JC69 creation failed");
 
     let parent = array![[0.7, 0.1, 0.1, 0.1]];
@@ -70,21 +76,9 @@ mod tests {
     let contribution = get_coefficients(&msg_to_parent, &msg_to_child, &gtr);
     let contributions = [contribution];
 
-    // Test at various branch lengths
-    for &branch_length in &[0.001, 0.01, 0.1, 1.0] {
-      let metrics = evaluate(&contributions, branch_length);
-      assert!(
-        metrics.log_lh.is_finite(),
-        "log-LH should be finite at branch_length={branch_length}"
-      );
-      assert!(
-        metrics.derivative.is_finite(),
-        "derivative should be finite at branch_length={branch_length}"
-      );
-      assert!(
-        metrics.second_derivative.is_finite(),
-        "second_derivative should be finite at branch_length={branch_length}"
-      );
-    }
+    let metrics = evaluate(&contributions, branch_length);
+    assert!(metrics.log_lh.is_finite(), "log-LH should be finite");
+    assert!(metrics.derivative.is_finite(), "derivative should be finite");
+    assert!(metrics.second_derivative.is_finite(), "second_derivative should be finite");
   }
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
@@ -57,7 +57,7 @@ mod tests {
 
     let contribution = PartitionContribution {
       site_contributions: vec![site],
-      gtr: gtr,
+      gtr,
     };
 
     // Numerical second derivative via central difference of first derivative:
@@ -72,8 +72,8 @@ mod tests {
   }
 
   /// Second derivative with high multiplicity must match numerical approximation.
-  /// Before the fix, multiplicity was squared in the Hessian, causing divergence
-  /// proportional to m for large m.
+  /// Multiplicity is a linear factor on the per-site Hessian contribution;
+  /// the squared term applies only to the per-site derivative ratio.
   #[rustfmt::skip]
   #[rstest]
   #[case::short( 0.01)]
@@ -91,7 +91,7 @@ mod tests {
 
     let contribution = PartitionContribution {
       site_contributions: vec![site],
-      gtr: gtr,
+      gtr,
     };
 
     let h = 1e-5;

--- a/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
@@ -57,8 +57,7 @@ mod tests {
 
     let contribution = PartitionContribution {
       site_contributions: vec![site],
-      eigenvalues: gtr.eigvals.to_owned(),
-      unimodal_branch_likelihood: gtr.unimodal_branch_likelihood,
+      gtr: gtr.clone(),
     };
 
     // Numerical second derivative via central difference of first derivative:
@@ -92,8 +91,7 @@ mod tests {
 
     let contribution = PartitionContribution {
       site_contributions: vec![site],
-      eigenvalues: gtr.eigvals.to_owned(),
-      unimodal_branch_likelihood: gtr.unimodal_branch_likelihood,
+      gtr: gtr.clone(),
     };
 
     let h = 1e-5;
@@ -170,8 +168,7 @@ mod tests {
           coefficients: coefficients_b.clone(),
         },
       ],
-      eigenvalues: gtr.eigvals.to_owned(),
-      unimodal_branch_likelihood: gtr.unimodal_branch_likelihood,
+      gtr: gtr.clone(),
     };
 
     // Dense: same two sites as rows of a 2D array

--- a/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
@@ -57,7 +57,7 @@ mod tests {
 
     let contribution = PartitionContribution {
       site_contributions: vec![site],
-      gtr: gtr.clone(),
+      gtr: gtr,
     };
 
     // Numerical second derivative via central difference of first derivative:
@@ -91,7 +91,7 @@ mod tests {
 
     let contribution = PartitionContribution {
       site_contributions: vec![site],
-      gtr: gtr.clone(),
+      gtr: gtr,
     };
 
     let h = 1e-5;

--- a/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs
@@ -9,18 +9,15 @@ mod tests {
 
   #[test]
   fn test_grid_search_branch_lengths_zero_branch_covers_full_range() {
-    // The original bug: when branch_length=0.0 and L=1000, the grid covered
-    // only [1e-4, 1e-3]. After the fix, the grid must extend to at least 0.5
-    // subs/site regardless of the current branch length.
+    // At branch_length=0 with L=1000, the grid must extend to at least 0.5
+    // subs/site (GRID_SEARCH_MIN_UPPER), covering the biologically plausible range.
     let one_mutation = 1.0 / 1000.0; // L = 1000
     let grid = grid_search_branch_lengths(0.0, one_mutation);
 
     let lower = grid[0];
     let upper = grid[grid.len() - 1];
 
-    // Lower bound: 0.1 * one_mutation = 1e-4
     assert_abs_diff_eq!(lower, 0.1 * one_mutation, epsilon = 1e-10);
-    // Upper bound: max(1.5*0.0 + 1e-3, 0.5) = 0.5
     assert_abs_diff_eq!(upper, 0.5, epsilon = 1e-10);
     // Grid must span at least 3 orders of magnitude
     assert!(
@@ -95,8 +92,7 @@ mod tests {
     // L_i(t) increases monotonically with t. For all-substitution
     // sites, the grid search returns the highest grid point.
     //
-    // With the old narrow grid at branch_length=0 (L=1000), the upper
-    // bound was ~0.001. The fix extends it to 0.5.
+    // At branch_length=0 (L=1000), the grid extends to GRID_SEARCH_MIN_UPPER=0.5.
     let coefficients = Array2::from_shape_fn((3, 4), |(_, j)| {
       // Negative non-stationary (indices 0-2), positive stationary (index 3)
       [-0.06, -0.06, -0.06, 0.25][j]
@@ -110,7 +106,7 @@ mod tests {
     let best_bl = grid_search(&contributions, branch_length, one_mutation);
 
     // With monotonically increasing likelihood, grid search returns near
-    // the upper bound (~0.5). The old grid would have returned ~0.001.
+    // the upper bound (~0.5).
     assert!(
       best_bl > 0.1,
       "Expected best_bl > 0.1 (grid should extend to 0.5), got {best_bl}"

--- a/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs
@@ -142,9 +142,18 @@ mod tests {
         lower <= one_mutation,
         "branch_length={branch_length}, one_mutation={one_mutation}: lower={lower} > one_mutation"
       );
+      // The grid upper bound is max(1.5*bl + one_mutation, 0.5). Assert both
+      // independently so the test catches regressions in either bound.
+      // The log-spaced grid computes exp(ln(upper)) which introduces round-trip
+      // error (~1 ulp), so use a small epsilon instead of exact >=.
+      let proportional = 1.5 * branch_length + one_mutation;
       assert!(
-        upper >= 0.5_f64.min(1.5 * branch_length + one_mutation),
-        "branch_length={branch_length}, one_mutation={one_mutation}: upper={upper} < min(0.5, proportional)"
+        upper >= 0.5 - 1e-12,
+        "branch_length={branch_length}, one_mutation={one_mutation}: upper={upper} < 0.5 (absolute minimum)"
+      );
+      assert!(
+        upper >= proportional - 1e-12,
+        "branch_length={branch_length}, one_mutation={one_mutation}: upper={upper} < {proportional} (proportional bound)"
       );
     }
   }

--- a/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs
@@ -3,6 +3,7 @@ mod tests {
   use crate::commands::optimize::optimize_unified::grid_search_branch_lengths;
   use approx::assert_abs_diff_eq;
   use ndarray::Array2;
+  use rstest::rstest;
 
   use super::super::test_grid_search_support::tests::{grid_search, make_dense_contribution};
 
@@ -117,44 +118,32 @@ mod tests {
     assert!(best_bl.is_finite());
   }
 
-  #[test]
-  fn test_grid_search_branch_lengths_coverage_invariant() {
-    // For any branch_length >= 0 and any reasonable one_mutation, the grid
-    // must always cover at least [one_mutation, 0.5].
-    #[rustfmt::skip]
-    let cases: &[(f64, f64)] = &[
-      (0.0,    0.001  ),
-      (0.0,    0.0001 ),
-      (0.0,    0.01   ),
-      (0.001,  0.001  ),
-      (0.1,    0.001  ),
-      (0.5,    0.001  ),
-      (1.0,    0.001  ),
-      (2.0,    0.0001 ),
-    ];
+  /// The grid must always cover at least [one_mutation, 0.5]. The upper bound
+  /// is max(1.5*bl + one_mutation, 0.5). The log-spaced grid computes
+  /// exp(ln(upper)) which introduces round-trip error (~1 ulp), so use a small
+  /// epsilon instead of exact >=.
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::zero_bl_medium_L(     (0.0,   0.001  ))]
+  #[case::zero_bl_large_L(      (0.0,   0.0001 ))]
+  #[case::zero_bl_small_L(      (0.0,   0.01   ))]
+  #[case::tiny_bl(               (0.001, 0.001  ))]
+  #[case::moderate_bl(           (0.1,   0.001  ))]
+  #[case::half_sub_per_site(     (0.5,   0.001  ))]
+  #[case::one_sub_per_site(      (1.0,   0.001  ))]
+  #[case::long_bl_large_L(      (2.0,   0.0001 ))]
+  #[trace]
+  fn test_grid_search_branch_lengths_coverage_invariant(
+    #[case] (branch_length, one_mutation): (f64, f64),
+  ) {
+    let grid = grid_search_branch_lengths(branch_length, one_mutation);
+    let lower = grid[0];
+    let upper = grid[grid.len() - 1];
 
-    for &(branch_length, one_mutation) in cases {
-      let grid = grid_search_branch_lengths(branch_length, one_mutation);
-      let lower = grid[0];
-      let upper = grid[grid.len() - 1];
+    assert!(lower <= one_mutation, "lower={lower} > one_mutation={one_mutation}");
 
-      assert!(
-        lower <= one_mutation,
-        "branch_length={branch_length}, one_mutation={one_mutation}: lower={lower} > one_mutation"
-      );
-      // The grid upper bound is max(1.5*bl + one_mutation, 0.5). Assert both
-      // independently so the test catches regressions in either bound.
-      // The log-spaced grid computes exp(ln(upper)) which introduces round-trip
-      // error (~1 ulp), so use a small epsilon instead of exact >=.
-      let proportional = 1.5 * branch_length + one_mutation;
-      assert!(
-        upper >= 0.5 - 1e-12,
-        "branch_length={branch_length}, one_mutation={one_mutation}: upper={upper} < 0.5 (absolute minimum)"
-      );
-      assert!(
-        upper >= proportional - 1e-12,
-        "branch_length={branch_length}, one_mutation={one_mutation}: upper={upper} < {proportional} (proportional bound)"
-      );
-    }
+    let proportional = 1.5 * branch_length + one_mutation;
+    assert!(upper >= 0.5 - 1e-12, "upper={upper} < 0.5 (absolute minimum)");
+    assert!(upper >= proportional - 1e-12, "upper={upper} < {proportional} (proportional bound)");
   }
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_edge_cases.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_edge_cases.rs
@@ -2,6 +2,7 @@
 mod tests {
   use crate::commands::optimize::optimize_unified::grid_search_branch_lengths;
   use ndarray::array;
+  use rstest::rstest;
 
   use super::super::test_grid_search_support::tests::{grid_search, make_dense_contribution};
 
@@ -27,21 +28,24 @@ mod tests {
     assert!(best_bl <= upper);
   }
 
-  #[test]
-  fn test_grid_search_preserves_positive_branch_length() {
-    // Grid search should always return a positive branch length
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::moderate_bl(  (0.1,   0.001  ))]
+  #[case::small_bl(     (0.01,  0.001  ))]
+  #[case::tiny_bl(      (0.001, 0.0001 ))]
+  #[case::large_bl(     (1.0,   0.001  ))]
+  #[trace]
+  fn test_grid_search_preserves_positive_branch_length(
+    #[case] (branch_length, one_mutation): (f64, f64),
+  ) {
     let coefficients = array![[0.9, 0.03, 0.03, 0.04], [0.03, 0.9, 0.03, 0.04],];
     let contribution = make_dense_contribution(coefficients);
     let contributions = vec![contribution];
 
-    let test_cases = [(0.1, 0.001), (0.01, 0.001), (0.001, 0.0001), (1.0, 0.001)];
-
-    for (branch_length, one_mutation) in test_cases {
-      let best_bl = grid_search(&contributions, branch_length, one_mutation);
-      assert!(
-        best_bl > 0.0,
-        "grid_search({branch_length}, {one_mutation}) = {best_bl} should be > 0"
-      );
-    }
+    let best_bl = grid_search(&contributions, branch_length, one_mutation);
+    assert!(
+      best_bl > 0.0,
+      "grid_search({branch_length}, {one_mutation}) = {best_bl} should be > 0"
+    );
   }
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs
@@ -4,6 +4,7 @@ mod tests {
   use approx::assert_abs_diff_eq;
   use ndarray::array;
   use num::clamp;
+  use rstest::rstest;
 
   use super::super::test_newton_convergence_support::tests::make_dense_contribution;
 
@@ -37,15 +38,22 @@ mod tests {
     assert_abs_diff_eq!(tol, 1e-8, epsilon = 1e-15);
   }
 
-  #[test]
-  fn test_newton_tolerance_always_positive() {
-    #[rustfmt::skip]
-    let cases = [0.0, 1e-15, 1e-10, 1e-8, 1e-5, 0.001, 0.1, 1.0, 10.0];
-    for bl in cases {
-      let tol = newton_tolerance(bl);
-      assert!(tol > 0.0, "Tolerance must be positive for branch_length={bl}");
-      assert!(tol.is_finite(), "Tolerance must be finite for branch_length={bl}");
-    }
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::zero(     0.0  )]
+  #[case::tiny(     1e-15)]
+  #[case::small(    1e-10)]
+  #[case::at_floor( 1e-8 )]
+  #[case::crossover(1e-5 )]
+  #[case::moderate( 0.001)]
+  #[case::typical(  0.1  )]
+  #[case::one(      1.0  )]
+  #[case::large(    10.0 )]
+  #[trace]
+  fn test_newton_tolerance_always_positive(#[case] bl: f64) {
+    let tol = newton_tolerance(bl);
+    assert!(tol > 0.0, "Tolerance must be positive for branch_length={bl}");
+    assert!(tol.is_finite(), "Tolerance must be finite for branch_length={bl}");
   }
 
   #[test]

--- a/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs
@@ -58,9 +58,8 @@ mod tests {
 
   #[test]
   fn test_newton_zero_start_converges_efficiently() {
-    // Before fix: starting from branch_length=0 caused the loop to exhaust
-    // all 10 iterations because 0.001 * 0.0 = 0.0 made the tolerance zero.
-    // After fix: the absolute floor allows early convergence.
+    // Starting from branch_length=0, the absolute tolerance floor (NEWTON_ABS_TOL)
+    // prevents degeneration to zero tolerance and allows early convergence.
     let coefficients = array![[0.9, 0.03, 0.03, 0.04], [0.03, 0.9, 0.03, 0.04], [0.1, 0.1, 0.7, 0.1],];
     let contribution = make_dense_contribution(coefficients);
     let contributions = vec![contribution];

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
@@ -23,6 +23,7 @@ mod tests {
   use maplit::btreemap;
   use ndarray::array;
   use parking_lot::RwLock;
+  use rstest::rstest;
   use std::sync::Arc;
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
@@ -279,49 +280,54 @@ mod tests {
 
   /// The Poisson indel contribution makes the combined second derivative more negative
   /// (more concave), aiding Newton convergence.
-  #[test]
-  fn test_optimize_indel_poisson_concavity() {
-    let k = 3;
-    let mu = 5.0;
-
-    for &t in &[0.01, 0.1, 0.5, 1.0, 5.0] {
-      let metrics = poisson_indel_log_lh(k, mu, t);
-      assert!(
-        metrics.second_derivative < 0.0,
-        "Poisson log-likelihood should be concave for k>0, but at t={t} got d2={:.6}",
-        metrics.second_derivative
-      );
-    }
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::tiny(    0.01)]
+  #[case::small(   0.1 )]
+  #[case::moderate( 0.5)]
+  #[case::one(     1.0 )]
+  #[case::large(   5.0 )]
+  #[trace]
+  fn test_optimize_indel_poisson_concavity(#[case] t: f64) {
+    let metrics = poisson_indel_log_lh(3, 5.0, t);
+    assert!(metrics.second_derivative < 0.0, "Poisson log-likelihood should be concave for k>0");
   }
 
   /// The Poisson derivative at the MLE (t = k/mu) is zero.
-  #[test]
-  fn test_optimize_indel_poisson_mle_derivative_zero() {
-    for k in 1..=10 {
-      let mu = 3.0;
-      let t_mle = k as f64 / mu;
-      let metrics = poisson_indel_log_lh(k, mu, t_mle);
-      assert_abs_diff_eq!(metrics.derivative, 0.0, epsilon = 1e-13);
-    }
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::k1( 1)]
+  #[case::k2( 2)]
+  #[case::k3( 3)]
+  #[case::k5( 5)]
+  #[case::k10(10)]
+  #[trace]
+  fn test_optimize_indel_poisson_mle_derivative_zero(#[case] k: usize) {
+    let mu = 3.0;
+    let t_mle = k as f64 / mu;
+    let metrics = poisson_indel_log_lh(k, mu, t_mle);
+    assert_abs_diff_eq!(metrics.derivative, 0.0, epsilon = 1e-13);
   }
 
   /// The Poisson log-likelihood at the MLE is the maximum.
-  #[test]
-  fn test_optimize_indel_poisson_mle_is_maximum() {
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::below_far(  -0.5 )]
+  #[case::below_near( -0.1 )]
+  #[case::below_close(-0.01)]
+  #[case::above_close( 0.01)]
+  #[case::above_near(  0.1 )]
+  #[case::above_far(   0.5 )]
+  #[trace]
+  fn test_optimize_indel_poisson_mle_is_maximum(#[case] delta: f64) {
     let k = 4;
     let mu = 2.0;
     let t_mle = k as f64 / mu;
-    let lh_mle = poisson_indel_log_lh(k, mu, t_mle).log_lh;
-
-    for &delta in &[-0.5, -0.1, -0.01, 0.01, 0.1, 0.5] {
-      let t = t_mle + delta;
-      if t > 0.0 {
-        let lh = poisson_indel_log_lh(k, mu, t).log_lh;
-        assert!(
-          lh <= lh_mle + 1e-14,
-          "log-lh at t={t} ({lh}) should be <= log-lh at MLE ({lh_mle})"
-        );
-      }
+    let t = t_mle + delta;
+    if t > 0.0 {
+      let lh_mle = poisson_indel_log_lh(k, mu, t_mle).log_lh;
+      let lh = poisson_indel_log_lh(k, mu, t).log_lh;
+      assert!(lh <= lh_mle + 1e-14, "log-lh at t={t} ({lh}) should be <= log-lh at MLE ({lh_mle})");
     }
   }
 


### PR DESCRIPTION

Manual `for` loops over test cases produced one test with N subcases: a single failure name, shared state leakage, and no independent pass/fail. Comments referenced the old grid layout (`before fix / after fix / old grid`) which became edit history after the grid search fixes landed.

Convert loop-over-cases in grid search, Newton convergence, dense properties, and indel tests to `rstest #[case]` parameterized tests. Replace edit-history comments with descriptions of current behavior. Fix the grid coverage invariant that used `min(0.5, proportional)`, which passed trivially for zero-branch cases, by asserting both bounds independently: `upper >= 0.5` and `upper >= 1.5 * bl + one_mutation`, with a $10^{-12}$ tolerance for `exp(ln(x))` round-trip error on the log-spaced grid.

Each rstest case gets its own test name and independent pass/fail, making failures localized and regressions easier to attribute.

### Work items

- [x] Convert grid search, Newton, dense properties, indel loops to rstest
- [x] Fix coverage invariant to assert both grid bounds independently
- [x] Replace edit-history comments with behavioral descriptions
- [x] Update feature inventory for Newton tolerance and indel-aware initial guess
