### PR TITLE
fix: write molecular_clock.txt in clock command

### DIFF
--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -79,6 +79,13 @@ def create_gtr(params):
     return gtr
 
 
+def save_molecular_clock(outdir, date2dist, suffix=''):
+    fname = outdir + f'molecular_clock{suffix}.txt'
+    with open(fname, 'w', encoding='utf-8') as ofile:
+        ofile.write(str(date2dist) + '\n')
+    return fname
+
+
 def scan_homoplasies(params):
     """
     the function implementing treetime homoplasies
@@ -515,9 +522,7 @@ def run_timetree(myTree, params, outdir, tree_suffix='', prune_short=True, metho
         print('\nInferred sequence evolution model (saved as %s):' % fname)
         print(myTree.gtr)
 
-    fname = outdir + f'molecular_clock{tree_suffix}.txt'
-    with open(fname, 'w', encoding='utf-8') as ofile:
-        ofile.write(str(myTree.date2dist) + '\n')
+    fname = save_molecular_clock(outdir, myTree.date2dist, suffix=tree_suffix)
     print('\nInferred sequence evolution model (saved as %s):' % fname)
     print(myTree.date2dist)
 
@@ -991,6 +996,10 @@ def estimate_clock_model(params):
         myTree.get_clock_model(covariation=params.covariation)
 
     d2d = utils.DateConversion.from_regression(myTree.clock_model)
+
+    fname = save_molecular_clock(outdir, d2d)
+    print('\n--- wrote molecular clock model to\n\t%s\n' % fname)
+
     print('\n', d2d)
     print(
         fill(

--- a/treetime/wrappers.py
+++ b/treetime/wrappers.py
@@ -83,6 +83,8 @@ def save_molecular_clock(outdir, date2dist, suffix=''):
     fname = outdir + f'molecular_clock{suffix}.txt'
     with open(fname, 'w', encoding='utf-8') as ofile:
         ofile.write(str(date2dist) + '\n')
+    print('\n--- molecular clock model (saved as %s):\n' % fname)
+    print(date2dist)
     return fname
 
 
@@ -522,9 +524,7 @@ def run_timetree(myTree, params, outdir, tree_suffix='', prune_short=True, metho
         print('\nInferred sequence evolution model (saved as %s):' % fname)
         print(myTree.gtr)
 
-    fname = save_molecular_clock(outdir, myTree.date2dist, suffix=tree_suffix)
-    print('\nInferred sequence evolution model (saved as %s):' % fname)
-    print(myTree.date2dist)
+    save_molecular_clock(outdir, myTree.date2dist, suffix=tree_suffix)
 
     basename = get_basename(params, outdir)
     if coalescent in ['skyline', 'opt', 'const']:
@@ -997,10 +997,7 @@ def estimate_clock_model(params):
 
     d2d = utils.DateConversion.from_regression(myTree.clock_model)
 
-    fname = save_molecular_clock(outdir, d2d)
-    print('\n--- wrote molecular clock model to\n\t%s\n' % fname)
-
-    print('\n', d2d)
+    save_molecular_clock(outdir, d2d)
     print(
         fill(
             'The R^2 value indicates the fraction of variation in'


### PR DESCRIPTION
# fix: write molecular_clock.txt in clock command

- Resolves: #574

The `treetime clock` command prints the rate estimate to stdout but never saves it to a file, despite the [documentation](https://treetime.readthedocs.io/en/latest/tutorials/clock.html) listing "a text-file with the rate estimate" among the output files. The `timetree` command already writes this file via inline code.

Extract a shared `save_molecular_clock()` helper [[src](https://github.com/neherlab/treetime/blob/c78edd1a60330d4f5fde34c83a3233ecff27f391/treetime/wrappers.py#L82-L89)] that writes `molecular_clock.txt` and prints a confirmation message. Use it in both `estimate_clock_model()` [[src](https://github.com/neherlab/treetime/blob/c78edd1a60330d4f5fde34c83a3233ecff27f391/treetime/wrappers.py#L1000)] and `run_timetree()` [[src](https://github.com/neherlab/treetime/blob/c78edd1a60330d4f5fde34c83a3233ecff27f391/treetime/wrappers.py#L527)], replacing the duplicated inline file-writing code.

The `run_timetree` print message for `molecular_clock.txt` incorrectly said "Inferred sequence evolution model" -- a copy-paste from the GTR block directly above it. The shared helper now prints a consistent `--- molecular clock model (saved as ...)` message for both commands.

### Verification

Before (clock command produces no `molecular_clock.txt`):

```
$ treetime clock --tree data/h3n2_na/h3n2_na_20.nwk --dates data/h3n2_na/h3n2_na_20.metadata.csv --sequence-len 1400 --outdir clock_results
$ ls clock_results/
outliers.tsv  rerooted.newick  root_to_tip_regression.pdf  rtt.csv
```

After:

```
$ treetime clock --tree data/h3n2_na/h3n2_na_20.nwk --dates data/h3n2_na/h3n2_na_20.metadata.csv --sequence-len 1400 --outdir clock_results
--- molecular clock model (saved as clock_results/molecular_clock.txt):

Root-Tip-Regression:
 --rate:	2.826e-03
 --r^2:  	0.98
$ ls clock_results/
molecular_clock.txt  outliers.tsv  rerooted.newick  root_to_tip_regression.pdf  rtt.csv
$ cat clock_results/molecular_clock.txt
Root-Tip-Regression:
 --rate:	2.826e-03
 --r^2:  	0.98
```

### Work items

- [x] Add `molecular_clock.txt` output to `estimate_clock_model()`
- [x] Extract shared `save_molecular_clock()` helper to deduplicate file-writing between `clock` and `timetree`
- [x] Fix copy-paste "Inferred sequence evolution model" message in `run_timetree()` for the molecular clock file

### Possible improvements

- [ ] Align print style for `sequence_evolution_model.txt` saves in `run_timetree` [[src](https://github.com/neherlab/treetime/blob/c78edd1a60330d4f5fde34c83a3233ecff27f391/treetime/wrappers.py#L524)] and `ancestral_reconstruction` [[src](https://github.com/neherlab/treetime/blob/c78edd1a60330d4f5fde34c83a3233ecff27f391/treetime/wrappers.py#L643)] to use `---` prefix (both use `'\nInferred ...'` while all other file-save messages use `'--- ...'`)
