### PR TITLE
fix: score sparse branches from reconstructed states

### DIFF
--- a/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
   use crate::commands::ancestral::marginal::update_marginal;
+  use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
+  use crate::representation::partition::traits::ExactStateCache;
   use crate::representation::payload::ancestral::GraphAncestral;
   use approx::assert_ulps_eq;
   use eyre::Report;
@@ -61,6 +63,88 @@ mod tests {
 
     // Initial log-LH should be equivalent
     assert_ulps_eq!(log_lh_dense, log_lh_sparse, max_ulps = 100);
+
+    Ok(())
+  }
+  #[test]
+  fn test_dense_sparse_ambiguous_r_edge_contribution_equivalence() -> Result<(), Report> {
+    let aln = read_many_fasta_str(
+      indoc! {r#"
+      >A
+      GCCC
+      >B
+      RCCC
+      >C
+      ACCC
+      >D
+      ACCC
+    "#},
+      &*NUC_ALPHABET,
+    )?;
+
+    let graph_dense: GraphAncestral = nwk_read_str("((A:0.05,B:0.05)AB:0.05,(C:0.05,D:0.05)CD:0.05)root:0.01;")?;
+    let dense_partitions = setup_dense_only(&graph_dense, &aln)?;
+    update_marginal(&graph_dense, &dense_partitions)?;
+
+    let graph_sparse: GraphAncestral = nwk_read_str("((A:0.05,B:0.05)AB:0.05,(C:0.05,D:0.05)CD:0.05)root:0.01;")?;
+    let sparse_partitions = setup_sparse_only(&graph_sparse, &aln)?;
+
+    let dense_edge_key = graph_dense
+      .get_edges()
+      .iter()
+      .find_map(|edge_ref| {
+        let edge = edge_ref.read_arc();
+        let child_name = graph_dense
+          .get_node(edge.target())
+          .expect("child exists")
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name
+          .clone();
+        (child_name.as_deref() == Some("B")).then_some(edge.key())
+      })
+      .expect("edge to B exists");
+    let sparse_edge_key = graph_sparse
+      .get_edges()
+      .iter()
+      .find_map(|edge_ref| {
+        let edge = edge_ref.read_arc();
+        let child_name = graph_sparse
+          .get_node(edge.target())
+          .expect("child exists")
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name
+          .clone();
+        (child_name.as_deref() == Some("B")).then_some(edge.key())
+      })
+      .expect("edge to B exists");
+
+    let mut dense_cache = ExactStateCache::new();
+    let dense_contribution =
+      dense_partitions[0]
+        .read_arc()
+        .create_edge_contribution(&graph_dense, dense_edge_key, &mut dense_cache)?;
+    let mut sparse_cache = ExactStateCache::new();
+    let sparse_contribution =
+      sparse_partitions[0]
+        .read_arc()
+        .create_edge_contribution(&graph_sparse, sparse_edge_key, &mut sparse_cache)?;
+
+    for branch_length in [0.01, 0.05, 0.1] {
+      let dense_metrics = dense_contribution.evaluate(branch_length);
+      let sparse_metrics = sparse_contribution.evaluate(branch_length);
+
+      assert_ulps_eq!(dense_metrics.log_lh, sparse_metrics.log_lh, max_ulps = 128);
+      assert_ulps_eq!(dense_metrics.derivative, sparse_metrics.derivative, max_ulps = 128);
+      assert_ulps_eq!(
+        dense_metrics.second_derivative,
+        sparse_metrics.second_derivative,
+        max_ulps = 128
+      );
+    }
 
     Ok(())
   }

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
@@ -12,6 +12,7 @@ mod tests {
   };
   use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
   use crate::gtr::get_gtr::{JC69Params, jc69};
+  use crate::representation::partition::traits::ExactStateCache;
   use crate::representation::payload::ancestral::GraphAncestral;
   use crate::seq::indel::InDel;
   use approx::assert_abs_diff_eq;
@@ -191,7 +192,11 @@ mod tests {
     let edge_key = graph.get_edges()[0].read_arc().key();
     let contributions: Vec<OptimizationContribution> = partitions
       .iter()
-      .map(|p| p.read_arc().create_edge_contribution(edge_key))
+      .map(|p| {
+        let mut exact_state_cache = ExactStateCache::new();
+        p.read_arc()
+          .create_edge_contribution(graph, edge_key, &mut exact_state_cache)
+      })
       .collect::<Result<_, _>>()?;
 
     let indel_count: usize = partitions.iter().map(|p| p.read_arc().edge_indel_count(edge_key)).sum();
@@ -212,7 +217,11 @@ mod tests {
     let edge_key = graph.get_edges()[0].read_arc().key();
     let contributions: Vec<OptimizationContribution> = partitions
       .iter()
-      .map(|p| p.read_arc().create_edge_contribution(edge_key))
+      .map(|p| {
+        let mut exact_state_cache = ExactStateCache::new();
+        p.read_arc()
+          .create_edge_contribution(graph, edge_key, &mut exact_state_cache)
+      })
       .collect::<Result<_, _>>()?;
 
     let indel_count: usize = partitions.iter().map(|p| p.read_arc().edge_indel_count(edge_key)).sum();

--- a/packages/treetime/src/commands/optimize/optimize_sparse.rs
+++ b/packages/treetime/src/commands/optimize/optimize_sparse.rs
@@ -26,8 +26,9 @@
 //!
 use crate::gtr::gtr::GTR;
 use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::representation::partition::traits::{ExactStateCache, GraphNodePathLookup};
 use crate::seq::mutation::Sub;
-use eyre::{OptionExt, Report};
+use eyre::Report;
 use itertools::Itertools;
 use std::iter::zip;
 use treetime_graph::edge::GraphEdgeKey;
@@ -43,10 +44,14 @@ pub struct PartitionContribution {
 }
 
 pub fn get_coefficients(
+  graph: &dyn GraphNodePathLookup,
   edge_key: GraphEdgeKey,
   partition: &PartitionMarginalSparse,
+  cache: &mut ExactStateCache,
 ) -> Result<PartitionContribution, Report> {
   let edge = &partition.edges[&edge_key];
+  let parent_key = graph.source_node_key(edge_key)?;
+  let child_key = graph.target_node_key(edge_key)?;
 
   // Collect variable positions from msg_to_child, msg_to_parent, and the substitutions along the edge
   let variable_positions: Vec<usize> = edge
@@ -62,41 +67,34 @@ pub fn get_coefficients(
   let variable_states = variable_positions
     .iter()
     .map(|pos| -> Result<_, Report> {
-      // Check whether the position is in substitutions
-      if let Some(sub) = edge.subs.iter().find(|m| m.pos() == *pos) {
-        Ok((sub.reff(), sub.qry()))
-      } else {
-        let parent = edge
-          .msg_to_child
-          .variable
-          .get(pos)
-          .or_else(|| edge.msg_to_parent.variable.get(pos))
-          .ok_or_eyre("Unable to find msg_to_parent")?
-          .state;
-        let child = edge
-          .msg_to_parent
-          .variable
-          .get(pos)
-          .or_else(|| edge.msg_to_child.variable.get(pos))
-          .ok_or_eyre("Unable to find msg_to_child")?
-          .state;
-        Ok((parent, child))
-      }
+      let parent = partition.node_canonical_state(graph, parent_key, *pos, cache)?;
+      let child = partition.node_canonical_state(graph, child_key, *pos, cache)?;
+      Ok((parent, child))
     })
     .collect::<Result<Vec<_>, Report>>()?;
+
+  // Neutral contribution at positions whose reconstructed state is non-canonical
+  // (gap or unknown). The `fixed` map is keyed by canonical states only, so we
+  // substitute a flat weight of 1 at masked positions, mirroring the fallback in
+  // `process_node_forward` at marginal_passes.rs.
+  let neutral = ndarray::Array1::from_elem(partition.alphabet.n_canonical(), 1.0);
 
   let mut site_contributions: Vec<SiteContribution> = Vec::new();
   for (&pos, (parent_state, child_state)) in zip(&variable_positions, variable_states) {
     let parent = if let Some(parent) = edge.msg_to_child.variable.get(&pos) {
       &parent.dis
-    } else {
+    } else if partition.alphabet.is_canonical(parent_state) {
       &edge.msg_to_child.fixed[&parent_state]
+    } else {
+      &neutral
     };
 
     let child = if let Some(child) = edge.msg_to_parent.variable.get(&pos) {
       &child.dis
-    } else {
+    } else if partition.alphabet.is_canonical(child_state) {
       &edge.msg_to_parent.fixed[&child_state]
+    } else {
+      &neutral
     };
     site_contributions.push(SiteContribution {
       multiplicity: 1.0,

--- a/packages/treetime/src/commands/optimize/optimize_unified.rs
+++ b/packages/treetime/src/commands/optimize/optimize_unified.rs
@@ -10,6 +10,7 @@ use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
 use crate::make_error;
 use crate::representation::partition::marginal_dense::PartitionMarginalDense;
 use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::representation::partition::traits::{ExactStateCache, GraphNodePathLookup};
 use crate::representation::payload::ancestral::GraphAncestral;
 use argmin::core::{CostFunction, Error, Executor};
 use argmin::solver::brent::BrentOpt;
@@ -108,8 +109,13 @@ impl OptimizationContribution {
   ///
   /// Extracts variable positions and mutations from the sparse partition and
   /// computes site contributions for optimization.
-  pub fn from_sparse(edge_key: GraphEdgeKey, partition: &PartitionMarginalSparse) -> Result<Self, Report> {
-    let contribution = optimize_sparse::get_coefficients(edge_key, partition)?;
+  pub fn from_sparse(
+    graph: &dyn GraphNodePathLookup,
+    edge_key: GraphEdgeKey,
+    partition: &PartitionMarginalSparse,
+    cache: &mut ExactStateCache,
+  ) -> Result<Self, Report> {
+    let contribution = optimize_sparse::get_coefficients(graph, edge_key, partition, cache)?;
     Ok(OptimizationContribution::Sparse(contribution))
   }
 
@@ -562,16 +568,20 @@ where
 
   let one_mutation = 1.0 / total_length as f64;
   let indel_rate = estimate_indel_rate(graph, partitions);
-
   graph.get_edges().iter().try_for_each(|edge_ref| -> Result<(), Report> {
     let edge_key = edge_ref.read_arc().key();
     let mut edge = edge_ref.write_arc().payload().write_arc();
     let mut branch_length = edge.branch_length().unwrap_or(0.0);
 
-    let contributions: Vec<OptimizationContribution> = partitions
-      .iter()
-      .map(|partition| partition.read_arc().create_edge_contribution(edge_key))
-      .collect::<Result<_, _>>()?;
+    let mut contributions = Vec::with_capacity(partitions.len());
+    for partition in partitions {
+      let mut exact_state_cache = ExactStateCache::new();
+      contributions.push(
+        partition
+          .read_arc()
+          .create_edge_contribution(graph, edge_key, &mut exact_state_cache)?,
+      );
+    }
 
     let indel_count: usize = partitions
       .iter()

--- a/packages/treetime/src/commands/optimize/partition_ops.rs
+++ b/packages/treetime/src/commands/optimize/partition_ops.rs
@@ -1,5 +1,5 @@
 use crate::commands::optimize::optimize_unified::OptimizationContribution;
-use crate::representation::partition::traits::PartitionBranchOps;
+use crate::representation::partition::traits::{ExactStateCache, GraphNodePathLookup, PartitionBranchOps};
 use eyre::Report;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -12,7 +12,12 @@ use treetime_graph::edge::GraphEdgeKey;
 /// optimize-specific likelihood contribution computation.
 pub trait PartitionOptimizeOps: PartitionBranchOps {
   /// Return the precomputed likelihood contribution for one edge.
-  fn create_edge_contribution(&self, edge_key: GraphEdgeKey) -> Result<OptimizationContribution, Report>;
+  fn create_edge_contribution(
+    &self,
+    graph: &dyn GraphNodePathLookup,
+    edge_key: GraphEdgeKey,
+    cache: &mut ExactStateCache,
+  ) -> Result<OptimizationContribution, Report>;
 
   /// Return the number of indel events on one edge.
   fn edge_indel_count(&self, edge_key: GraphEdgeKey) -> usize;

--- a/packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs
+++ b/packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs
@@ -2,6 +2,7 @@ use crate::commands::optimize::optimize_unified::{OptimizationContribution, eval
 use crate::make_error;
 use crate::representation::partition::marginal_dense::PartitionMarginalDense;
 use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::representation::partition::traits::{ExactStateCache, GraphNodePathLookup};
 use eyre::Report;
 use ndarray::Array1;
 use ndarray_stats::QuantileExt;
@@ -11,6 +12,7 @@ use treetime_distribution::DistributionFunction;
 use treetime_graph::edge::GraphEdgeKey;
 
 pub fn collect_edge_contributions(
+  graph: &dyn GraphNodePathLookup,
   edge_key: GraphEdgeKey,
   dense_partitions: &[&PartitionMarginalDense],
   sparse_partitions: &[&PartitionMarginalSparse],
@@ -22,7 +24,13 @@ pub fn collect_edge_contributions(
   }
 
   for partition in sparse_partitions {
-    contributions.push(OptimizationContribution::from_sparse(edge_key, partition)?);
+    let mut exact_state_cache = ExactStateCache::new();
+    contributions.push(OptimizationContribution::from_sparse(
+      graph,
+      edge_key,
+      partition,
+      &mut exact_state_cache,
+    )?);
   }
 
   Ok(contributions)

--- a/packages/treetime/src/commands/timetree/inference/runner.rs
+++ b/packages/treetime/src/commands/timetree/inference/runner.rs
@@ -9,6 +9,7 @@ use crate::commands::timetree::partition_ops::PartitionTimetreeAll;
 use crate::commands::timetree::timetree_traits::{TimetreeEdge, TimetreeNode};
 use crate::commands::timetree::utils::initialize_node_divergences;
 use crate::make_error;
+use crate::representation::partition::traits::ExactStateCache;
 use eyre::Report;
 use log::{debug, info};
 use parking_lot::RwLock;
@@ -101,7 +102,7 @@ where
 
     debug!("Edge {edge_key:?}: input branch_length = {branch_length:.6e}, gamma = {gamma:.4}");
 
-    let contributions = collect_contributions(partitions, edge_key)?;
+    let contributions = collect_contributions(graph, partitions, edge_key)?;
     let distribution = compute_branch_length_distribution(
       &contributions,
       branch_length,
@@ -135,6 +136,7 @@ where
 }
 
 fn collect_contributions<N, E, P>(
+  graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
   edge_key: GraphEdgeKey,
 ) -> Result<Vec<OptimizationContribution>, Report>
@@ -145,7 +147,12 @@ where
 {
   partitions
     .iter()
-    .map(|partition| partition.read_arc().create_edge_contribution(edge_key))
+    .map(|partition| {
+      let mut exact_state_cache = ExactStateCache::new();
+      partition
+        .read_arc()
+        .create_edge_contribution(graph, edge_key, &mut exact_state_cache)
+    })
     .collect()
 }
 

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -8,7 +8,7 @@ use crate::representation::partition::marginal_helpers::logsumexp_normalize;
 use crate::representation::partition::traits::HasLogLh;
 use crate::representation::partition::traits::PartitionBranchOps;
 use crate::representation::partition::traits::{
-  ExactStateCache, PartitionMarginal, PartitionMarginalOps, SequenceReconstructionCache,
+  ExactStateCache, GraphNodePathLookup, PartitionMarginal, PartitionMarginalOps, SequenceReconstructionCache,
 };
 use crate::representation::payload::ancestral::GraphAncestral;
 use crate::representation::payload::dense::{DenseEdgePartition, DenseNodePartition, DenseSeqDis, DenseSeqInfo};
@@ -135,7 +135,9 @@ impl PartitionBranchOps for PartitionMarginalDense {
 impl PartitionOptimizeOps for PartitionMarginalDense {
   fn create_edge_contribution(
     &self,
+    _graph: &dyn GraphNodePathLookup,
     edge_key: GraphEdgeKey,
+    _cache: &mut ExactStateCache,
   ) -> Result<crate::commands::optimize::optimize_unified::OptimizationContribution, Report> {
     Ok(crate::commands::optimize::optimize_unified::OptimizationContribution::from_dense(edge_key, self))
   }

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -498,9 +498,11 @@ impl PartitionBranchOps for PartitionMarginalSparse {
 impl PartitionOptimizeOps for PartitionMarginalSparse {
   fn create_edge_contribution(
     &self,
+    graph: &dyn GraphNodePathLookup,
     edge_key: GraphEdgeKey,
+    cache: &mut ExactStateCache,
   ) -> Result<crate::commands::optimize::optimize_unified::OptimizationContribution, Report> {
-    crate::commands::optimize::optimize_unified::OptimizationContribution::from_sparse(edge_key, self)
+    crate::commands::optimize::optimize_unified::OptimizationContribution::from_sparse(graph, edge_key, self, cache)
   }
 
   fn edge_indel_count(&self, edge_key: GraphEdgeKey) -> usize {


### PR DESCRIPTION
Sparse branch-length optimization used to read parent and child states from `edge.msg_to_{child,parent}.variable[pos].state`. Two problems.

**Lookup could fail.** When a position was absent from the variable message on one side (e.g. a substitution on the edge with no posterior variability), the code errored with `"Unable to find msg_to_parent"` and the branch could not be scored.

**The `state` field is stale-by-design.** It carries the Fitch-resolved state from the initial reconstruction, not the current posterior. For positions where scoring looks up `fixed[&state]`, that stale key produced wrong contributions.

Fix: resolve parent and child states by walking the graph [[src](https://github.com/neherlab/treetime/blob/de8969d1/packages/treetime/src/commands/optimize/optimize_sparse.rs#L64-L80)] through `node_canonical_state` [[src](https://github.com/neherlab/treetime/blob/de8969d1/packages/treetime/src/representation/partition/marginal_sparse.rs#L243-L260)]. This returns the Fitch-resolved canonical state at any `(node, pos)` regardless of which messages currently carry it, so the lookup always succeeds and returns the correct `fixed[&state]` key. The variable-position posterior `.dis` continues to be used directly for scoring; canonical state is needed only to key the fixed path.

Secondary fixes in the same commit:

- `is_canonical` guard with neutral fallback on `fixed[&state]` for gap and unknown positions [[src](https://github.com/neherlab/treetime/blob/de8969d1/packages/treetime/src/commands/optimize/optimize_sparse.rs#L81-L99)], mirroring the fallback in `process_node_forward` [[src](https://github.com/neherlab/treetime/blob/de8969d1/packages/treetime/src/representation/partition/marginal_passes.rs#L316-L326)]. Prevents a panic at masked positions that can enter `variable_positions` under PR 1's mask precedence.
- Per-traversal `ExactStateCache` allocated fresh per partition contribution via `OptimizationContribution::from_sparse` [[src](https://github.com/neherlab/treetime/blob/de8969d1/packages/treetime/src/commands/optimize/optimize_unified.rs#L107-L119)], so reconstructed state never leaks across partitions with differing canonical sequences.

Note: this does not switch state lookup from Fitch to MAP. It switches from a message-field read that could fail or stale-key to a graph-walk that is always available and always correct for `fixed[&state]`. Overlaying MAP via `node_state_at` remains a future option.

### Work items

- [x] `PartitionOptimizeOps::create_edge_contribution` takes `&dyn GraphNodePathLookup` + `&mut ExactStateCache`
- [x] Sparse edge contribution routes both endpoints through `node_canonical_state`
- [x] Timetree inference callers propagate graph + cache
- [x] `is_canonical` guard with neutral fallback in `get_coefficients`
- [x] Fresh `ExactStateCache` per partition contribution
- [x] Dense-vs-sparse equivalence test on initial log-likelihood

