### PR TITLE
docs: file known issues from optimizer code review

### DIFF
--- a/docs/port-intentional-changes/optimize-indel-contribution-to-likelihood.md
+++ b/docs/port-intentional-changes/optimize-indel-contribution-to-likelihood.md
@@ -46,7 +46,6 @@ The primary goal is preventing zero-length assignment on branches with only inde
 
 ## Related known issues
 
-- ~~Grid search zero-comparison ignores indel likelihood~~ **FIXED**
 - [Timetree branch length distribution ignores indels](../port-known-issues/N-timetree-branch-length-distribution-ignores-indels.md)
 
 ## v0 handling

--- a/docs/port-known-issues/N-gtr-expqt-diagonal-matrix-cubic.md
+++ b/docs/port-known-issues/N-gtr-expqt-diagonal-matrix-cubic.md
@@ -1,0 +1,29 @@
+# expQt uses O(n^3) diagonal matrix multiply instead of O(n^2) broadcast
+
+`GTR::expQt()` constructs a full diagonal matrix via `Array2::from_diag()` then multiplies with two `dot()` calls, producing O(n^3) work. A row-wise broadcast scaling achieves the same result in O(n^2).
+
+## Location
+
+- [packages/treetime/src/gtr/gtr.rs#L471-L480](../../packages/treetime/src/gtr/gtr.rs#L471-L480): `expQt()` and `exp_lt()`
+- [packages/treetime/src/gtr/gtr.rs#L329-L333](../../packages/treetime/src/gtr/gtr.rs#L329-L333): `expQt_with_rate()`
+
+```rust
+let eLambdaT = Array2::from_diag(&self.exp_lt(t));
+let Qt = self.v.dot(&eLambdaT.dot(&self.v_inv));
+```
+
+## Impact
+
+Negligible for nucleotides (n=4, 64 vs 16 ops). Measurable for amino acids (n=20, 8000 vs 400 ops per call). `expQt` is called once per edge per marginal reconstruction pass.
+
+## Fix
+
+Replace `from_diag` + dot with broadcast row scaling:
+
+```rust
+let exp_ev = self.exp_lt(t);
+let scaled_v_inv = &self.v_inv * &exp_ev.insert_axis(Axis(1));
+let Qt = self.v.dot(&scaled_v_inv);
+```
+
+Or use `v * exp_ev` (column scaling) depending on the layout convention.

--- a/docs/port-known-issues/N-gtr-is-multi-site-dead-code.md
+++ b/docs/port-known-issues/N-gtr-is-multi-site-dead-code.md
@@ -1,0 +1,13 @@
+# Dead `GTR::is_multi_site()` method
+
+`GTR::is_multi_site()` at [packages/treetime/src/gtr/gtr.rs#L493-L495](../../packages/treetime/src/gtr/gtr.rs#L493-L495) checks `self.pi.shape().len() > 1`. Since `pi` is `Array1<f64>`, this always returns `false` by type constraint. The method is never called from any production or test code.
+
+Two commented-out call sites exist at `gtr.rs:526` and `gtr.rs:546`, suggesting it was part of a planned multi-site GTR feature that was not completed.
+
+## Impact
+
+Negligible. Dead code that increases maintenance surface.
+
+## Fix
+
+Remove the method and the commented-out call sites. If multi-site GTR is needed later, it will use `GtrSiteSpecific` which has a different architecture.

--- a/docs/port-known-issues/N-optimize-coefficient-property-tests-missing.md
+++ b/docs/port-known-issues/N-optimize-coefficient-property-tests-missing.md
@@ -1,0 +1,22 @@
+# Coefficient extraction lacks invariant property tests
+
+The eigenvalue-space coefficient extraction (`get_coefficients()` in `optimize_dense.rs` and `optimize_sparse.rs`) computes `k_c = (msg_child . V) * (msg_parent . V_inv^T)`. These coefficients have mathematical invariants that are tested only by manual examples, not by property-based tests.
+
+## Invariants not tested
+
+- **Non-negative site likelihood at t=0**: `sum_c k_{ic} >= 0` for valid probability messages (coefficients sum to a probability, which is non-negative)
+- **Multiplicity linearity**: sparse contribution with multiplicity `m` must produce `m *` the single-site log-likelihood, derivative, and second derivative
+- **Dense-sparse equivalence**: `m` sparse sites with multiplicity 1 must match one dense contribution with `m` rows
+- **Coefficient additivity**: coefficients from independent sites sum independently in the log-likelihood
+
+## Why it matters
+
+The Hessian multiplicity bug (sparse second derivative squaring multiplicity incorrectly) would have been caught by the multiplicity linearity property test. Property tests over random coefficients and branch lengths provide coverage that manual examples miss.
+
+## Impact
+
+Medium. Missing property tests leave algebraic invariants unverified. The `proptest` infrastructure already exists in this module (`test_coefficient_extraction_sparse/` has generators).
+
+## Fix
+
+Add `proptest` tests for the listed invariants, using the existing generator infrastructure.

--- a/docs/port-known-issues/N-optimize-dense-evaluate-dead-code.md
+++ b/docs/port-known-issues/N-optimize-dense-evaluate-dead-code.md
@@ -1,0 +1,14 @@
+# Dead `optimize_dense::evaluate()` function
+
+`optimize_dense::evaluate()` at [packages/treetime/src/commands/optimize/optimize_dense.rs#L39-L57](../../packages/treetime/src/commands/optimize/optimize_dense.rs#L39-L57) duplicates `evaluate_dense_contribution_impl()` from `optimize_dense_eval.rs` with a slightly different structure (always computes derivatives, no option to skip). It is not called from production code - only from two test files:
+
+- `test_coefficient_extraction_dense_basic.rs`
+- `test_coefficient_extraction_dense_properties.rs`
+
+## Impact
+
+Negligible. Dead production code that increases maintenance surface. Tests should use `evaluate_dense_contribution()` from `optimize_dense_eval.rs` instead.
+
+## Fix
+
+Remove `optimize_dense::evaluate()`, update the two test files to import `evaluate_dense_contribution` from `optimize_dense_eval`.

--- a/docs/port-known-issues/N-optimize-duplicate-derivative-computation.md
+++ b/docs/port-known-issues/N-optimize-duplicate-derivative-computation.md
@@ -1,0 +1,31 @@
+# Derivative ratio computed twice per site in evaluation functions
+
+The per-site first derivative ratio `(coefficients * &ev_exp_ev).sum() / site_lh` is computed twice in the Newton evaluation path: once for the first derivative and once for the squared term in the second derivative. Caching the ratio eliminates one temporary allocation and element-wise multiply per site per edge per Newton iteration.
+
+## Location
+
+- [packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L34-L36](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L34-L36)
+- [packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L35-L37](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L35-L37)
+- [packages/treetime/src/commands/optimize/optimize_dense.rs#L52-L53](../../packages/treetime/src/commands/optimize/optimize_dense.rs#L52-L53)
+
+```rust
+derivative += (coefficients * &ev_exp_ev).sum() / site_lh;
+second_derivative += (coefficients * &ev2_exp_ev).sum() / site_lh
+  - ((coefficients * &ev_exp_ev).sum() / site_lh).powi(2);  // recomputed
+```
+
+## Impact
+
+Negligible for small alignments. For large alignments with many sites per edge, the duplicate computation doubles the per-site work in the derivative path. The allocation is a 4-element (nucleotide) or 20-element (amino acid) temporary array.
+
+## Fix
+
+Cache the ratio:
+
+```rust
+let d1 = (coefficients * &ev_exp_ev).sum() / site_lh;
+derivative += d1;
+second_derivative += (coefficients * &ev2_exp_ev).sum() / site_lh - d1.powi(2);
+```
+
+This also makes the Hessian formula clearer and prevents the multiplicity-squaring bug pattern.

--- a/docs/port-known-issues/N-optimize-eval-unguarded-ln-zero.md
+++ b/docs/port-known-issues/N-optimize-eval-unguarded-ln-zero.md
@@ -1,0 +1,22 @@
+# Unguarded ln(site_lh) in evaluation functions
+
+The evaluation functions `evaluate_dense_contribution_impl()` and `evaluate_sparse_contribution_impl()` compute `site_lh.ln()` without checking `site_lh > 0`. When per-site coefficients sum to zero or negative (degenerate eigenvalue-space projections), `ln(0)` produces `-inf` and `ln(negative)` produces `NaN`. These propagate silently through the Newton step and can corrupt branch length estimates.
+
+## Location
+
+- [packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L33](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L33): `log_lh += site_lh.ln();`
+- [packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L41](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L41): same in no-derivatives path
+- [packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L34](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L34): `log_lh += multiplicity * site_lh.ln();`
+- [packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L46](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L46): same in no-derivatives path
+
+## Partial mitigation
+
+`is_zero_branch_optimal()` checks `all_sites_valid_at_zero()` which verifies `site_lh > 0 && site_lh.is_finite()` before the zero-branch shortcut. But the main Newton and grid search evaluation paths do not guard against this. For valid phylogenetic data, coefficients produce positive site likelihoods. The risk is degenerate input or numerical edge cases.
+
+## Impact
+
+Medium. NaN/Inf corruption would produce silently wrong branch lengths. Mitigated by the fact that valid phylogenetic inputs produce positive coefficient sums.
+
+## Fix
+
+Add `debug_assert!(site_lh > 0.0)` or return early with a sentinel value when `site_lh <= 0.0`.

--- a/docs/port-known-issues/N-optimize-indel-newton-path-untested.md
+++ b/docs/port-known-issues/N-optimize-indel-newton-path-untested.md
@@ -1,0 +1,20 @@
+# Indel-aware Newton optimization path has no direct tests
+
+The Newton optimization loop in `run_optimize_mixed()` includes indel-aware evaluation (`evaluate_with_indels()`), a `min_branch_length` clamp for indel-bearing edges, and an `indel_count == 0` guard before the zero-branch check. None of these are tested directly. Existing integration tests assert only `bl > 0.0` and `bl.is_finite()`.
+
+## Location
+
+- [packages/treetime/src/commands/optimize/optimize_unified.rs#L375-L440](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L375-L440): Newton loop with indel contributions
+- [packages/treetime/src/commands/optimize/optimize_unified.rs#L398](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L398): `min_branch_length` clamping for indel edges
+- [packages/treetime/src/commands/optimize/optimize_unified.rs#L388](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L388): `indel_count == 0` guard
+
+## Impact
+
+Medium. The Poisson indel model changes Newton step behavior (additional log-likelihood term, derivative divergence at zero, minimum branch length clamping). Without direct tests, regressions in the indel-aware path are detected only through end-to-end integration tests, which lack precision.
+
+## Tests needed
+
+- Unit test: Newton with `indel_count > 0` converges to the Poisson MLE `k/mu` for indel-only edges (zero substitution signal)
+- Unit test: `min_branch_length` clamping prevents Newton from reaching zero on indel-bearing edges
+- Unit test: `evaluate_with_indels()` returns correct log-likelihood for known Poisson parameters
+- Property test: `evaluate_with_indels(contributions, k, mu, t) >= evaluate_mixed(contributions, t)` for all `k >= 0` (indel term is non-positive for k=0, so this holds when indels are present)

--- a/docs/port-known-issues/N-optimize-indel-rate-never-mode-zero-bl.md
+++ b/docs/port-known-issues/N-optimize-indel-rate-never-mode-zero-bl.md
@@ -10,7 +10,7 @@ When `--branch-length-initial-guess=never` is used with a tree where all branch 
 
 ## Mechanism
 
-The `Auto` path was fixed by treating zero-BL indel-bearing edges as invalid in `initial_guess_mixed()`, seeding positive BLs before `run_optimize_mixed()`. The `Never` path skips `initial_guess_mixed()` entirely, so `estimate_indel_rate()` sees total BL = 0 and returns zero. The per-edge bootstrap at `optimize_unified.rs:L377-L382` sets a local `branch_length = one_mutation`, but `indel_rate` was already computed as zero.
+The `Auto` path treats zero-BL indel-bearing edges as invalid in `initial_guess_mixed()`, seeding positive BLs before `run_optimize_mixed()`. The `Never` path skips `initial_guess_mixed()` entirely, so `estimate_indel_rate()` sees total BL = 0 and returns zero. The per-edge bootstrap at `optimize_unified.rs:L377-L382` sets a local `branch_length = one_mutation`, but `indel_rate` was already computed as zero.
 
 ## Impact
 

--- a/docs/port-known-issues/N-optimize-zero-sequence-length-division.md
+++ b/docs/port-known-issues/N-optimize-zero-sequence-length-division.md
@@ -1,0 +1,16 @@
+# Division by zero when total sequence length is zero
+
+`run_optimize_mixed()` and `initial_guess_mixed()` compute `one_mutation = 1.0 / total_length as f64` where `total_length` is the sum of sequence lengths across all partitions. If all partitions have zero sequence length, this produces `+inf`, which propagates into grid search bounds, Newton tolerance, and initial guess values.
+
+## Location
+
+- [packages/treetime/src/commands/optimize/optimize_unified.rs#L357](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L357): `let one_mutation = 1.0 / total_length as f64;` in `run_optimize_mixed()`
+- [packages/treetime/src/commands/optimize/optimize_unified.rs#L473](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L473): same in `initial_guess_mixed()`
+
+## Impact
+
+Medium. An empty alignment (zero sequence length) is invalid input that should be rejected upstream. No current code path reaches this with zero-length partitions. The risk is future code paths or malformed input bypassing validation.
+
+## Fix
+
+Add an early check: `if total_length == 0 { return make_error!("...") }` before computing `one_mutation`.

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -69,6 +69,10 @@ exactly.
 | Medium     | Dates        | [Column auto-detection gaps in CSV readers](M-dates-column-auto-detection-gaps.md)                                              |
 | Medium     | GTR          | [Per-site rate variation not implemented](M-gtr-per-site-rate-variation.md)                                                     |
 | Medium     | Mugration    | [Iterative GTR inference not implemented for mugration](M-mugration-iterative-gtr.md)                                           |
+| Medium     | Optimize     | [Unguarded ln(site_lh) in evaluation functions](N-optimize-eval-unguarded-ln-zero.md)                                           |
+| Medium     | Optimize     | [Division by zero when total sequence length is zero](N-optimize-zero-sequence-length-division.md)                              |
+| Medium     | Optimize     | [Indel-aware Newton optimization path has no direct tests](N-optimize-indel-newton-path-untested.md)                            |
+| Medium     | Optimize     | [Coefficient extraction lacks invariant property tests](N-optimize-coefficient-property-tests-missing.md)                       |
 | Low        | Optimize     | [Duplicate edge-collapse implementations in prune and optimize](L-optimize-prune-duplicate-collapse.md)                         |
 | Low        | GTR          | [Site-specific GTR partition integration pending](L-gtr-site-specific-partition-integration.md)                                 |
 | Low        | GTR          | [Site-specific GTR end-to-end inference test pending](L-gtr-site-specific-e2e-inference-test.md)                                |
@@ -102,6 +106,9 @@ exactly.
 | Negligible | Optimize     | [Dense/sparse equivalence validity tests silently skip None branch lengths](N-optimize-validity-test-silent-none-skip.md)       |
 | Negligible | Optimize     | [Dead `optimize_dense::evaluate()` function](N-optimize-dense-evaluate-dead-code.md)                                            |
 | Negligible | Optimize     | [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md)                                                          |
+| Negligible | Optimize     | [Derivative ratio computed twice per site](N-optimize-duplicate-derivative-computation.md)                                      |
+| Negligible | GTR          | [expQt uses O(n^3) diagonal matrix multiply](N-gtr-expqt-diagonal-matrix-cubic.md)                                              |
+| Negligible | GTR          | [Dead `GTR::is_multi_site()` method](N-gtr-is-multi-site-dead-code.md)                                                          |
 | Negligible | Optimize     | [Indel rate estimation bypassed in Never mode on all-zero-BL trees](N-optimize-indel-rate-never-mode-zero-bl.md)                |
 | Negligible | Timetree     | [--dates not required, misleading error when omitted](N-timetree-dates-not-required.md)                                         |
 | Negligible | Timetree     | [Dead CLI flags in timetree](N-timetree-dead-cli-flags.md)                                                                      |

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -100,6 +100,7 @@ exactly.
 | Negligible | Optimize     | [Dense/sparse equivalence test bounds undocumented](N-optimize-equivalence-bounds-undocumented.md)                              |
 | Negligible | Optimize     | [Optimize command accepts only a single alignment](N-optimize-multi-alignment-input.md)                                         |
 | Negligible | Optimize     | [Dense/sparse equivalence validity tests silently skip None branch lengths](N-optimize-validity-test-silent-none-skip.md)       |
+| Negligible | Optimize     | [Dead `optimize_dense::evaluate()` function](N-optimize-dense-evaluate-dead-code.md)                                            |
 | Negligible | Optimize     | [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md)                                                          |
 | Negligible | Optimize     | [Indel rate estimation bypassed in Never mode on all-zero-BL trees](N-optimize-indel-rate-never-mode-zero-bl.md)                |
 | Negligible | Timetree     | [--dates not required, misleading error when omitted](N-timetree-dates-not-required.md)                                         |

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
@@ -137,7 +137,7 @@ mod tests {
   }
 
   /// With identical sequences (zero subs on every edge), `initial_guess_mixed` uses
-  /// the Poisson MLE for indel-bearing edges.
+  /// the Poisson maximum likelihood estimate (MLE) for indel-bearing edges.
   #[test]
   fn test_optimize_indel_initial_guess_nonzero_with_indels() -> Result<(), Report> {
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;

--- a/packages/treetime/src/commands/optimize/optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/optimize_indel.rs
@@ -115,7 +115,7 @@ mod tests {
 
   #[test]
   fn test_optimize_indel_poisson_mle_at_optimum() {
-    // At the MLE t = k/mu, the derivative should be zero
+    // At the maximum likelihood estimate (MLE) t = k/mu, the derivative should be zero
     let k = 5;
     let mu = 10.0;
     let t_mle = k as f64 / mu; // 0.5

--- a/packages/treetime/src/commands/optimize/optimize_unified.rs
+++ b/packages/treetime/src/commands/optimize/optimize_unified.rs
@@ -451,7 +451,7 @@ where
 /// The denominator is the per-edge effective alignment length rather than the raw
 /// sequence length, so gap-heavy edges get correctly scaled rates.
 ///
-/// For edges with indels but no substitutions, the Poisson MLE $\hat{t} = k / \mu$
+/// For edges with indels but no substitutions, the Poisson maximum likelihood estimate (MLE) $\hat{t} = k / \mu$
 /// provides a non-zero initial estimate so Newton optimization starts from a
 /// reasonable point (the indel derivative diverges at $t = 0$).
 ///


### PR DESCRIPTION

Auditing the optimizer modules surfaced seven issues not tracked in the ledger, plus a stale `FIXED` strikethrough marker that the current-state-only ledger rule forbids.

File seven known issues: four medium (unguarded `site_lh.ln()`, zero-length division, untested indel Newton path, missing coefficient property tests) and three negligible (duplicate derivative computation, $O(n^3)$ expQt for amino acids, dead `is_multi_site()`). File a known issue for the unused `optimize_dense::evaluate()`. Remove the stale FIXED marker from the indel-contribution intentional-changes file. Expand MLE acronym on first use and add it to the glossary.

### Work items

- [x] File issue: [docs/port-known-issues/N-optimize-eval-unguarded-ln-zero.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-optimize-eval-unguarded-ln-zero.md): `site_lh.ln()` without positivity guard
- [x] File issue: [docs/port-known-issues/N-optimize-zero-sequence-length-division.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-optimize-zero-sequence-length-division.md): `1.0/total_length` on empty alignment
- [x] File issue: [docs/port-known-issues/N-optimize-indel-newton-path-untested.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-optimize-indel-newton-path-untested.md): no direct tests for `evaluate_with_indels`
- [x] File issue: [docs/port-known-issues/N-optimize-coefficient-property-tests-missing.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-optimize-coefficient-property-tests-missing.md): no proptest for coefficient invariants
- [x] File issue: [docs/port-known-issues/N-optimize-duplicate-derivative-computation.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-optimize-duplicate-derivative-computation.md): derivative ratio computed twice per site
- [x] File issue: [docs/port-known-issues/N-gtr-expqt-diagonal-matrix-cubic.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-gtr-expqt-diagonal-matrix-cubic.md): O(n^3) vs O(n^2) for amino acid alphabets
- [x] File issue: [docs/port-known-issues/N-gtr-is-multi-site-dead-code.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-gtr-is-multi-site-dead-code.md): never called, always returns false
- [x] File issue: [docs/port-known-issues/N-optimize-dense-evaluate-dead-code.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-known-issues/N-optimize-dense-evaluate-dead-code.md): unused `optimize_dense::evaluate()`
- [x] Remove stale FIXED marker from [docs/port-intentional-changes/optimize-indel-contribution-to-likelihood.md](https://github.com/neherlab/treetime/blob/1da2a9c0/docs/port-intentional-changes/optimize-indel-contribution-to-likelihood.md)
- [x] Expand MLE acronym at first use and add to glossary
