### PR TITLE
refactor: array max primitives and semantic helpers

### DIFF
--- a/packages/treetime-ops/src/multiplication.rs
+++ b/packages/treetime-ops/src/multiplication.rs
@@ -1,17 +1,14 @@
 use crate::ScaledArray;
 use crate::traits::MultiplyAlgo;
 use ndarray::Array1;
+use treetime_utils::array::ndarray::max_or;
 
 /// Threshold below which we normalize to prevent underflow.
 /// This is much smaller than 1.0 to avoid unnecessary normalizations.
 const UNDERFLOW_THRESHOLD: f64 = 1e-100;
 
-fn array_max(arr: &Array1<f64>) -> f64 {
-  arr.iter().copied().fold(f64::NEG_INFINITY, f64::max)
-}
-
 fn normalize_and_extract_scale(arr: &Array1<f64>) -> ScaledArray {
-  let max_val = array_max(arr);
+  let max_val = max_or(arr, f64::NEG_INFINITY);
   let log_scale = if max_val > 0.0 && max_val.is_finite() {
     max_val.ln()
   } else {
@@ -50,7 +47,7 @@ pub fn multiply_many_lazy_normalize(distributions: &[&Array1<f64>]) -> ScaledArr
   let mut accumulated_log_scale = 0.0;
 
   // Initial check
-  let max_val = array_max(&product);
+  let max_val = max_or(&product, f64::NEG_INFINITY);
   if max_val <= 0.0 || !max_val.is_finite() {
     return ScaledArray::empty(n);
   }
@@ -58,7 +55,7 @@ pub fn multiply_many_lazy_normalize(distributions: &[&Array1<f64>]) -> ScaledArr
   for dist in distributions.iter().skip(1) {
     product = &product * *dist;
 
-    let max_val = array_max(&product);
+    let max_val = max_or(&product, f64::NEG_INFINITY);
     if max_val <= 0.0 || !max_val.is_finite() {
       return ScaledArray::empty(n);
     }
@@ -71,7 +68,7 @@ pub fn multiply_many_lazy_normalize(distributions: &[&Array1<f64>]) -> ScaledArr
   }
 
   // Final normalization to ensure invariant max = 1.0
-  let max_val = array_max(&product);
+  let max_val = max_or(&product, f64::NEG_INFINITY);
   if max_val <= 0.0 || !max_val.is_finite() {
     return ScaledArray::empty(n);
   }
@@ -103,7 +100,7 @@ pub fn multiply_many(distributions: &[&Array1<f64>]) -> ScaledArray {
   let mut accumulated_log_scale = 0.0;
   let mut normalized_result = distributions[0].clone();
 
-  let max_val = array_max(&normalized_result);
+  let max_val = max_or(&normalized_result, f64::NEG_INFINITY);
   if max_val <= 0.0 || !max_val.is_finite() {
     return ScaledArray::empty(n);
   }
@@ -113,7 +110,7 @@ pub fn multiply_many(distributions: &[&Array1<f64>]) -> ScaledArray {
   for dist in distributions.iter().skip(1) {
     normalized_result = &normalized_result * *dist;
 
-    let max_val = array_max(&normalized_result);
+    let max_val = max_or(&normalized_result, f64::NEG_INFINITY);
     if max_val <= 0.0 || !max_val.is_finite() {
       return ScaledArray::empty(n);
     }
@@ -141,7 +138,7 @@ pub fn multiply_many_naive(distributions: &[&Array1<f64>]) -> ScaledArray {
     result = &result * *dist;
   }
 
-  let max_val = array_max(&result);
+  let max_val = max_or(&result, f64::NEG_INFINITY);
   let log_scale = if max_val > 0.0 && max_val.is_finite() {
     max_val.ln()
   } else {

--- a/packages/treetime-utils/src/array/ndarray.rs
+++ b/packages/treetime-utils/src/array/ndarray.rs
@@ -5,6 +5,7 @@ use ndarray::{
   Array, Array1, Array2, ArrayBase, ArrayView, Axis, Data, Dimension, Ix1, Ix2, RemoveAxis, ShapeBuilder, ShapeError,
   Zip, s, stack,
 };
+use ndarray_stats::QuantileExt;
 use ndarray_rand::RandomExt;
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::distributions::Uniform;
@@ -177,6 +178,24 @@ pub fn argmax_first<T: PartialOrd>(arr: &ArrayView<T, Ix1>) -> Option<usize> {
     }
   }
   Some(max_idx)
+}
+
+/// Maximum element, or `default` for empty arrays.
+#[inline]
+pub fn max_or<S: Data<Elem = f64>>(arr: &ArrayBase<S, Ix1>, default: f64) -> f64 {
+  arr.max().map_or(default, |&max| max)
+}
+
+/// Minimum element, or `default` for empty arrays.
+#[inline]
+pub fn min_or<S: Data<Elem = f64>>(arr: &ArrayBase<S, Ix1>, default: f64) -> f64 {
+  arr.min().map_or(default, |&min| min)
+}
+
+/// Whether the maximum element is >= threshold. Returns false for empty arrays.
+#[inline]
+pub fn is_max_above<S: Data<Elem = f64>>(arr: &ArrayBase<S, Ix1>, threshold: f64) -> bool {
+  arr.max().is_ok_and(|&max| max >= threshold)
 }
 
 /// Element-wise minimum of two arrays

--- a/packages/treetime/src/commands/mugration/gtr_refinement.rs
+++ b/packages/treetime/src/commands/mugration/gtr_refinement.rs
@@ -1,7 +1,7 @@
 use crate::commands::mugration::discrete_marginal::{discrete_marginal_backward, run_discrete_marginal};
 use crate::constants::SUPERTINY_NUMBER;
 use crate::gtr::gtr::{GTR, GTRParams};
-use crate::gtr::infer_gtr::common::{InferGtrOptions, InferGtrResult, MutationCounts, infer_gtr_impl};
+use crate::gtr::infer_gtr::common::{InferGtrOptions, InferGtrResult, MutationCounts, infer_gtr_impl, is_profile_informative};
 use crate::gtr::infer_gtr::dense::{accumulate_mutation_counts, get_branch_mutation_matrix};
 use crate::make_report;
 use crate::representation::partition::discrete::PartitionDiscrete;
@@ -136,9 +136,7 @@ where
   let root_key = root.read_arc().key();
   let root_profile = &partition.nodes[&root_key].profile;
   let mut root_state = Array1::zeros(n_states);
-  let uniform_threshold = 1.0 / n_states as f64 + 1e-10;
-  let max_prob = root_profile.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-  if max_prob > uniform_threshold {
+  if is_profile_informative(&root_profile.view(), n_states) {
     if let Some(root_idx) = argmax_first(&root_profile.view()) {
       root_state[root_idx] = 1.0;
     }

--- a/packages/treetime/src/gtr/infer_gtr/common.rs
+++ b/packages/treetime/src/gtr/infer_gtr/common.rs
@@ -1,10 +1,10 @@
 use crate::gtr::gtr::avg_transition;
 use eyre::Report;
 use log::warn;
-use ndarray::{Array1, Array2, Axis};
+use ndarray::{Array1, Array2, ArrayView1, Axis};
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
-use treetime_utils::array::ndarray::outer;
+use treetime_utils::array::ndarray::{is_max_above, outer};
 use treetime_utils::array::serde::{array1_as_vec, array1_from_vec, array2_as_vec, array2_from_vec};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -159,4 +159,10 @@ pub fn infer_gtr_impl(counts: &MutationCounts, options: &InferGtrOptions) -> Res
 
 pub fn distance(pi_old: &Array1<f64>, pi: &Array1<f64>) -> f64 {
   (pi_old - pi).mapv(|x| x * x).sum().sqrt()
+}
+
+/// Whether a profile is peaked above the uniform baseline (carries phylogenetic signal).
+pub fn is_profile_informative(profile: &ArrayView1<'_, f64>, n_states: usize) -> bool {
+  let uniform_threshold = 1.0 / n_states as f64 + 1e-10;
+  is_max_above(profile, uniform_threshold)
 }

--- a/packages/treetime/src/gtr/infer_gtr/dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/dense.rs
@@ -1,6 +1,6 @@
 use crate::constants::SUPERTINY_NUMBER;
 use crate::gtr::gtr::{GTR, GTRParams};
-use crate::gtr::infer_gtr::common::{InferGtrOptions, InferGtrResult, MutationCounts, infer_gtr_impl};
+use crate::gtr::infer_gtr::common::{InferGtrOptions, InferGtrResult, MutationCounts, infer_gtr_impl, is_profile_informative};
 use crate::hacks::fix_branch_length::fix_branch_length;
 use crate::make_internal_report;
 use crate::representation::partition::marginal_dense::PartitionMarginalDense;
@@ -155,10 +155,8 @@ where
     let root_key = root.read_arc().key();
     let root_profile = &partition.nodes[&root_key].profile.dis;
     let mut counts = Array1::zeros(n_states);
-    let uniform_threshold = 1.0 / n_states as f64 + 1e-10;
     for row in root_profile.rows() {
-      let max_val = row.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-      if max_val > uniform_threshold {
+      if is_profile_informative(&row, n_states) {
         let state =
           argmax_first(&row).ok_or_else(|| make_internal_report!("Empty profile row in root marginal distribution"))?;
         counts[state] += 1.0;

--- a/packages/treetime/src/representation/partition/marginal_helpers.rs
+++ b/packages/treetime/src/representation/partition/marginal_helpers.rs
@@ -8,6 +8,7 @@ use ndarray::{Array1, Array2, ArrayView1};
 use std::collections::BTreeMap;
 use std::iter::zip;
 use treetime_primitives::AsciiChar;
+use treetime_utils::array::ndarray::{is_max_above, max_or};
 use treetime_utils::interval::range::range_contains;
 
 pub const EPS: f64 = 1e-4;
@@ -65,8 +66,7 @@ pub fn combine_messages(
       *count -= 1.0;
     }
 
-    let max_prob = dis.iter().copied().fold(0.0_f64, f64::max);
-    if max_prob < (1.0 - EPS) || !all_states_equal {
+    if !is_site_resolved(&dis, EPS) || !all_states_equal {
       seq_dis.fixed_counts.adjust_count(state, -1);
       seq_dis.variable.insert(pos, VarPos { dis, state });
     }
@@ -86,25 +86,33 @@ pub fn combine_messages(
   Ok(seq_dis)
 }
 
-/// Normalize a log-probability vector using the logsumexp trick.
+/// Fused LSE + softmax: returns `(softmax(x), LSE(x))` from unnormalized log-probabilities.
 ///
-/// Subtracts the maximum log-value before exponentiating to prevent underflow
-/// when combining many small probabilities. Returns the normalized probability
-/// vector and log(sum(exp(log_vec))).
+/// Naive `exp()` of log-probabilities overflows or underflows for large magnitudes.
+/// The LSE shift (`exp(x - max)`) keeps all exponents in a safe range. LSE and
+/// softmax share the intermediate `exp(x - max)` in a single fused pass. Direct
+/// division `exp(x - max) / sum` preserves tighter sum-to-one than the decomposed
+/// `exp(x - LSE(x))` form, which would introduce an extra `ln` to `exp` round-trip.
 ///
-/// When all entries are -inf (all states have zero probability), returns a
-/// uniform distribution with log_norm = NEG_INFINITY.
+/// Degenerate input (all -inf): returns uniform distribution, LSE = -inf.
 pub fn logsumexp_normalize(log_vec: ArrayView1<'_, f64>) -> (Array1<f64>, f64) {
-  let max_val = log_vec.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+  // LSE shift constant: subtract max before exp to prevent overflow
+  let max_val = max_or(&log_vec, f64::NEG_INFINITY);
 
+  // All states have zero probability: fall back to uniform
   if !max_val.is_finite() {
     let n = log_vec.len();
     return (Array1::from_elem(n, 1.0 / n as f64), f64::NEG_INFINITY);
   }
 
+  // Shared intermediate: exp(x - max) used by both LSE and softmax
   let shifted = log_vec.mapv(|v| (v - max_val).exp());
   let shifted_sum = shifted.sum();
+
+  // LSE(x) = max + ln(sum(exp(x - max)))
   let log_norm = max_val + shifted_sum.ln();
+
+  // softmax(x) = exp(x - max) / sum(exp(x - max))
   let normalized = shifted / shifted_sum;
 
   (normalized, log_norm)
@@ -212,6 +220,12 @@ pub fn propagate_raw_per_site(
   }
 
   message
+}
+
+/// Whether a posterior is dominated by a single state (peak probability >= 1 - epsilon),
+/// meaning the site can be demoted from variable to fixed in the sparse representation.
+fn is_site_resolved(dis: &Array1<f64>, epsilon: f64) -> bool {
+  is_max_above(dis, 1.0 - epsilon)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Ad-hoc `fold(f64::max)` + threshold comparisons appear across marginal inference, GTR refinement, and multiplication code. These patterns obscure intent and duplicate logic.

This PR adds three array primitives to `treetime-utils` (`max_or`, `min_or`, `is_max_above`) wrapping `QuantileExt`, then extracts two semantic helpers that use them: `is_site_resolved` for sparse variable-to-fixed demotion in marginal inference, and `is_profile_informative` for root signal detection in GTR refinement. The private `array_max` in `treetime-ops/multiplication.rs` is replaced with `max_or`.

### Work items

- [x] Add `max_or`, `min_or`, `is_max_above` to `treetime-utils/src/array/ndarray.rs`
- [x] Extract `is_site_resolved` in marginal_helpers for sparsity demotion
- [x] Extract `is_profile_informative` in infer_gtr/common for root signal detection
- [x] Replace `array_max` in treetime-ops/multiplication.rs with `max_or`