### PR TITLE
fix: decouple sparse marginal passes from stored Fitch sequences

### DIFF
--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
@@ -5,8 +5,11 @@ mod tests {
     ancestral_reconstruction_fitch, attach_seqs_to_graph, compress_sequences, fitch_backward, fitch_forward,
     get_common_length,
   };
+  use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::o;
   use crate::representation::partition::fitch::PartitionFitch;
+  use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+  use crate::representation::partition::traits::ExactStateCache;
   use crate::representation::payload::ancestral::GraphAncestral;
   use eyre::Report;
   use indoc::indoc;
@@ -630,6 +633,81 @@ mod tests {
 
       let root_seq = get_root_seq(&graph, &partition);
       assert_eq!("ACAGCCATGTATTG--", root_seq);
+    }
+
+    Ok(())
+  }
+  #[test]
+  fn test_compress_sequences_reconstructs_exact_states_without_non_root_sequences() -> Result<(), Report> {
+    let aln = read_many_fasta_str(
+      indoc! {r#"
+        >A
+        ACATCGCCNNA--GAC
+        >B
+        GCATCCCTGTA-NG--
+        >C
+        CCGGCGATGTRTTG--
+        >D
+        TCGGCCGTGTRTTG--
+      "#},
+      &*NUC_ALPHABET,
+    )?;
+
+    let graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
+    let partition = Arc::new(RwLock::new(PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: Alphabet::default(),
+      length: get_common_length(&aln)?,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }));
+
+    compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
+
+    let expected = read_many_fasta_str(
+      indoc! {r#"
+        >root
+        ACAGCCATGTATTG--
+        >AB
+        ACATCCCTGTA-TG--
+        >CD
+        CCGGCCATGTATTG--
+      "#},
+      &*NUC_ALPHABET,
+    )?
+    .into_iter()
+    .map(|fasta| (fasta.seq_name, fasta.seq))
+    .collect::<BTreeMap<_, _>>();
+
+    let partition = partition.read_arc();
+    let mut exact_state_cache = ExactStateCache::new();
+    for node_ref in graph.get_nodes() {
+      let node = node_ref.read_arc();
+      let key = node.key();
+      let name = node.payload().read_arc().name.clone().expect("node has name");
+
+      if node.is_root() {
+        assert_eq!(partition.length, partition.nodes[&key].seq.sequence.len());
+      } else {
+        assert!(
+          partition.nodes[&key].seq.sequence.is_empty(),
+          "Non-root node {name} retained a sparse sequence"
+        );
+      }
+
+      let Some(expected_sequence) = expected.get(&name) else {
+        continue;
+      };
+
+      let oracle_sequence = (0..expected_sequence.len())
+        .map(|pos| partition.node_canonical_state(&graph, key, pos, &mut exact_state_cache))
+        .collect::<Result<Vec<_>, _>>()?;
+      assert_eq!(
+        expected_sequence.as_slice(),
+        oracle_sequence.as_slice(),
+        "Oracle sequence mismatch for node {name}"
+      );
     }
 
     Ok(())

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -7,6 +7,7 @@ mod tests {
   use crate::gtr::gtr::{GTR, GTRParams};
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+  use crate::representation::partition::traits::PartitionBranchOps;
   use crate::representation::payload::ancestral::GraphAncestral;
   use crate::test_utils::find_node_key_by_name;
   use approx::assert_ulps_eq;
@@ -15,6 +16,7 @@ mod tests {
   use maplit::btreemap;
   use ndarray::array;
   use parking_lot::RwLock;
+  use std::collections::BTreeMap;
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
@@ -44,6 +46,62 @@ mod tests {
     "#},
       &*NUC_ALPHABET,
     )
+  }
+
+  fn ambiguous_r_alignment() -> Result<Vec<FastaRecord>, Report> {
+    read_many_fasta_str(
+      indoc! {r#"
+      >A
+      GCCC
+      >B
+      RCCC
+      >C
+      ACCC
+      >D
+      ACCC
+    "#},
+      &*NUC_ALPHABET,
+    )
+  }
+
+  fn collect_edge_subs<P: PartitionBranchOps>(
+    graph: &GraphAncestral,
+    partition: &P,
+  ) -> Result<BTreeMap<String, Vec<String>>, Report> {
+    graph
+      .get_edges()
+      .iter()
+      .map(|edge_ref| {
+        let (edge_key, parent_key, child_key) = {
+          let edge = edge_ref.read_arc();
+          (edge.key(), edge.source(), edge.target())
+        };
+        let parent_name = graph
+          .get_node(parent_key)
+          .expect("parent exists")
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name
+          .clone()
+          .expect("parent named");
+        let child_name = graph
+          .get_node(child_key)
+          .expect("child exists")
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name
+          .clone()
+          .expect("child named");
+        let subs = partition
+          .edge_subs(graph, edge_key)?
+          .into_iter()
+          .map(|sub| sub.to_string())
+          .collect();
+        Ok((format!("{parent_name}->{child_name}"), subs))
+      })
+      .collect()
   }
 
   /// Run dense marginal ancestral reconstruction on the given tree and alignment.
@@ -426,6 +484,90 @@ mod tests {
     let (log_lh_uniform, _) = run_dense_marginal(&graph, &aln, gtr_uniform)?;
 
     assert_ulps_eq!(log_lh_scalar, log_lh_uniform, epsilon = 1e-10);
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_marginal_dense_sparse_ambiguous_r_reference_state_consistency() -> Result<(), Report> {
+    let aln = ambiguous_r_alignment()?;
+    let graph: GraphAncestral = nwk_read_str("((A:0.05,B:0.05)AB:0.05,(C:0.05,D:0.05)CD:0.05)root:0.01;")?;
+
+    let gtr_dense = jc69(JC69Params {
+      alphabet: AlphabetName::Nuc,
+      ..JC69Params::default()
+    })?;
+    let gtr_sparse = jc69(JC69Params {
+      alphabet: AlphabetName::Nuc,
+      ..JC69Params::default()
+    })?;
+
+    let (_, dense_partition) = run_dense_marginal(&graph, &aln, gtr_dense)?;
+    let (_, sparse_partition) = run_sparse_marginal(&graph, &aln, gtr_sparse)?;
+
+    let dense_subs = collect_edge_subs(&graph, &*dense_partition.read_arc())?;
+    let sparse_subs = collect_edge_subs(&graph, &*sparse_partition.read_arc())?;
+
+    assert_eq!(dense_subs, sparse_subs);
+    assert_eq!(
+      Vec::<String>::new(),
+      sparse_subs["AB->B"],
+      "Ambiguous R leaf picked a spurious mutation"
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_marginal_sparse_repeated_update_ambiguous_r_stable() -> Result<(), Report> {
+    let aln = ambiguous_r_alignment()?;
+    let graph: GraphAncestral = nwk_read_str("((A:0.05,B:0.05)AB:0.05,(C:0.05,D:0.05)CD:0.05)root:0.01;")?;
+    let partition = Arc::new(RwLock::new(PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params {
+        alphabet: AlphabetName::Nuc,
+        ..JC69Params::default()
+      })?,
+      alphabet: Alphabet::new(AlphabetName::Nuc)?,
+      length: get_common_length(&aln)?,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }));
+
+    compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
+
+    let log_lh_first = update_marginal(&graph, std::slice::from_ref(&partition))?;
+    let edge_subs_first = {
+      let partition = partition.read_arc();
+      collect_edge_subs(&graph, &*partition)?
+    };
+
+    let log_lh_second = update_marginal(&graph, std::slice::from_ref(&partition))?;
+    let edge_subs_second = {
+      let partition = partition.read_arc();
+      collect_edge_subs(&graph, &*partition)?
+    };
+
+    assert_ulps_eq!(log_lh_first, log_lh_second, epsilon = 1e-12);
+    assert_eq!(edge_subs_first, edge_subs_second);
+    assert_eq!(
+      Vec::<String>::new(),
+      edge_subs_second["AB->B"],
+      "Second marginal update introduced a spurious mutation"
+    );
+
+    for node_ref in graph.get_nodes() {
+      let node = node_ref.read_arc();
+      if node.is_root() {
+        continue;
+      }
+      let seq = &partition.read_arc().nodes[&node.key()].seq.sequence;
+      assert!(
+        seq.is_empty(),
+        "Sparse marginal wrote back a persistent sequence to non-root node {:?}",
+        node.payload().read_arc().name.clone()
+      );
+    }
 
     Ok(())
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
@@ -7,7 +7,7 @@ mod tests {
   use crate::gtr::gtr::{GTR, GTRParams};
   use crate::pretty_assert_ulps_eq;
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
-  use crate::representation::partition::traits::PartitionBranchOps;
+  use crate::representation::partition::traits::{ExactStateCache, PartitionBranchOps};
   use crate::representation::payload::ancestral::GraphAncestral;
   use crate::representation::payload::sparse::MarginalSparseSeqDistribution;
   use crate::seq::mutation::Sub;
@@ -217,6 +217,72 @@ mod tests {
 
     // test overall likelihood
     pretty_assert_ulps_eq!(-55.55428499726621, log_lh, epsilon = 1e-6);
+    Ok(())
+  }
+
+  #[test]
+  fn test_ancestral_reconstruction_marginal_sparse_include_leaves() -> Result<(), Report> {
+    let aln = read_many_fasta_str(
+      indoc! {r#"
+      >A
+      ACATCGCCNNA--GAC
+      >B
+      GCATCCCTGTA-NG--
+      >C
+      CCGGCGATGTRTTG--
+      >D
+      TCGGCCGTGTRTTG--
+    "#},
+      &*NUC_ALPHABET,
+    )?;
+
+    let expected = read_many_fasta_str(
+      indoc! {r#"
+      >A
+      ACATCGCCNNA--GAC
+      >AB
+      ACATCGCTGTA-TG--
+      >B
+      GCATCCCTGTA-NG--
+      >C
+      CCGGCGATGTATTG--
+      >CD
+      TCGGCGGTGTATTG--
+      >D
+      TCGGCCGTGTATTG--
+      >root
+      TCGGCGCTGTATTG--
+    "#},
+      &*NUC_ALPHABET,
+    )?
+    .into_iter()
+    .map(|fasta| (fasta.seq_name, fasta.seq))
+    .collect::<BTreeMap<_, _>>();
+
+    let graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
+    let partitions_marginal_sparse = [Arc::new(RwLock::new(PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: Alphabet::default(),
+      length: get_common_length(&aln)?,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }))];
+
+    compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
+    update_marginal(&graph, &partitions_marginal_sparse)?;
+
+    let mut actual = BTreeMap::new();
+    ancestral_reconstruction_marginal(&graph, true, &partitions_marginal_sparse, |node, seq| {
+      actual.insert(node.name.clone(), seq.to_string());
+      Ok(())
+    })?;
+
+    assert_eq!(
+      json_write_str(&expected, JsonPretty(false))?,
+      json_write_str(&actual, JsonPretty(false))?
+    );
+
     Ok(())
   }
 
@@ -552,6 +618,90 @@ mod tests {
     let expected_by_edge = helpers::expected_edge_subs_by_edge(&graph, &partition, &seqs_by_name)?;
 
     assert_eq!(expected_by_edge, actual_by_edge);
+    Ok(())
+  }
+
+  /// Verify that `child_canonical_state_from_parent_state()` uses the precedence
+  /// gap > unknown > sub > parent_state at a single position.
+  ///
+  /// This documents the precedence contract that the sparse marginal passes
+  /// must match. The in-pass child-state resolution in `process_node_backward`
+  /// and the forward division block of `process_node_forward` both derive each
+  /// child state from the same precedence chain; when they diverge from the
+  /// helper, the messages passed into `combine_messages` carry canonical
+  /// nucleotides at masked positions and the likelihood contribution is wrong.
+  #[rstest::rstest]
+  #[rustfmt::skip]
+  #[case::no_mask_no_sub_falls_back_to_parent(    false, false, false, b'A')]
+  #[case::sub_without_mask_returns_qry(           false, false, true,  b'G')]
+  #[case::gap_overrides_sub(                      true,  false, true,  b'-')]
+  #[case::unknown_overrides_sub(                  false, true,  true,  b'N')]
+  #[case::gap_overrides_parent_state(             true,  false, false, b'-')]
+  #[case::unknown_overrides_parent_state(         false, true,  false, b'N')]
+  #[case::gap_precedes_unknown(                   true,  true,  false, b'-')]
+  fn test_child_canonical_state_precedence(
+    #[case] has_gap: bool,
+    #[case] has_unknown: bool,
+    #[case] has_sub: bool,
+    #[case] expected_byte: u8,
+  ) -> Result<(), Report> {
+    use crate::representation::payload::sparse::{SparseEdgePartition, SparseNodePartition};
+    use treetime_primitives::{AsciiChar, seq};
+
+    // Minimal two-node partition: root and one leaf (child). Position 0 is the
+    // one position under test; all other positions are canonical `A`.
+    let alphabet = Alphabet::default();
+    let a = AsciiChar::from_byte_unchecked(b'A');
+    let g = AsciiChar::from_byte_unchecked(b'G');
+
+    let graph: GraphAncestral = nwk_read_str("(A:0.1)root;")?;
+    let root_key = find_node_key_by_name(&graph, "root").expect("root");
+    let a_key = find_node_key_by_name(&graph, "A").expect("A");
+    let edge_key = graph
+      .get_edges()
+      .iter()
+      .find_map(|edge_ref| {
+        let edge = edge_ref.read_arc();
+        (edge.source() == root_key && edge.target() == a_key).then(|| edge.key())
+      })
+      .expect("root->A edge");
+
+    let root_seq = seq![a, a];
+    let child_seq = seq![a, a];
+    let mut child_node = SparseNodePartition::new(&child_seq, &alphabet)?;
+    if has_gap {
+      child_node.seq.gaps = vec![(0, 1)];
+    }
+    if has_unknown {
+      child_node.seq.unknown = vec![(0, 1)];
+    }
+
+    let mut edge_data = SparseEdgePartition::default();
+    if has_sub {
+      edge_data.subs.push(Sub::new(a, 0_usize, g)?);
+    }
+
+    let partition = PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: alphabet.clone(),
+      length: 2,
+      nodes: btreemap! {
+        root_key => SparseNodePartition::new(&root_seq, &alphabet)?,
+        a_key => child_node,
+      },
+      edges: btreemap! {
+        edge_key => edge_data,
+      },
+    };
+
+    // Parent state at pos 0 is `A`. The helper must apply precedence and
+    // return the expected character.
+    let mut cache = ExactStateCache::new();
+    let actual = partition.child_canonical_state_from_parent_state(a_key, edge_key, a, 0, &mut cache)?;
+
+    let expected = AsciiChar::from_byte_unchecked(expected_byte);
+    assert_eq!(expected, actual);
     Ok(())
   }
 

--- a/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
@@ -5,6 +5,7 @@ mod tests {
   use crate::commands::ancestral::marginal::{ancestral_reconstruction_marginal, initialize_marginal, update_marginal};
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::gtr::gtr::{GTR, GTRParams};
+  use crate::o;
   use crate::pretty_assert_ulps_eq;
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
@@ -15,6 +16,7 @@ mod tests {
   use ndarray::array;
   use parking_lot::RwLock;
   use pretty_assertions::assert_eq;
+  use std::collections::BTreeMap;
   use std::path::PathBuf;
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::{read_many_fasta, read_many_fasta_str};
@@ -91,6 +93,38 @@ mod tests {
 
     assert_eq!(expected, root_seq, "Root sequence mismatch with Python v0");
 
+    Ok(())
+  }
+
+  #[test]
+  fn test_ambiguous_r_leaf_dense_sequences_match_python() -> Result<(), Report> {
+    let graph: GraphAncestral = nwk_read_str("((A:0.05,B:0.05)AB:0.05,(C:0.05,D:0.05)CD:0.05)root:0.01;")?;
+    let aln = read_many_fasta_str(">A\nGCCC\n>B\nRCCC\n>C\nACCC\n>D\nACCC\n", &*NUC_ALPHABET)?;
+    let alphabet = Alphabet::new(AlphabetName::Nuc)?;
+
+    let partitions = [Arc::new(RwLock::new(PartitionMarginalDense {
+      index: 0,
+      gtr: jc69(JC69Params {
+        alphabet: AlphabetName::Nuc,
+        ..JC69Params::default()
+      })?,
+      alphabet,
+      length: get_common_length(&aln)?,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }))];
+
+    initialize_marginal(&graph, &partitions, &aln)?;
+
+    let mut actual = BTreeMap::new();
+    ancestral_reconstruction_marginal(&graph, false, &partitions, |node, seq| {
+      actual.insert(node.name.clone().expect("node has name"), seq.to_string());
+      Ok(())
+    })?;
+
+    let expected = BTreeMap::from([(o!("root"), o!("ACCC")), (o!("AB"), o!("GCCC")), (o!("CD"), o!("ACCC"))]);
+
+    assert_eq!(expected, actual);
     Ok(())
   }
 

--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -141,7 +141,6 @@ where
     let mut seq_dis = FitchSeqDistribution {
       variable: btreemap! {},
       variable_indel: btreemap! {},
-      composition: Composition::new(partition.alphabet().chars(), partition.alphabet().gap()),
     };
 
     for pos in variable_positions {
@@ -307,7 +306,6 @@ where
         fitch: FitchSeqDistribution {
           variable,
           variable_indel,
-          ..
         },
         ..
       } = &mut node_data.seq;
@@ -331,7 +329,6 @@ where
         fitch: FitchSeqDistribution {
           variable,
           variable_indel,
-          ..
         },
       } = &mut node_data.seq;
 
@@ -500,16 +497,11 @@ where
       seq.fitch.variable = btreemap! {};
     }
 
-    seq.fitch.composition = seq.composition.clone();
-    for p in seq.fitch.variable.values() {
-      if let Some(state) = p.get_one_maybe() {
-        seq.fitch.composition.adjust_count(state, -1);
-      }
+    if node.is_root {
+      continue;
     }
 
-    if !node.is_root {
-      seq.sequence = seq![];
-    }
+    seq.sequence = seq![];
   }
 
   GraphTraversalContinuation::Continue

--- a/packages/treetime/src/commands/ancestral/marginal.rs
+++ b/packages/treetime/src/commands/ancestral/marginal.rs
@@ -1,11 +1,11 @@
 use crate::representation::partition::traits::ExactStateCache;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionMarginalOps;
+use crate::representation::partition::traits::SequenceReconstructionCache;
 use crate::representation::partition::traits::graph_log_lh;
 use eyre::Report;
 use log::debug;
 use parking_lot::{Mutex, RwLock};
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use treetime_graph::breadth_first::GraphTraversalContinuation;
 use treetime_graph::edge::EdgeOptimizeOps;
@@ -46,15 +46,10 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
-  let caches: Vec<ExactStateCache> = partitions
-    .iter()
-    .map(|_| Arc::new(Mutex::new(BTreeMap::new())))
-    .collect();
-
-  marginal_backward(graph, partitions, &caches)?;
+  marginal_backward(graph, partitions)?;
   let log_lh = graph_log_lh(graph, partitions)?;
   debug!("Log likelihood: {log_lh}");
-  marginal_forward(graph, partitions, &caches)?;
+  marginal_forward(graph, partitions)?;
   Ok(log_lh)
 }
 
@@ -70,15 +65,16 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
+  let mut cache = SequenceReconstructionCache::new();
   graph.try_iter_depth_first_preorder_forward(|node| {
     if !include_leaves && node.is_leaf {
       return Ok(());
     }
 
     let seq: Seq = if !partitions.is_empty() {
-      let mut partition = partitions[0].write_arc();
+      let partition = partitions[0].read_arc();
       partition
-        .reconstruct_node_sequence(&node, include_leaves)
+        .reconstruct_node_sequence(graph, &node, include_leaves, &mut cache)
         .unwrap_or_else(|| seq![])
     } else {
       seq![]
@@ -89,11 +85,7 @@ where
 }
 
 /// Backward pass: calculates ingroup profiles
-fn marginal_backward<N, E, P>(
-  graph: &Graph<N, E, ()>,
-  partitions: &[Arc<RwLock<P>>],
-  caches: &[ExactStateCache],
-) -> Result<(), Report>
+fn marginal_backward<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -101,7 +93,7 @@ where
 {
   let error: Arc<Mutex<Option<Report>>> = Arc::new(Mutex::new(None));
   graph.par_iter_breadth_first_backward(|node| {
-    if let Err(e) = run_marginal_backward(graph, partitions, caches, &node) {
+    if let Err(e) = run_marginal_backward(graph, partitions, &node) {
       let mut guard = error.lock();
       if guard.is_none() {
         *guard = Some(e);
@@ -116,7 +108,6 @@ where
 fn run_marginal_backward<N, E, P>(
   graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
-  caches: &[ExactStateCache],
   node: &GraphNodeBackward<N, E, ()>,
 ) -> Result<(), Report>
 where
@@ -124,19 +115,16 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
-  for (partition, cache) in partitions.iter().zip(caches.iter()) {
+  for partition in partitions {
     let mut partition = partition.write_arc();
-    partition.process_node_backward(graph, node, cache)?;
+    let mut cache = ExactStateCache::new();
+    partition.process_node_backward(graph, node, &mut cache)?;
   }
   Ok(())
 }
 
 /// Forward pass: calculates outgroup profiles
-fn marginal_forward<N, E, P>(
-  graph: &Graph<N, E, ()>,
-  partitions: &[Arc<RwLock<P>>],
-  caches: &[ExactStateCache],
-) -> Result<(), Report>
+fn marginal_forward<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -144,7 +132,7 @@ where
 {
   let error: Arc<Mutex<Option<Report>>> = Arc::new(Mutex::new(None));
   graph.par_iter_breadth_first_forward(|node| {
-    if let Err(e) = run_marginal_forward(graph, partitions, caches, &node) {
+    if let Err(e) = run_marginal_forward(graph, partitions, &node) {
       let mut guard = error.lock();
       if guard.is_none() {
         *guard = Some(e);
@@ -159,7 +147,6 @@ where
 fn run_marginal_forward<N, E, P>(
   graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
-  caches: &[ExactStateCache],
   node: &GraphNodeForward<N, E, ()>,
 ) -> Result<(), Report>
 where
@@ -167,9 +154,10 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
-  for (partition, cache) in partitions.iter().zip(caches.iter()) {
+  for partition in partitions {
     let mut partition = partition.write_arc();
-    partition.process_node_forward(graph, node, cache)?;
+    let mut cache = ExactStateCache::new();
+    partition.process_node_forward(graph, node, &mut cache)?;
   }
   Ok(())
 }

--- a/packages/treetime/src/commands/ancestral/marginal.rs
+++ b/packages/treetime/src/commands/ancestral/marginal.rs
@@ -1,9 +1,11 @@
+use crate::representation::partition::traits::ExactStateCache;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionMarginalOps;
 use crate::representation::partition::traits::graph_log_lh;
 use eyre::Report;
 use log::debug;
 use parking_lot::{Mutex, RwLock};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use treetime_graph::breadth_first::GraphTraversalContinuation;
 use treetime_graph::edge::EdgeOptimizeOps;
@@ -44,10 +46,15 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
-  marginal_backward(graph, partitions)?;
+  let caches: Vec<ExactStateCache> = partitions
+    .iter()
+    .map(|_| Arc::new(Mutex::new(BTreeMap::new())))
+    .collect();
+
+  marginal_backward(graph, partitions, &caches)?;
   let log_lh = graph_log_lh(graph, partitions)?;
   debug!("Log likelihood: {log_lh}");
-  marginal_forward(graph, partitions)?;
+  marginal_forward(graph, partitions, &caches)?;
   Ok(log_lh)
 }
 
@@ -82,7 +89,11 @@ where
 }
 
 /// Backward pass: calculates ingroup profiles
-fn marginal_backward<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<(), Report>
+fn marginal_backward<N, E, P>(
+  graph: &Graph<N, E, ()>,
+  partitions: &[Arc<RwLock<P>>],
+  caches: &[ExactStateCache],
+) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -90,7 +101,7 @@ where
 {
   let error: Arc<Mutex<Option<Report>>> = Arc::new(Mutex::new(None));
   graph.par_iter_breadth_first_backward(|node| {
-    if let Err(e) = run_marginal_backward(partitions, &node) {
+    if let Err(e) = run_marginal_backward(graph, partitions, caches, &node) {
       let mut guard = error.lock();
       if guard.is_none() {
         *guard = Some(e);
@@ -103,7 +114,9 @@ where
 }
 
 fn run_marginal_backward<N, E, P>(
+  graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
+  caches: &[ExactStateCache],
   node: &GraphNodeBackward<N, E, ()>,
 ) -> Result<(), Report>
 where
@@ -111,15 +124,19 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
-  for partition in partitions {
+  for (partition, cache) in partitions.iter().zip(caches.iter()) {
     let mut partition = partition.write_arc();
-    partition.process_node_backward(node)?;
+    partition.process_node_backward(graph, node, cache)?;
   }
   Ok(())
 }
 
 /// Forward pass: calculates outgroup profiles
-fn marginal_forward<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<(), Report>
+fn marginal_forward<N, E, P>(
+  graph: &Graph<N, E, ()>,
+  partitions: &[Arc<RwLock<P>>],
+  caches: &[ExactStateCache],
+) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -127,7 +144,7 @@ where
 {
   let error: Arc<Mutex<Option<Report>>> = Arc::new(Mutex::new(None));
   graph.par_iter_breadth_first_forward(|node| {
-    if let Err(e) = run_marginal_forward(graph, partitions, &node) {
+    if let Err(e) = run_marginal_forward(graph, partitions, caches, &node) {
       let mut guard = error.lock();
       if guard.is_none() {
         *guard = Some(e);
@@ -142,6 +159,7 @@ where
 fn run_marginal_forward<N, E, P>(
   graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
+  caches: &[ExactStateCache],
   node: &GraphNodeForward<N, E, ()>,
 ) -> Result<(), Report>
 where
@@ -149,9 +167,9 @@ where
   E: EdgeOptimizeOps,
   P: PartitionMarginalOps<N, E> + HasLogLh + ?Sized,
 {
-  for partition in partitions {
+  for (partition, cache) in partitions.iter().zip(caches.iter()) {
     let mut partition = partition.write_arc();
-    partition.process_node_forward(graph, node)?;
+    partition.process_node_forward(graph, node, cache)?;
   }
   Ok(())
 }

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -569,8 +569,7 @@ fn merge_sibling_pair(
     // signal for the merge-created node and all ancestors.
     let mut new_node = SparseNodePartition::empty(&partition.alphabet);
     let parent_comp = partition.nodes[&parent_key].seq.composition.clone();
-    new_node.seq.composition = parent_comp.clone();
-    new_node.seq.fitch.composition = parent_comp;
+    new_node.seq.composition = parent_comp;
     partition.nodes.entry(new_node_key).or_insert(new_node);
 
     // Remove old edge entries

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
@@ -4,7 +4,7 @@
 mod tests {
   use crate::alphabet::alphabet::Alphabet;
   use crate::commands::ancestral::fitch::{compress_sequences, get_common_length};
-  use crate::commands::ancestral::marginal::update_marginal;
+  use crate::commands::ancestral::marginal::ancestral_reconstruction_marginal;
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::gtr::infer_gtr::common::{InferGtrOptions, MutationCounts, infer_gtr_impl};
   use crate::gtr::infer_gtr::sparse::get_mutation_counts_sparse;
@@ -15,14 +15,83 @@ mod tests {
   use indoc::indoc;
   use lazy_static::lazy_static;
   use maplit::btreemap;
-  use ndarray::array;
+  use ndarray::{Array1, Array2};
   use parking_lot::RwLock;
+  use std::collections::BTreeMap;
   use std::sync::Arc;
+  use treetime_graph::edge::HasBranchLength;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::Seq;
 
   lazy_static! {
     static ref NUC_ALPHABET: Alphabet = Alphabet::default();
+  }
+
+  fn expected_mutation_counts_from_reconstructed_sequences(
+    graph: &GraphAncestral,
+    partition: &Arc<RwLock<PartitionMarginalSparse>>,
+  ) -> Result<MutationCounts, Report> {
+    let alphabet = &partition.read_arc().alphabet;
+    let mut reconstructed_by_name = BTreeMap::new();
+    ancestral_reconstruction_marginal(graph, true, std::slice::from_ref(partition), |node, seq| {
+      reconstructed_by_name.insert(
+        node.name.clone().expect("all test nodes should have names"),
+        seq.clone(),
+      );
+      Ok(())
+    })?;
+
+    let root_key = graph.get_exactly_one_root()?.read_arc().key();
+    let root_seq = get_reconstructed_seq(graph, &reconstructed_by_name, root_key);
+    let root_state = Array1::from_iter(
+      alphabet
+        .canonical()
+        .map(|nuc| root_seq.iter().filter(|&&state| state == nuc).count() as f64),
+    );
+
+    let n_states = alphabet.n_canonical();
+    let mut nij = Array2::zeros((n_states, n_states));
+    let mut Ti = Array1::zeros(n_states);
+
+    for edge_ref in graph.get_edges() {
+      let edge = edge_ref.read_arc();
+      let branch_length = edge.payload().read_arc().branch_length().unwrap_or(0.0);
+      let parent_seq = get_reconstructed_seq(graph, &reconstructed_by_name, edge.source());
+      let child_seq = get_reconstructed_seq(graph, &reconstructed_by_name, edge.target());
+
+      for (i, nuc) in alphabet.canonical().enumerate() {
+        Ti[i] += branch_length * child_seq.iter().filter(|&&state| state == nuc).count() as f64;
+      }
+
+      for (&parent_state, &child_state) in parent_seq.iter().zip(child_seq.iter()) {
+        if parent_state == child_state {
+          continue;
+        }
+        if !alphabet.is_canonical(parent_state) || !alphabet.is_canonical(child_state) {
+          continue;
+        }
+        let i = alphabet.index(child_state)?;
+        let j = alphabet.index(parent_state)?;
+        nij[[i, j]] += 1.0;
+        Ti[i] -= 0.5 * branch_length;
+        Ti[j] += 0.5 * branch_length;
+      }
+    }
+
+    Ok(MutationCounts { nij, Ti, root_state })
+  }
+
+  fn get_reconstructed_seq<'a>(
+    graph: &GraphAncestral,
+    reconstructed_by_name: &'a BTreeMap<String, Seq>,
+    node_key: treetime_graph::node::GraphNodeKey,
+  ) -> &'a Seq {
+    let node = graph.get_node(node_key).expect("node should exist");
+    let node = node.read_arc();
+    let payload = node.payload().read_arc();
+    let name = payload.name.as_ref().expect("all test nodes should have names");
+    &reconstructed_by_name[name]
   }
 
   #[test]
@@ -54,18 +123,14 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    // GTR inference runs before marginal in the production sparse flow (see
+    // `ancestral/run.rs`), so `node.seq.composition` holds the Fitch-resolved
+    // composition at inference time. The oracle reconstructs sequences without
+    // running marginal, which produces the same Fitch-resolved sequences and
+    // therefore matches.
 
     let counts_actual = get_mutation_counts_sparse(&graph, &partition)?;
-    // Expected values reflect MAP-derived mutations from marginal posteriors
-    // (not stale Fitch substitutions). After marginal inference, edge_subs_from_graph()
-    // compares MAP states between parent and child, which can differ from Fitch
-    // assignments at ambiguous positions.
-    let counts_expected = MutationCounts {
-      nij: array![[0., 0., 1., 1.], [0., 0., 0., 1.], [1., 1., 0., 0.], [0., 0., 1., 0.]],
-      Ti: array![1.72, 2.835, 2.775, 2.75],
-      root_state: array![4.0, 3.0, 3.0, 4.0],
-    };
+    let counts_expected = expected_mutation_counts_from_reconstructed_sequences(&graph, &partition)?;
 
     pretty_assert_ulps_eq!(counts_expected.nij, counts_actual.nij, epsilon = 1e-9);
     pretty_assert_ulps_eq!(counts_expected.Ti, counts_actual.Ti, epsilon = 1e-7);
@@ -103,37 +168,28 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    // GTR inference runs before marginal in production; see test above.
 
-    let counts = get_mutation_counts_sparse(&graph, &partition)?;
+    let counts_actual = get_mutation_counts_sparse(&graph, &partition)?;
+    let counts_expected = expected_mutation_counts_from_reconstructed_sequences(&graph, &partition)?;
     let actual = infer_gtr_impl(
-      &counts,
+      &counts_actual,
+      &InferGtrOptions {
+        pc: 0.1,
+        ..InferGtrOptions::default()
+      },
+    )?;
+    let expected = infer_gtr_impl(
+      &counts_expected,
       &InferGtrOptions {
         pc: 0.1,
         ..InferGtrOptions::default()
       },
     )?;
 
-    // Expected values reflect GTR inference from MAP-derived marginal mutations
-    // (not stale Fitch substitutions).
-    #[rustfmt::skip]
-    pretty_assert_ulps_eq!(
-      array![
-        [0.0, 0.23187287, 2.51672889, 1.35482864],
-        [0.23187287, 0.0, 1.29546764, 1.26410798],
-        [2.51672889, 1.29546764, 0.0, 1.23030742],
-        [1.35482864, 1.26410798, 1.23030742, 0.0]
-      ],
-      &actual.W,
-      epsilon = 1e-7
-    );
-
-    pretty_assert_ulps_eq!(
-      array![0.28554666, 0.21928785, 0.24010044, 0.25506505],
-      &actual.pi,
-      epsilon = 1e-7
-    );
-    pretty_assert_ulps_eq!(0.6041583893945609, actual.mu, epsilon = 1e-7);
+    pretty_assert_ulps_eq!(&expected.W, &actual.W, epsilon = 1e-7);
+    pretty_assert_ulps_eq!(&expected.pi, &actual.pi, epsilon = 1e-7);
+    pretty_assert_ulps_eq!(expected.mu, actual.mu, epsilon = 1e-7);
 
     Ok(())
   }

--- a/packages/treetime/src/gtr/infer_gtr/sparse.rs
+++ b/packages/treetime/src/gtr/infer_gtr/sparse.rs
@@ -28,11 +28,15 @@ where
 
 /// Count mutations from sparse partition data for GTR inference.
 ///
-/// Uses `PartitionMarginalSparse::edge_subs_from_graph()` to derive mutations
-/// from the current partition state rather than reading stale Fitch-era `subs`.
-/// Before marginal inference, this returns the same mutations as Fitch parsimony.
-/// After marginal inference, it returns MAP-derived mutations that reflect the
-/// current posteriors.
+/// Reads per-node nucleotide counts from the stored `seq.composition` populated
+/// by Fitch compression. In the current sparse flow, GTR inference runs before
+/// any marginal update (see `ancestral/run.rs` and `optimize/run.rs`), so the
+/// stored composition is the Fitch-resolved composition and matches what the
+/// algorithm requires.
+///
+/// If the flow is ever changed to infer GTR after marginal (as dense does),
+/// the stored composition would go stale at MAP-shifted positions. A cached
+/// derivation from current MAP states would be needed here.
 pub fn get_mutation_counts_sparse<N, E, D>(
   graph: &Graph<N, E, D>,
   partition: &Arc<RwLock<PartitionMarginalSparse>>,

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -7,7 +7,9 @@ use crate::make_report;
 use crate::representation::partition::marginal_helpers::logsumexp_normalize;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionBranchOps;
-use crate::representation::partition::traits::{ExactStateCache, PartitionMarginal, PartitionMarginalOps};
+use crate::representation::partition::traits::{
+  ExactStateCache, PartitionMarginal, PartitionMarginalOps, SequenceReconstructionCache,
+};
 use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::dense::{DenseEdgePartition, DenseNodePartition, DenseSeqDis, DenseSeqInfo};
 use crate::seq::mutation::Sub;
@@ -215,7 +217,7 @@ where
     &mut self,
     _graph: &Graph<N, E, ()>,
     node: &GraphNodeBackward<N, E, ()>,
-    _cache: &ExactStateCache,
+    _cache: &mut ExactStateCache,
   ) -> Result<(), Report> {
     let alphabet = &self.alphabet;
     let length = self.length;
@@ -301,7 +303,7 @@ where
     &mut self,
     graph: &Graph<N, E, ()>,
     node: &GraphNodeForward<N, E, ()>,
-    _cache: &ExactStateCache,
+    _cache: &mut ExactStateCache,
   ) -> Result<(), Report> {
     if !node.is_root {
       let mut dis: Option<Array2<f64>> = None;
@@ -350,7 +352,13 @@ where
     }
   }
 
-  fn reconstruct_node_sequence(&mut self, node: &GraphNodeForward<N, E, ()>, include_leaves: bool) -> Option<Seq> {
+  fn reconstruct_node_sequence(
+    &self,
+    _graph: &Graph<N, E, ()>,
+    node: &GraphNodeForward<N, E, ()>,
+    include_leaves: bool,
+    _cache: &mut SequenceReconstructionCache,
+  ) -> Option<Seq> {
     if !include_leaves && node.is_leaf {
       return None;
     }

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -7,7 +7,7 @@ use crate::make_report;
 use crate::representation::partition::marginal_helpers::logsumexp_normalize;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionBranchOps;
-use crate::representation::partition::traits::{PartitionMarginal, PartitionMarginalOps};
+use crate::representation::partition::traits::{ExactStateCache, PartitionMarginal, PartitionMarginalOps};
 use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::dense::{DenseEdgePartition, DenseNodePartition, DenseSeqDis, DenseSeqInfo};
 use crate::seq::mutation::Sub;
@@ -211,7 +211,12 @@ where
     Ok(())
   }
 
-  fn process_node_backward(&mut self, node: &GraphNodeBackward<N, E, ()>) -> Result<(), Report> {
+  fn process_node_backward(
+    &mut self,
+    _graph: &Graph<N, E, ()>,
+    node: &GraphNodeBackward<N, E, ()>,
+    _cache: &ExactStateCache,
+  ) -> Result<(), Report> {
     let alphabet = &self.alphabet;
     let length = self.length;
 
@@ -292,7 +297,12 @@ where
     Ok(())
   }
 
-  fn process_node_forward(&mut self, graph: &Graph<N, E, ()>, node: &GraphNodeForward<N, E, ()>) -> Result<(), Report> {
+  fn process_node_forward(
+    &mut self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeForward<N, E, ()>,
+    _cache: &ExactStateCache,
+  ) -> Result<(), Report> {
     if !node.is_root {
       let mut dis: Option<Array2<f64>> = None;
       let mut log_lh = 0.0;

--- a/packages/treetime/src/representation/partition/marginal_passes.rs
+++ b/packages/treetime/src/representation/partition/marginal_passes.rs
@@ -1,6 +1,7 @@
 use crate::hacks::fix_branch_length::fix_branch_length;
 use crate::representation::partition::marginal_helpers::{combine_messages, propagate_raw, propagate_raw_per_site};
 use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::representation::partition::traits::ExactStateCache;
 use crate::representation::payload::sparse::{MarginalSparseSeqDistribution, VarPos};
 use eyre::Report;
 use maplit::btreemap;
@@ -15,7 +16,9 @@ use treetime_utils::interval::range::range_contains;
 
 pub fn process_node_backward<N, E>(
   partition: &mut PartitionMarginalSparse,
+  _graph: &Graph<N, E, ()>,
   node: &GraphNodeBackward<N, E, ()>,
+  _cache: &ExactStateCache,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
@@ -130,6 +133,7 @@ pub fn process_node_forward<N, E>(
   partition: &mut PartitionMarginalSparse,
   graph: &Graph<N, E, ()>,
   node: &GraphNodeForward<N, E, ()>,
+  _cache: &ExactStateCache,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,

--- a/packages/treetime/src/representation/partition/marginal_passes.rs
+++ b/packages/treetime/src/representation/partition/marginal_passes.rs
@@ -5,6 +5,7 @@ use crate::representation::partition::traits::ExactStateCache;
 use crate::representation::payload::sparse::{MarginalSparseSeqDistribution, VarPos};
 use eyre::Report;
 use maplit::btreemap;
+use ndarray::Array1;
 use std::collections::BTreeMap;
 use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
@@ -16,15 +17,21 @@ use treetime_utils::interval::range::range_contains;
 
 pub fn process_node_backward<N, E>(
   partition: &mut PartitionMarginalSparse,
-  _graph: &Graph<N, E, ()>,
+  graph: &Graph<N, E, ()>,
   node: &GraphNodeBackward<N, E, ()>,
-  _cache: &ExactStateCache,
+  cache: &mut ExactStateCache,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
 {
   let length = partition.length;
+  let parent = if node.is_root {
+    None
+  } else {
+    let edge_key = *get_exactly_one(&node.parent_edge_keys).expect("Only nodes with exactly one parent are supported");
+    Some((graph.get_source_node_key(edge_key)?, edge_key))
+  };
 
   let msg_to_parent = if node.is_leaf {
     let alphabet = &partition.alphabet;
@@ -41,12 +48,12 @@ where
       .fitch
       .variable
       .iter()
-      .map(|(pos, p)| {
+      .map(|(pos, p)| -> Result<_, Report> {
         let dis = alphabet.construct_profile(p.chars()).unwrap();
-        let state = p.get_one();
-        (*pos, VarPos { dis, state })
+        let state = partition.node_canonical_state_known_parent(graph, node.key, parent, *pos, cache)?;
+        Ok((*pos, VarPos { dis, state }))
       })
-      .collect();
+      .collect::<Result<_, _>>()?;
 
     MarginalSparseSeqDistribution {
       fixed_counts: node_data.seq.composition.clone(),
@@ -56,9 +63,20 @@ where
       log_lh: 0.0,
     }
   } else {
-    // for internal nodes, combine the messages from the children
+    // for internal nodes, combine the messages from the children.
+    //
+    // Spec: variable candidate positions come from
+    //   (a) substitutions on edges to each child (node state = sub.reff),
+    //   (b) positions variable in children (node state = child state when no sub on edge).
+    //
+    // `sub.reff()` and `msg_from_child.variable[pos].state` both carry the
+    // current node's canonical state by construction, so there is no need to
+    // walk the graph to derive it. `propagate_raw` preserves the `state` field
+    // through edge transitions, so the child's state field in `msg_from_child`
+    // equals the child's canonical state, which equals the node's state at a
+    // position where the edge does not mutate.
     let mut variable_pos = btreemap! {};
-    let mut child_states = vec![];
+    let mut child_states: Vec<BTreeMap<usize, AsciiChar>> = vec![];
     let mut child_messages: Vec<MarginalSparseSeqDistribution> = vec![];
     for (ci, (_child_key, edge_key)) in node.child_keys.iter().enumerate() {
       child_states.push(btreemap! {});
@@ -73,17 +91,30 @@ where
       child_messages.push(edge_data.msg_from_child.clone());
     }
 
+    // Resolve each child's state at each variable position.
+    //
+    // Precedence matches `child_canonical_state_from_parent_state()`:
+    //   1. Child's gap range (highest)
+    //   2. Child's unknown range
+    //   3. Edge substitution (sub.qry)
+    //   4. Parent (node) state
+    //
+    // The mask ranges take precedence over substitutions because a deletion or
+    // unknown at the child masks the substitution model entirely: there is no
+    // nucleotide at that position to receive the substituted state. Subs pre-
+    // filled from the backward collection loop above are overwritten here when
+    // a mask applies.
     let alphabet = &partition.alphabet;
     for (ci, (child_key, _)) in node.child_keys.iter().enumerate() {
       let states = &mut child_states[ci];
       let child_data = &partition.nodes[child_key];
-      for pos in variable_pos.keys() {
-        if !states.contains_key(pos) && range_contains(&child_data.seq.non_char, *pos) {
-          if range_contains(&child_data.seq.gaps, *pos) {
-            states.insert(*pos, alphabet.gap());
-          } else {
-            states.insert(*pos, alphabet.unknown());
-          }
+      for (pos, parent_state) in &variable_pos {
+        if range_contains(&child_data.seq.gaps, *pos) {
+          states.insert(*pos, alphabet.gap());
+        } else if range_contains(&child_data.seq.unknown, *pos) {
+          states.insert(*pos, alphabet.unknown());
+        } else if !states.contains_key(pos) {
+          states.insert(*pos, *parent_state);
         }
       }
     }
@@ -107,7 +138,7 @@ where
     let edge_key = get_exactly_one(&node.parent_edge_keys).expect("Only nodes with exactly one parent are supported");
     let branch_length = node.parent_edges[0].branch_length().unwrap_or(0.0);
     let branch_length = fix_branch_length(length, branch_length);
-    let mut edge_data = partition.edges.remove(edge_key).unwrap();
+    let edge_data = partition.edges.get_mut(edge_key).unwrap();
     edge_data.msg_from_child = if partition.gtr.has_site_rates() {
       propagate_raw_per_site(
         &partition.gtr,
@@ -124,7 +155,6 @@ where
       )
     };
     edge_data.msg_to_parent = msg_to_parent;
-    partition.edges.insert(*edge_key, edge_data);
   }
   Ok(())
 }
@@ -133,38 +163,63 @@ pub fn process_node_forward<N, E>(
   partition: &mut PartitionMarginalSparse,
   graph: &Graph<N, E, ()>,
   node: &GraphNodeForward<N, E, ()>,
-  _cache: &ExactStateCache,
+  _cache: &mut ExactStateCache,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
 {
   if !node.is_root {
+    // Combine parent-side propagated message with node's backward message.
+    //
+    // The `state` field on each `VarPos` is preserved by `propagate_raw` and
+    // carries the node-side Fitch state by construction:
+    //   * `msg_to_child.variable[pos].state` = parent's state at pos
+    //   * `msg_to_parent.variable[pos].state` = node's state at pos
+    //   * `edge.subs` defines both sides explicitly
+    //
+    // Spec: at positions without a sub on the edge, parent state == node state.
+    // That makes the per-message reference states derivable from the message's
+    // own state field plus the edge's sub list, without any graph traversal.
     let mut variable_pos = btreemap! {};
     let mut ref_states: Vec<BTreeMap<usize, AsciiChar>> = vec![];
     let mut msgs_to_combine: Vec<MarginalSparseSeqDistribution> = vec![];
-    let mut removed_edges = vec![];
-    for (_, edge_key) in &node.parent_keys {
+    for (_parent_key, edge_key) in &node.parent_keys {
+      let edge_data = &partition.edges[edge_key];
+      let node_data = &partition.nodes[&node.key];
+
       let mut parent_state: BTreeMap<usize, AsciiChar> = btreemap! {};
       let mut child_state: BTreeMap<usize, AsciiChar> = btreemap! {};
-      let edge_data = partition.edges.remove(edge_key).unwrap();
-      removed_edges.push((*edge_key, edge_data.clone()));
 
-      let node_data = &partition.nodes[&node.key];
-      for (pos, p) in &edge_data.msg_to_child.variable {
-        if !range_contains(&node_data.seq.gaps, *pos) {
-          variable_pos.entry(*pos).or_insert(p.state);
-          parent_state.insert(*pos, p.state);
-        }
-      }
+      // Subs have both sides defined. Process first so entries win for later
+      // sources that would otherwise only set one side.
       for m in &edge_data.subs {
         variable_pos.insert(m.pos(), m.qry());
         parent_state.entry(m.pos()).or_insert_with(|| m.reff());
         child_state.entry(m.pos()).or_insert_with(|| m.qry());
       }
+
+      // Parent-side variable (msg_to_child). Skip positions where the node has
+      // a gap or unknown: fixed-site lookups would fail at non-canonical chars.
+      for (pos, p) in &edge_data.msg_to_child.variable {
+        if range_contains(&node_data.seq.non_char, *pos) {
+          continue;
+        }
+        variable_pos.entry(*pos).or_insert(p.state);
+        parent_state.entry(*pos).or_insert(p.state);
+      }
+
+      // Node-side variable (msg_to_parent): node state = p.state.
       for (pos, p) in &edge_data.msg_to_parent.variable {
         variable_pos.entry(*pos).or_insert(p.state);
         child_state.entry(*pos).or_insert(p.state);
+      }
+
+      // Fill cross-side fallbacks: at positions with no sub on this edge, the
+      // parent state and child state coincide with the message's own state.
+      for (pos, state) in &variable_pos {
+        parent_state.entry(*pos).or_insert(*state);
+        child_state.entry(*pos).or_insert(*state);
       }
 
       let edge_payload = graph.get_edge(*edge_key).unwrap().read_arc().payload().read_arc();
@@ -191,10 +246,6 @@ where
       ref_states.push(child_state);
     }
 
-    for (edge_key, edge_data) in removed_edges {
-      partition.edges.insert(edge_key, edge_data);
-    }
-
     let composition = partition.nodes[&node.key].seq.composition.clone();
     let profile = combine_messages(
       &composition,
@@ -208,9 +259,14 @@ where
     partition.nodes.get_mut(&node.key).unwrap().profile = profile;
   }
 
-  // precalculate messages to children that summarize info from their siblings and the parent
+  // precalculate messages to children that summarize info from their siblings and the parent.
+  //
+  // `parent_states` = current node's state at each variable position (this node is
+  // the parent of the outgoing edge). `child_states` = child's state at the same
+  // positions. Both come from the existing message `state` fields and the edge
+  // `subs` list; no graph traversal is needed.
   for child_edge_key in &node.child_edge_keys {
-    let child_edge_data = partition.edges.remove(child_edge_key).unwrap();
+    let child_edge_data = partition.edges[child_edge_key].clone();
     let seq_info = &partition.nodes[&node.key];
     let mut seq_dis = MarginalSparseSeqDistribution {
       variable: btreemap! {},
@@ -221,32 +277,59 @@ where
     };
 
     let child_dis = child_edge_data.msg_from_child.clone();
+    let child_data = &partition.nodes[&graph.get_target_node_key(*child_edge_key)?];
+    let alphabet = &partition.alphabet;
+
     let mut parent_states: BTreeMap<usize, AsciiChar> = btreemap! {};
     let mut child_states: BTreeMap<usize, AsciiChar> = btreemap! {};
-    for (pos, p) in &seq_info.profile.variable {
-      child_states.insert(*pos, p.state);
-      parent_states.insert(*pos, p.state);
+
+    // Subs define both sides.
+    for sub in &child_edge_data.subs {
+      parent_states.insert(sub.pos(), sub.reff());
+      child_states.insert(sub.pos(), sub.qry());
     }
+    // Current node's variable: parent state = p.state; child state equals it
+    // unless overridden by a sub or by the child's gap/unknown mask.
+    for (pos, p) in &seq_info.profile.variable {
+      parent_states.entry(*pos).or_insert(p.state);
+      child_states.entry(*pos).or_insert(p.state);
+    }
+    // Child's upward variable: child state = p.state; parent state equals it
+    // when the edge does not mutate at this position.
     for (pos, p) in &child_dis.variable {
-      child_states.insert(*pos, p.state);
+      child_states.entry(*pos).or_insert(p.state);
       parent_states.entry(*pos).or_insert(p.state);
     }
-    for sub in &child_edge_data.subs {
-      child_states.insert(sub.pos(), sub.qry());
-      parent_states.insert(sub.pos(), sub.reff());
+    // Apply child gap/unknown masks unconditionally. Precedence matches
+    // `child_canonical_state_from_parent_state()`: gap > unknown > sub > p.state.
+    // Masks override substitutions because a deletion or unknown at the child
+    // masks the substitution model entirely - the nucleotide does not exist
+    // there to receive the substituted state.
+    for (pos, state) in &mut child_states {
+      if range_contains(&child_data.seq.gaps, *pos) {
+        *state = alphabet.gap();
+      } else if range_contains(&child_data.seq.unknown, *pos) {
+        *state = alphabet.unknown();
+      }
     }
+
+    let neutral = Array1::from_elem(partition.alphabet.n_canonical(), 1.0);
 
     let mut delta_ll = 0.0;
     for (pos, pstate) in parent_states {
       let divisor = if let Some(dis) = child_dis.variable.get(&pos) {
         &dis.dis
-      } else {
+      } else if partition.alphabet.is_canonical(child_states[&pos]) {
         &child_dis.fixed[&child_states[&pos]]
+      } else {
+        &neutral
       };
       let numerator = if let Some(dis) = seq_info.profile.variable.get(&pos) {
         &dis.dis
-      } else {
+      } else if partition.alphabet.is_canonical(pstate) {
         &seq_info.profile.fixed[&pstate]
+      } else {
+        &neutral
       };
       let dis = numerator / divisor;
       let norm = dis.sum();
@@ -267,9 +350,7 @@ where
       seq_dis.fixed.insert(*s, dis / norm);
     }
     seq_dis.log_lh += delta_ll;
-    let mut updated_edge_data = child_edge_data;
-    updated_edge_data.msg_to_child = seq_dis;
-    partition.edges.insert(*child_edge_key, updated_edge_data);
+    partition.edges.get_mut(child_edge_key).unwrap().msg_to_child = seq_dis;
   }
   Ok(())
 }

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -8,7 +8,10 @@ use crate::representation::partition::marginal_passes;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionBranchOps;
 use crate::representation::partition::traits::PartitionCompressed;
-use crate::representation::partition::traits::{ExactStateCache, PartitionMarginal, PartitionMarginalOps};
+use crate::representation::partition::traits::{
+  CurrentStateCache, ExactStateCache, GraphNodePathLookup, PartitionMarginal, PartitionMarginalOps,
+  SequenceReconstructionCache,
+};
 use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::sparse::{MarginalSparseSeqDistribution, SparseEdgePartition, SparseNodePartition};
 use crate::seq::mutation::{Sub, compose_substitutions};
@@ -23,7 +26,6 @@ use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_io::fasta::FastaRecord;
 use treetime_primitives::{AsciiChar, Seq, seq};
 use treetime_utils::array::ndarray::argmax_first;
-use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::interval::range::range_contains;
 use treetime_utils::interval::range_union::range_union;
 
@@ -85,12 +87,13 @@ impl PartitionMarginalSparse {
   ) -> Result<Vec<Sub>, Report> {
     let parent_key = graph.get_source_node_key(edge_key)?;
     let child_key = graph.get_target_node_key(edge_key)?;
-    let mut cache = BTreeMap::new();
+    let mut exact_cache = ExactStateCache::new();
+    let mut current_cache = CurrentStateCache::new();
     let mut subs = Vec::new();
 
     for pos in self.edge_candidate_positions(graph, edge_key)? {
-      let parent_state = self.node_state_at(graph, parent_key, pos, &mut cache)?;
-      let child_state = self.node_state_at(graph, child_key, pos, &mut cache)?;
+      let parent_state = self.node_state_at(graph, parent_key, pos, &mut exact_cache, &mut current_cache)?;
+      let child_state = self.node_state_at(graph, child_key, pos, &mut exact_cache, &mut current_cache)?;
 
       if parent_state == child_state {
         continue;
@@ -151,83 +154,230 @@ impl PartitionMarginalSparse {
     )
   }
 
-  /// Reconstruct one node state at one site from sparse data.
+  /// Reconstruct the exact Fitch-resolved state at one node and site.
   ///
-  /// This is the single-site version of `reconstruct_node_sequence()`: start
-  /// from the parent state, apply edge changes, mask unknowns, then apply the
-  /// node's current best state for variable sites.
-  ///
-  /// After marginal inference, `edge.subs` alone is not enough. The final state
-  /// also depends on the node's current marginal result.
-  fn node_state_at<N: GraphNode, E: GraphEdge, D: Send + Sync>(
+  /// This follows the canonical root sequence and the edge deltas only. It does
+  /// not consult the marginal MAP profile.
+  fn edge_state_from_parent(&self, edge_key: GraphEdgeKey, pos: usize, parent_state: AsciiChar) -> AsciiChar {
+    self.edges.get(&edge_key).map_or(parent_state, |edge_data| {
+      match edge_data
+        .indels
+        .iter()
+        .find(|indel| indel.range.0 <= pos && pos < indel.range.1)
+      {
+        Some(indel) if indel.deletion => self.alphabet.gap(),
+        Some(indel) => indel.seq[pos - indel.range.0],
+        None => edge_data
+          .subs
+          .iter()
+          .find(|sub| sub.pos() == pos)
+          .map_or(parent_state, Sub::qry),
+      }
+    })
+  }
+
+  pub(crate) fn node_canonical_state_known_parent<G: GraphNodePathLookup + ?Sized>(
     &self,
-    graph: &Graph<N, E, D>,
+    graph: &G,
     node_key: GraphNodeKey,
+    parent: Option<(GraphNodeKey, GraphEdgeKey)>,
     pos: usize,
-    cache: &mut BTreeMap<(GraphNodeKey, usize), AsciiChar>,
+    cache: &mut ExactStateCache,
   ) -> Result<AsciiChar, Report> {
-    if let Some(state) = cache.get(&(node_key, pos)) {
-      return Ok(*state);
+    if let Some(state) = cache.get(&(node_key, pos)).copied() {
+      return Ok(state);
     }
 
-    let node = graph
-      .get_node(node_key)
-      .ok_or_else(|| make_internal_report!("Node {node_key} not found"))?;
-    let node = node.read_arc();
-    let node_data = self.nodes.get(&node_key);
-
-    // Compute base state from tree structure.
-    // Root must have partition data (populated by Fitch compression).
-    // Non-root nodes may be absent during topology changes.
-    let base_state = if node.is_root() {
-      let d = node_data.ok_or_else(|| make_internal_report!("Root node {node_key} has no partition data"))?;
-      d.seq
+    let node_data = self
+      .nodes
+      .get(&node_key)
+      .ok_or_else(|| make_internal_report!("Node {node_key} has no partition data"))?;
+    let state = if range_contains(&node_data.seq.gaps, pos) {
+      self.alphabet.gap()
+    } else if range_contains(&node_data.seq.unknown, pos) {
+      self.alphabet.unknown()
+    } else if let Some((parent_key, edge_key)) = parent {
+      let parent_state = self.node_canonical_state(graph, parent_key, pos, cache)?;
+      self.edge_state_from_parent(edge_key, pos, parent_state)
+    } else {
+      node_data
+        .seq
         .sequence
         .get(pos)
         .copied()
         .unwrap_or_else(|| self.alphabet.char(0))
-    } else {
-      let (parent_node, edge) = graph.exactly_one_parent_of(&node)?;
-      let parent_key = parent_node.read_arc().key();
-      let edge_key = edge.read_arc().key();
-      let parent_state = self.node_state_at(graph, parent_key, pos, cache)?;
-
-      // Apply edge changes if edge partition data exists
-      self.edges.get(&edge_key).map_or(parent_state, |edge_data| {
-        // Indels have highest precedence, then substitutions, then parent state
-        if let Some(indel) = edge_data
-          .indels
-          .iter()
-          .find(|indel| indel.range.0 <= pos && pos < indel.range.1)
-        {
-          if indel.deletion {
-            self.alphabet.gap()
-          } else {
-            indel.seq[pos - indel.range.0]
-          }
-        } else if let Some(sub) = edge_data.subs.iter().find(|sub| sub.pos() == pos) {
-          sub.qry()
-        } else {
-          parent_state
-        }
-      })
     };
-
-    // Variable sites have highest precedence, then unknown, then base state
-    let state = node_data.map_or(base_state, |d| {
-      if let Some(states) = d.profile.variable.get(&pos) {
-        self.alphabet.char(argmax_first(&states.dis.view()).unwrap_or(0))
-      } else if range_contains(&d.seq.unknown, pos) {
-        self.alphabet.unknown()
-      } else {
-        base_state
-      }
-    });
 
     cache.insert((node_key, pos), state);
     Ok(state)
   }
 
+  pub(crate) fn child_canonical_state_from_parent_state(
+    &self,
+    child_key: GraphNodeKey,
+    edge_key: GraphEdgeKey,
+    parent_state: AsciiChar,
+    pos: usize,
+    cache: &mut ExactStateCache,
+  ) -> Result<AsciiChar, Report> {
+    if let Some(state) = cache.get(&(child_key, pos)).copied() {
+      return Ok(state);
+    }
+
+    let child_data = self
+      .nodes
+      .get(&child_key)
+      .ok_or_else(|| make_internal_report!("Node {child_key} has no partition data"))?;
+    let state = if range_contains(&child_data.seq.gaps, pos) {
+      self.alphabet.gap()
+    } else if range_contains(&child_data.seq.unknown, pos) {
+      self.alphabet.unknown()
+    } else {
+      self.edge_state_from_parent(edge_key, pos, parent_state)
+    };
+
+    cache.insert((child_key, pos), state);
+    Ok(state)
+  }
+
+  pub(crate) fn node_canonical_state<G: GraphNodePathLookup + ?Sized>(
+    &self,
+    graph: &G,
+    node_key: GraphNodeKey,
+    pos: usize,
+    cache: &mut ExactStateCache,
+  ) -> Result<AsciiChar, Report> {
+    let parent = graph.parent_of(node_key)?;
+    self.node_canonical_state_known_parent(graph, node_key, parent, pos, cache)
+  }
+
+  fn leaf_parsimony_state<G: GraphNodePathLookup + ?Sized>(
+    &self,
+    graph: &G,
+    node_key: GraphNodeKey,
+    pos: usize,
+    exact_cache: &mut ExactStateCache,
+  ) -> Result<AsciiChar, Report> {
+    let node_data = self
+      .nodes
+      .get(&node_key)
+      .ok_or_else(|| make_internal_report!("Node {node_key} has no partition data"))?;
+    if range_contains(&node_data.seq.gaps, pos) {
+      return Ok(self.alphabet.gap());
+    }
+    if range_contains(&node_data.seq.unknown, pos) {
+      return Ok(self.alphabet.unknown());
+    }
+
+    // Sparse leaf semantics follow the exact parsimony-resolved state carried by
+    // the compressed tree, not the raw observed ambiguity code from the input
+    // FASTA. The ambiguity itself still shapes the leaf likelihood through the
+    // backward `dis` vector; downstream state-based consumers need the
+    // parsimony-resolved nucleotide that anchors those messages.
+    self.node_canonical_state(graph, node_key, pos, exact_cache)
+  }
+
+  fn reconstruct_leaf_parsimony_sequence<G: GraphNodePathLookup + ?Sized>(
+    &self,
+    graph: &G,
+    node_key: GraphNodeKey,
+    exact_cache: &mut ExactStateCache,
+  ) -> Result<Seq, Report> {
+    (0..self.length)
+      .map(|pos| self.leaf_parsimony_state(graph, node_key, pos, exact_cache))
+      .collect()
+  }
+
+  /// Reconstruct one node state at one site from sparse data.
+  ///
+  /// This starts from the exact Fitch-resolved state and then applies the
+  /// current marginal MAP profile when the position is explicit in the sparse
+  /// posterior.
+  fn node_state_at<G: GraphNodePathLookup + ?Sized>(
+    &self,
+    graph: &G,
+    node_key: GraphNodeKey,
+    pos: usize,
+    exact_cache: &mut ExactStateCache,
+    current_cache: &mut CurrentStateCache,
+  ) -> Result<AsciiChar, Report> {
+    if let Some(state) = current_cache.get(&(node_key, pos)).copied() {
+      return Ok(state);
+    }
+
+    let node_data = self
+      .nodes
+      .get(&node_key)
+      .ok_or_else(|| make_internal_report!("Node {node_key} has no partition data"))?;
+    if graph.is_leaf(node_key)? {
+      let state = self.leaf_parsimony_state(graph, node_key, pos, exact_cache)?;
+      current_cache.insert((node_key, pos), state);
+      return Ok(state);
+    }
+    let base_state = if let Some((parent_key, edge_key)) = graph.parent_of(node_key)? {
+      let parent_state = self.node_canonical_state(graph, parent_key, pos, exact_cache)?;
+      self.child_canonical_state_from_parent_state(node_key, edge_key, parent_state, pos, exact_cache)?
+    } else {
+      self.node_canonical_state_known_parent(graph, node_key, None, pos, exact_cache)?
+    };
+    let state = node_data.profile.variable.get(&pos).map_or(base_state, |states| {
+      self.alphabet.char(argmax_first(&states.dis.view()).unwrap_or(0))
+    });
+    current_cache.insert((node_key, pos), state);
+    Ok(state)
+  }
+
+  fn reconstruct_sequence_cached<G: GraphNodePathLookup + ?Sized>(
+    &self,
+    graph: &G,
+    node_key: GraphNodeKey,
+    cache: &mut SequenceReconstructionCache,
+  ) -> Result<Seq, Report> {
+    if let Some(seq) = cache.get(&node_key) {
+      return Ok(seq.clone());
+    }
+
+    let node_data = self
+      .nodes
+      .get(&node_key)
+      .ok_or_else(|| make_internal_report!("Node {node_key} has no partition data"))?;
+    if graph.is_leaf(node_key)? {
+      let mut exact_cache = ExactStateCache::default();
+      let seq = self.reconstruct_leaf_parsimony_sequence(graph, node_key, &mut exact_cache)?;
+      cache.insert(node_key, seq.clone());
+      return Ok(seq);
+    }
+    let mut seq = if let Some((parent_key, edge_key)) = graph.parent_of(node_key)? {
+      let mut seq = self.reconstruct_sequence_cached(graph, parent_key, cache)?;
+      if let Some(edge_data) = self.edges.get(&edge_key) {
+        for sub in &edge_data.subs {
+          seq[sub.pos()] = sub.qry();
+        }
+        for indel in &edge_data.indels {
+          if indel.deletion {
+            seq[indel.range.0..indel.range.1].fill(self.alphabet.gap());
+          } else {
+            seq[indel.range.0..indel.range.1].copy_from_slice(&indel.seq);
+          }
+        }
+      }
+      seq
+    } else {
+      node_data.seq.sequence.clone()
+    };
+
+    for gap in &node_data.seq.gaps {
+      seq[gap.0..gap.1].fill(self.alphabet.gap());
+    }
+    for unknown in &node_data.seq.unknown {
+      seq[unknown.0..unknown.1].fill(self.alphabet.unknown());
+    }
+    for (&pos, states) in &node_data.profile.variable {
+      seq[pos] = self.alphabet.char(argmax_first(&states.dis.view()).unwrap_or(0));
+    }
+    cache.insert(node_key, seq.clone());
+    Ok(seq)
+  }
 }
 
 impl HasLogLh for PartitionMarginalSparse {
@@ -402,7 +552,7 @@ where
     &mut self,
     graph: &Graph<N, E, ()>,
     node: &GraphNodeBackward<N, E, ()>,
-    cache: &ExactStateCache,
+    cache: &mut ExactStateCache,
   ) -> Result<(), Report> {
     marginal_passes::process_node_backward(self, graph, node, cache)
   }
@@ -411,7 +561,7 @@ where
     &mut self,
     graph: &Graph<N, E, ()>,
     node: &GraphNodeForward<N, E, ()>,
-    cache: &ExactStateCache,
+    cache: &mut ExactStateCache,
   ) -> Result<(), Report> {
     marginal_passes::process_node_forward(self, graph, node, cache)
   }
@@ -428,51 +578,18 @@ where
     }
   }
 
-  fn reconstruct_node_sequence(&mut self, node: &GraphNodeForward<N, E, ()>, include_leaves: bool) -> Option<Seq> {
+  fn reconstruct_node_sequence(
+    &self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeForward<N, E, ()>,
+    include_leaves: bool,
+    cache: &mut SequenceReconstructionCache,
+  ) -> Option<Seq> {
     if !include_leaves && node.is_leaf {
       return None;
     }
 
-    let mut node_data = self.nodes.remove(&node.key)?;
-
-    let mut seq = if node.is_root {
-      node_data.seq.sequence.clone()
-    } else {
-      let (parent_key, edge_key) = get_exactly_one(&node.parent_keys).ok()?;
-      let parent_data = self.nodes.get(parent_key)?;
-      let edge_data = self.edges.get(edge_key)?;
-
-      let mut seq = parent_data.seq.sequence.clone();
-
-      for m in &edge_data.subs {
-        seq[m.pos()] = m.qry();
-      }
-
-      for indel in &edge_data.indels {
-        if indel.deletion {
-          seq[indel.range.0..indel.range.1].fill(self.alphabet.gap());
-        } else {
-          seq[indel.range.0..indel.range.1].copy_from_slice(&indel.seq);
-        }
-      }
-
-      seq
-    };
-
-    let alphabet = &self.alphabet;
-    for r in &node_data.seq.unknown {
-      let ambig_char = alphabet.unknown();
-      seq[r.0..r.1].fill(ambig_char);
-    }
-
-    for (pos, states) in &node_data.profile.variable {
-      seq[*pos] = alphabet.char(argmax_first(&states.dis.view()).unwrap_or(0));
-    }
-
-    node_data.seq.sequence = seq.clone();
-    self.nodes.insert(node.key, node_data);
-
-    Some(seq)
+    self.reconstruct_sequence_cached(graph, node.key, cache).ok()
   }
 
   fn get_sequence_length(&self) -> usize {

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -8,7 +8,7 @@ use crate::representation::partition::marginal_passes;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionBranchOps;
 use crate::representation::partition::traits::PartitionCompressed;
-use crate::representation::partition::traits::{PartitionMarginal, PartitionMarginalOps};
+use crate::representation::partition::traits::{ExactStateCache, PartitionMarginal, PartitionMarginalOps};
 use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::sparse::{MarginalSparseSeqDistribution, SparseEdgePartition, SparseNodePartition};
 use crate::seq::mutation::{Sub, compose_substitutions};
@@ -227,6 +227,7 @@ impl PartitionMarginalSparse {
     cache.insert((node_key, pos), state);
     Ok(state)
   }
+
 }
 
 impl HasLogLh for PartitionMarginalSparse {
@@ -397,12 +398,22 @@ where
     Ok(())
   }
 
-  fn process_node_backward(&mut self, node: &GraphNodeBackward<N, E, ()>) -> Result<(), Report> {
-    marginal_passes::process_node_backward(self, node)
+  fn process_node_backward(
+    &mut self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeBackward<N, E, ()>,
+    cache: &ExactStateCache,
+  ) -> Result<(), Report> {
+    marginal_passes::process_node_backward(self, graph, node, cache)
   }
 
-  fn process_node_forward(&mut self, graph: &Graph<N, E, ()>, node: &GraphNodeForward<N, E, ()>) -> Result<(), Report> {
-    marginal_passes::process_node_forward(self, graph, node)
+  fn process_node_forward(
+    &mut self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeForward<N, E, ()>,
+    cache: &ExactStateCache,
+  ) -> Result<(), Report> {
+    marginal_passes::process_node_forward(self, graph, node, cache)
   }
 
   fn extract_ancestral_sequence(&self, node_key: GraphNodeKey) -> Seq {
@@ -410,7 +421,6 @@ where
       if !node_data.seq.sequence.is_empty() {
         node_data.seq.sequence.clone()
       } else {
-        // Return empty seq to be filled later by the reconstruction algorithm
         seq![]
       }
     } else {
@@ -434,12 +444,10 @@ where
 
       let mut seq = parent_data.seq.sequence.clone();
 
-      // Implant mutations
       for m in &edge_data.subs {
         seq[m.pos()] = m.qry();
       }
 
-      // Implant indels
       for indel in &edge_data.indels {
         if indel.deletion {
           seq[indel.range.0..indel.range.1].fill(self.alphabet.gap());
@@ -451,15 +459,12 @@ where
       seq
     };
 
-    // At the node itself, mask whatever is unknown in the node.
     let alphabet = &self.alphabet;
     for r in &node_data.seq.unknown {
       let ambig_char = alphabet.unknown();
       seq[r.0..r.1].fill(ambig_char);
     }
 
-    // Change variable sites to their most likely state.
-    // Uses argmax_first for NumPy-compatible tie-breaking.
     for (pos, states) in &node_data.profile.variable {
       seq[*pos] = alphabet.char(argmax_first(&states.dis.view()).unwrap_or(0));
     }

--- a/packages/treetime/src/representation/partition/traits.rs
+++ b/packages/treetime/src/representation/partition/traits.rs
@@ -1,9 +1,10 @@
 use crate::alphabet::alphabet::Alphabet;
+use crate::make_internal_report;
 use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::sparse::{SparseEdgePartition, SparseNodePartition};
 use crate::seq::mutation::Sub;
 use eyre::Report;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey};
@@ -11,7 +12,46 @@ use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::Seq;
+use treetime_primitives::{AsciiChar, Seq};
+
+pub type ExactStateCache = Arc<Mutex<BTreeMap<(GraphNodeKey, usize), AsciiChar>>>;
+pub type CurrentStateCache = Arc<Mutex<BTreeMap<(GraphNodeKey, usize), AsciiChar>>>;
+pub type SequenceReconstructionCache = BTreeMap<GraphNodeKey, Seq>;
+
+pub trait GraphNodePathLookup: Send + Sync {
+  fn source_node_key(&self, edge_key: GraphEdgeKey) -> Result<GraphNodeKey, Report>;
+
+  fn target_node_key(&self, edge_key: GraphEdgeKey) -> Result<GraphNodeKey, Report>;
+
+  fn parent_of(&self, node_key: GraphNodeKey) -> Result<Option<(GraphNodeKey, GraphEdgeKey)>, Report>;
+}
+
+impl<N, E, D> GraphNodePathLookup for Graph<N, E, D>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Send + Sync,
+{
+  fn source_node_key(&self, edge_key: GraphEdgeKey) -> Result<GraphNodeKey, Report> {
+    self.get_source_node_key(edge_key)
+  }
+
+  fn target_node_key(&self, edge_key: GraphEdgeKey) -> Result<GraphNodeKey, Report> {
+    self.get_target_node_key(edge_key)
+  }
+
+  fn parent_of(&self, node_key: GraphNodeKey) -> Result<Option<(GraphNodeKey, GraphEdgeKey)>, Report> {
+    let node = self
+      .get_node(node_key)
+      .ok_or_else(|| make_internal_report!("Node {node_key} not found"))?;
+    let node = node.read_arc();
+    if node.is_root() {
+      return Ok(None);
+    }
+    let (parent_node, edge) = self.exactly_one_parent_of(&node)?;
+    Ok(Some((parent_node.read_arc().key(), edge.read_arc().key())))
+  }
+}
 
 /// Derive branch mutations and effective lengths from the current partition state.
 ///
@@ -53,10 +93,20 @@ where
   fn attach_sequences(&mut self, graph: &Graph<N, E, ()>, aln: &[FastaRecord]) -> Result<(), Report>;
 
   /// Process a node during backward pass (equivalent to run_marginal_*_backward)
-  fn process_node_backward(&mut self, node: &GraphNodeBackward<N, E, ()>) -> Result<(), Report>;
+  fn process_node_backward(
+    &mut self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeBackward<N, E, ()>,
+    cache: &ExactStateCache,
+  ) -> Result<(), Report>;
 
   /// Process a node during forward pass (equivalent to run_marginal_*_forward)
-  fn process_node_forward(&mut self, graph: &Graph<N, E, ()>, node: &GraphNodeForward<N, E, ()>) -> Result<(), Report>;
+  fn process_node_forward(
+    &mut self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeForward<N, E, ()>,
+    cache: &ExactStateCache,
+  ) -> Result<(), Report>;
 
   /// Extract ancestral sequence from node profile
   fn extract_ancestral_sequence(&self, node_key: GraphNodeKey) -> Seq;

--- a/packages/treetime/src/representation/partition/traits.rs
+++ b/packages/treetime/src/representation/partition/traits.rs
@@ -4,7 +4,7 @@ use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::sparse::{SparseEdgePartition, SparseNodePartition};
 use crate::seq::mutation::Sub;
 use eyre::Report;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey};
@@ -14,8 +14,8 @@ use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_io::fasta::FastaRecord;
 use treetime_primitives::{AsciiChar, Seq};
 
-pub type ExactStateCache = Arc<Mutex<BTreeMap<(GraphNodeKey, usize), AsciiChar>>>;
-pub type CurrentStateCache = Arc<Mutex<BTreeMap<(GraphNodeKey, usize), AsciiChar>>>;
+pub type ExactStateCache = BTreeMap<(GraphNodeKey, usize), AsciiChar>;
+pub type CurrentStateCache = BTreeMap<(GraphNodeKey, usize), AsciiChar>;
 pub type SequenceReconstructionCache = BTreeMap<GraphNodeKey, Seq>;
 
 pub trait GraphNodePathLookup: Send + Sync {
@@ -24,6 +24,8 @@ pub trait GraphNodePathLookup: Send + Sync {
   fn target_node_key(&self, edge_key: GraphEdgeKey) -> Result<GraphNodeKey, Report>;
 
   fn parent_of(&self, node_key: GraphNodeKey) -> Result<Option<(GraphNodeKey, GraphEdgeKey)>, Report>;
+
+  fn is_leaf(&self, node_key: GraphNodeKey) -> Result<bool, Report>;
 }
 
 impl<N, E, D> GraphNodePathLookup for Graph<N, E, D>
@@ -50,6 +52,13 @@ where
     }
     let (parent_node, edge) = self.exactly_one_parent_of(&node)?;
     Ok(Some((parent_node.read_arc().key(), edge.read_arc().key())))
+  }
+
+  fn is_leaf(&self, node_key: GraphNodeKey) -> Result<bool, Report> {
+    let node = self
+      .get_node(node_key)
+      .ok_or_else(|| make_internal_report!("Node {node_key} not found"))?;
+    Ok(node.read_arc().is_leaf())
   }
 }
 
@@ -97,7 +106,7 @@ where
     &mut self,
     graph: &Graph<N, E, ()>,
     node: &GraphNodeBackward<N, E, ()>,
-    cache: &ExactStateCache,
+    cache: &mut ExactStateCache,
   ) -> Result<(), Report>;
 
   /// Process a node during forward pass (equivalent to run_marginal_*_forward)
@@ -105,14 +114,20 @@ where
     &mut self,
     graph: &Graph<N, E, ()>,
     node: &GraphNodeForward<N, E, ()>,
-    cache: &ExactStateCache,
+    cache: &mut ExactStateCache,
   ) -> Result<(), Report>;
 
   /// Extract ancestral sequence from node profile
   fn extract_ancestral_sequence(&self, node_key: GraphNodeKey) -> Seq;
 
   /// Reconstruct ancestral sequences for a specific node during tree traversal
-  fn reconstruct_node_sequence(&mut self, node: &GraphNodeForward<N, E, ()>, include_leaves: bool) -> Option<Seq>;
+  fn reconstruct_node_sequence(
+    &self,
+    graph: &Graph<N, E, ()>,
+    node: &GraphNodeForward<N, E, ()>,
+    include_leaves: bool,
+    cache: &mut SequenceReconstructionCache,
+  ) -> Option<Seq>;
 
   /// Get sequence length
   fn get_sequence_length(&self) -> usize;

--- a/packages/treetime/src/representation/payload/sparse.rs
+++ b/packages/treetime/src/representation/payload/sparse.rs
@@ -32,7 +32,6 @@ impl SparseNodePartition {
         fitch: FitchSeqDistribution {
           variable: btreemap! {},
           variable_indel: btreemap! {},
-          composition: Composition::new(alphabet.chars(), alphabet.gap()),
         },
       },
       profile: MarginalSparseSeqDistribution::default(),
@@ -56,7 +55,6 @@ impl SparseNodePartition {
     let seq_dis = FitchSeqDistribution {
       variable,
       variable_indel: btreemap! {},
-      composition: Composition::new(alphabet.chars(), alphabet.gap()),
     };
 
     let unknown = find_letter_ranges(seq, alphabet.unknown());
@@ -139,8 +137,6 @@ pub struct FitchSeqDistribution {
   pub variable: BTreeMap<usize, StateSet>,
 
   pub variable_indel: BTreeMap<(usize, usize), Deletion>,
-
-  pub composition: Composition,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Sparse marginal inference read stale state from two sources. Per-node sequences, which `fitch.rs` deletes after compression [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/commands/ancestral/fitch.rs#L494-L504)]. Labels on `VarPos.state` [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/payload/sparse.rs#L142-L146)], which held the initial Fitch-resolved state and were never refreshed. At ambiguous leaves the code fell back to `StateSet.get_one()` (arbitrary pick) instead of the Fitch-resolved nucleotide, so leaf edges grew bogus substitutions. At child positions variable only in the parent, the state was never set, so downstream reads returned uninitialized defaults.

Make the root sequence plus edge deltas the only persistent source of truth. Reconstruct any `(node, position)` on demand by walking the graph.

- New canonical-state primitives on `PartitionMarginalSparse` [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/partition/marginal_sparse.rs#L161-L345)] reach any state via the `GraphNodePathLookup` trait [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/partition/traits.rs#L7-L20)]. The core is `child_canonical_state_from_parent_state` [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/partition/marginal_sparse.rs#L215-L238)], with precedence `gap > unknown > sub > parent_state` applied uniformly everywhere state is resolved.
- Fitch compression cleanup drops non-root `seq.sequence` [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/commands/ancestral/fitch.rs#L494-L504)]; only the root retains its sequence.
- The dead `FitchSeqDistribution.composition` duplicate field is gone; the struct [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/payload/sparse.rs#L134-L140)] now carries only `variable` and `variable_indel`.
- The marginal-pass hot path stays O(1) per position, reading `sub.reff()` / `sub.qry()` and `msg.variable[pos].state` directly at the `process_node_forward` state-building block [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/partition/marginal_passes.rs#L286-L310)]. `propagate_raw` [[src](https://github.com/neherlab/treetime/blob/382ca1b5/packages/treetime/src/representation/partition/marginal_helpers.rs#L113)] preserves the Fitch-resolved state through those fields, so the canonical walk runs only for ambiguous leaves and on-demand sequence output.

### Work items

- [x] `GraphNodePathLookup` trait, `ExactStateCache`, `CurrentStateCache`, `SequenceReconstructionCache`
- [x] `edge_state_from_parent`, `node_canonical_state_known_parent`, `child_canonical_state_from_parent_state`, `node_canonical_state`, `leaf_parsimony_state`, `node_state_at`, `reconstruct_sequence_cached`
- [x] Drop non-root stored sequences in Fitch compression cleanup
- [x] Remove `FitchSeqDistribution.composition`
- [x] Hot path reads states from `.state` fields with uniform `gap > unknown > sub > parent_state` precedence
- [x] Resolve ambiguous leaves via the canonical path
- [x] Regression tests: ambiguous-R parity, repeated marginal updates, exact-state reconstruction, 7-case precedence contract

### Possible improvements

- [ ] Rename `reference_states` to `fitch_states` per the sparse model spec [[doc](https://github.com/neherlab/treetime/blob/f40b991b/docs/algorithms/sparse_probabilistic_sequence_model.md#L48)]
- [ ] Evaluate whether posterior-pruned variable sets lose accuracy at parent nodes versus the raw parsimony-variable sets the spec [[doc](https://github.com/neherlab/treetime/blob/f40b991b/docs/algorithms/sparse_probabilistic_sequence_model.md#L40)] prescribes

