### PR TITLE
test: strengthen and expand the optimize test suite

### DIFF
--- a/docs/port-known-issues/M-optimize-gm-per-branch-divergence.md
+++ b/docs/port-known-issues/M-optimize-gm-per-branch-divergence.md
@@ -1,0 +1,72 @@
+# Optimize per-branch lengths diverge from v0 fixture beyond 10% relative tolerance
+
+## Problem
+
+The optimize golden-master fixture
+`packages/treetime/src/commands/optimize/__tests__/__fixtures__/gm_optimize_outputs.json`
+records a per-branch `final_branch_lengths` map captured from v0 on the same
+tree, alignment, GTR model, and damping schedule. The summed branch length
+matches v0 within 5% (asserted by `test_gm_optimize`), but a per-branch
+comparison after skipping branches v0 collapsed to near-zero (`expected_bl < 1e-5`)
+exceeds 10% relative tolerance on individual non-zero branches. Example on
+`flu_h3n2_20_jc69_damped`: v1 reports `0.00488` on a branch where v0
+reports `0.00071` (a factor of 7 disagreement on a branch larger than the
+`prune_short_branches` threshold).
+
+## Evidence
+
+`packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs`
+`test_gm_optimize_per_branch` is `#[ignore]`'d with this issue path in the
+ignore reason. Removing the ignore reproduces the divergence on every
+non-skipped fixture case.
+
+## Likely contributors
+
+1. **Topology cleanup criterion.** v0's `prune_short_branches` collapses any
+   internal branch with `bl < 0.1 * one_mutation && prob_t(parent, child, 0) > 0.1`.
+   v1 collapses only branches the optimizer drives to exact zero. Branches
+   the optimizer leaves at e.g. `1e-12 - 1e-3` subs/site that v0 collapses
+   stay positive in v1 and absorb mass that v0 redistributes to siblings.
+2. **Indel rate handling.** v1 estimates `indel_rate` once at the start of
+   `run_optimize_mixed` and treats it as a constant; v0 may recompute per
+   iteration. A different rate biases the per-edge Newton/Brent objective.
+3. **Damping schedule application order.** v0 and v1 both apply
+   `bl = bl_new * (1 - damping^(i+1)) + bl_old * damping^(i+1)`, but v1
+   restores zeros for internal zero-optimal edges after damping (see
+   `prune_and_merge_in_loop`), while v0 prunes at the end of each pass with
+   the threshold above. Different cleanup ordering can leave different mass
+   distributions per branch even when the sum agrees.
+
+## Impact
+
+`test_gm_optimize` summed-total check still passes (within 5%), so v1's
+overall scale is correct. The per-branch disagreement matters for
+downstream consumers that read individual branch lengths (e.g., comparison
+runs against v0, ancestral-state visualizations that color edges by
+length, or downstream timetree inputs that consume the optimized tree).
+
+## Approach
+
+Three orthogonal options:
+
+1. Implement v0's `prune_short_branches` criterion (`bl < 0.1 * one_mutation`
+   AND `prob_t(parent, child, 0) > 0.1`) inside the v1 optimize loop and
+   recheck the per-branch divergence.
+2. Re-derive the GM fixture from v1 itself (snapshot rather than oracle)
+   and accept the per-branch divergence as an intentional v0/v1 deviation,
+   moving the entry to `port-intentional-changes/`.
+3. Tighten the v1 internal-edge collapse criterion to match v0's threshold
+   (without copying the probability gate).
+
+Option 1 is the most aligned with the porting goal. Option 2 is the
+fastest path to a green CI but loses the v0 oracle. Option 3 is a
+compromise but introduces a new threshold parameter.
+
+## Cross-references
+
+- `docs/port-intentional-changes/command-prune-standalone.md` (v1 prune as
+  a standalone command, not in the optimize loop)
+- `docs/port-known-issues/L-optimize-prune-duplicate-collapse.md`
+- `packages/treetime/src/commands/optimize/run.rs` `find_zero_optimal_internal_edges`
+  and `prune_and_merge_in_loop`
+- `packages/legacy/treetime/treetime/treeanc.py` `prune_short_branches` (line 1475)

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -76,6 +76,7 @@ exactly.
 | Low        | Optimize     | [Dense-sparse duplication in OptimizationContribution enum dispatch](L-optimize-eval-dense-sparse-duplication.md)                     |
 | Medium     | Optimize     | [Analytical Hessian loses precision via catastrophic cancellation](M-optimize-hessian-catastrophic-cancellation.md)                   |
 | Medium     | Optimize     | [Optimize iterative log-likelihood becomes `-inf`/NaN on larger datasets](M-optimize-iterative-log-likelihood-nan.md)                 |
+| Medium     | Optimize     | [Optimize per-branch lengths diverge from v0 fixture beyond 10% relative tolerance](M-optimize-gm-per-branch-divergence.md)           |
 | Medium     | GTR          | [Sparse GTR inference mixes MAP mutations with Fitch-era compositions](M-gtr-sparse-composition-stale-after-marginal.md)              |
 | Medium     | Timetree     | [Timetree skips initial ML branch length optimization before time inference](M-timetree-missing-initial-branch-optimization.md)       |
 | Medium     | Timetree     | [--aln flag silently ignored](M-timetree-aln-flag-ignored.md)                                                                         |

--- a/packages/treetime/src/commands/optimize/__tests__/mod.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/mod.rs
@@ -1,3 +1,4 @@
+mod test_args;
 mod test_coefficient_extraction_dense;
 mod test_coefficient_extraction_sparse;
 pub mod test_convergence;

