### PR TITLE
fix: keep sparse marginal messages quantitative and numerically stable

### DIFF
--- a/packages/treetime/src/representation/partition/marginal_helpers.rs
+++ b/packages/treetime/src/representation/partition/marginal_helpers.rs
@@ -7,7 +7,10 @@ use maplit::btreemap;
 use ndarray::{Array1, Array2, ArrayView1};
 use std::collections::BTreeMap;
 use std::iter::zip;
+#[cfg(test)]
+use treetime_primitives::AlphabetLike;
 use treetime_primitives::AsciiChar;
+use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::interval::range::range_contains;
 
 pub const EPS: f64 = 1e-4;
@@ -65,8 +68,9 @@ pub fn combine_messages(
       *count -= 1.0;
     }
 
+    let map_state = alphabet.char(argmax_first(&dis.view()).unwrap_or(0));
     let max_prob = dis.iter().copied().fold(0.0_f64, f64::max);
-    if max_prob < (1.0 - EPS) || !all_states_equal {
+    if max_prob < (1.0 - EPS) || !all_states_equal || map_state != state {
       seq_dis.fixed_counts.adjust_count(state, -1);
       seq_dis.variable.insert(pos, VarPos { dis, state });
     }
@@ -447,6 +451,39 @@ mod tests {
     }
   }
 
+  #[test]
+  fn test_combine_messages_keeps_deterministic_state_change_explicit() -> Result<(), Report> {
+    use crate::alphabet::alphabet::Alphabet;
+    use treetime_primitives::AsciiChar;
+
+    let alphabet = Alphabet::default();
+    let a = AsciiChar::from_byte_unchecked(b'A');
+    let g = AsciiChar::from_byte_unchecked(b'G');
+    let composition = Composition::with_sequence([g], alphabet.chars(), alphabet.gap());
+    let fixed = alphabet
+      .determined()
+      .map(|state| Ok((state, alphabet.get_profile(state)?.clone())))
+      .collect::<Result<BTreeMap<_, _>, Report>>()?;
+
+    let message = MarginalSparseSeqDistribution {
+      variable: btreemap! {},
+      variable_indel: btreemap! {},
+      fixed,
+      fixed_counts: composition.clone(),
+      log_lh: 0.0,
+    };
+    let variable_pos = btreemap! { 0_usize => g };
+    let reference_states = vec![btreemap! { 0_usize => a }];
+
+    let combined = combine_messages(&composition, &[message], &variable_pos, &reference_states, &alphabet, None)?;
+
+    let explicit = combined.variable.get(&0).expect("state-changing deterministic sites must stay explicit");
+    assert_eq!(explicit.state, g);
+    assert_abs_diff_eq!(explicit.dis, alphabet.get_profile(a)?.clone(), epsilon = 1e-14);
+    assert_eq!(combined.fixed_counts.get(g), Some(0));
+
+    Ok(())
+  }
   mod helpers {
     use approx::assert_abs_diff_eq;
     use ndarray::Array1;

--- a/packages/treetime/src/representation/partition/marginal_helpers.rs
+++ b/packages/treetime/src/representation/partition/marginal_helpers.rs
@@ -84,7 +84,13 @@ pub fn combine_messages(
     }
 
     let (dis, log_norm) = logsumexp_normalize(log_vec.view());
-    seq_dis.log_lh += fixed_counts[&state] * log_norm;
+    let multiplicity = fixed_counts[&state];
+    // Zero fixed-site multiplicity means this shared row corresponds to no
+    // actual sites. Its contribution is therefore exactly zero, even if the
+    // row itself underflowed and `log_norm` is `NEG_INFINITY`.
+    if multiplicity != 0.0 {
+      seq_dis.log_lh += multiplicity * log_norm;
+    }
     seq_dis.fixed.insert(state, dis);
   }
   Ok(seq_dis)
