### PR TITLE
perf: use dot() in zero_branch_length_derivative

### DIFF
--- a/packages/treetime/src/commands/optimize/__tests__/test_args.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_args.rs
@@ -33,12 +33,7 @@ mod tests {
   /// the `default_value_t` would silently route CLI runs to the wrong optimizer.
   #[test]
   fn test_args_opt_method_default_is_brent_sqrt() {
-    let args = TreetimeOptimizeArgs::try_parse_from([
-      "treetime",
-      "--tree=/dev/null",
-      "--outdir=/dev/null",
-    ])
-    .unwrap();
+    let args = TreetimeOptimizeArgs::try_parse_from(["treetime", "--tree=/dev/null", "--outdir=/dev/null"]).unwrap();
     assert_eq!(BranchOptMethod::BrentSqrt, args.opt_method);
   }
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
@@ -318,7 +318,8 @@ mod tests {
     // the extent argument is smaller than the $0.5$ floor. That range
     // contains the local max at $t \approx 0.2$.
     let branch_length_extent = 0.2;
-    let result = reconcile_zero_boundary(candidate, branch_length_extent, &contributions, 0, 0.0, one_mutation).unwrap();
+    let result =
+      reconcile_zero_boundary(candidate, branch_length_extent, &contributions, 0, 0.0, one_mutation).unwrap();
 
     assert!(
       result > 0.0,
@@ -421,7 +422,8 @@ mod tests {
     let indel_rate = 44.4;
     let one_mutation = 0.01;
 
-    let result = reconcile_zero_boundary(candidate, 0.2, &contributions, indel_count, indel_rate, one_mutation).unwrap();
+    let result =
+      reconcile_zero_boundary(candidate, 0.2, &contributions, indel_count, indel_rate, one_mutation).unwrap();
     assert!(
       result.to_bits() == candidate.to_bits(),
       "reconcile_zero_boundary must return candidate unchanged when indel_count > 0, got {result}"
@@ -627,7 +629,8 @@ mod tests {
     // input branch length, which would be 0.6 in this scenario.
     let candidate = 0.0;
     let branch_length_extent = 0.6;
-    let result = reconcile_zero_boundary(candidate, branch_length_extent, &contributions, 0, 0.0, one_mutation).unwrap();
+    let result =
+      reconcile_zero_boundary(candidate, branch_length_extent, &contributions, 0, 0.0, one_mutation).unwrap();
 
     assert!(
       result > 0.0,

--- a/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs
@@ -15,7 +15,7 @@ mod tests {
 
     // Indel contribution makes the second derivative negative even when the
     // substitution variance Var(lambda) is positive, so Newton actually runs.
-    let indel_count = 2usize;
+    let indel_count = 2_usize;
     let indel_rate = 10.0;
     // Floor matches min_branch_length_for_indels(2, one_mutation=0.001) so the
     // simulated loop preserves the Poisson indel domain (t > 0).
@@ -82,7 +82,7 @@ mod tests {
     let contribution = make_dense_contribution(coefficients);
     let contributions = vec![contribution];
 
-    let indel_count = 2usize;
+    let indel_count = 2_usize;
     let indel_rate = 10.0;
     // Floor matches min_branch_length_for_indels(2, one_mutation=0.001) so the
     // simulated loop preserves the Poisson indel domain (t > 0).

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs
@@ -18,6 +18,7 @@ mod tests {
   use crate::seq::indel::InDel;
   use approx::assert_abs_diff_eq;
   use eyre::Report;
+  use helpers::*;
   use ndarray::array;
   use parking_lot::RwLock;
   use rstest::rstest;
@@ -25,7 +26,6 @@ mod tests {
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::Seq;
-  use helpers::*;
 
   /// At s=0, the first derivative is zero (chain rule factor 2s = 0) and
   /// the second derivative equals 2 * dl_dt (the only surviving term).
@@ -267,7 +267,6 @@ mod tests {
 
     Ok(())
   }
-
 
   /// C1: Local optimality. The combined log-likelihood at the reported
   /// optimum must exceed the log-likelihood at nearby points.
@@ -1036,8 +1035,7 @@ mod tests {
     /// is missing or NaN. Captures the 5-line read chain that recurs across
     /// tests in this file.
     pub(super) fn first_edge_bl(graph: &GraphAncestral) -> f64 {
-      graph
-        .get_edges()[0]
+      graph.get_edges()[0]
         .read_arc()
         .payload()
         .read_arc()

--- a/packages/treetime/src/commands/optimize/optimize_unified.rs
+++ b/packages/treetime/src/commands/optimize/optimize_unified.rs
@@ -11,10 +11,10 @@ use crate::commands::optimize::optimize_sparse_eval::{
   evaluate_sparse_contribution, evaluate_sparse_contribution_impl,
 };
 use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
-use crate::{make_error, make_internal_report};
 use crate::representation::partition::marginal_dense::PartitionMarginalDense;
 use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
 use crate::representation::payload::ancestral::GraphAncestral;
+use crate::{make_error, make_internal_report};
 use eyre::Report;
 use ndarray::{Array1, Axis};
 use ordered_float::OrderedFloat;
@@ -183,16 +183,19 @@ impl OptimizationContribution {
       "zero_branch_length_derivative called without verifying all_sites_valid_at_zero"
     );
     match self {
+      // Use `dot` for the (n_sites, n_states) * (n_states,) reduction so the
+      // intermediate (n_sites, n_states) broadcast multiply does not allocate.
+      // BLAS-backed when ndarray's `blas` feature is enabled (it is).
       OptimizationContribution::Dense(contribution) => {
         let gtr = &contribution.gtr;
         let coefficients = &contribution.coefficients;
-        ((coefficients * &gtr.eigvals).sum_axis(Axis(1)) / coefficients.sum_axis(Axis(1))).sum()
+        (coefficients.dot(&gtr.eigvals) / coefficients.sum_axis(Axis(1))).sum()
       },
       OptimizationContribution::Sparse(contribution) => contribution
         .site_contributions
         .iter()
         .map(|coeff| {
-          coeff.multiplicity * ((&coeff.coefficients * &contribution.gtr.eigvals).sum() / coeff.coefficients.sum())
+          coeff.multiplicity * (coeff.coefficients.dot(&contribution.gtr.eigvals) / coeff.coefficients.sum())
         })
         .sum(),
     }
@@ -392,7 +395,9 @@ pub(crate) fn grid_search_inner(
       let log_lh = evaluate_with_indels_log_lh_only(contributions, indel_count, indel_rate, bl);
       OrderedFloat(log_lh)
     })
-    .ok_or_else(|| make_internal_report!("grid_search_inner: empty grid (GRID_SEARCH_POINTS = {GRID_SEARCH_POINTS})"))?;
+    .ok_or_else(|| {
+      make_internal_report!("grid_search_inner: empty grid (GRID_SEARCH_POINTS = {GRID_SEARCH_POINTS})")
+    })?;
 
   let zero_is_better = is_zero_better_than_grid_best(contributions, indel_count, indel_rate, best_positive);
   Ok(if zero_is_better { 0.0 } else { best_positive })


### PR DESCRIPTION
`zero_branch_length_derivative` [[src](https://github.com/neherlab/treetime/blob/51ffaf6c/packages/treetime/src/commands/optimize/optimize_unified.rs#L180)] computed the per-site inner product as `(coefficients * &gtr.eigvals).sum_axis(Axis(1))`. This materializes a `(n_sites, n_states)` $f64$ temporary, then reduces along the state axis. `ndarray` exposes a BLAS-backed `.dot(&Array1<f64>)` that performs the same computation as a GEMV without the temporary (BLAS kicks in because the workspace enables ndarray's `blas` feature).

This PR replaces the elementwise-multiply-then-sum pattern with `coefficients.dot(&gtr.eigvals)` in both the dense [[src](https://github.com/neherlab/treetime/blob/51ffaf6c/packages/treetime/src/commands/optimize/optimize_unified.rs#L192)] and sparse [[src](https://github.com/neherlab/treetime/blob/51ffaf6c/packages/treetime/src/commands/optimize/optimize_unified.rs#L198)] per-site paths. Removes one $(n_\text{sites}, n_\text{states})$ $f64$ temporary per `is_zero_branch_optimal` call [[src](https://github.com/neherlab/treetime/blob/51ffaf6c/packages/treetime/src/commands/optimize/optimize_unified.rs#L311)]. Behavior is unchanged; the substitution is a numerical identity (both forms compute $\sum_j c_{ij} \lambda_j$, where $c_{ij}$ is the coefficient at site $i$ and state $j$ and $\lambda_j$ is the $j$-th GTR eigenvalue).

### Work items

- [x] Replace `(coefficients * &gtr.eigvals).sum_axis(Axis(1))` with `coefficients.dot(&gtr.eigvals)` (dense) [[src](https://github.com/neherlab/treetime/blob/51ffaf6c/packages/treetime/src/commands/optimize/optimize_unified.rs#L192)]
- [x] Mirror the rewrite for the sparse per-site inner product [[src](https://github.com/neherlab/treetime/blob/51ffaf6c/packages/treetime/src/commands/optimize/optimize_unified.rs#L198)]