--- a/packages/treetime/src/commands/optimize/__tests__/test_args.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_args.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests {
+  use crate::commands::optimize::args::{BranchOptMethod, TreetimeOptimizeArgs};
+  use clap::Parser;
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  /// Each kebab-case label on `--opt-method` parses to the corresponding
+  /// `BranchOptMethod` variant. Pins the `clap::ValueEnum` `rename_all = "kebab-case"`
+  /// mapping so a future variant rename or deletion fails this test.
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::brent(     "brent",      BranchOptMethod::Brent)]
+  #[case::brent_sqrt("brent-sqrt", BranchOptMethod::BrentSqrt)]
+  #[case::brent_log( "brent-log",  BranchOptMethod::BrentLog)]
+  #[case::newton(    "newton",     BranchOptMethod::Newton)]
+  #[case::newton_sqrt("newton-sqrt", BranchOptMethod::NewtonSqrt)]
+  #[case::newton_log("newton-log", BranchOptMethod::NewtonLog)]
+  #[trace]
+  fn test_args_opt_method_kebab_case_parses(#[case] flag: &str, #[case] expected: BranchOptMethod) {
+    let args = TreetimeOptimizeArgs::try_parse_from([
+      "treetime",
+      "--tree=/dev/null",
+      "--outdir=/dev/null",
+      &format!("--opt-method={flag}"),
+    ])
+    .unwrap();
+    assert_eq!(expected, args.opt_method);
+  }
+
+  /// Omitting `--opt-method` selects `BrentSqrt`. This is the v0-matching
+  /// default; a regression that moved the `#[default]` annotation or changed
+  /// the `default_value_t` would silently route CLI runs to the wrong optimizer.
+  #[test]
+  fn test_args_opt_method_default_is_brent_sqrt() {
+    let args = TreetimeOptimizeArgs::try_parse_from([
+      "treetime",
+      "--tree=/dev/null",
+      "--outdir=/dev/null",
+    ])
+    .unwrap();
+    assert_eq!(BranchOptMethod::BrentSqrt, args.opt_method);
+  }
+
+  /// An unknown `--opt-method` value is rejected at parse time. Pins the
+  /// `value_enum` constraint and prevents a typo from silently routing to a
+  /// fallback variant.
+  #[test]
+  fn test_args_opt_method_rejects_unknown() {
+    let result = TreetimeOptimizeArgs::try_parse_from([
+      "treetime",
+      "--tree=/dev/null",
+      "--outdir=/dev/null",
+      "--opt-method=brent-foo",
+    ]);
+    assert!(result.is_err(), "expected parse error for unknown --opt-method value");
+  }
+}

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_iterations.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_iterations.rs
@@ -24,31 +24,37 @@ mod tests {
   #[trace]
   fn test_optimization_converges_within_iterations(#[case] method: BranchOptMethod) -> Result<(), Report> {
     let aln = simple_alignment()?;
-    let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
-
-    let (dense_partitions, sparse_partitions, mixed_partitions) = setup_partitions(&graph, &aln)?;
-
-    let initial_lh = compute_total_lh(&graph, &dense_partitions, &sparse_partitions)?;
     let max_iter = 50;
 
-    let mut lh_history = Vec::with_capacity(max_iter);
-    lh_history.push(initial_lh);
+    // Reference: run BrentSqrt (the v0-matching default) on a fresh graph
+    // and capture its final undamped log-likelihood. Tying the per-method
+    // assertion to the reference ties this test to cross-method agreement
+    // rather than to a hand-chosen LH range that would silently drift.
+    let lh_ref = {
+      let graph_ref: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+      let (dp_ref, sp_ref, mp_ref) = setup_partitions(&graph_ref, &aln)?;
+      for _ in 0..max_iter {
+        run_optimize_mixed(&graph_ref, &mp_ref, BranchOptMethod::BrentSqrt)?;
+      }
+      compute_total_lh(&graph_ref, &dp_ref, &sp_ref)?
+    };
+
+    let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+    let (dense_partitions, sparse_partitions, mixed_partitions) = setup_partitions(&graph, &aln)?;
 
     for _ in 0..max_iter {
       run_optimize_mixed(&graph, &mixed_partitions, method)?;
-      let lh = compute_total_lh(&graph, &dense_partitions, &sparse_partitions)?;
-      lh_history.push(lh);
     }
+    let final_lh = compute_total_lh(&graph, &dense_partitions, &sparse_partitions)?;
 
-    // The undamped alternating optimization (marginal reconstruction / branch length
-    // optimization) produces a stable 2-cycle. Oscillation is expected without damping -
-    // that is why the production code applies damping by default. This test verifies the
-    // undamped path (--damping=0.0) stays bounded rather than diverging.
-    // Both phases of the 2-cycle must stay within a tight LH range.
-    let final_lh = lh_history[lh_history.len() - 1];
+    // The undamped alternating optimization produces a stable 2-cycle. Each
+    // method must converge to within 1e-2 of the BrentSqrt reference's final
+    // log-likelihood. The 1e-2 tolerance accommodates the 2-cycle
+    // (sub-iteration variation) for all six methods on this toy alignment.
+    let lh_diff = (final_lh - lh_ref).abs();
     assert!(
-      final_lh > -73.5 && final_lh < -72.0,
-      "Final log-lh {final_lh:.6} outside expected range (-73.5, -72.0)"
+      lh_diff < 1e-2,
+      "{method:?} final lh {final_lh:.6} differs from BrentSqrt reference {lh_ref:.6} by {lh_diff:.6} > 1e-2"
     );
 
     Ok(())

--- a/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
@@ -48,6 +48,68 @@ mod tests {
     Ok(())
   }
 
+  /// Per-branch GM comparison: walk each edge, look up the target node's name,
+  /// and check the optimized length against the v0-derived expected length
+  /// stored in `final_branch_lengths`. Branch-level checks catch regressions
+  /// that cancel out in the summed total checked by `test_gm_optimize`.
+  ///
+  /// Branches where v0 collapsed to "essentially zero" (below 1e-5 subs/site,
+  /// far below the smallest meaningful branch length 1/L) are skipped: v0's
+  /// `prune_short_branches` collapses any internal branch with
+  /// `bl < 0.1 * one_mutation && prob_t(parent, child, 0) > 0.1`, while v1's
+  /// optimize loop collapses only branches the optimizer drives to exact zero.
+  /// Comparing the two criteria on near-zero branches is out of scope for
+  /// this test; that divergence is tracked separately under the prune
+  /// command intentional-change docs.
+  ///
+  /// Currently expected to fail with the existing fixture: per-branch
+  /// divergences exceed 10% relative tolerance even after skipping
+  /// v0-collapsed branches. See
+  /// `docs/port-known-issues/M-optimize-gm-per-branch-divergence.md`.
+  #[ignore = "Per-branch divergence with v0 fixture exceeds 10% relative tolerance; tracked in M-optimize-gm-per-branch-divergence.md"]
+  #[rstest]
+  #[case::flu_h3n2_20("flu_h3n2_20_jc69_damped")]
+  fn test_gm_optimize_per_branch(#[case] case_name: &str) -> Result<(), Report> {
+    let inputs = load_gm_inputs();
+    let outputs = load_gm_outputs();
+    let case = &inputs[case_name];
+    let expected = &outputs[case_name];
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+      .parent()
+      .and_then(|p| p.parent())
+      .unwrap();
+
+    let result = setup_and_run(workspace_root, case, BranchOptMethod::BrentSqrt)?;
+
+    let v1_branch_lengths: std::collections::BTreeMap<String, f64> = result
+      .graph
+      .get_edges()
+      .iter()
+      .filter_map(|e| {
+        let edge = e.read_arc();
+        let bl = edge.payload().read_arc().branch_length()?;
+        let target_key = edge.target();
+        let node = result.graph.get_node(target_key)?;
+        let name = node.read_arc().payload().read_arc().name.clone()?;
+        Some((name, bl))
+      })
+      .collect();
+
+    for (name, &expected_bl) in &expected.final_branch_lengths {
+      let actual_bl = v1_branch_lengths
+        .get(name)
+        .copied()
+        .unwrap_or_else(|| panic!("missing branch length for node '{name}' in optimized graph"));
+      if expected_bl.abs() < 1e-5 {
+        continue;
+      }
+      assert_relative_eq!(actual_bl, expected_bl, max_relative = 0.10);
+    }
+
+    Ok(())
+  }
+
   // End-to-end: damped vs undamped on same dataset using BrentSqrt (v0-matching method).
   // Damped should converge and show fewer sign flips.
   #[rstest]
@@ -139,7 +201,6 @@ mod tests {
     #[derive(Deserialize)]
     pub struct GmOptimizeExpected {
       pub final_total_branch_length: f64,
-      #[allow(dead_code)]
       pub final_branch_lengths: BTreeMap<String, f64>,
     }
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_mode.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_mode.rs
@@ -5,7 +5,7 @@ mod tests {
   use crate::commands::ancestral::marginal::{initialize_marginal, update_marginal};
   use crate::commands::optimize::args::InitialGuessMode;
   use crate::commands::optimize::optimize_unified::initial_guess_mixed;
-  use crate::commands::optimize::run::any_edge_missing_branch_length;
+  use crate::commands::optimize::run::{any_edge_missing_branch_length, apply_initial_guess_mode};
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
   use crate::representation::payload::ancestral::GraphAncestral;
@@ -138,15 +138,24 @@ mod tests {
 
   #[test]
   fn test_initial_guess_mode_never_accepts_complete_tree() -> Result<(), Report> {
-    let graph: GraphAncestral = nwk_read_str(TREE_WITH_LENGTHS)?;
-    assert!(!any_edge_missing_branch_length(&graph));
+    let (graph, partitions) = setup_dense_with_marginal(TREE_WITH_LENGTHS)?;
+    let before = get_branch_lengths(&graph);
+    apply_initial_guess_mode(&graph, &partitions, InitialGuessMode::Never)?;
+    let after = get_branch_lengths(&graph);
+    assert_eq!(before, after, "Never mode must leave branch lengths unchanged");
     Ok(())
   }
 
   #[test]
   fn test_initial_guess_mode_never_rejects_nan_tree() -> Result<(), Report> {
-    let graph: GraphAncestral = nwk_read_str(TREE_WITHOUT_LENGTHS)?;
-    assert!(any_edge_missing_branch_length(&graph));
+    let (graph, partitions) = setup_dense_with_marginal(TREE_WITHOUT_LENGTHS)?;
+    let result = apply_initial_guess_mode(&graph, &partitions, InitialGuessMode::Never);
+    let err = result.expect_err("Never mode must reject a tree with NaN branch lengths");
+    let msg = format!("{err:?}");
+    assert!(
+      msg.contains("--branch-length-initial-guess=never"),
+      "Never-mode error must mention the offending flag, got: {msg}"
+    );
     Ok(())
   }
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-  use crate::commands::optimize::optimize_unified::{evaluate_mixed, newton_tolerance_t};
+  use crate::commands::optimize::optimize_unified::{evaluate_with_indels, newton_tolerance_t};
   use ndarray::array;
   use num::clamp;
 
@@ -13,72 +13,120 @@ mod tests {
     let contribution = make_dense_contribution(coefficients);
     let contributions = vec![contribution];
 
-    let mut branch_length = 0.1;
-    let metrics = evaluate_mixed(&contributions, branch_length);
+    // Indel contribution makes the second derivative negative even when the
+    // substitution variance Var(lambda) is positive, so Newton actually runs.
+    let indel_count = 2usize;
+    let indel_rate = 10.0;
+    // Floor matches min_branch_length_for_indels(2, one_mutation=0.001) so the
+    // simulated loop preserves the Poisson indel domain (t > 0).
+    let min_bl = 1e-5;
+    let initial_bl = 0.1;
+    let mut branch_length = initial_bl;
+    let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
     let max_iter = 10;
     let mut n_iter = 0;
 
-    if metrics.second_derivative < 0.0 {
-      let mut new_branch_length =
-        branch_length - clamp(metrics.derivative / metrics.second_derivative, -1.0, branch_length);
+    // Precondition: the chosen inputs must have negative curvature at the
+    // start, otherwise the test never enters the Newton loop and the rest
+    // of the assertions become vacuous.
+    assert!(
+      metrics.second_derivative < 0.0,
+      "precondition: second_derivative at branch_length=0.1 must be negative for Newton to run, got {}",
+      metrics.second_derivative
+    );
+    let initial_lh = metrics.log_lh;
 
-      while (new_branch_length - branch_length).abs() > newton_tolerance_t(branch_length) && n_iter < max_iter {
-        let new_metrics = evaluate_mixed(&contributions, new_branch_length);
-        if new_metrics.second_derivative < 0.0 {
-          branch_length = new_branch_length;
-          new_branch_length = branch_length
-            - clamp(
-              new_metrics.derivative / new_metrics.second_derivative,
-              -1.0,
-              branch_length,
-            );
-        } else {
-          break;
-        }
-        n_iter += 1;
+    let mut new_branch_length =
+      (branch_length - clamp(metrics.derivative / metrics.second_derivative, -1.0, branch_length)).max(min_bl);
+
+    while (new_branch_length - branch_length).abs() > newton_tolerance_t(branch_length) && n_iter < max_iter {
+      let new_metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, new_branch_length);
+      if new_metrics.second_derivative < 0.0 {
+        branch_length = new_branch_length;
+        new_branch_length = (branch_length
+          - clamp(
+            new_metrics.derivative / new_metrics.second_derivative,
+            -1.0,
+            branch_length,
+          ))
+        .max(min_bl);
+      } else {
+        break;
       }
-      branch_length = new_branch_length;
+      n_iter += 1;
     }
+    branch_length = new_branch_length;
 
-    // Verify convergence happened within iteration limit
+    // At least one Newton update ran (the loop body executed). Without this
+    // the test would pass even if the loop guard rejected the very first
+    // iteration.
+    assert!(n_iter > 0, "expected at least one Newton iteration to run");
+    // Standard envelope checks.
     assert!(n_iter <= max_iter);
-    // Verify branch length is non-negative
     assert!(branch_length >= 0.0);
+    // Newton must improve (or not degrade) the log-likelihood from the
+    // starting point. This is the actual contract being tested.
+    let final_metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
+    assert!(
+      final_metrics.log_lh >= initial_lh - 1e-10,
+      "Newton degraded log_lh from {initial_lh} to {final}",
+      final = final_metrics.log_lh,
+    );
   }
 
   #[test]
   fn test_newton_iteration_respects_max_iter() {
-    // Even with slow convergence, should stop at max_iter
-    let coefficients = array![[0.25, 0.25, 0.25, 0.25], [0.25, 0.25, 0.25, 0.25],];
+    // Even with slow convergence, should stop at max_iter. Use a tiny
+    // tolerance to force the loop to exhaust the iteration budget.
+    let coefficients = array![[0.5, 0.3, 0.1, 0.1], [0.4, 0.4, 0.1, 0.1],];
     let contribution = make_dense_contribution(coefficients);
     let contributions = vec![contribution];
 
+    let indel_count = 2usize;
+    let indel_rate = 10.0;
+    // Floor matches min_branch_length_for_indels(2, one_mutation=0.001) so the
+    // simulated loop preserves the Poisson indel domain (t > 0).
+    let min_bl = 1e-5;
     let mut branch_length = 0.5;
-    let max_iter = 10;
+    let max_iter = 3;
     let mut n_iter = 0;
 
-    let metrics = evaluate_mixed(&contributions, branch_length);
-    if metrics.second_derivative < 0.0 {
-      let mut new_branch_length =
-        branch_length - clamp(metrics.derivative / metrics.second_derivative, -1.0, branch_length);
+    let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
+    // Precondition: Newton must enter the loop, otherwise the max_iter
+    // budget is never tested.
+    assert!(
+      metrics.second_derivative < 0.0,
+      "precondition: chosen inputs must yield negative curvature, got {}",
+      metrics.second_derivative
+    );
 
-      while (new_branch_length - branch_length).abs() > newton_tolerance_t(branch_length) && n_iter < max_iter {
-        let new_metrics = evaluate_mixed(&contributions, new_branch_length);
-        if new_metrics.second_derivative < 0.0 {
-          branch_length = new_branch_length;
-          new_branch_length = branch_length
-            - clamp(
-              new_metrics.derivative / new_metrics.second_derivative,
-              -1.0,
-              branch_length,
-            );
-        } else {
-          break;
-        }
-        n_iter += 1;
+    let mut new_branch_length =
+      (branch_length - clamp(metrics.derivative / metrics.second_derivative, -1.0, branch_length)).max(min_bl);
+
+    // Force the loop to run by using an impossibly tight per-step tolerance.
+    let tight_tol = 1e-15;
+    while (new_branch_length - branch_length).abs() > tight_tol && n_iter < max_iter {
+      let new_metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, new_branch_length);
+      if new_metrics.second_derivative < 0.0 {
+        branch_length = new_branch_length;
+        new_branch_length = (branch_length
+          - clamp(
+            new_metrics.derivative / new_metrics.second_derivative,
+            -1.0,
+            branch_length,
+          ))
+        .max(min_bl);
+      } else {
+        break;
       }
+      n_iter += 1;
     }
 
-    assert!(n_iter <= max_iter);
+    // The contract: the iteration count is bounded by max_iter even when
+    // the per-step tolerance is impossibly tight.
+    assert_eq!(
+      max_iter, n_iter,
+      "expected the iteration cap to fire, but loop exited early"
+    );
   }
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
@@ -21,7 +21,6 @@ mod tests {
   use ndarray::array;
   use parking_lot::RwLock;
   use rstest::rstest;
-  use std::collections::BTreeMap;
   use std::sync::Arc;
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::nwk::nwk_read_str;
@@ -413,46 +412,56 @@ mod tests {
 
   /// C3c: Full cross-method log-likelihood agreement.
   ///
-  /// All 6 methods produce combined log-likelihood values within tolerance when
-  /// run on the same input. Compares log-likelihood (not branch lengths) because
-  /// the objective can be flat near the optimum.
+  /// Each non-reference method's combined log-likelihood must agree with
+  /// `BrentSqrt`'s within 1e-3 on the same input. Compares log-likelihood
+  /// (not branch lengths) because the objective can be flat near the optimum.
+  ///
+  /// Parameterized one case per (method, n_indels) so a regression in any
+  /// single method on any single indel count fails its own case rather than
+  /// short-circuiting on the first failure across a manual loop.
   #[rustfmt::skip]
   #[rstest]
-  #[case::k1(1)]
-  #[case::k2(2)]
-  #[case::k4(4)]
+  #[case::newton_k1(     BranchOptMethod::Newton,      1)]
+  #[case::newton_k2(     BranchOptMethod::Newton,      2)]
+  #[case::newton_k4(     BranchOptMethod::Newton,      4)]
+  #[case::newton_sqrt_k1(BranchOptMethod::NewtonSqrt,  1)]
+  #[case::newton_sqrt_k2(BranchOptMethod::NewtonSqrt,  2)]
+  #[case::newton_sqrt_k4(BranchOptMethod::NewtonSqrt,  4)]
+  #[case::newton_log_k1( BranchOptMethod::NewtonLog,   1)]
+  #[case::newton_log_k2( BranchOptMethod::NewtonLog,   2)]
+  #[case::newton_log_k4( BranchOptMethod::NewtonLog,   4)]
+  #[case::brent_k1(      BranchOptMethod::Brent,       1)]
+  #[case::brent_k2(      BranchOptMethod::Brent,       2)]
+  #[case::brent_k4(      BranchOptMethod::Brent,       4)]
+  #[case::brent_log_k1(  BranchOptMethod::BrentLog,    1)]
+  #[case::brent_log_k2(  BranchOptMethod::BrentLog,    2)]
+  #[case::brent_log_k4(  BranchOptMethod::BrentLog,    4)]
   #[trace]
-  fn test_optimize_method_cross_method_all_six_lh_agreement(#[case] n_indels: usize) -> Result<(), Report> {
-    let methods = [
-      ("Newton",     BranchOptMethod::Newton),
-      ("NewtonSqrt", BranchOptMethod::NewtonSqrt),
-      ("NewtonLog",  BranchOptMethod::NewtonLog),
-      ("Brent",      BranchOptMethod::Brent),
-      ("BrentSqrt",  BranchOptMethod::BrentSqrt),
-      ("BrentLog",   BranchOptMethod::BrentLog),
-    ];
+  fn test_optimize_method_cross_method_all_six_lh_agreement(
+    #[case] method: BranchOptMethod,
+    #[case] n_indels: usize,
+  ) -> Result<(), Report> {
+    // Reference: run BrentSqrt (the v0-matching default) on a fresh graph
+    // and capture its post-optimization log-likelihood at the first edge.
+    let lh_ref = {
+      let graph_ref: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+      let (partitions_ref, rate_ref) = setup_with_indels(&graph_ref, n_indels)?;
+      run_optimize_mixed(&graph_ref, &partitions_ref, BranchOptMethod::BrentSqrt)?;
+      let bl_ref = first_edge_bl(&graph_ref);
+      eval_combined_first_edge(&graph_ref, &partitions_ref, rate_ref, bl_ref)?
+    };
 
-    let mut results: BTreeMap<&str, (f64, f64)> = BTreeMap::new();
+    let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
+    let (partitions, rate) = setup_with_indels(&graph, n_indels)?;
+    run_optimize_mixed(&graph, &partitions, method)?;
+    let bl = first_edge_bl(&graph);
+    let lh = eval_combined_first_edge(&graph, &partitions, rate, bl)?;
 
-    for (name, method) in &methods {
-      let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
-      let (partitions, rate) = setup_with_indels(&graph, n_indels)?;
-      run_optimize_mixed(&graph, &partitions, *method)?;
-      let bl = first_edge_bl(&graph);
-      let lh = eval_combined_first_edge(&graph, &partitions, rate, bl)?;
-      results.insert(name, (bl, lh));
-    }
-
-    // Use BrentSqrt as reference (v0-matching method, default)
-    let (_, lh_ref) = results["BrentSqrt"];
-
-    for (name, (bl, lh)) in &results {
-      let diff = (*lh - lh_ref).abs();
-      assert!(
-        diff < 1e-3,
-        "Method {name} lh ({lh}) differs from BrentSqrt lh ({lh_ref}) by {diff} > 1e-3, bl={bl}"
-      );
-    }
+    let diff = (lh - lh_ref).abs();
+    assert!(
+      diff < 1e-3,
+      "{method:?} (n_indels={n_indels}) lh ({lh}) differs from BrentSqrt lh ({lh_ref}) by {diff} > 1e-3, bl={bl}"
+    );
 
     Ok(())
   }

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
@@ -828,6 +828,131 @@ mod tests {
     Ok(())
   }
 
+  mod generators {
+    use proptest::prelude::*;
+    /// Strategy for `s = sqrt(t)` values used by `chain_rule_sqrt`.
+    /// Bounded above well below the catastrophic-cancellation regime of the
+    /// step-clamping invariants (production never sees `s` near these caps).
+    pub fn gen_s() -> impl Strategy<Value = f64> {
+      1e-6_f64..1e3_f64
+    }
+    /// Strategy for `t > 0` values used by `chain_rule_log`.
+    pub fn gen_t() -> impl Strategy<Value = f64> {
+      1e-10_f64..1e3_f64
+    }
+    /// Strategy for first-derivative magnitudes typical of substitution +
+    /// indel objectives at the per-edge scale.
+    pub fn gen_dl_dt() -> impl Strategy<Value = f64> {
+      -1e6_f64..1e6_f64
+    }
+    /// Strategy for second-derivative magnitudes (Hessians can swing widely
+    /// on indel-heavy short branches).
+    pub fn gen_d2l_dt2() -> impl Strategy<Value = f64> {
+      -1e8_f64..1e8_f64
+    }
+    /// Strategy for a non-zero scalar multiplier in the linearity invariant.
+    pub fn gen_scalar() -> impl Strategy<Value = f64> {
+      prop_oneof![-1e3_f64..-1e-3_f64, 1e-3_f64..1e3_f64]
+    }
+  }
+
+  use proptest::prelude::*;
+
+  proptest! {
+    /// `chain_rule_sqrt(s, dl_dt, d2l_dt2)` must equal the closed-form
+    /// (2*s*dl_dt, 4*s^2*d2l_dt2 + 2*dl_dt). Pinning the formula identity
+    /// catches any algebraic regression in the chain rule.
+    #[test]
+    fn test_prop_optimize_method_chain_rule_sqrt_formula(
+      s in generators::gen_s(),
+      dl_dt in generators::gen_dl_dt(),
+      d2l_dt2 in generators::gen_d2l_dt2(),
+    ) {
+      let (dl_ds, d2l_ds2) = chain_rule_sqrt(s, dl_dt, d2l_dt2);
+      let expected_dl_ds = 2.0 * s * dl_dt;
+      let expected_d2l_ds2 = 4.0 * s * s * d2l_dt2 + 2.0 * dl_dt;
+      let dl_tol = 1e-9 * expected_dl_ds.abs().max(1.0);
+      let d2l_tol = 1e-9 * expected_d2l_ds2.abs().max(1.0);
+      prop_assert!(
+        (dl_ds - expected_dl_ds).abs() <= dl_tol,
+        "dl_ds: got {dl_ds}, expected {expected_dl_ds}"
+      );
+      prop_assert!(
+        (d2l_ds2 - expected_d2l_ds2).abs() <= d2l_tol,
+        "d2l_ds2: got {d2l_ds2}, expected {expected_d2l_ds2}"
+      );
+    }
+
+    /// `chain_rule_sqrt` is linear in `(dl_dt, d2l_dt2)`: scaling both inputs
+    /// by `k` scales both outputs by `k`. This is the homogeneity invariant
+    /// of a linear transform.
+    #[test]
+    fn test_prop_optimize_method_chain_rule_sqrt_linear(
+      s in generators::gen_s(),
+      dl_dt in generators::gen_dl_dt(),
+      d2l_dt2 in generators::gen_d2l_dt2(),
+      k in generators::gen_scalar(),
+    ) {
+      let (dl_ds, d2l_ds2) = chain_rule_sqrt(s, dl_dt, d2l_dt2);
+      let (dl_ds_k, d2l_ds2_k) = chain_rule_sqrt(s, k * dl_dt, k * d2l_dt2);
+      let dl_tol = 1e-9 * (k * dl_ds).abs().max(1.0);
+      let d2l_tol = 1e-9 * (k * d2l_ds2).abs().max(1.0);
+      prop_assert!(
+        (dl_ds_k - k * dl_ds).abs() <= dl_tol,
+        "linearity violated for dl_ds: {dl_ds_k} vs k*{dl_ds}"
+      );
+      prop_assert!(
+        (d2l_ds2_k - k * d2l_ds2).abs() <= d2l_tol,
+        "linearity violated for d2l_ds2: {d2l_ds2_k} vs k*{d2l_ds2}"
+      );
+    }
+
+    /// `chain_rule_log(t, dl_dt, d2l_dt2)` must equal the closed-form
+    /// (t*dl_dt, t^2*d2l_dt2 + t*dl_dt).
+    #[test]
+    fn test_prop_optimize_method_chain_rule_log_formula(
+      t in generators::gen_t(),
+      dl_dt in generators::gen_dl_dt(),
+      d2l_dt2 in generators::gen_d2l_dt2(),
+    ) {
+      let (dl_du, d2l_du2) = chain_rule_log(t, dl_dt, d2l_dt2);
+      let expected_dl_du = t * dl_dt;
+      let expected_d2l_du2 = t * t * d2l_dt2 + t * dl_dt;
+      let dl_tol = 1e-9 * expected_dl_du.abs().max(1.0);
+      let d2l_tol = 1e-9 * expected_d2l_du2.abs().max(1.0);
+      prop_assert!(
+        (dl_du - expected_dl_du).abs() <= dl_tol,
+        "dl_du: got {dl_du}, expected {expected_dl_du}"
+      );
+      prop_assert!(
+        (d2l_du2 - expected_d2l_du2).abs() <= d2l_tol,
+        "d2l_du2: got {d2l_du2}, expected {expected_d2l_du2}"
+      );
+    }
+
+    /// `chain_rule_log` is linear in `(dl_dt, d2l_dt2)`.
+    #[test]
+    fn test_prop_optimize_method_chain_rule_log_linear(
+      t in generators::gen_t(),
+      dl_dt in generators::gen_dl_dt(),
+      d2l_dt2 in generators::gen_d2l_dt2(),
+      k in generators::gen_scalar(),
+    ) {
+      let (dl_du, d2l_du2) = chain_rule_log(t, dl_dt, d2l_dt2);
+      let (dl_du_k, d2l_du2_k) = chain_rule_log(t, k * dl_dt, k * d2l_dt2);
+      let dl_tol = 1e-9 * (k * dl_du).abs().max(1.0);
+      let d2l_tol = 1e-9 * (k * d2l_du2).abs().max(1.0);
+      prop_assert!(
+        (dl_du_k - k * dl_du).abs() <= dl_tol,
+        "linearity violated for dl_du: {dl_du_k} vs k*{dl_du}"
+      );
+      prop_assert!(
+        (d2l_du2_k - k * d2l_du2).abs() <= d2l_tol,
+        "linearity violated for d2l_du2: {d2l_du2_k} vs k*{d2l_du2}"
+      );
+    }
+  }
+
   mod helpers {
     use super::*;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_method_step_clamping.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_method_step_clamping.rs
@@ -148,4 +148,70 @@ mod tests {
     let asymptote = -1.0 / t;
     assert_abs_diff_eq!(bound, asymptote, epsilon = 1e-6);
   }
+
+  mod generators {
+    use proptest::prelude::*;
+    /// Strategy for non-negative `s` values used by `sqrt_step_lower_bound`.
+    /// Capped at 1e3 because the unit-`t`-increase invariant computes
+    /// `s_new^2 - s^2 ~ 1` and loses relative precision once `s^2` exceeds
+    /// `1e10` (catastrophic cancellation on the squared values). Production
+    /// code never sees `s` near this cap (`s` is `sqrt(branch_length)` and
+    /// branch lengths cap at `GRID_SEARCH_MIN_UPPER = 0.5` plus a soft
+    /// boundary, far below `s = 1e3`).
+    pub fn gen_s() -> impl Strategy<Value = f64> {
+      0.0_f64..1e3_f64
+    }
+    /// Strategy for strictly positive `t` values used by `log_step_lower_bound`.
+    pub fn gen_t() -> impl Strategy<Value = f64> {
+      1e-10_f64..1e6_f64
+    }
+  }
+
+  use proptest::prelude::*;
+
+  proptest! {
+    /// Sign invariant for `sqrt_step_lower_bound`: always non-positive on
+    /// the admissible domain `s >= 0`.
+    #[test]
+    fn test_prop_optimize_method_step_clamping_sqrt_non_positive(s in generators::gen_s()) {
+      let bound = sqrt_step_lower_bound(s);
+      prop_assert!(bound <= 0.0, "sqrt_step_lower_bound({s}) = {bound} should be <= 0");
+    }
+
+    /// Unit-`t`-increase invariant for `sqrt_step_lower_bound`: applying
+    /// the lower-bound step in s-space produces exactly delta_t = 1.0
+    /// (up to round-off).
+    #[test]
+    fn test_prop_optimize_method_step_clamping_sqrt_unit_t_increase(s in generators::gen_s()) {
+      let delta_s = sqrt_step_lower_bound(s);
+      let s_new = s - delta_s;
+      let delta_t = s_new * s_new - s * s;
+      prop_assert!(
+        (delta_t - 1.0).abs() < 1e-6,
+        "sqrt step from s={s} should yield delta_t = 1.0, got {delta_t}"
+      );
+    }
+
+    /// Sign invariant for `log_step_lower_bound`: always negative on the
+    /// admissible domain `t > 0`.
+    #[test]
+    fn test_prop_optimize_method_step_clamping_log_negative(t in generators::gen_t()) {
+      let bound = log_step_lower_bound(t);
+      prop_assert!(bound < 0.0, "log_step_lower_bound({t}) = {bound} should be < 0");
+    }
+
+    /// Unit-`t`-increase invariant for `log_step_lower_bound`: applying
+    /// the lower-bound step in u-space produces exactly delta_t = 1.0
+    /// (up to round-off).
+    #[test]
+    fn test_prop_optimize_method_step_clamping_log_unit_t_increase(t in generators::gen_t()) {
+      let delta_u = log_step_lower_bound(t);
+      let t_new = (t.ln() - delta_u).exp();
+      let delta_t = t_new - t;
+      prop_assert!(
+        (delta_t - 1.0).abs() < 1e-6,
+        "log step from t={t} should yield delta_t = 1.0, got {delta_t}"
+      );
+    }
+  }
 }

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -195,23 +195,7 @@ pub fn run_optimize(args: &TreetimeOptimizeArgs) -> Result<(), Report> {
     normalize_partition_rates(&graph, &sparse_partitions, &dense_partitions);
   }
 
-  match branch_length_initial_guess {
-    InitialGuessMode::Auto => {
-      initial_guess_mixed(&graph, &mixed_partitions, false)?;
-    },
-    InitialGuessMode::Always => {
-      initial_guess_mixed(&graph, &mixed_partitions, true)?;
-    },
-    InitialGuessMode::Never => {
-      if any_edge_missing_branch_length(&graph) {
-        return make_error!(
-          "--branch-length-initial-guess=never requires all edges to have finite branch lengths, \
-           but some edges have missing or NaN values. \
-           Use 'auto' to fill in missing values or 'always' to recompute all branch lengths"
-        );
-      }
-    },
-  }
+  apply_initial_guess_mode(&graph, &mixed_partitions, *branch_length_initial_guess)?;
 
   let mut lh_prev = f64::MIN;
   for i in 0..*max_iter {
@@ -512,6 +496,39 @@ where
     .get_edges()
     .iter()
     .any(|edge_ref| is_branch_length_missing(edge_ref.read_arc().payload().read_arc().branch_length()))
+}
+
+/// Apply the initial-guess mode to the graph.
+///
+/// - `Auto`: estimate only edges with missing or invalid branch lengths.
+/// - `Always`: estimate all edges, overwriting existing values.
+/// - `Never`: keep input branch lengths; error if any edge lacks a usable
+///   value.
+///
+/// Extracted from `run_optimize` so the Never-mode rejection path is unit
+/// testable without standing up partitions and reading files.
+pub(crate) fn apply_initial_guess_mode<P>(
+  graph: &GraphAncestral,
+  mixed_partitions: &[Arc<RwLock<P>>],
+  mode: InitialGuessMode,
+) -> Result<(), Report>
+where
+  P: PartitionOptimizeOps + ?Sized,
+{
+  match mode {
+    InitialGuessMode::Auto => initial_guess_mixed(graph, mixed_partitions, false),
+    InitialGuessMode::Always => initial_guess_mixed(graph, mixed_partitions, true),
+    InitialGuessMode::Never => {
+      if any_edge_missing_branch_length(graph) {
+        return make_error!(
+          "--branch-length-initial-guess=never requires all edges to have finite branch lengths, \
+           but some edges have missing or NaN values. \
+           Use 'auto' to fill in missing values or 'always' to recompute all branch lengths"
+        );
+      }
+      Ok(())
+    },
+  }
 }
 
 fn write_graph<N, E, D>(outdir: impl AsRef<Path>, graph: &Graph<N, E, D>) -> Result<(), Report>


### PR DESCRIPTION
The existing optimize test suite had structural gaps: no CLI parser coverage for `--opt-method`, no per-branch comparison against the v0 golden master (only the summed total), Newton iteration tests [[src](https://github.com/neherlab/treetime/blob/0fc1fb35/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs)] that terminated on the first iteration because substitution-only $\text{Var}(\lambda)$ is non-negative and the `if d2 < 0` guard never fired, hand-chosen absolute log-likelihood ranges ("between $-73.5$ and $-72.0$") instead of cross-method agreement, no coverage of the `InitialGuessMode::Never` rejection path, and no property-based verification of chain rule or step clamping invariants.

This PR adds eight `--opt-method` parser cases; a per-branch golden master check ignored-by-default with a filed divergence issue; Newton iteration tests that use an indel-bearing surface where $d^2\ell/dt^2 < 0$ at short branches so the loop runs; a 15-case rstest matrix (5 methods x 3 indel counts) replacing the manual loop for cross-method log-likelihood agreement against a precomputed BrentSqrt reference; an `apply_initial_guess_mode` helper [[src](https://github.com/neherlab/treetime/blob/0fc1fb35/packages/treetime/src/commands/optimize/run.rs#L510)] making the Never-mode rejection path unit-testable; eight proptest invariants for `chain_rule_{sqrt,log}` formula and linearity [[src](https://github.com/neherlab/treetime/blob/0fc1fb35/packages/treetime/src/commands/optimize/method_newton.rs#L143)] plus `{sqrt,log}_step_lower_bound` sign and unit-$t$-increase.

### Work items

- [x] CLI parser tests for `--opt-method` (8 cases)
- [x] Per-branch GM check (ignored by default; divergence issue filed)
- [x] Strengthen Newton iteration tests to exercise the iteration loop [[src](https://github.com/neherlab/treetime/blob/0fc1fb35/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs)]
- [x] Replace hand-chosen LH range with cross-method agreement via 15-case rstest matrix
- [x] Extract `apply_initial_guess_mode` helper [[src](https://github.com/neherlab/treetime/blob/0fc1fb35/packages/treetime/src/commands/optimize/run.rs#L510)]; exercise Never-mode rejection
- [x] Proptest invariants for chain rule and step clamping helpers
- [x] File issue: [M-optimize-gm-per-branch-divergence.md](https://github.com/neherlab/treetime/blob/0fc1fb35/docs/port-known-issues/M-optimize-gm-per-branch-divergence.md): per-branch golden master exceeds 10% relative tolerance; likely contributors are differing topology cleanup criterion, indel rate handling, damping schedule order