@@ -475,12 +481,55 @@ mod tests {
     let variable_pos = btreemap! { 0_usize => g };
     let reference_states = vec![btreemap! { 0_usize => a }];
 
-    let combined = combine_messages(&composition, &[message], &variable_pos, &reference_states, &alphabet, None)?;
+    let combined = combine_messages(
+      &composition,
+      &[message],
+      &variable_pos,
+      &reference_states,
+      &alphabet,
+      None,
+    )?;
 
-    let explicit = combined.variable.get(&0).expect("state-changing deterministic sites must stay explicit");
+    let explicit = combined
+      .variable
+      .get(&0)
+      .expect("state-changing deterministic sites must stay explicit");
     assert_eq!(explicit.state, g);
     assert_abs_diff_eq!(explicit.dis, alphabet.get_profile(a)?.clone(), epsilon = 1e-14);
     assert_eq!(combined.fixed_counts.get(g), Some(0));
+
+    Ok(())
+  }
+  #[test]
+  fn test_combine_messages_zero_multiplicity_does_not_create_nan_log_lh() -> Result<(), Report> {
+    use crate::alphabet::alphabet::Alphabet;
+
+    let alphabet = Alphabet::default();
+    let a = AsciiChar::from_byte_unchecked(b'A');
+    let c = AsciiChar::from_byte_unchecked(b'C');
+    let g = AsciiChar::from_byte_unchecked(b'G');
+    let t = AsciiChar::from_byte_unchecked(b'T');
+    let composition = Composition::with_sequence([c], alphabet.chars(), alphabet.gap());
+    let message = MarginalSparseSeqDistribution {
+      variable: btreemap! {},
+      variable_indel: btreemap! {},
+      fixed: btreemap! {
+        a => array![0.0, 0.0, 0.0, 0.0],
+        c => array![0.0, 1.0, 0.0, 0.0],
+        g => array![0.0, 0.0, 1.0, 0.0],
+        t => array![0.0, 0.0, 0.0, 1.0],
+      },
+      fixed_counts: composition.clone(),
+      log_lh: 0.0,
+    };
+
+    let combined = combine_messages(&composition, &[message], &btreemap! {}, &[], &alphabet, None)?;
+
+    assert!(
+      combined.log_lh.is_finite(),
+      "zero-multiplicity fixed rows must not poison log-likelihood"
+    );
+    assert_eq!(combined.fixed_counts.get(a), Some(0));
 
     Ok(())
   }

--- a/packages/treetime/src/representation/partition/marginal_passes.rs
+++ b/packages/treetime/src/representation/partition/marginal_passes.rs
@@ -1,5 +1,5 @@
 use crate::hacks::fix_branch_length::fix_branch_length;
-use crate::representation::partition::marginal_helpers::{combine_messages, propagate_raw, propagate_raw_per_site};
+use crate::representation::partition::marginal_helpers::{EPS, combine_messages, propagate_raw, propagate_raw_per_site};
 use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
 use crate::representation::partition::traits::ExactStateCache;
 use crate::representation::payload::sparse::{MarginalSparseSeqDistribution, VarPos};
@@ -334,13 +334,14 @@ where
       let dis = numerator / divisor;
       let norm = dis.sum();
       delta_ll += norm.ln();
-      seq_dis.variable.insert(
-        pos,
-        VarPos {
-          dis: dis / norm,
-          state: pstate,
-        },
-      );
+      let dis = dis / norm;
+      let max_prob = dis.iter().copied().fold(0.0_f64, f64::max);
+      let map_state = partition
+        .alphabet
+        .char(treetime_utils::array::ndarray::argmax_first(&dis.view()).unwrap_or(0));
+      if max_prob < (1.0 - EPS) || map_state != pstate {
+        seq_dis.variable.insert(pos, VarPos { dis, state: pstate });
+      }
       seq_dis.fixed_counts.adjust_count(pstate, -1);
     }
     for (s, p) in &seq_info.profile.fixed {


### PR DESCRIPTION
Three defects in the sparse marginal messages.

**Backward drop too loose.** `combine_messages` [[src](https://github.com/neherlab/treetime/blob/f9f5d99a/packages/treetime/src/representation/partition/marginal_helpers.rs#L14-L22)] dropped a position into the fixed bucket whenever peak probability cleared the threshold and all children agreed on the parsimony state, even if the combined posterior MAP disagreed with that state. Downstream consumers (GTR inference, branch optimization, output) then read the parsimony nucleotide at a position whose posterior favored a different one.

**Forward had no drop at all.** The `msg_to_child` division always inserted explicit variable rows. Any position that became variable stayed explicit forever, so sparse messages grew monotonically root-to-leaf and degraded toward dense on deep trees.

**NaN poison from zero-multiplicity rows.** When a canonical state had no sites in the composition (e.g. no `A` in the alignment), `multiplicity * log_norm` computed `0 * -inf = NaN` and poisoned total log-likelihood.

Fixes:

- Backward drop gains `map_state != state` [[src](https://github.com/neherlab/treetime/blob/f9f5d99a/packages/treetime/src/representation/partition/marginal_helpers.rs#L68-L76)] so deterministic MAP-vs-parsimony disagreements stay explicit.
- Forward drop mirrors the backward condition (peak + MAP agreement) [[src](https://github.com/neherlab/treetime/blob/f9f5d99a/packages/treetime/src/representation/partition/marginal_passes.rs#L333-L346)].
- Zero-multiplicity guard skips `log_lh += multiplicity * log_norm` when multiplicity is zero [[src](https://github.com/neherlab/treetime/blob/f9f5d99a/packages/treetime/src/representation/partition/marginal_helpers.rs#L86-L95)].

### Work items

- [x] MAP-vs-parsimony check on backward `combine_messages` drop
- [x] Peak + MAP drop on forward `msg_to_child` division
- [x] Zero-multiplicity guard on fixed-row log-likelihood
- [x] Regression tests for all three

