### PR TITLE
refactor: unify dense and sparse evaluation loops

### DIFF
--- a/docs/port-known-issues/L-optimize-eval-dense-sparse-duplication.md
+++ b/docs/port-known-issues/L-optimize-eval-dense-sparse-duplication.md
@@ -1,47 +1,19 @@
-# Dense and sparse evaluation loops duplicated across 4 inner loops
+# Dense-sparse duplication in OptimizationContribution enum dispatch
 
-The branch-length evaluation functions `evaluate_dense_contribution_impl()` and `evaluate_sparse_contribution_impl()` implement the same eigenvalue-space log-likelihood formula. Each function has an `if compute_derivatives` branch, giving 4 structurally identical inner loops across 2 files:
+The eval loop duplication (4 identical inner loops across dense/sparse eval files) is resolved: `evaluate_site_contributions()` in `optimize_eval.rs` provides a single implementation, with thin wrappers in `optimize_dense_eval.rs` and `optimize_sparse_eval.rs`.
 
-| File                                                                                                                                                     | Branch              | Multiplicity          |
-| :------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ | :-------------------- |
-| [packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L31-L37](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L31-L37)   | with derivatives    | implicit 1.0          |
-| [packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L39-L42](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs#L39-L42)   | without derivatives | implicit 1.0          |
-| [packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L33-L38](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L33-L38) | with derivatives    | explicit multiplicity |
-| [packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L45-L47](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs#L45-L47) | without derivatives | explicit multiplicity |
+The same Dense-vs-Sparse iteration split still exists in `OptimizationContribution` methods in [packages/treetime/src/commands/optimize/optimize_unified.rs#L112-L184](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L112-L184):
 
-The only semantic difference between dense and sparse is iteration: dense iterates rows of `Array2<f64>` (each row is one site, implicit multiplicity 1.0), sparse iterates `Vec<SiteContribution>` (each element has explicit `multiplicity: f64` and `coefficients: Array1<f64>`). The per-site formula is identical.
-
-## Evidence
-
-Commit `ecea678d` ("fix(optimize): prevent ln(0) and division-by-zero at zero branch length") required changing the same `debug_assert!` in all 4 loops. Earlier commit `6765f079` ("perf(optimize): cache first-derivative ratio in evaluation loops") similarly required applying the same `d1` caching optimization in all 4 derivative loops. Any per-site change must be replicated 4 times.
-
-## Impact
-
-Low. Maintenance cost: formula changes, assertions, or instrumentation require 4 identical edits. No correctness issue, but the duplication is a defect magnet (the sparse Hessian multiplicity bug in `c56a0a8d` existed in one copy but not the other).
+| Method                             | Arms identical? | Notes                                                                  |
+| :--------------------------------- | :-------------: | :--------------------------------------------------------------------- |
+| `all_sites_valid_at_zero()`        |      near       | same `site_lh > 0.0 && site_lh.is_finite()` check, different iteration |
+| `has_unimodal_branch_likelihood()` |     **yes**     | both arms access `.gtr.unimodal_branch_likelihood`                     |
+| `zero_branch_length_derivative()`  |      near       | same weighted-eigenvalue formula, different iteration                  |
 
 ## Fix
 
-Unify into a single evaluator taking `impl Iterator<Item = (f64, ArrayView1<f64>)>` (multiplicity, coefficients). Dense wraps `coefficients.outer_iter().map(|row| (1.0, row))`; sparse wraps `site_contributions.iter().map(|sc| (sc.multiplicity, sc.coefficients.view()))`. The 4 loops collapse to 2 (with/without derivatives), each written once.
+Add a shared site-iteration accessor to `OptimizationContribution` returning `impl Iterator<Item = (f64, ArrayView1<f64>)>` (same interface as `evaluate_site_contributions`). The three methods above can then use the shared iterator, and `has_unimodal_branch_likelihood()` can access `.gtr` via a shared accessor.
 
-Keep thin wrapper functions (`evaluate_dense_contribution`, `evaluate_sparse_contribution`) to preserve existing call sites.
+## Impact
 
-Detailed implementation plan in [.memory/99-optimize-eval-dedup/refactor1.md](../../.memory/99-optimize-eval-dedup/refactor1.md).
-
-## Downstream: `OptimizationContribution` enum dispatch
-
-The same Dense-vs-Sparse iteration split propagates into `OptimizationContribution` methods in [packages/treetime/src/commands/optimize/optimize_unified.rs#L112-L184](../../packages/treetime/src/commands/optimize/optimize_unified.rs#L112-L184):
-
-| Method                             | Arms identical? | Notes                                                                       |
-| :--------------------------------- | :-------------: | :-------------------------------------------------------------------------- |
-| `evaluate()`                       |       no        | delegates to `evaluate_dense_contribution` / `evaluate_sparse_contribution` |
-| `all_sites_valid_at_zero()`        |      near       | same `site_lh > 0.0 && site_lh.is_finite()` check, different iteration      |
-| `has_unimodal_branch_likelihood()` |     **yes**     | both arms access `.gtr.unimodal_branch_likelihood`                          |
-| `zero_branch_length_derivative()`  |      near       | same weighted-eigenvalue formula, different iteration                       |
-
-Once the eval functions are unified behind a shared site iterator (see Fix above), `evaluate()` dispatch collapses to a single call. `all_sites_valid_at_zero()` and `zero_branch_length_derivative()` can use the same iterator. `has_unimodal_branch_likelihood()` can access `.gtr` directly via a shared accessor, eliminating the match entirely.
-
-This is not a separate issue - it shares the same root cause (Dense and Sparse lack a common site-iteration interface) and the same fix resolves both.
-
-## Related
-
-- [Dead `optimize_dense::evaluate()` function](N-optimize-dense-evaluate-dead-code.md) - a third copy of the same formula, already dead code
+Low. Maintenance cost only, no correctness issue.

--- a/packages/treetime/src/commands/optimize/mod.rs
+++ b/packages/treetime/src/commands/optimize/mod.rs
@@ -4,6 +4,7 @@ mod __tests__;
 pub mod args;
 pub mod optimize_dense;
 mod optimize_dense_eval;
+mod optimize_eval;
 pub mod optimize_indel;
 pub mod optimize_sparse;
 mod optimize_sparse_eval;

--- a/packages/treetime/src/commands/optimize/optimize_dense_eval.rs
+++ b/packages/treetime/src/commands/optimize/optimize_dense_eval.rs
@@ -1,7 +1,8 @@
 use crate::commands::optimize::optimize_dense;
+use crate::commands::optimize::optimize_eval::evaluate_site_contributions;
 use crate::commands::optimize::optimize_unified::OptimizationMetrics;
 
-/// Evaluate dense contribution for a given branch length
+/// Evaluate dense contribution for a given branch length (with derivatives).
 pub fn evaluate_dense_contribution(
   contribution: &optimize_dense::PartitionContribution,
   branch_length: f64,
@@ -9,40 +10,12 @@ pub fn evaluate_dense_contribution(
   evaluate_dense_contribution_impl(contribution, branch_length, true)
 }
 
-/// Evaluate dense contribution for a given branch length (implementation with optional derivatives)
+/// Evaluate dense contribution for a given branch length (optional derivatives).
 pub fn evaluate_dense_contribution_impl(
   contribution: &optimize_dense::PartitionContribution,
   branch_length: f64,
   compute_derivatives: bool,
 ) -> OptimizationMetrics {
-  let mut log_lh = 0.0;
-  let mut derivative = 0.0;
-  let mut second_derivative = 0.0;
-
-  let gtr = &contribution.gtr;
-  let coefficients = &contribution.coefficients;
-
-  let exp_ev = gtr.exp_eigvals_branch_length(branch_length);
-
-  if compute_derivatives {
-    let ev_exp_ev = &gtr.eigvals * &exp_ev;
-    let ev2_exp_ev = &gtr.eigvals * &ev_exp_ev;
-
-    for coefficients in coefficients.outer_iter() {
-      let site_lh = (&coefficients * &exp_ev).sum();
-      debug_assert!(site_lh.is_finite(), "Non-finite site likelihood: {site_lh}");
-      log_lh += site_lh.ln();
-      let d1 = (&coefficients * &ev_exp_ev).sum() / site_lh;
-      derivative += d1;
-      second_derivative += (&coefficients * &ev2_exp_ev).sum() / site_lh - d1.powi(2);
-    }
-  } else {
-    for coefficients in coefficients.outer_iter() {
-      let site_lh = (&coefficients * &exp_ev).sum();
-      debug_assert!(site_lh.is_finite(), "Non-finite site likelihood: {site_lh}");
-      log_lh += site_lh.ln();
-    }
-  }
-
-  OptimizationMetrics::new(log_lh, derivative, second_derivative)
+  let sites = contribution.coefficients.outer_iter().map(|row| (1.0, row));
+  evaluate_site_contributions(sites, &contribution.gtr.eigvals, branch_length, compute_derivatives)
 }

--- a/packages/treetime/src/commands/optimize/optimize_eval.rs
+++ b/packages/treetime/src/commands/optimize/optimize_eval.rs
@@ -1,0 +1,51 @@
+use crate::commands::optimize::optimize_unified::OptimizationMetrics;
+use ndarray::{Array1, ArrayView1};
+
+/// Unified evaluation of eigenvalue-space site contributions.
+///
+/// Computes log-likelihood, first derivative, and second derivative of the
+/// branch-length likelihood from a sequence of (multiplicity, coefficient)
+/// pairs. Dense and sparse representations differ only in iteration: dense
+/// yields `(1.0, row)` for each alignment position, sparse yields
+/// `(multiplicity, coefficients)` for each compressed site pattern.
+///
+/// The per-site log-likelihood for branch length $t$ is:
+///
+///   $\ell_i(t) = \ln\!\bigl(\sum_c k_{ic}\, e^{\lambda_c t}\bigr)$
+///
+/// where $k_{ic}$ are the eigenvalue-space coefficients and $\lambda_c$ the
+/// eigenvalues. The first and second derivatives follow from the quotient rule.
+pub fn evaluate_site_contributions<'a>(
+  sites: impl Iterator<Item = (f64, ArrayView1<'a, f64>)>,
+  eigvals: &Array1<f64>,
+  branch_length: f64,
+  compute_derivatives: bool,
+) -> OptimizationMetrics {
+  let mut log_lh = 0.0;
+  let mut derivative = 0.0;
+  let mut second_derivative = 0.0;
+
+  let exp_ev = (eigvals * branch_length).mapv(f64::exp);
+
+  if compute_derivatives {
+    let ev_exp_ev = eigvals * &exp_ev;
+    let ev2_exp_ev = eigvals * &ev_exp_ev;
+
+    for (multiplicity, coefficients) in sites {
+      let site_lh = (&coefficients * &exp_ev).sum();
+      debug_assert!(site_lh.is_finite(), "Non-finite site likelihood: {site_lh}");
+      log_lh += multiplicity * site_lh.ln();
+      let d1 = (&coefficients * &ev_exp_ev).sum() / site_lh;
+      derivative += multiplicity * d1;
+      second_derivative += multiplicity * (&coefficients * &ev2_exp_ev).sum() / site_lh - multiplicity * d1.powi(2);
+    }
+  } else {
+    for (multiplicity, coefficients) in sites {
+      let site_lh = (&coefficients * &exp_ev).sum();
+      debug_assert!(site_lh.is_finite(), "Non-finite site likelihood: {site_lh}");
+      log_lh += multiplicity * site_lh.ln();
+    }
+  }
+
+  OptimizationMetrics::new(log_lh, derivative, second_derivative)
+}

--- a/packages/treetime/src/commands/optimize/optimize_sparse_eval.rs
+++ b/packages/treetime/src/commands/optimize/optimize_sparse_eval.rs
@@ -1,7 +1,8 @@
+use crate::commands::optimize::optimize_eval::evaluate_site_contributions;
 use crate::commands::optimize::optimize_sparse;
 use crate::commands::optimize::optimize_unified::OptimizationMetrics;
 
-/// Evaluate sparse contribution for a given branch length
+/// Evaluate sparse contribution for a given branch length (with derivatives).
 pub fn evaluate_sparse_contribution(
   contribution: &optimize_sparse::PartitionContribution,
   branch_length: f64,
@@ -9,45 +10,15 @@ pub fn evaluate_sparse_contribution(
   evaluate_sparse_contribution_impl(contribution, branch_length, true)
 }
 
-/// Evaluate sparse contribution for a given branch length (implementation with optional derivatives)
+/// Evaluate sparse contribution for a given branch length (optional derivatives).
 pub fn evaluate_sparse_contribution_impl(
   contribution: &optimize_sparse::PartitionContribution,
   branch_length: f64,
   compute_derivatives: bool,
 ) -> OptimizationMetrics {
-  let mut log_lh = 0.0;
-  let mut derivative = 0.0;
-  let mut second_derivative = 0.0;
-
-  let exp_ev = contribution.gtr.exp_eigvals_branch_length(branch_length);
-
-  if compute_derivatives {
-    let ev_exp_ev = &contribution.gtr.eigvals * &exp_ev;
-    let ev2_exp_ev = &contribution.gtr.eigvals * &ev_exp_ev;
-
-    for optimize_sparse::SiteContribution {
-      multiplicity,
-      coefficients,
-    } in &contribution.site_contributions
-    {
-      let site_lh = (coefficients * &exp_ev).sum();
-      debug_assert!(site_lh.is_finite(), "Non-finite site likelihood: {site_lh}");
-      log_lh += multiplicity * site_lh.ln();
-      let d1 = (coefficients * &ev_exp_ev).sum() / site_lh;
-      derivative += multiplicity * d1;
-      second_derivative += multiplicity * (coefficients * &ev2_exp_ev).sum() / site_lh - multiplicity * d1.powi(2);
-    }
-  } else {
-    for optimize_sparse::SiteContribution {
-      multiplicity,
-      coefficients,
-    } in &contribution.site_contributions
-    {
-      let site_lh = (coefficients * &exp_ev).sum();
-      debug_assert!(site_lh.is_finite(), "Non-finite site likelihood: {site_lh}");
-      log_lh += multiplicity * site_lh.ln();
-    }
-  }
-
-  OptimizationMetrics::new(log_lh, derivative, second_derivative)
+  let sites = contribution
+    .site_contributions
+    .iter()
+    .map(|sc| (sc.multiplicity, sc.coefficients.view()));
+  evaluate_site_contributions(sites, &contribution.gtr.eigvals, branch_length, compute_derivatives)
 }


### PR DESCRIPTION

Dense and sparse evaluators duplicated four inner loops: with and without derivatives, times two (dense and sparse). The four loops differed only in the source of `(multiplicity, coefficients)` per site.

Extract `evaluate_site_contributions()` in a new `optimize_eval.rs` module, taking `impl Iterator<Item = (f64, ArrayView1<f64>)>`. Dense wraps rows as `(1.0, row)`, sparse passes `(multiplicity, coefficients.view())`. The four duplicated inner loops collapse to two (with and without derivatives), each written once. Thin wrappers in `optimize_dense_eval.rs` and `optimize_sparse_eval.rs` preserve existing call sites.

### Work items

- [x] Extract `evaluate_site_contributions()` taking iterator
- [x] Collapse 4 duplicated inner loops to 2
- [x] Thin wrappers preserve existing call sites
- [x] Update issue: [docs/port-known-issues/L-optimize-eval-dense-sparse-duplication.md](https://github.com/neherlab/treetime/blob/ea6e3608/docs/port-known-issues/L-optimize-eval-dense-sparse-duplication.md): remaining enum dispatch duplication
