### PR TITLE
test: assert error on zero total sequence length

### DIFF
--- a/packages/treetime/src/commands/optimize/__tests__/mod.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/mod.rs
@@ -16,4 +16,5 @@ mod test_is_zero_branch_optimal;
 mod test_newton_convergence;
 mod test_optimization_metrics;
 mod test_optimize_indel;
+mod test_optimize_zero_sequence_length;
 mod test_topology_cleanup;

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs
@@ -13,9 +13,7 @@ mod tests {
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::assert_error;
 
-  fn zero_length_partitions(
-    graph: &GraphAncestral,
-  ) -> crate::commands::optimize::partition_ops::PartitionOptimizeVec {
+  fn zero_length_partitions(graph: &GraphAncestral) -> crate::commands::optimize::partition_ops::PartitionOptimizeVec {
     let dense = vec![Arc::new(RwLock::new(PartitionMarginalDense {
       index: 0,
       gtr: jc69(JC69Params::default()).unwrap(),

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs
@@ -1,0 +1,52 @@
+#[cfg(test)]
+mod tests {
+  use crate::alphabet::alphabet::{Alphabet, AlphabetName};
+  use crate::commands::optimize::optimize_unified::{initial_guess_mixed, run_optimize_mixed};
+  use crate::commands::optimize::run::collect_optimize_partitions;
+  use crate::gtr::get_gtr::{JC69Params, jc69};
+  use crate::representation::partition::marginal_dense::PartitionMarginalDense;
+  use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+  use crate::representation::payload::ancestral::GraphAncestral;
+  use maplit::btreemap;
+  use parking_lot::RwLock;
+  use std::sync::Arc;
+  use treetime_io::nwk::nwk_read_str;
+  use treetime_utils::assert_error;
+
+  fn zero_length_partitions(
+    graph: &GraphAncestral,
+  ) -> crate::commands::optimize::partition_ops::PartitionOptimizeVec {
+    let dense = vec![Arc::new(RwLock::new(PartitionMarginalDense {
+      index: 0,
+      gtr: jc69(JC69Params::default()).unwrap(),
+      alphabet: Alphabet::new(AlphabetName::Nuc).unwrap(),
+      length: 0,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }))];
+    let sparse: Vec<Arc<RwLock<PartitionMarginalSparse>>> = vec![];
+    collect_optimize_partitions(&dense, &sparse)
+  }
+
+  #[test]
+  fn test_optimize_zero_sequence_length_run_optimize_error() {
+    let graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.2)AB:0.1,C:0.2)root:0.01;").unwrap();
+    let partitions = zero_length_partitions(&graph);
+    let result = run_optimize_mixed(&graph, &partitions);
+    assert_error!(
+      result,
+      "Total sequence length across all partitions is zero; cannot optimize branch lengths"
+    );
+  }
+
+  #[test]
+  fn test_optimize_zero_sequence_length_initial_guess_error() {
+    let graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.2)AB:0.1,C:0.2)root:0.01;").unwrap();
+    let partitions = zero_length_partitions(&graph);
+    let result = initial_guess_mixed(&graph, &partitions, true);
+    assert_error!(
+      result,
+      "Total sequence length across all partitions is zero; cannot compute initial guess"
+    );
+  }
+}


### PR DESCRIPTION
- Related to: #544

`run_optimize_mixed` and `initial_guess_mixed` divide by the total sequence length across all partitions. On empty input the division yields `+inf` and corrupts downstream grid search bounds, Newton tolerance, and initial guess values. The evaluators now guard against this with an early error return, but the error path has no regression coverage.

Add tests verifying that `run_optimize_mixed` and `initial_guess_mixed` return descriptive errors when the total sequence length across all partitions is zero.

### Work items

- [x] Assert `run_optimize_mixed` errors on zero total length
- [x] Assert `initial_guess_mixed` errors on zero total length
