### PR TITLE
fix: preserve sparse partition state across reroot

### DIFF
--- a/docs/port-known-issues/L-timetree-reroot-merge-composition-untested.md
+++ b/docs/port-known-issues/L-timetree-reroot-merge-composition-untested.md
@@ -1,0 +1,60 @@
+# Reroot merge branch in `PartitionMarginalSparse::apply_reroot` lacks direct assertion
+
+The merge branch of `PartitionMarginalSparse::apply_reroot` at [packages/treetime/src/representation/partition/marginal_sparse.rs#L480-L506](../../packages/treetime/src/representation/partition/marginal_sparse.rs#L480-L506) runs when rerooting removes a trivial old root. It composes substitutions via `compose_substitutions` and concatenates indel lists into the merged edge.
+
+## Current coverage
+
+- `test_sparse_reroot_split_root_sequence_applies_path_node_masks` at [packages/treetime/src/commands/timetree/optimization/**tests**/test_reroot.rs#L163](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs#L163): split-root sequence masking
+- `test_sparse_reroot_inverts_subs_and_indels_on_path`: sub inversion and indel inversion on the reroot path
+- `test_reroot_tree_sparse_with_edge_split`: end-to-end reroot smoke path
+
+## What is not directly asserted
+
+None of the existing tests:
+
+- Force a trivial old root that requires merge branch execution
+- Assert the composed substitution list on the merged edge matches the concatenation-then-inversion of the two constituent edges' subs
+- Assert the indel list on the merged edge matches the concatenation of the constituent edges' indels
+- Assert the merged edge carries no stale metadata from either constituent edge
+
+## Latent correctness risk: overlapping indels
+
+The merged edge stores a concatenated indel list. `edge_state_from_parent` at [packages/treetime/src/representation/partition/marginal_sparse.rs#L161-L177](../../packages/treetime/src/representation/partition/marginal_sparse.rs#L161-L177) selects a covering indel with `Iterator::find`, returning the first match rather than composing all matches in order. When both constituent edges carry indels spanning the same aligned position (for example, an insertion on the parent-side edge that the child-side edge then deletes), only the parent-side indel is observed. The merged edge's apparent child state at the overlapping positions is the parent-side transition, not the composed parent-then-child transition.
+
+### Decision required
+
+The fix is not uniquely determined by the observation. An implementer must choose one of:
+
+- **O1. Enforce non-overlap at merge time**: extend the merge branch of `apply_reroot` to canonicalize the concatenated indel list into non-overlapping intervals (insert-then-delete collapses; adjacent same-type indels merge). `edge_state_from_parent` stays with `.find`.
+- **O2. Compose on lookup**: keep the merge branch as concatenation; change `edge_state_from_parent` to fold all covering indels in list order so the last one wins at overlapping positions.
+- **O3. Both**: canonicalize on merge AND make `edge_state_from_parent` robust to overlap for defense in depth.
+
+The precedence contract the lookup must match lives in `child_canonical_state_from_parent_state` at [packages/treetime/src/representation/partition/marginal_sparse.rs#L215](../../packages/treetime/src/representation/partition/marginal_sparse.rs#L215) with a parameterized test at [packages/treetime/src/commands/ancestral/**tests**/test_marginal_sparse.rs#L642](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs#L642). That helper handles single-edge precedence (gap > unknown > sub > parent_state); the merge-branch decision is about multi-indel composition on a single edge, which the helper does not currently cover.
+
+## How to trigger the merge branch from a test
+
+The merge runs when `remove_trivial_root` is set on `RerootParams`. `RerootParams` is defined at [packages/treetime/src/commands/clock/reroot.rs#L17](../../packages/treetime/src/commands/clock/reroot.rs#L17) with `remove_trivial_root` at [`reroot.rs#L26`](../../packages/treetime/src/commands/clock/reroot.rs#L26). The condition that emits `edge_merge` into `RerootResult` is at [`reroot.rs#L161`](../../packages/treetime/src/commands/clock/reroot.rs#L161).
+
+A test driving the real path:
+
+- Build a tree where the old root has exactly two children and rerooting to one of them leaves the old root with a single remaining child, making it trivial.
+- Seed partition data so each relevant edge carries known `subs` and/or `indels` to test composition.
+- Call `reroot_in_place` with `RerootParams { remove_trivial_root: true, ... }`, feed the returned `RerootResult.changes` into `apply_reroot`.
+- Assert the merged edge's `subs` via `compose_substitutions` semantics and `indels` via the chosen canonical form (O1/O2/O3).
+
+Alternative (bypasses the producer): hand-construct `RerootChanges` with `edge_merge: Some(EdgeMergeInfo { ... })` and call `apply_reroot` directly. This pattern already exists in `test_reroot.rs` for the inversion path and is easier to assemble; the tradeoff is that it does not exercise `reroot_in_place` metadata production.
+
+## Proposed test
+
+A focused reroot integration test that:
+
+1. Constructs a three-node path (root, intermediate, new root candidate) with known substitutions and indels on both edges, including an overlapping indel pair
+2. Triggers reroot with `remove_trivial_root = true` so the intermediate node is removed and the two edges merge
+3. Asserts the merged edge's `subs` and `indels` match the expected composition against an independent oracle computed by hand
+4. Asserts `edge_state_from_parent` through the merged edge reproduces the expected child state, including at overlapping indel positions
+
+## What it catches
+
+- Errors in substitution composition (`compose_substitutions`) during merge
+- Errors in indel concatenation across merged edges, including overlapping indels that the current lookup cannot resolve
+- Stale edge metadata (messages, transmission) not reset after merge

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -52,81 +52,82 @@ exactly.
 
 ## Summary
 
-| Severity       | Scope        | Issue                                                                                                                           |
-| -------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| ~~High~~       | ~~Timetree~~ | ~~Timetree crashes on zero-length branches with grid spacing error~~ **FIXED**                                                  |
-| Medium         | Timetree     | [Golden master runner missing internal node times](M-timetree-gm-runner-missing-internal-times.md)                              |
-| ~~High~~       | ~~Clock~~    | ~~Clock fails with negative rate before filtering outliers~~ **FIXED**                                                          |
-| Medium         | Clock        | [Clock filter residual parity](M-clock-filter-residual-parity.md)                                                               |
-| Negligible     | Clock        | [Clock regression all-negative-rate divergence](N-clock-regression-all-negative-rate.md)                                        |
-| Negligible     | Clock        | [Clock chisq near-zero determinant](N-clock-chisq-near-zero-determinant.md)                                                     |
-| Medium         | Ancestral    | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                |
-| Medium         | Ancestral    | [Marginal reconstruction uses plain probability space](M-ancestral-marginal-probability-space.md)                               |
-| Medium         | Ancestral    | [Sparse root invariance violation](M-ancestral-sparse-root-invariance.md)                                                       |
-| Medium         | Ancestral    | [Sparse variable-site alphabet mismatch](M-ancestral-sparse-alphabet-mismatch.md)                                               |
-| Medium         | Core         | [Dummy GTR initialization pattern across commands](M-core-dummy-gtr-initialization.md)                                          |
-| Medium         | Clock        | [Clock covariation overdispersion hardcoded](M-clock-covariation-overdispersion.md)                                             |
-| Medium         | Dates        | [Column auto-detection gaps in CSV readers](M-dates-column-auto-detection-gaps.md)                                              |
-| Medium         | GTR          | [Per-site rate variation not implemented](M-gtr-per-site-rate-variation.md)                                                     |
-| Medium         | Mugration    | [Iterative GTR inference not implemented for mugration](M-mugration-iterative-gtr.md)                                           |
-| ~~Medium~~     | ~~Optimize~~ | ~~Per-edge optimizer converges to wrong optimum on indel-bearing edges~~ **FIXED**                                              |
-| Medium         | Optimize     | [Negative branch lengths not validated or reported across optimizer modes](M-optimize-negative-branch-length-validation.md)     |
+| Severity       | Scope        | Issue                                                                                                                                |
+| -------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| ~~High~~       | ~~Timetree~~ | ~~Timetree crashes on zero-length branches with grid spacing error~~ **FIXED**                                                       |
+| Medium         | Timetree     | [Golden master runner missing internal node times](M-timetree-gm-runner-missing-internal-times.md)                                   |
+| ~~High~~       | ~~Clock~~    | ~~Clock fails with negative rate before filtering outliers~~ **FIXED**                                                               |
+| Medium         | Clock        | [Clock filter residual parity](M-clock-filter-residual-parity.md)                                                                    |
+| Negligible     | Clock        | [Clock regression all-negative-rate divergence](N-clock-regression-all-negative-rate.md)                                             |
+| Negligible     | Clock        | [Clock chisq near-zero determinant](N-clock-chisq-near-zero-determinant.md)                                                          |
+| Medium         | Ancestral    | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                     |
+| Medium         | Ancestral    | [Marginal reconstruction uses plain probability space](M-ancestral-marginal-probability-space.md)                                    |
+| Medium         | Ancestral    | [Sparse root invariance violation](M-ancestral-sparse-root-invariance.md)                                                            |
+| Medium         | Ancestral    | [Sparse variable-site alphabet mismatch](M-ancestral-sparse-alphabet-mismatch.md)                                                    |
+| Medium         | Core         | [Dummy GTR initialization pattern across commands](M-core-dummy-gtr-initialization.md)                                               |
+| Medium         | Clock        | [Clock covariation overdispersion hardcoded](M-clock-covariation-overdispersion.md)                                                  |
+| Medium         | Dates        | [Column auto-detection gaps in CSV readers](M-dates-column-auto-detection-gaps.md)                                                   |
+| Medium         | GTR          | [Per-site rate variation not implemented](M-gtr-per-site-rate-variation.md)                                                          |
+| Medium         | Mugration    | [Iterative GTR inference not implemented for mugration](M-mugration-iterative-gtr.md)                                                |
+| ~~Medium~~     | ~~Optimize~~ | ~~Per-edge optimizer converges to wrong optimum on indel-bearing edges~~ **FIXED**                                                   |
+| Medium         | Optimize     | [Negative branch lengths not validated or reported across optimizer modes](M-optimize-negative-branch-length-validation.md)          |
 | Medium         | Optimize     | [Optimizer and marginal propagation use incompatible branch-length scales when GTR mu ≠ 1](M-optimize-gtr-mu-coordinate-mismatch.md) |
-| Low            | Optimize     | [Duplicate edge-collapse implementations in prune and optimize](L-optimize-prune-duplicate-collapse.md)                         |
-| Low            | GTR          | [Site-specific GTR partition integration pending](L-gtr-site-specific-partition-integration.md)                                 |
-| Low            | GTR          | [Site-specific GTR end-to-end inference test pending](L-gtr-site-specific-e2e-inference-test.md)                                |
-| Low            | Optimize     | [Optimize loop not extracted from I/O wrapper](L-optimize-loop-not-extracted.md)                                                |
-| Low            | Optimize     | [Dense-sparse duplication in OptimizationContribution enum dispatch](L-optimize-eval-dense-sparse-duplication.md)               |
-| Medium         | Timetree     | [Timetree skips initial ML branch length optimization before time inference](M-timetree-missing-initial-branch-optimization.md) |
-| Medium         | Timetree     | [--aln flag silently ignored](M-timetree-aln-flag-ignored.md)                                                                   |
-| Medium         | Timetree     | [Coalescent backward pass missing leaf and root contributions](M-timetree-coalescent-missing-leaf-and-root-contributions.md)    |
-| ~~Medium~~     | ~~Timetree~~ | ~~Coalescent likelihood always returns None~~ **FIXED**                                                                         |
-| Medium         | Timetree     | [--coalescent-opt alone skips initial Tc pass](M-timetree-coalescent-opt-skips-initial.md)                                      |
-| Medium         | Timetree     | [Date column header matching breaks on hash](M-timetree-date-header-hash.md)                                                    |
-| Medium         | Timetree     | [Internal node dates missing in nexus for input branch length mode](M-timetree-internal-dates-missing-input-bl.md)              |
-| ~~Medium~~     | ~~Timetree~~ | ~~Internal node dates missing at scale~~ **FIXED**                                                                              |
-| ~~Medium~~     | ~~Timetree~~ | ~~Internal node dates missing with bad fixed clock rate~~ **FIXED**                                                             |
-| Medium         | Timetree     | [--method-anc ignored in timetree](M-timetree-method-anc-ignored.md)                                                            |
-| Medium         | Timetree     | [Nexus output missing mutation annotations](M-timetree-nexus-missing-mutations.md)                                              |
-| Medium         | Timetree     | [Positional likelihood metric differs from v0](M-timetree-positional-likelihood-metric.md)                                      |
-| Medium         | Timetree     | [Skyline coalescent uses Nelder-Mead instead of SLSQP](M-timetree-skyline-nelder-mead-optimizer.md)                             |
-| ~~Medium~~     | ~~Timetree~~ | ~~--time-marginal=always has no effect~~ **FIXED**                                                                              |
-| Medium         | Timetree     | [Marginal dense golden master node key mismatch on ebola_20](M-timetree-dense-golden-master-node-mismatch.md)                   |
-| Medium         | Timetree     | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)            |
-| Negligible     | Ancestral    | [Sparse marginal passes still use remove/insert pattern](N-ancestral-sparse-remove-insert-pattern.md)                           |
-| Negligible     | Ancestral    | [Dense normalize_inplace produces NaN for all-zero probability rows](N-dense-normalize-inplace-zero-row.md)                     |
-| Negligible     | Clock        | [assign_dates fails for small trees](N-clock-small-trees.md)                                                                    |
-| Negligible     | Core         | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                 |
-| Negligible     | Dates        | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                 |
-| Negligible     | Distribution | [Formula discretization errors silently swallowed](N-distribution-formula-silent-discretization.md)                             |
-| Negligible     | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                      |
-| Negligible     | Optimize     | [initial_guess_mixed allocates Vec\<Sub\> per edge for count only](L-optimize-initial-guess-alloc.md)                           |
-| Negligible     | Optimize     | [Dense/sparse equivalence test bounds undocumented](N-optimize-equivalence-bounds-undocumented.md)                              |
-| Negligible     | Optimize     | [Optimize command accepts only a single alignment](N-optimize-multi-alignment-input.md)                                         |
-| Negligible     | Optimize     | [Dense/sparse equivalence validity tests silently skip None branch lengths](N-optimize-validity-test-silent-none-skip.md)       |
-| Negligible     | Optimize     | [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md)                                                          |
-| Negligible     | Optimize     | [Indel rate estimation bypassed in Never mode on all-zero-BL trees](N-optimize-indel-rate-never-mode-zero-bl.md)                |
-| ~~Negligible~~ | ~~Optimize~~ | ~~Missing end-to-end test coverage for indel Newton path~~ **FIXED**                                                            |
-| Negligible     | Timetree     | [--dates not required, misleading error when omitted](N-timetree-dates-not-required.md)                                         |
-| Negligible     | Timetree     | [Dead CLI flags in timetree](N-timetree-dead-cli-flags.md)                                                                      |
-| Negligible     | Timetree     | [gtr.json missing for --branch-length-mode=input](N-timetree-gtr-json-missing-input-bl.md)                                      |
-| Negligible     | Timetree     | [timetree.json missing coalescent and skyline parameters](N-timetree-json-missing-coalescent.md)                                |
-| Negligible     | Timetree     | [Missing output files compared to v0](N-timetree-missing-output-files.md)                                                       |
-| Negligible     | Timetree     | [Missing skyline output files](N-timetree-missing-skyline-output.md)                                                            |
-| Negligible     | Timetree     | [--n-branches-posterior panics with todo!()](N-timetree-n-branches-posterior-unimplemented.md)                                  |
-| Negligible     | Timetree     | [Negative coalescent Tc accepted without validation](N-timetree-negative-coalescent-tc.md)                                      |
-| Negligible     | Timetree     | [write_node_dates() is a todo!() stub](N-timetree-node-dates-output-unimplemented.md)                                           |
-| Negligible     | Timetree     | [--plot-rtt and --plot-tree typed as Option\<usize\>](N-timetree-plot-arg-type.md)                                              |
-| Negligible     | Timetree     | [--plot-rtt and --plot-tree panic with todo!()](N-timetree-plot-unimplemented.md)                                               |
-| Negligible     | Timetree     | [--keep-polytomies and --resolve-polytomies no conflicts_with declaration](N-timetree-polytomy-flags-no-conflict.md)            |
-| Negligible     | Timetree     | [Stochastic polytomy resolution not implemented](N-timetree-stochastic-polytomy-unimplemented.md)                               |
-| Negligible     | Timetree     | [Auspice JSON output incomplete](N-timetree-auspice-json-incomplete.md)                                                         |
-| Negligible     | Timetree     | [Unnamed root after reroot](N-timetree-unnamed-root-after-reroot.md)                                                            |
-| Negligible     | Timetree     | [No tree inference from alignment](N-timetree-tree-inference-unimplemented.md)                                                  |
-| Negligible     | Timetree     | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                         |
-| Negligible     | Timetree     | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                               |
-| Medium         | Timetree     | [Branch distribution grid uses uniform spacing](M-timetree-branch-grid-uniform-resolution.md)                                   |
-| Negligible     | Timetree     | [Branch grid extent uses base clock_rate, not effective rate](N-timetree-branch-grid-gamma-omitted.md)                          |
+| Low            | Optimize     | [Duplicate edge-collapse implementations in prune and optimize](L-optimize-prune-duplicate-collapse.md)                              |
+| Low            | GTR          | [Site-specific GTR partition integration pending](L-gtr-site-specific-partition-integration.md)                                      |
+| Low            | GTR          | [Site-specific GTR end-to-end inference test pending](L-gtr-site-specific-e2e-inference-test.md)                                     |
+| Low            | Optimize     | [Optimize loop not extracted from I/O wrapper](L-optimize-loop-not-extracted.md)                                                     |
+| Low            | Optimize     | [Dense-sparse duplication in OptimizationContribution enum dispatch](L-optimize-eval-dense-sparse-duplication.md)                    |
+| Low            | Timetree     | [Reroot merge composition branch lacks direct assertion](L-timetree-reroot-merge-composition-untested.md)                            |
+| Medium         | Timetree     | [Timetree skips initial ML branch length optimization before time inference](M-timetree-missing-initial-branch-optimization.md)      |
+| Medium         | Timetree     | [--aln flag silently ignored](M-timetree-aln-flag-ignored.md)                                                                        |
+| Medium         | Timetree     | [Coalescent backward pass missing leaf and root contributions](M-timetree-coalescent-missing-leaf-and-root-contributions.md)         |
+| ~~Medium~~     | ~~Timetree~~ | ~~Coalescent likelihood always returns None~~ **FIXED**                                                                              |
+| Medium         | Timetree     | [--coalescent-opt alone skips initial Tc pass](M-timetree-coalescent-opt-skips-initial.md)                                           |
+| Medium         | Timetree     | [Date column header matching breaks on hash](M-timetree-date-header-hash.md)                                                         |
+| Medium         | Timetree     | [Internal node dates missing in nexus for input branch length mode](M-timetree-internal-dates-missing-input-bl.md)                   |
+| ~~Medium~~     | ~~Timetree~~ | ~~Internal node dates missing at scale~~ **FIXED**                                                                                   |
+| ~~Medium~~     | ~~Timetree~~ | ~~Internal node dates missing with bad fixed clock rate~~ **FIXED**                                                                  |
+| Medium         | Timetree     | [--method-anc ignored in timetree](M-timetree-method-anc-ignored.md)                                                                 |
+| Medium         | Timetree     | [Nexus output missing mutation annotations](M-timetree-nexus-missing-mutations.md)                                                   |
+| Medium         | Timetree     | [Positional likelihood metric differs from v0](M-timetree-positional-likelihood-metric.md)                                           |
+| Medium         | Timetree     | [Skyline coalescent uses Nelder-Mead instead of SLSQP](M-timetree-skyline-nelder-mead-optimizer.md)                                  |
+| ~~Medium~~     | ~~Timetree~~ | ~~--time-marginal=always has no effect~~ **FIXED**                                                                                   |
+| Medium         | Timetree     | [Marginal dense golden master node key mismatch on ebola_20](M-timetree-dense-golden-master-node-mismatch.md)                        |
+| Medium         | Timetree     | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)                 |
+| Negligible     | Ancestral    | [Sparse marginal passes still use remove/insert pattern](N-ancestral-sparse-remove-insert-pattern.md)                                |
+| Negligible     | Ancestral    | [Dense normalize_inplace produces NaN for all-zero probability rows](N-dense-normalize-inplace-zero-row.md)                          |
+| Negligible     | Clock        | [assign_dates fails for small trees](N-clock-small-trees.md)                                                                         |
+| Negligible     | Core         | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                      |
+| Negligible     | Dates        | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                      |
+| Negligible     | Distribution | [Formula discretization errors silently swallowed](N-distribution-formula-silent-discretization.md)                                  |
+| Negligible     | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                           |
+| Negligible     | Optimize     | [initial_guess_mixed allocates Vec\<Sub\> per edge for count only](L-optimize-initial-guess-alloc.md)                                |
+| Negligible     | Optimize     | [Dense/sparse equivalence test bounds undocumented](N-optimize-equivalence-bounds-undocumented.md)                                   |
+| Negligible     | Optimize     | [Optimize command accepts only a single alignment](N-optimize-multi-alignment-input.md)                                              |
+| Negligible     | Optimize     | [Dense/sparse equivalence validity tests silently skip None branch lengths](N-optimize-validity-test-silent-none-skip.md)            |
+| Negligible     | Optimize     | [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md)                                                               |
+| Negligible     | Optimize     | [Indel rate estimation bypassed in Never mode on all-zero-BL trees](N-optimize-indel-rate-never-mode-zero-bl.md)                     |
+| ~~Negligible~~ | ~~Optimize~~ | ~~Missing end-to-end test coverage for indel Newton path~~ **FIXED**                                                                 |
+| Negligible     | Timetree     | [--dates not required, misleading error when omitted](N-timetree-dates-not-required.md)                                              |
+| Negligible     | Timetree     | [Dead CLI flags in timetree](N-timetree-dead-cli-flags.md)                                                                           |
+| Negligible     | Timetree     | [gtr.json missing for --branch-length-mode=input](N-timetree-gtr-json-missing-input-bl.md)                                           |
+| Negligible     | Timetree     | [timetree.json missing coalescent and skyline parameters](N-timetree-json-missing-coalescent.md)                                     |
+| Negligible     | Timetree     | [Missing output files compared to v0](N-timetree-missing-output-files.md)                                                            |
+| Negligible     | Timetree     | [Missing skyline output files](N-timetree-missing-skyline-output.md)                                                                 |
+| Negligible     | Timetree     | [--n-branches-posterior panics with todo!()](N-timetree-n-branches-posterior-unimplemented.md)                                       |
+| Negligible     | Timetree     | [Negative coalescent Tc accepted without validation](N-timetree-negative-coalescent-tc.md)                                           |
+| Negligible     | Timetree     | [write_node_dates() is a todo!() stub](N-timetree-node-dates-output-unimplemented.md)                                                |
+| Negligible     | Timetree     | [--plot-rtt and --plot-tree typed as Option\<usize\>](N-timetree-plot-arg-type.md)                                                   |
+| Negligible     | Timetree     | [--plot-rtt and --plot-tree panic with todo!()](N-timetree-plot-unimplemented.md)                                                    |
+| Negligible     | Timetree     | [--keep-polytomies and --resolve-polytomies no conflicts_with declaration](N-timetree-polytomy-flags-no-conflict.md)                 |
+| Negligible     | Timetree     | [Stochastic polytomy resolution not implemented](N-timetree-stochastic-polytomy-unimplemented.md)                                    |
+| Negligible     | Timetree     | [Auspice JSON output incomplete](N-timetree-auspice-json-incomplete.md)                                                              |
+| Negligible     | Timetree     | [Unnamed root after reroot](N-timetree-unnamed-root-after-reroot.md)                                                                 |
+| Negligible     | Timetree     | [No tree inference from alignment](N-timetree-tree-inference-unimplemented.md)                                                       |
+| Negligible     | Timetree     | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                              |
+| Negligible     | Timetree     | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                                    |
+| Medium         | Timetree     | [Branch distribution grid uses uniform spacing](M-timetree-branch-grid-uniform-resolution.md)                                        |
+| Negligible     | Timetree     | [Branch grid extent uses base clock_rate, not effective rate](N-timetree-branch-grid-gamma-omitted.md)                               |
 
 ## Cross-references
 

--- a/docs/port-test-inventory/ancestral.md
+++ b/docs/port-test-inventory/ancestral.md
@@ -8,7 +8,7 @@
 | ------------------------ | ------ | ------- | --------------- |
 | Fitch parsimony          | 1      | 6       | Unit            |
 | Marginal ML dense        | 1      | 5       | Unit            |
-| Marginal ML sparse       | 1      | 6       | Unit            |
+| Marginal ML sparse       | 1      | 13      | Unit            |
 | Dense/sparse equivalence | 2      | 2       | Unit + Property |
 | Idempotency              | 2      | 4       | Unit + Property |
 | Normalization            | 2      | 6       | Unit + Property |
@@ -21,7 +21,7 @@
 | Analytical               | 3      | 10      | Golden-master   |
 | Sparse composition       | 1      | 12      | Unit            |
 | Generator validation     | 4      | 15      | Property        |
-| **Total**                | **28** | **123** | Mixed           |
+| **Total**                | **28** | **130** | Mixed           |
 
 Support files (helpers only, no tests): `prop_marginal_support.rs`, `test_marginal_analytical_support.rs`, `test_marginal_stability_support.rs`
 
@@ -64,14 +64,15 @@ Support files (helpers only, no tests): `prop_marginal_support.rs`, `test_margin
 
 **File:** [`test_marginal_sparse.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs)
 
-| Test                                                           | Purpose                                           |
-| -------------------------------------------------------------- | ------------------------------------------------- |
-| `test_ancestral_reconstruction_marginal_sparse`                | MAP sequences using Fitch compression + marginal  |
-| `test_marginal_sparse_probability_normalization`               | Variable and fixed distributions sum to 1.0       |
-| `test_marginal_sparse_update_is_idempotent`                    | Fixed-point test for sparse representation        |
-| `test_marginal_sparse_log_lh_root_invariance_reversible_model` | Root invariance with non-uniform GTR              |
-| `test_marginal_sparse_posterior_values_python_parity`          | Specific posterior values match Python v0         |
-| `test_total_likelihood_marginal_sparse_all_triplets`           | Law of total probability for sparse (64 triplets) |
+| Test                                                           | Purpose                                                               |
+| -------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `test_ancestral_reconstruction_marginal_sparse`                | MAP sequences using Fitch compression + marginal                      |
+| `test_marginal_sparse_probability_normalization`               | Variable and fixed distributions sum to 1.0                           |
+| `test_marginal_sparse_update_is_idempotent`                    | Fixed-point test for sparse representation                            |
+| `test_marginal_sparse_log_lh_root_invariance_reversible_model` | Root invariance with non-uniform GTR                                  |
+| `test_marginal_sparse_posterior_values_python_parity`          | Specific posterior values match Python v0                             |
+| `test_total_likelihood_marginal_sparse_all_triplets`           | Law of total probability for sparse (64 triplets)                     |
+| `test_child_canonical_state_precedence`                        | Child-state precedence: gap > unknown > sub > parent (7 rstest cases) |
 
 **Algorithm:** Fitch compression + marginal ML on variable positions
 

--- a/packages/treetime/src/commands/clock/reroot.rs
+++ b/packages/treetime/src/commands/clock/reroot.rs
@@ -63,26 +63,37 @@ pub struct EdgeMergeInfo {
 /// Result of a reroot operation.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RerootResult {
+  /// The key of the previous root node before rerooting.
+  pub old_root_key: GraphNodeKey,
   /// The key of the new root node.
   pub new_root_key: GraphNodeKey,
   /// Information about edge split, if one occurred.
   pub edge_split: Option<EdgeSplitInfo>,
   /// Information about edge merge, if a trivial node was removed.
   pub edge_merge: Option<EdgeMergeInfo>,
+  /// Keys of edges on the path from the previous root to the new root.
+  pub inverted_edge_keys: Vec<GraphEdgeKey>,
+  /// Node keys on the same path, starting at the old root and ending at the new root.
+  pub path_node_keys: Vec<GraphNodeKey>,
 }
 
 /// Bundles all topology changes from a reroot operation for partition updates.
 ///
 /// Passed to `PartitionRerootOps::apply_reroot` to update partition state in a single call.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct RerootChanges {
+  /// The key of the previous root node before rerooting.
+  pub old_root_key: GraphNodeKey,
+  /// The key of the new root node after rerooting.
+  pub new_root_key: GraphNodeKey,
   /// Edge split info if a new node was created at the reroot point.
   pub edge_split: Option<EdgeSplitInfo>,
   /// Edge merge info if the old root was removed as a trivial node.
   pub edge_merge: Option<EdgeMergeInfo>,
-  /// Keys of edges on the path from old root to new root (post-inversion direction).
-  /// Empty if root did not change or old root was removed.
+  /// Keys of edges on the path from old root to new root before any trivial-root removal.
   pub inverted_edge_keys: Vec<GraphEdgeKey>,
+  /// Node keys on the same path, starting at the old root and ending at the new root.
+  pub path_node_keys: Vec<GraphNodeKey>,
 }
 
 pub fn reroot_in_place<N, E, D>(
@@ -104,9 +115,12 @@ where
   let Some(edge_key) = edge else {
     // Already at the best root
     return Ok(RerootResult {
+      old_root_key,
       new_root_key: old_root_key,
       edge_split: None,
       edge_merge: None,
+      inverted_edge_keys: vec![],
+      path_node_keys: vec![],
     });
   };
 
@@ -132,24 +146,37 @@ where
     (if split < 0.5 { target_key } else { source_key }, None)
   };
 
-  let edge_merge = if new_root_key != old_root_key {
+  let (edge_merge, inverted_edge_keys, path_node_keys) = if new_root_key != old_root_key {
     apply_reroot(graph, old_root_key, new_root_key, options)?;
+    let path = graph.path_from_node_to_node(old_root_key, new_root_key)?;
+    let inverted_edge_keys = path
+      .iter()
+      .filter_map(|(_, edge)| edge.as_ref().map(|edge| edge.read_arc().key()))
+      .collect();
+    let path_node_keys = path.iter().map(|(node, _)| node.read_arc().key()).collect();
+    // `remove_node_if_trivial()` takes ownership of the old-root edges. Drop the
+    // path snapshots first so those Arc handles do not keep the same edges alive.
+    drop(path);
 
-    if reroot_params.remove_trivial_root {
+    let edge_merge = if reroot_params.remove_trivial_root {
       // Clean up old root if it is now a trivial node, i.e. has exactly one parent and one child
       // Nb: the attributes of the old root node and branches (other than branch lengths) are discarded
       remove_node_if_trivial(graph, old_root_key)?
     } else {
       None
-    }
+    };
+    (edge_merge, inverted_edge_keys, path_node_keys)
   } else {
-    None
+    (None, vec![], vec![])
   };
 
   Ok(RerootResult {
+    old_root_key,
     new_root_key,
     edge_split,
     edge_merge,
+    inverted_edge_keys,
+    path_node_keys,
   })
 }
 

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
@@ -5,6 +5,7 @@ mod tests {
   use crate::commands::ancestral::marginal::update_marginal;
   use crate::commands::clock::clock_regression::{ClockParams, clock_regression_backward, clock_regression_forward};
   use crate::commands::clock::find_best_root::params::BranchPointOptimizationParams;
+  use crate::commands::clock::reroot::EdgeSplitInfo;
   use crate::commands::clock::reroot::RerootChanges;
   use crate::commands::timetree::optimization::reroot::reroot_tree;
   use crate::commands::timetree::partition_ops::{PartitionRerootOps, PartitionTimetreeAll};
@@ -28,7 +29,8 @@ mod tests {
   use pretty_assertions::assert_eq;
   use std::sync::Arc;
   use treetime_distribution::Distribution;
-  use treetime_graph::node::{Named, TimeConstraint};
+  use treetime_graph::edge::GraphEdgeKey;
+  use treetime_graph::node::{GraphNodeKey, Named, TimeConstraint};
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::{AsciiChar, Seq, seq};
@@ -159,6 +161,81 @@ mod tests {
   }
 
   #[test]
+  fn test_sparse_reroot_split_root_sequence_applies_path_node_masks() -> Result<(), Report> {
+    let graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.1)AB:0.1,C:0.1)root;")?;
+    let alphabet = Alphabet::new(AlphabetName::Nuc)?;
+    let gtr = jc69(JC69Params::default())?;
+
+    let root_key = find_node_key_by_name(&graph, "root").ok_or_else(|| make_report!("root not found"))?;
+    let ab_key = find_node_key_by_name(&graph, "AB").ok_or_else(|| make_report!("AB not found"))?;
+    let a_key = find_node_key_by_name(&graph, "A").ok_or_else(|| make_report!("A not found"))?;
+    let root_to_ab_key = graph
+      .get_edges()
+      .iter()
+      .find_map(|edge_ref| {
+        let edge = edge_ref.read_arc();
+        ((edge.source() == root_key && edge.target() == ab_key)
+          || (edge.source() == ab_key && edge.target() == root_key))
+          .then(|| edge.key())
+      })
+      .ok_or_else(|| make_report!("root->AB edge not found"))?;
+    let ab_to_a_key = graph
+      .get_edges()
+      .iter()
+      .find_map(|edge_ref| {
+        let edge = edge_ref.read_arc();
+        ((edge.source() == ab_key && edge.target() == a_key) || (edge.source() == a_key && edge.target() == ab_key))
+          .then(|| edge.key())
+      })
+      .ok_or_else(|| make_report!("AB->A edge not found"))?;
+
+    let split_root_key = GraphNodeKey(10_000);
+    let parent_side_edge_key = GraphEdgeKey(10_001);
+    let child_side_edge_key = GraphEdgeKey(10_002);
+    let mut sparse_partition = PartitionMarginalSparse {
+      index: 0,
+      gtr,
+      alphabet: alphabet.clone(),
+      length: 4,
+      nodes: btreemap! {
+        root_key => SparseNodePartition::new(&seq![c(b'A'), c(b'A'), c(b'A'), c(b'A')], &alphabet)?,
+        ab_key => SparseNodePartition::new(&seq![c(b'A'), c(b'A'), c(b'A'), c(b'A')], &alphabet)?,
+        a_key => SparseNodePartition::new(&seq![c(b'A'), c(b'A'), c(b'A'), c(b'A')], &alphabet)?,
+      },
+      edges: btreemap! {
+        root_to_ab_key => SparseEdgePartition::default(),
+        ab_to_a_key => SparseEdgePartition::default(),
+      },
+    };
+    sparse_partition.nodes.get_mut(&ab_key).unwrap().seq.gaps = vec![(1, 2)];
+    sparse_partition.nodes.get_mut(&ab_key).unwrap().seq.unknown = vec![(2, 3)];
+
+    let changes = RerootChanges {
+      old_root_key: root_key,
+      new_root_key: split_root_key,
+      edge_split: Some(EdgeSplitInfo {
+        old_edge_key: ab_to_a_key,
+        new_node_key: split_root_key,
+        parent_side_edge_key,
+        child_side_edge_key,
+        split_position: 0.5,
+      }),
+      edge_merge: None,
+      inverted_edge_keys: vec![root_to_ab_key, parent_side_edge_key],
+      path_node_keys: vec![root_key, ab_key, split_root_key],
+    };
+
+    sparse_partition.apply_reroot(&changes)?;
+
+    let split_root = &sparse_partition.nodes[&split_root_key];
+    assert_eq!(
+      seq![c(b'A'), alphabet.gap(), alphabet.unknown(), c(b'A')],
+      split_root.seq.sequence
+    );
+    Ok(())
+  }
+
+  #[test]
   fn test_sparse_reroot_inverts_subs_and_indels_on_path() -> Result<(), Report> {
     // Tree: (A:0.1,B:0.2)root;
     // After reroot to A, edge direction inverts
@@ -234,8 +311,12 @@ mod tests {
 
     // Build RerootChanges with inverted edge keys (simulating reroot from root to A)
     let changes = RerootChanges {
+      old_root_key: root_key,
+      new_root_key: a_key,
+      edge_split: None,
+      edge_merge: None,
       inverted_edge_keys: vec![edge_to_a_key],
-      ..RerootChanges::default()
+      path_node_keys: vec![root_key, a_key],
     };
 
     // Call apply_reroot directly
@@ -324,8 +405,12 @@ mod tests {
 
     // Build RerootChanges with inverted edge keys (simulating reroot from root to A)
     let changes = RerootChanges {
+      old_root_key: root_key,
+      new_root_key: a_key,
+      edge_split: None,
+      edge_merge: None,
       inverted_edge_keys: vec![edge_to_a_key],
-      ..RerootChanges::default()
+      path_node_keys: vec![root_key, a_key],
     };
 
     // Call apply_reroot

--- a/packages/treetime/src/commands/timetree/optimization/reroot.rs
+++ b/packages/treetime/src/commands/timetree/optimization/reroot.rs
@@ -8,7 +8,6 @@ use crate::representation::partition::timetree::GraphTimetree;
 use crate::representation::payload::timetree::EdgeTimetree;
 use crate::representation::payload::timetree::NodeTimetree;
 use eyre::{Report, WrapErr};
-use itertools::Itertools;
 use log::info;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -25,8 +24,6 @@ pub fn reroot_tree(
   branch_params: &BranchPointOptimizationParams,
   force_positive_rate: bool,
 ) -> Result<ClockModel, Report> {
-  let old_root_key = graph.get_exactly_one_root()?.read_arc().key();
-
   let reroot_params = RerootParams {
     force_positive_rate,
     ..RerootParams::default()
@@ -54,29 +51,20 @@ pub fn reroot_tree(
   // Update partitions if we have any and rerooting occurred
   if let Some(reroot_result) = &clock_reroot_result.reroot_result {
     if !partitions.is_empty() {
-      // Build inverted edge keys: edges on path from old root to new root (if old root still exists)
-      let inverted_edge_keys = if new_root_key != old_root_key && graph.get_node(old_root_key).is_some() {
+      if reroot_result.new_root_key != reroot_result.old_root_key {
         info!(
-          "Root changed from {} to {} - computing reroot path",
-          old_root_key.0, new_root_key.0
+          "Root changed from {} to {} - applying cached reroot path",
+          reroot_result.old_root_key.0, reroot_result.new_root_key.0
         );
-
-        let path = graph
-          .path_from_node_to_node(old_root_key, new_root_key)
-          .wrap_err("Failed to compute path from old root to new root")?;
-
-        path
-          .iter()
-          .filter_map(|(_, edge)| edge.as_ref().map(|e| e.read_arc().key()))
-          .collect_vec()
-      } else {
-        vec![]
-      };
+      }
 
       let changes = RerootChanges {
+        old_root_key: reroot_result.old_root_key,
+        new_root_key: reroot_result.new_root_key,
         edge_split: reroot_result.edge_split.clone(),
         edge_merge: reroot_result.edge_merge.clone(),
-        inverted_edge_keys,
+        inverted_edge_keys: reroot_result.inverted_edge_keys.clone(),
+        path_node_keys: reroot_result.path_node_keys.clone(),
       };
 
       info!("Applying reroot changes to {} partitions", partitions.len());

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -378,6 +378,45 @@ impl PartitionMarginalSparse {
     cache.insert(node_key, seq.clone());
     Ok(seq)
   }
+
+  fn reconstruct_split_root_sequence(&self, changes: &RerootChanges) -> Result<Seq, Report> {
+    let root_data = self
+      .nodes
+      .get(&changes.old_root_key)
+      .ok_or_else(|| make_internal_report!("Old root {} has no partition data", changes.old_root_key))?;
+    let mut sequence = root_data.seq.sequence.clone();
+    if sequence.len() != self.length {
+      return Err(make_internal_report!(
+        "Old root {} sequence length {} does not match partition length {}",
+        changes.old_root_key,
+        sequence.len(),
+        self.length
+      ));
+    }
+
+    for (step, edge_key) in changes.inverted_edge_keys.iter().enumerate() {
+      for pos in 0..self.length {
+        sequence[pos] = self.edge_state_from_parent(*edge_key, pos, sequence[pos]);
+      }
+
+      // Split-root reconstruction must follow the same exact-state precedence as
+      // the canonical sparse path. Existing nodes on the reroot path can impose
+      // gap and unknown masks after the edge transition, and the new split node
+      // itself has no partition payload yet.
+      if let Some(node_key) = changes.path_node_keys.get(step + 1).copied() {
+        if let Some(node_data) = self.nodes.get(&node_key) {
+          for gap in &node_data.seq.gaps {
+            sequence[gap.0..gap.1].fill(self.alphabet.gap());
+          }
+          for unknown in &node_data.seq.unknown {
+            sequence[unknown.0..unknown.1].fill(self.alphabet.unknown());
+          }
+        }
+      }
+    }
+
+    Ok(sequence)
+  }
 }
 
 impl HasLogLh for PartitionMarginalSparse {
@@ -392,9 +431,11 @@ impl PartitionRerootOps for PartitionMarginalSparse {
   fn apply_reroot(&mut self, changes: &RerootChanges) -> Result<(), Report> {
     // Handle edge split: create new node entry, move mutations to child-side edge
     if let Some(info) = &changes.edge_split {
-      self
-        .nodes
-        .insert(info.new_node_key, SparseNodePartition::empty(&self.alphabet));
+      let split_root_sequence = self.reconstruct_split_root_sequence(changes)?;
+      self.nodes.insert(
+        info.new_node_key,
+        SparseNodePartition::new(&split_root_sequence, &self.alphabet)?,
+      );
 
       let old_edge_data = self
         .edges
@@ -410,7 +451,32 @@ impl PartitionRerootOps for PartitionMarginalSparse {
         .insert(info.parent_side_edge_key, SparseEdgePartition::default());
     }
 
-    // Handle edge merge: compose mutations from two edges
+    // Invert edge data for each edge on the reroot path
+    for edge_key in &changes.inverted_edge_keys {
+      let edge_data = self
+        .edges
+        .get_mut(edge_key)
+        .ok_or_else(|| make_internal_report!("Edge {edge_key:?} must exist on reroot path"))?;
+
+      // Invert all substitutions
+      for sub in &mut edge_data.subs {
+        sub.invert();
+      }
+
+      // Invert all indels
+      for indel in &mut edge_data.indels {
+        indel.invert();
+      }
+
+      // Swap directional messages
+      mem::swap(&mut edge_data.msg_to_parent, &mut edge_data.msg_to_child);
+
+      // Reset msg_from_child (stale propagated message cache)
+      edge_data.msg_from_child = MarginalSparseSeqDistribution::default();
+    }
+
+    // Handle edge merge after inversion so path edges still exist when their
+    // mutations are flipped into the new root orientation.
     if let Some(info) = &changes.edge_merge {
       self.nodes.remove(&info.removed_node_key);
 
@@ -437,30 +503,6 @@ impl PartitionRerootOps for PartitionMarginalSparse {
       };
 
       self.edges.insert(info.merged_edge_key, merged_edge);
-    }
-
-    // Invert edge data for each edge on the reroot path
-    for edge_key in &changes.inverted_edge_keys {
-      let edge_data = self
-        .edges
-        .get_mut(edge_key)
-        .ok_or_else(|| make_internal_report!("Edge {edge_key:?} must exist on reroot path"))?;
-
-      // Invert all substitutions
-      for sub in &mut edge_data.subs {
-        sub.invert();
-      }
-
-      // Invert all indels
-      for indel in &mut edge_data.indels {
-        indel.invert();
-      }
-
-      // Swap directional messages
-      mem::swap(&mut edge_data.msg_to_parent, &mut edge_data.msg_to_child);
-
-      // Reset msg_from_child (stale propagated message cache)
-      edge_data.msg_from_child = MarginalSparseSeqDistribution::default();
     }
 
     Ok(())


### PR DESCRIPTION
Sparse `apply_reroot` [[src](https://github.com/neherlab/treetime/blob/73f1eaa0/packages/treetime/src/representation/partition/marginal_sparse.rs#L432-L454)] used to insert an empty `SparseNodePartition` at the new split-root node, so every downstream read of the new root got defaults instead of the sequence at the split point. The merge branch also ran before edge inversion, so if a merge consumed an edge on the inversion path, the subsequent inversion either failed or operated on already-merged data. The `timetree` command reroots between iterations, so without a correct reroot the sparse posteriors went silently wrong after the first iteration.

Fixes:

- New `reconstruct_split_root_sequence` [[src](https://github.com/neherlab/treetime/blob/73f1eaa0/packages/treetime/src/representation/partition/marginal_sparse.rs#L382-L420)] walks the reroot path from the old root to the split point, applying edge transitions and intermediate-node gap/unknown masks at each step. The new root is built via `SparseNodePartition::new(...)` with that sequence instead of `::empty(...)`.
- Edge inversion now runs before the trivial-root merge [[src](https://github.com/neherlab/treetime/blob/73f1eaa0/packages/treetime/src/representation/partition/marginal_sparse.rs#L455-L490)], so the merge sees already-inverted edges.
- `RerootChanges` [[src](https://github.com/neherlab/treetime/blob/73f1eaa0/packages/treetime/src/commands/clock/reroot.rs#L82-L104)] carries `inverted_edge_keys` and `path_node_keys`, populated in `clock::reroot` before any trivial-root removal. Partition code no longer recomputes them from a post-reroot graph that may have dropped the old root.
- `RerootChanges` no longer derives `Default`. The old `Default` impl produced `GraphNodeKey(usize::MAX)` sentinels that the real reroot path never emits. Two tests that used `..RerootChanges::default()` now initialize every field explicitly using the test graph's own keys.

Filed a low-severity test gap: the merge branch composes substitutions and concatenates indels, but no test asserts the composed payload directly, and `edge_state_from_parent` only returns the first indel covering a position. Overlapping indels on a merged edge could silently yield wrong states. See [docs/port-known-issues/L-timetree-reroot-merge-composition-untested.md](https://github.com/neherlab/treetime/blob/73f1eaa0/docs/port-known-issues/L-timetree-reroot-merge-composition-untested.md).

### Work items

- [x] `reconstruct_split_root_sequence` walks the reroot path with exact-state precedence
- [x] Split-root node built via `SparseNodePartition::new`
- [x] Invert edges before trivial-root merge
- [x] `inverted_edge_keys` and `path_node_keys` on `RerootResult` / `RerootChanges`
- [x] Remove `RerootChanges::default()`; update tests to initialize every field
- [x] Split-root path-mask regression test
- [x] File issue: [docs/port-known-issues/L-timetree-reroot-merge-composition-untested.md](https://github.com/neherlab/treetime/blob/73f1eaa0/docs/port-known-issues/L-timetree-reroot-merge-composition-untested.md): untested merge branch, "Decision required" section with three fix options and a test-trigger recipe

