### PR TITLE
docs: add impl links and full paths to test inventory

### DIFF
--- a/docs/port-test-inventory/ancestral.md
+++ b/docs/port-test-inventory/ancestral.md
@@ -24,13 +24,15 @@
 | [Sparse composition](#substitution-composition-tests)       | Unit            |
 | [Generator validation](#property-test-generator-validation) | Property        |
 
-Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs), [`test_marginal_analytical_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs), [`test_marginal_stability_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs)
+Support files (helpers only, no tests): [`packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs)
 
 ---
 
 ## Fitch Parsimony
 
-**File:** [`test_fitch.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs)
+
+**Impl:** [`packages/treetime/src/commands/ancestral/fitch.rs`](../../packages/treetime/src/commands/ancestral/fitch.rs)
 
 | Test                                                       | Purpose                                                     |
 | ---------------------------------------------------------- | ----------------------------------------------------------- |
@@ -48,7 +50,12 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Marginal ML - Dense
 
-**File:** [`test_marginal_dense.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
 
 | Test                                                          | Purpose                                            |
 | ------------------------------------------------------------- | -------------------------------------------------- |
@@ -64,7 +71,12 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Marginal ML - Sparse
 
-**File:** [`test_marginal_sparse.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                                           | Purpose                                           |
 | -------------------------------------------------------------- | ------------------------------------------------- |
@@ -81,7 +93,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Dense/Sparse Equivalence
 
-**Files:** [`test_marginal_dense_sparse_example.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense_sparse_example.rs), [`test_marginal_dense_sparse_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense_sparse_prop.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense_sparse_example.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense_sparse_example.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense_sparse_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense_sparse_prop.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                                      | Purpose                                               | Type                  |
 | --------------------------------------------------------- | ----------------------------------------------------- | --------------------- |
@@ -95,7 +113,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Idempotency Tests
 
-**Files:** [`test_marginal_idempotency_example.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_idempotency_example.rs), [`test_marginal_idempotency_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_idempotency_prop.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_idempotency_example.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_idempotency_example.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_idempotency_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_idempotency_prop.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                       | Purpose                                                           | Type     |
 | ------------------------------------------ | ----------------------------------------------------------------- | -------- |
@@ -110,7 +134,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Normalization Tests
 
-**Files:** [`test_marginal_normalization_example.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_normalization_example.rs), [`test_marginal_normalization_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_normalization_prop.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_normalization_example.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_normalization_example.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_normalization_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_normalization_prop.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                                    | Purpose                                          | Type     |
 | ------------------------------------------------------- | ------------------------------------------------ | -------- |
@@ -127,7 +157,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Root Invariance Tests
 
-**File:** [`test_marginal_root_invariance_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_root_invariance_prop.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_root_invariance_prop.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_root_invariance_prop.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                                     | Purpose                                             | Type                         |
 | -------------------------------------------------------- | --------------------------------------------------- | ---------------------------- |
@@ -142,7 +178,14 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Python v0 Parity Tests
 
-**File:** [`test_python_parity.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/fitch.rs`](../../packages/treetime/src/commands/ancestral/fitch.rs)
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                            | Purpose                                                        |
 | ----------------------------------------------- | -------------------------------------------------------------- |
@@ -159,7 +202,14 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Consistency Tests
 
-**File:** [`test_marginal_consistency.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/fitch.rs`](../../packages/treetime/src/commands/ancestral/fitch.rs)
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 | Test                                                                     | Purpose                                                                 |
 | ------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
@@ -173,7 +223,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Branch Length Tests
 
-**Files:** [`test_marginal_branch_length_equilibrium.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_branch_length/test_marginal_branch_length_equilibrium.rs), [`test_marginal_branch_length_monotonicity.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_branch_length/test_marginal_branch_length_monotonicity.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_branch_length/test_marginal_branch_length_equilibrium.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_branch_length/test_marginal_branch_length_equilibrium.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_branch_length/test_marginal_branch_length_monotonicity.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_branch_length/test_marginal_branch_length_monotonicity.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 ### Equilibrium Convergence
 
@@ -201,7 +257,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Topology Tests
 
-**Files:** [`test_marginal_topology_caterpillar.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_caterpillar.rs), [`test_marginal_topology_deep_tree.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_deep_tree.rs), [`test_marginal_topology_polytomy.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_polytomy.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_caterpillar.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_caterpillar.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_deep_tree.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_deep_tree.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_polytomy.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_topology/test_marginal_topology_polytomy.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 ### Caterpillar Trees
 
@@ -235,7 +297,13 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Stability Tests (Edge Cases)
 
-**Files:** [`test_marginal_stability_extreme_branches.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_extreme_branches.rs), [`test_marginal_stability_near_zero_pi.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_near_zero_pi.rs), [`test_marginal_stability_rapid_transitions.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_rapid_transitions.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_extreme_branches.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_extreme_branches.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_near_zero_pi.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_near_zero_pi.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_rapid_transitions.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_rapid_transitions.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
+- [`packages/treetime/src/representation/partition/marginal_sparse.rs`](../../packages/treetime/src/representation/partition/marginal_sparse.rs)
 
 ### Extreme Branches
 
@@ -272,7 +340,12 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Analytical Verification Tests
 
-**Files:** [`test_marginal_analytical_two_taxon.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_two_taxon.rs), [`test_marginal_analytical_three_taxon.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_three_taxon.rs), [`test_marginal_analytical_star_tree.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_star_tree.rs)
+**Test:** [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_two_taxon.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_two_taxon.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_three_taxon.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_three_taxon.rs), [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_star_tree.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_star_tree.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/ancestral/marginal.rs`](../../packages/treetime/src/commands/ancestral/marginal.rs)
+- [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
 
 ### Two-Taxon
 
@@ -305,7 +378,9 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Softmax with Log-Norm Tests
 
-**File:** [`softmax_with_log_norm.rs`](../../packages/treetime-utils/src/array/softmax_with_log_norm.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime-utils/src/array/softmax_with_log_norm.rs`](../../packages/treetime-utils/src/array/softmax_with_log_norm.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime-utils/src/array/softmax_with_log_norm.rs`](../../packages/treetime-utils/src/array/softmax_with_log_norm.rs)
 
 | Test                                         | Purpose                                                |
 | -------------------------------------------- | ------------------------------------------------------ |
@@ -322,7 +397,9 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Dense Normalize-from-Log Tests
 
-**File:** [`marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
 
 | Test                                                      | Purpose                                                            |
 | --------------------------------------------------------- | ------------------------------------------------------------------ |
@@ -346,7 +423,9 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Substitution Composition Tests
 
-**File:** [`test_mutation.rs`](../../packages/treetime/src/seq/__tests__/test_mutation.rs)
+**Test:** [`packages/treetime/src/seq/__tests__/test_mutation.rs`](../../packages/treetime/src/seq/__tests__/test_mutation.rs)
+
+**Impl:** [`packages/treetime/src/seq/mutation.rs`](../../packages/treetime/src/seq/mutation.rs)
 
 | Test                                                            | Purpose                                          |
 | --------------------------------------------------------------- | ------------------------------------------------ |
@@ -364,7 +443,12 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ### Prune integration tests for composition
 
-**File:** [`test_run.rs`](../../packages/treetime/src/commands/prune/__tests__/test_run.rs)
+**Test:** [`packages/treetime/src/commands/prune/__tests__/test_run.rs`](../../packages/treetime/src/commands/prune/__tests__/test_run.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/prune/run.rs`](../../packages/treetime/src/commands/prune/run.rs)
+- [`packages/treetime/src/seq/mutation.rs`](../../packages/treetime/src/seq/mutation.rs)
 
 | Test                                             | Purpose                                                      |
 | ------------------------------------------------ | ------------------------------------------------------------ |
@@ -418,11 +502,11 @@ Support files (helpers only, no tests): [`prop_marginal_support.rs`](../../packa
 
 ## Support Files (No Tests)
 
-| File                                                                                                                                                           | Purpose                                                                              |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [`prop_marginal_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs)                                                | `run_dense_marginal()`, `run_sparse_marginal()` for property tests                   |
-| [`test_marginal_analytical_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs) | Analytical likelihood formulas and `run_dense_marginal_get_log_lh()`                 |
-| [`test_marginal_stability_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs)    | `assert_dense_profile_stable()`, `assert_sparse_profile_stable()`, partition runners |
+| File                                                                                                                                                                                                                                       | Purpose                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| [`packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs)                                                                         | `run_dense_marginal()`, `run_sparse_marginal()` for property tests                   |
+| [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs) | Analytical likelihood formulas and `run_dense_marginal_get_log_lh()`                 |
+| [`packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs)     | `assert_dense_profile_stable()`, `assert_sparse_profile_stable()`, partition runners |
 
 ---
 

--- a/docs/port-test-inventory/clock.md
+++ b/docs/port-test-inventory/clock.md
@@ -17,7 +17,9 @@
 
 ## Clock Regression
 
-**File:** [`test_clock_regression.rs`](../../packages/treetime/src/commands/clock/__tests__/test_clock_regression.rs)
+**Test:** [`packages/treetime/src/commands/clock/__tests__/test_clock_regression.rs`](../../packages/treetime/src/commands/clock/__tests__/test_clock_regression.rs)
+
+**Impl:** [`packages/treetime/src/commands/clock/clock_regression.rs`](../../packages/treetime/src/commands/clock/clock_regression.rs)
 
 | Test                    | Purpose                                             |
 | ----------------------- | --------------------------------------------------- |
@@ -27,7 +29,9 @@
 
 ## Date Constraints
 
-**File:** [`test_date_constraints.rs`](../../packages/treetime/src/commands/clock/__tests__/test_date_constraints.rs)
+**Test:** [`packages/treetime/src/commands/clock/__tests__/test_date_constraints.rs`](../../packages/treetime/src/commands/clock/__tests__/test_date_constraints.rs)
+
+**Impl:** [`packages/treetime/src/commands/clock/date_constraints.rs`](../../packages/treetime/src/commands/clock/date_constraints.rs)
 
 | Test                                                       | Purpose                               |
 | ---------------------------------------------------------- | ------------------------------------- |
@@ -50,7 +54,9 @@
 
 ## Rerooting
 
-**File:** [`test_reroot.rs`](../../packages/treetime/src/commands/clock/__tests__/test_reroot.rs)
+**Test:** [`packages/treetime/src/commands/clock/__tests__/test_reroot.rs`](../../packages/treetime/src/commands/clock/__tests__/test_reroot.rs)
+
+**Impl:** [`packages/treetime/src/commands/clock/reroot.rs`](../../packages/treetime/src/commands/clock/reroot.rs)
 
 | Test                                                                     | Purpose                              |
 | ------------------------------------------------------------------------ | ------------------------------------ |
@@ -63,7 +69,13 @@
 
 ## Find Best Root
 
-**File:** [`test_find_best_root.rs`](../../packages/treetime/src/commands/clock/find_best_root/__tests__/test_find_best_root.rs)
+**Test:** [`packages/treetime/src/commands/clock/find_best_root/__tests__/test_find_best_root.rs`](../../packages/treetime/src/commands/clock/find_best_root/__tests__/test_find_best_root.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/clock/find_best_root/find_best_root.rs`](../../packages/treetime/src/commands/clock/find_best_root/find_best_root.rs)
+- [`packages/treetime/src/commands/clock/find_best_root/find_best_split.rs`](../../packages/treetime/src/commands/clock/find_best_root/find_best_split.rs)
+- [`packages/treetime/src/commands/clock/find_best_root/params.rs`](../../packages/treetime/src/commands/clock/find_best_root/params.rs)
 
 | Test                                                             | Purpose                                                |
 | ---------------------------------------------------------------- | ------------------------------------------------------ |
@@ -81,7 +93,9 @@
 
 ## Clock Filter
 
-**File:** [`test_clock_filter.rs`](../../packages/treetime/src/commands/clock/__tests__/test_clock_filter.rs)
+**Test:** [`packages/treetime/src/commands/clock/__tests__/test_clock_filter.rs`](../../packages/treetime/src/commands/clock/__tests__/test_clock_filter.rs)
+
+**Impl:** [`packages/treetime/src/commands/clock/clock_filter.rs`](../../packages/treetime/src/commands/clock/clock_filter.rs)
 
 | Test                                                       | Purpose                                                          |
 | ---------------------------------------------------------- | ---------------------------------------------------------------- |
@@ -92,7 +106,15 @@
 
 ## Dengue/100 Pipeline
 
-**File:** [`test_clock_dengue100.rs`](../../packages/treetime/src/commands/clock/__tests__/test_clock_dengue100.rs)
+**Test:** [`packages/treetime/src/commands/clock/__tests__/test_clock_dengue100.rs`](../../packages/treetime/src/commands/clock/__tests__/test_clock_dengue100.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/clock/assign_dates.rs`](../../packages/treetime/src/commands/clock/assign_dates.rs)
+- [`packages/treetime/src/commands/clock/clock_filter.rs`](../../packages/treetime/src/commands/clock/clock_filter.rs)
+- [`packages/treetime/src/commands/clock/clock_model.rs`](../../packages/treetime/src/commands/clock/clock_model.rs)
+- [`packages/treetime/src/commands/clock/clock_regression.rs`](../../packages/treetime/src/commands/clock/clock_regression.rs)
+- [`packages/treetime/src/commands/clock/reroot.rs`](../../packages/treetime/src/commands/clock/reroot.rs)
 
 | Test                                                  | Purpose                                                                        |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------ |

--- a/docs/port-test-inventory/distribution.md
+++ b/docs/port-test-inventory/distribution.md
@@ -30,7 +30,9 @@
 
 **Directory:** [`distribution_core/__tests__/`](../../packages/treetime-distribution/src/distribution_core/__tests__/)
 
-**File:** [`test_distribution.rs`](../../packages/treetime-distribution/src/distribution_core/__tests__/test_distribution.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_core/__tests__/test_distribution.rs`](../../packages/treetime-distribution/src/distribution_core/__tests__/test_distribution.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_core/distribution.rs`](../../packages/treetime-distribution/src/distribution_core/distribution.rs)
 
 | Test                                        | Purpose                        |
 | ------------------------------------------- | ------------------------------ |
@@ -39,7 +41,9 @@
 | `test_distribution_normalize`               | Normalize to max=1             |
 | `test_distribution_normalize_empty_on_zero` | Zero values normalize to Empty |
 
-**File:** [`test_function.rs`](../../packages/treetime-distribution/src/distribution_core/__tests__/test_function.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_core/__tests__/test_function.rs`](../../packages/treetime-distribution/src/distribution_core/__tests__/test_function.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_core/function.rs`](../../packages/treetime-distribution/src/distribution_core/function.rs)
 
 | Test                                          | Purpose                          |
 | --------------------------------------------- | -------------------------------- |
@@ -52,7 +56,9 @@
 
 **Directory:** [`distribution_ops/__tests__/`](../../packages/treetime-distribution/src/distribution_ops/__tests__/)
 
-**File:** [`test_multiply.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/multiply.rs`](../../packages/treetime-distribution/src/distribution_ops/multiply.rs)
 
 | Test                                                            | Purpose                                      |
 | --------------------------------------------------------------- | -------------------------------------------- |
@@ -67,7 +73,9 @@
 
 ### Distribution Operations - Divide
 
-**File:** [`test_divide.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_divide.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_divide.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_divide.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/divide.rs`](../../packages/treetime-distribution/src/distribution_ops/divide.rs)
 
 | Test                                               | Purpose                            |
 | -------------------------------------------------- | ---------------------------------- |
@@ -86,7 +94,9 @@
 
 ### Distribution Operations - Convolve
 
-**File:** [`test_convolve.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_convolve.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_convolve.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_convolve.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/convolve.rs`](../../packages/treetime-distribution/src/distribution_ops/convolve.rs)
 
 | Test                                                   | Purpose                          |
 | ------------------------------------------------------ | -------------------------------- |
@@ -114,7 +124,9 @@
 
 ### Distribution Operations - Negation
 
-**File:** [`test_negation.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_negation.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_negation.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_negation.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/negate.rs`](../../packages/treetime-distribution/src/distribution_ops/negate.rs)
 
 | Test                           | Purpose                          |
 | ------------------------------ | -------------------------------- |
@@ -132,7 +144,9 @@
 
 ### Distribution Operations - Scalar Multiply
 
-**File:** [`test_scalar_multiply.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_scalar_multiply.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_scalar_multiply.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_scalar_multiply.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/scalar_multiply.rs`](../../packages/treetime-distribution/src/distribution_ops/scalar_multiply.rs)
 
 | Test                                                                 | Purpose                        |
 | -------------------------------------------------------------------- | ------------------------------ |
@@ -152,7 +166,9 @@
 
 ### Distribution Operations - Time Bounds
 
-**File:** [`test_time_bounds.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/time_bounds.rs`](../../packages/treetime-distribution/src/distribution_ops/time_bounds.rs)
 
 **Parameterized: `test_distribution_time_bounds_union`**
 
@@ -242,7 +258,9 @@
 
 **Directory:** [`distribution_scaled/__tests__/`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/)
 
-**File:** [`test_distribution_scaled.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_distribution_scaled.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_scaled/__tests__/test_distribution_scaled.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_distribution_scaled.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_scaled/scaled.rs`](../../packages/treetime-distribution/src/distribution_scaled/scaled.rs)
 
 | Test                                             | Purpose                             |
 | ------------------------------------------------ | ----------------------------------- |
@@ -254,7 +272,9 @@
 | `test_scaled_distribution_renormalize`           | Renormalize preserves scale         |
 | `test_scaled_distribution_from_parts`            | Construct from parts                |
 
-**File:** [`test_multiply.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_multiply.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_scaled/__tests__/test_multiply.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_multiply.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_scaled/multiply.rs`](../../packages/treetime-distribution/src/distribution_scaled/multiply.rs)
 
 | Test                                                                    | Purpose                          |
 | ----------------------------------------------------------------------- | -------------------------------- |
@@ -271,7 +291,9 @@
 | `test_scaled_distribution_multiply_many_mixed_types_fallback`           | Mixed types use fallback path    |
 | `test_scaled_distribution_multiply_many_different_grids_fallback`       | Different grids use fallback     |
 
-**File:** [`test_divide.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_divide.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_scaled/__tests__/test_divide.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_divide.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_scaled/divide.rs`](../../packages/treetime-distribution/src/distribution_scaled/divide.rs)
 
 | Test                                                      | Purpose                      |
 | --------------------------------------------------------- | ---------------------------- |
@@ -281,7 +303,9 @@
 | `test_scaled_distribution_divide_inverse_of_multiply`     | (a\*b)/b recovers a          |
 | `test_scaled_distribution_divide_preserves_normalization` | Quotient inner max = 1       |
 
-**File:** [`test_convolve.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_convolve.rs)
+**Test:** [`packages/treetime-distribution/src/distribution_scaled/__tests__/test_convolve.rs`](../../packages/treetime-distribution/src/distribution_scaled/__tests__/test_convolve.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_scaled/convolve.rs`](../../packages/treetime-distribution/src/distribution_scaled/convolve.rs)
 
 | Test                                                        | Purpose                         |
 | ----------------------------------------------------------- | ------------------------------- |
@@ -295,7 +319,13 @@
 
 ### Root-Level Tests
 
-**File:** [`test_gaussian_product.rs`](../../packages/treetime-distribution/src/__tests__/test_gaussian_product.rs)
+**Test:** [`packages/treetime-distribution/src/__tests__/test_gaussian_product.rs`](../../packages/treetime-distribution/src/__tests__/test_gaussian_product.rs)
+
+**Impl:**
+
+- [`packages/treetime-distribution/src/distribution_scaled/scaled.rs`](../../packages/treetime-distribution/src/distribution_scaled/scaled.rs)
+- [`packages/treetime-distribution/src/distribution_scaled/multiply.rs`](../../packages/treetime-distribution/src/distribution_scaled/multiply.rs)
+- [`packages/treetime-distribution/src/distribution_scaled/convolve.rs`](../../packages/treetime-distribution/src/distribution_scaled/convolve.rs)
 
 | Test                                               | Purpose                          |
 | -------------------------------------------------- | -------------------------------- |
@@ -310,7 +340,9 @@
 | `test_gaussian_product_matches_analytical`         | Numerical matches analytical     |
 | `test_gaussian_normalization_preserved`            | Amplitude tracking via log_scale |
 
-**File:** [`test_quantile.rs`](../../packages/treetime-distribution/src/__tests__/test_quantile.rs)
+**Test:** [`packages/treetime-distribution/src/__tests__/test_quantile.rs`](../../packages/treetime-distribution/src/__tests__/test_quantile.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_core/distribution.rs`](../../packages/treetime-distribution/src/distribution_core/distribution.rs)
 
 | Test                                          | Purpose                         |
 | --------------------------------------------- | ------------------------------- |
@@ -331,7 +363,9 @@
 
 **Directory:** [`__tests__/`](../../packages/treetime-analytical/src/__tests__/)
 
-**File:** [`gaussian.rs`](../../packages/treetime-analytical/src/__tests__/gaussian.rs)
+**Test:** [`packages/treetime-analytical/src/__tests__/gaussian.rs`](../../packages/treetime-analytical/src/__tests__/gaussian.rs)
+
+**Impl:** [`packages/treetime-analytical/src/gaussian.rs`](../../packages/treetime-analytical/src/gaussian.rs)
 
 | Test                                         | Purpose                        |
 | -------------------------------------------- | ------------------------------ |
@@ -352,7 +386,9 @@
 
 ### Exponential (inline tests)
 
-**File:** [`exponential.rs`](../../packages/treetime-analytical/src/exponential.rs)
+**Test:** [`packages/treetime-analytical/src/exponential.rs`](../../packages/treetime-analytical/src/exponential.rs)
+
+**Impl:** [`packages/treetime-analytical/src/exponential.rs`](../../packages/treetime-analytical/src/exponential.rs)
 
 | Test                                          | Purpose                        |
 | --------------------------------------------- | ------------------------------ |
@@ -368,7 +404,9 @@
 
 ### Gaussian-Exponential (inline tests)
 
-**File:** [`gaussian_exponential.rs`](../../packages/treetime-analytical/src/gaussian_exponential.rs)
+**Test:** [`packages/treetime-analytical/src/gaussian_exponential.rs`](../../packages/treetime-analytical/src/gaussian_exponential.rs)
+
+**Impl:** [`packages/treetime-analytical/src/gaussian_exponential.rs`](../../packages/treetime-analytical/src/gaussian_exponential.rs)
 
 | Test                                               | Purpose                      |
 | -------------------------------------------------- | ---------------------------- |
@@ -382,7 +420,9 @@
 
 **Directory:** [`__tests__/`](../../packages/treetime-ops/src/__tests__/)
 
-**File:** [`multiplication.rs`](../../packages/treetime-ops/src/__tests__/multiplication.rs)
+**Test:** [`packages/treetime-ops/src/__tests__/multiplication.rs`](../../packages/treetime-ops/src/__tests__/multiplication.rs)
+
+**Impl:** [`packages/treetime-ops/src/multiplication.rs`](../../packages/treetime-ops/src/multiplication.rs)
 
 | Test                                                  | Purpose                       |
 | ----------------------------------------------------- | ----------------------------- |
@@ -396,7 +436,9 @@
 
 ### Convolution (inline tests)
 
-**File:** [`convolution.rs`](../../packages/treetime-ops/src/convolution.rs)
+**Test:** [`packages/treetime-ops/src/convolution.rs`](../../packages/treetime-ops/src/convolution.rs)
+
+**Impl:** [`packages/treetime-ops/src/convolution.rs`](../../packages/treetime-ops/src/convolution.rs)
 
 | Test                               | Purpose                         |
 | ---------------------------------- | ------------------------------- |

--- a/docs/port-test-inventory/gtr.md
+++ b/docs/port-test-inventory/gtr.md
@@ -37,7 +37,12 @@ Property tests use proptest with random inputs. Generator tests use smaller samp
 
 ## Golden-Master Model Tests
 
-**File:** [`test_gm_gtr.rs`](../../packages/treetime/src/gtr/__tests__/test_gm_gtr.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gm_gtr.rs`](../../packages/treetime/src/gtr/__tests__/test_gm_gtr.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 Validates Rust v1 GTR model construction against Python v0 reference outputs.
 
@@ -58,7 +63,9 @@ Validates Rust v1 GTR model construction against Python v0 reference outputs.
 
 ## Matrix Exponentiation Properties
 
-**File:** [`test_prop_gtr_expqt.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_expqt.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_expqt.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_expqt.rs)
+
+**Impl:** [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 Verifies P(t) = exp(Qt) mathematical invariants.
 
@@ -77,7 +84,9 @@ Verifies P(t) = exp(Qt) mathematical invariants.
 
 ## Eigendecomposition Properties
 
-**File:** [`test_prop_gtr_eigen.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_eigen.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_eigen.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_eigen.rs)
+
+**Impl:** [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 Verifies eigendecomposition invariants.
 
@@ -91,7 +100,12 @@ Verifies eigendecomposition invariants.
 
 ## Q Matrix Properties
 
-**File:** [`test_prop_gtr_q.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_q.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_q.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_q.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
 
 Verifies rate matrix Q invariants.
 
@@ -110,7 +124,9 @@ Verifies rate matrix Q invariants.
 
 ## Numerical Stability Properties
 
-**File:** [`test_prop_gtr_numerical.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_numerical.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_numerical.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_numerical.rs)
+
+**Impl:** [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 Verifies no NaN/Inf and valid outputs.
 
@@ -127,7 +143,12 @@ Verifies no NaN/Inf and valid outputs.
 
 ### Branch Length
 
-**File:** [`test_gtr_numerical_edge_branch_length.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_branch_length.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_branch_length.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_branch_length.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
 
 | Test                                 | Scenario  | Expected                        |
 | ------------------------------------ | --------- | ------------------------------- |
@@ -139,7 +160,12 @@ Verifies no NaN/Inf and valid outputs.
 
 ### Extreme Parameters
 
-**File:** [`test_gtr_numerical_edge_extreme_parameters.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_extreme_parameters.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_extreme_parameters.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_extreme_parameters.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
 
 | Test                                    | Parameter | Edge Value                    | Notes            |
 | --------------------------------------- | --------- | ----------------------------- | ---------------- |
@@ -153,7 +179,12 @@ Verifies no NaN/Inf and valid outputs.
 
 ### Parameterized Edge Cases
 
-**File:** [`test_gtr_numerical_edge_parameterized.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_parameterized.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_parameterized.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_parameterized.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
 
 | Test                                 | Parameter Range         |
 | ------------------------------------ | ----------------------- |
@@ -165,7 +196,12 @@ Verifies no NaN/Inf and valid outputs.
 
 ## Model Hierarchy Tests
 
-**File:** [`test_gtr_hierarchy_model_relationships.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_hierarchy/test_gtr_hierarchy_model_relationships.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gtr_hierarchy/test_gtr_hierarchy_model_relationships.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_hierarchy/test_gtr_hierarchy_model_relationships.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 Verifies nested model relationships:
 
@@ -184,7 +220,12 @@ JC69 ----> K80 ----> HKY85 ----> TN93 ----> GTR
 | `test_gtr_hky85_equals_tn93_equal_transitions` | HKY85 = TN93 | kappa1 = 0.5, kappa2 = 1 |
 | `test_gtr_tn93_equals_gtr_with_structured_w`   | TN93 = GTR   | W with TN93 structure    |
 
-**File:** [`test_gtr_hierarchy_additional_verification.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_hierarchy/test_gtr_hierarchy_additional_verification.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gtr_hierarchy/test_gtr_hierarchy_additional_verification.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_hierarchy/test_gtr_hierarchy_additional_verification.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
+- [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 | Test                                  | Verification                     |
 | ------------------------------------- | -------------------------------- |
@@ -196,7 +237,9 @@ JC69 ----> K80 ----> HKY85 ----> TN93 ----> GTR
 
 ## Generator Validation
 
-**File:** [`generators.rs`](../../packages/treetime/src/gtr/__tests__/generators.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/generators.rs`](../../packages/treetime/src/gtr/__tests__/generators.rs)
+
+**Impl:** [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 Validates that proptest generators produce valid outputs.
 
@@ -216,7 +259,9 @@ Validates that proptest generators produce valid outputs.
 
 ### Golden-Master
 
-**File:** [`test_gm_infer_gtr_dense.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs)
+
+**Impl:** [`packages/treetime/src/gtr/infer_gtr/dense.rs`](../../packages/treetime/src/gtr/infer_gtr/dense.rs)
 
 | Test                                | Datasets                                                                                                   |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
@@ -230,7 +275,12 @@ Validates that proptest generators produce valid outputs.
 
 ### Unit Tests
 
-**File:** [`test_dense.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/infer_gtr/dense.rs`](../../packages/treetime/src/gtr/infer_gtr/dense.rs)
+- [`packages/treetime/src/gtr/infer_gtr/common.rs`](../../packages/treetime/src/gtr/infer_gtr/common.rs)
 
 | Test                                 | Purpose                                     |
 | ------------------------------------ | ------------------------------------------- |
@@ -244,7 +294,12 @@ Validates that proptest generators produce valid outputs.
 
 ## GTR Inference Tests - Sparse
 
-**File:** [`test_sparse.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/infer_gtr/sparse.rs`](../../packages/treetime/src/gtr/infer_gtr/sparse.rs)
+- [`packages/treetime/src/gtr/infer_gtr/common.rs`](../../packages/treetime/src/gtr/infer_gtr/common.rs)
 
 | Test                              | Purpose                                      |
 | --------------------------------- | -------------------------------------------- |
@@ -255,7 +310,12 @@ Validates that proptest generators produce valid outputs.
 
 ## Inference Contract Tests
 
-**File:** [`test_contract.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/infer_gtr/dense.rs`](../../packages/treetime/src/gtr/infer_gtr/dense.rs)
+- [`packages/treetime/src/gtr/infer_gtr/sparse.rs`](../../packages/treetime/src/gtr/infer_gtr/sparse.rs)
 
 Verifies mutation count invariants across dense and sparse paths.
 
@@ -281,7 +341,12 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Dense-Sparse Cross-Validation
 
-**File:** [`test_contract_dense_sparse_real.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/infer_gtr/dense.rs`](../../packages/treetime/src/gtr/infer_gtr/dense.rs)
+- [`packages/treetime/src/gtr/infer_gtr/sparse.rs`](../../packages/treetime/src/gtr/infer_gtr/sparse.rs)
 
 | Test                                  | Datasets                                                                        |
 | ------------------------------------- | ------------------------------------------------------------------------------- |
@@ -297,7 +362,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Common Functions
 
-**File:** [`test_common.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_common.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_common.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_common.rs)
+
+**Impl:** [`packages/treetime/src/gtr/infer_gtr/common.rs`](../../packages/treetime/src/gtr/infer_gtr/common.rs)
 
 | Test                              | Purpose                                  |
 | --------------------------------- | ---------------------------------------- |
@@ -312,7 +379,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## GTR Output Tests
 
-**File:** [`test_write_gtr_json.rs`](../../packages/treetime/src/gtr/__tests__/test_write_gtr_json.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_write_gtr_json.rs`](../../packages/treetime/src/gtr/__tests__/test_write_gtr_json.rs)
+
+**Impl:** [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs)
 
 | Test                                               | Purpose                                                 |
 | -------------------------------------------------- | ------------------------------------------------------- |
@@ -323,7 +392,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Jukes-Cantor Distance Correction
 
-**File:** [`jc_distance.rs`](../../packages/treetime/src/gtr/jc_distance.rs)
+**Test:** [`packages/treetime/src/gtr/jc_distance.rs`](../../packages/treetime/src/gtr/jc_distance.rs)
+
+**Impl:** [`packages/treetime/src/gtr/jc_distance.rs`](../../packages/treetime/src/gtr/jc_distance.rs)
 
 | Test                                                           | Purpose                                                      |
 | -------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -343,7 +414,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ### Property Tests
 
-**File:** [`test_prop_gtr_site_specific.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs)
+
+**Impl:** [`packages/treetime/src/gtr/gtr_site_specific.rs`](../../packages/treetime/src/gtr/gtr_site_specific.rs)
 
 | Test                                                        | Purpose                                              | Notes              |
 | ----------------------------------------------------------- | ---------------------------------------------------- | ------------------ |
@@ -369,7 +442,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ### Unit + Validation Tests
 
-**File:** [`test_prop_gtr_site_specific.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs) (same file)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs) (same file)
+
+**Impl:** [`packages/treetime/src/gtr/gtr_site_specific.rs`](../../packages/treetime/src/gtr/gtr_site_specific.rs)
 
 | Test                                                | Purpose                                       |
 | --------------------------------------------------- | --------------------------------------------- |
@@ -381,7 +456,12 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ### Golden-Master Tests
 
-**File:** [`test_gm_gtr_site_specific.rs`](../../packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs`](../../packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/gtr/gtr_site_specific.rs`](../../packages/treetime/src/gtr/gtr_site_specific.rs)
+- [`packages/treetime/src/gtr/infer_gtr/site_specific.rs`](../../packages/treetime/src/gtr/infer_gtr/site_specific.rs)
 
 | Test                                         | Tolerance | Purpose                                            | Notes                         |
 | -------------------------------------------- | --------- | -------------------------------------------------- | ----------------------------- |
@@ -394,7 +474,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Site-Specific GTR Inference Tests
 
-**File:** [`test_site_specific.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_site_specific.rs)
+**Test:** [`packages/treetime/src/gtr/infer_gtr/__tests__/test_site_specific.rs`](../../packages/treetime/src/gtr/infer_gtr/__tests__/test_site_specific.rs)
+
+**Impl:** [`packages/treetime/src/gtr/infer_gtr/site_specific.rs`](../../packages/treetime/src/gtr/infer_gtr/site_specific.rs)
 
 | Test                                                | Purpose                                         | Notes                          |
 | --------------------------------------------------- | ----------------------------------------------- | ------------------------------ |
@@ -405,7 +487,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Site-Rate Variation
 
-**File:** [`site_rate_variation.rs`](../../packages/treetime/src/gtr/site_rate_variation.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/gtr/site_rate_variation.rs`](../../packages/treetime/src/gtr/site_rate_variation.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/gtr/site_rate_variation.rs`](../../packages/treetime/src/gtr/site_rate_variation.rs)
 
 | Test                                                      | Purpose                                                        | Notes               |
 | --------------------------------------------------------- | -------------------------------------------------------------- | ------------------- |
@@ -425,7 +509,9 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Site-Rate Variation Property Tests
 
-**File:** [`test_prop_gtr_site_rates.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_site_rates.rs)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_prop_gtr_site_rates.rs`](../../packages/treetime/src/gtr/__tests__/test_prop_gtr_site_rates.rs)
+
+**Impl:** [`packages/treetime/src/gtr/gtr.rs`](../../packages/treetime/src/gtr/gtr.rs)
 
 | Test                                              | Purpose                                                             |
 | ------------------------------------------------- | ------------------------------------------------------------------- |
@@ -447,8 +533,8 @@ Verifies mutation count invariants across dense and sparse paths.
 
 ## Shared Test Support
 
-**File:** [`prop_support.rs`](../../packages/treetime/src/gtr/__tests__/prop_support.rs) - Proptest assertion helpers (`prop_assert_columns_sum_to`, `prop_assert_rows_sum_to`, `prop_assert_detailed_balance`)
+**Test:** [`packages/treetime/src/gtr/__tests__/prop_support.rs`](../../packages/treetime/src/gtr/__tests__/prop_support.rs) - Proptest assertion helpers (`prop_assert_columns_sum_to`, `prop_assert_rows_sum_to`, `prop_assert_detailed_balance`)
 
-**File:** [`test_gtr_numerical_edge_support.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_support.rs) - Stochastic matrix assertion helper (`assert_stochastic_matrix`)
+**Test:** [`packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_support.rs`](../../packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_support.rs) - Stochastic matrix assertion helper (`assert_stochastic_matrix`)
 
-**File:** [`site_specific_support.rs`](../../packages/treetime/src/gtr/__tests__/site_specific_support.rs) - `simulate_counts()`, `value_to_array2()`, `value_to_array3()`
+**Test:** [`packages/treetime/src/gtr/__tests__/site_specific_support.rs`](../../packages/treetime/src/gtr/__tests__/site_specific_support.rs) - `simulate_counts()`, `value_to_array2()`, `value_to_array3()`

--- a/docs/port-test-inventory/mugration.md
+++ b/docs/port-test-inventory/mugration.md
@@ -18,7 +18,13 @@
 
 ## Golden Master (v0 parity)
 
-**File:** [`test_gm_mugration.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs)
+**Test:** [`packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/mugration/run.rs`](../../packages/treetime/src/commands/mugration/run.rs)
+- [`packages/treetime/src/commands/mugration/input.rs`](../../packages/treetime/src/commands/mugration/input.rs)
+- [`packages/treetime/src/commands/mugration/output.rs`](../../packages/treetime/src/commands/mugration/output.rs)
 
 | Test                                      | Datasets                                   | Notes                                                                            |
 | ----------------------------------------- | ------------------------------------------ | -------------------------------------------------------------------------------- |
@@ -31,7 +37,9 @@
 
 ## Structural / Unit
 
-**File:** [`test_run.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_run.rs)
+**Test:** [`packages/treetime/src/commands/mugration/__tests__/test_run.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_run.rs)
+
+**Impl:** [`packages/treetime/src/commands/mugration/run.rs`](../../packages/treetime/src/commands/mugration/run.rs)
 
 | Test                                                                    | Purpose                                                       |
 | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
@@ -56,7 +64,9 @@
 
 ## Algorithm Invariants
 
-**File:** [`test_run.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_run.rs) (same file)
+**Test:** [`packages/treetime/src/commands/mugration/__tests__/test_run.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_run.rs) (same file)
+
+**Impl:** [`packages/treetime/src/commands/mugration/run.rs`](../../packages/treetime/src/commands/mugration/run.rs)
 
 | Test                                           | Purpose                                            |
 | ---------------------------------------------- | -------------------------------------------------- |
@@ -68,7 +78,9 @@
 
 ## Discrete Marginal
 
-**File:** [`test_discrete_marginal.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_discrete_marginal.rs)
+**Test:** [`packages/treetime/src/commands/mugration/__tests__/test_discrete_marginal.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_discrete_marginal.rs)
+
+**Impl:** [`packages/treetime/src/commands/mugration/discrete_marginal.rs`](../../packages/treetime/src/commands/mugration/discrete_marginal.rs)
 
 | Test                                                                               | Purpose                                          |
 | ---------------------------------------------------------------------------------- | ------------------------------------------------ |
@@ -82,7 +94,9 @@
 
 ## Comment Output
 
-**File:** [`test_comment_output.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_comment_output.rs)
+**Test:** [`packages/treetime/src/commands/mugration/__tests__/test_comment_output.rs`](../../packages/treetime/src/commands/mugration/__tests__/test_comment_output.rs)
+
+**Impl:** [`packages/treetime/src/commands/mugration/comment_provider.rs`](../../packages/treetime/src/commands/mugration/comment_provider.rs)
 
 | Test                                               | Purpose                                         |
 | -------------------------------------------------- | ----------------------------------------------- |
@@ -92,7 +106,9 @@
 
 ## Brent Optimizer
 
-**File:** [`gtr_refinement.rs`](../../packages/treetime/src/commands/mugration/gtr_refinement.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/commands/mugration/gtr_refinement.rs`](../../packages/treetime/src/commands/mugration/gtr_refinement.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/commands/mugration/gtr_refinement.rs`](../../packages/treetime/src/commands/mugration/gtr_refinement.rs)
 
 | Test                                            | Purpose                            |
 | ----------------------------------------------- | ---------------------------------- |
@@ -105,7 +121,9 @@
 
 ## Partition / Discrete
 
-**File:** [`discrete.rs`](../../packages/treetime/src/representation/partition/discrete.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/partition/discrete.rs`](../../packages/treetime/src/representation/partition/discrete.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/partition/discrete.rs`](../../packages/treetime/src/representation/partition/discrete.rs)
 
 | Test                                                   | Purpose                                     |
 | ------------------------------------------------------ | ------------------------------------------- |

--- a/docs/port-test-inventory/optimization.md
+++ b/docs/port-test-inventory/optimization.md
@@ -44,7 +44,12 @@
 
 ### Basic Tests
 
-**File:** [`test_coefficient_extraction_dense_basic.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_basic.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_basic.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_basic.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs)
 
 | Test                                              | Purpose                          |
 | ------------------------------------------------- | -------------------------------- |
@@ -56,7 +61,9 @@
 
 ### GTR Model Tests
 
-**File:** [`test_coefficient_extraction_dense_gtr.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_gtr.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_gtr.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_gtr.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
 
 | Test                                              | Purpose                          |
 | ------------------------------------------------- | -------------------------------- |
@@ -65,7 +72,9 @@
 
 ### Partition Tests
 
-**File:** [`test_coefficient_extraction_dense_partition.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_partition.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_partition.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_partition.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
 
 | Test                              | Purpose                           |
 | --------------------------------- | --------------------------------- |
@@ -73,7 +82,9 @@
 
 ### Position Tests
 
-**File:** [`test_coefficient_extraction_dense_positions.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_positions.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_positions.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_positions.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
 
 | Test                                       | Purpose                          |
 | ------------------------------------------ | -------------------------------- |
@@ -82,7 +93,12 @@
 
 ### Properties Tests
 
-**File:** [`test_coefficient_extraction_dense_properties.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs)
 
 | Test                                                          | Purpose                            |
 | ------------------------------------------------------------- | ---------------------------------- |
@@ -92,7 +108,14 @@
 
 ### Property Invariants
 
-**File:** [`test_coefficient_extraction_dense_prop_invariants.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_prop_invariants.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_prop_invariants.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_prop_invariants.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 | Test                                                               | Purpose                                                                            | Notes                 |
 | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------- | --------------------- |
@@ -108,7 +131,7 @@
 
 ### Support
 
-**File:** [`test_coefficient_extraction_dense_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_support.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_support.rs)
 
 Helper file. Provides `make_dense_seq_dis()`. No tests.
 
@@ -116,7 +139,14 @@ Helper file. Provides `make_dense_seq_dis()`. No tests.
 
 ## Coefficient Extraction - Dense Invariants
 
-**File:** [`test_coefficient_extraction_dense_invariants.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_invariants.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_invariants.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_invariants.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 Parameterized invariant tests using rstest.
 
@@ -135,7 +165,9 @@ Parameterized invariant tests using rstest.
 
 ### Site Tests
 
-**File:** [`test_coefficient_extraction_sparse_site.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_site.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_site.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_site.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
 
 | Test                                                          | Purpose                         |
 | ------------------------------------------------------------- | ------------------------------- |
@@ -144,7 +176,12 @@ Parameterized invariant tests using rstest.
 
 ### Coefficients Tests
 
-**File:** [`test_coefficient_extraction_sparse_coefficients.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_coefficients.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_coefficients.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_coefficients.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 | Test                                                       | Purpose                      |
 | ---------------------------------------------------------- | ---------------------------- |
@@ -154,7 +191,14 @@ Parameterized invariant tests using rstest.
 
 ### Derivatives Tests
 
-**File:** [`test_coefficient_extraction_sparse_derivatives.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_dense_eval.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 | Test                                                                 | Purpose                                         |
 | -------------------------------------------------------------------- | ----------------------------------------------- |
@@ -166,7 +210,12 @@ Parameterized invariant tests using rstest.
 
 ### Eigenvalues Tests
 
-**File:** [`test_coefficient_extraction_sparse_eigenvalues.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_eigenvalues.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_eigenvalues.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_eigenvalues.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 | Test                                               | Purpose                          |
 | -------------------------------------------------- | -------------------------------- |
@@ -175,7 +224,12 @@ Parameterized invariant tests using rstest.
 
 ### Evaluate Tests
 
-**File:** [`test_coefficient_extraction_sparse_evaluate.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_evaluate.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_evaluate.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_evaluate.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 | Test                                               | Purpose                     |
 | -------------------------------------------------- | --------------------------- |
@@ -186,7 +240,12 @@ Parameterized invariant tests using rstest.
 
 ### Mixed Sites Tests
 
-**File:** [`test_coefficient_extraction_sparse_mixed_sites.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_mixed_sites.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_mixed_sites.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_mixed_sites.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse_eval.rs)
 
 | Test                                               | Purpose                        |
 | -------------------------------------------------- | ------------------------------ |
@@ -195,7 +254,9 @@ Parameterized invariant tests using rstest.
 
 ### Partition Tests
 
-**File:** [`test_coefficient_extraction_sparse_partition.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_partition.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_partition.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_partition.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
 
 | Test                                                        | Purpose                       |
 | ----------------------------------------------------------- | ----------------------------- |
@@ -212,7 +273,9 @@ Parameterized invariant tests using rstest.
 
 ### Iteration Tests
 
-**File:** [`test_newton_convergence_iteration.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                            | Purpose                   |
 | ----------------------------------------------- | ------------------------- |
@@ -221,7 +284,12 @@ Parameterized invariant tests using rstest.
 
 ### Tolerance Tests
 
-**File:** [`test_newton_convergence_tolerance.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_tolerance.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/method_newton.rs`](../../packages/treetime/src/commands/optimize/method_newton.rs)
 
 | Test                                                     | Purpose                                    |
 | -------------------------------------------------------- | ------------------------------------------ |
@@ -234,7 +302,9 @@ Parameterized invariant tests using rstest.
 
 ### Evaluate Mixed Tests
 
-**File:** [`test_newton_convergence_evaluate_mixed.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_evaluate_mixed.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_evaluate_mixed.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_evaluate_mixed.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                          | Purpose                       |
 | --------------------------------------------- | ----------------------------- |
@@ -244,7 +314,7 @@ Parameterized invariant tests using rstest.
 
 ### Support
 
-**File:** [`test_newton_convergence_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_support.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_newton_convergence/test_newton_convergence_support.rs)
 
 Helper file. Provides `make_dense_contribution()`. No tests.
 
@@ -256,7 +326,9 @@ Helper file. Provides `make_dense_contribution()`. No tests.
 
 ### Basic Tests
 
-**File:** [`test_grid_search_basic.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_basic.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_basic.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_basic.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                        | Purpose                     |
 | ------------------------------------------- | --------------------------- |
@@ -267,7 +339,9 @@ Helper file. Provides `make_dense_contribution()`. No tests.
 
 ### Edge Cases Tests
 
-**File:** [`test_grid_search_edge_cases.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_edge_cases.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_edge_cases.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_edge_cases.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                | Purpose                      |
 | --------------------------------------------------- | ---------------------------- |
@@ -276,7 +350,9 @@ Helper file. Provides `make_dense_contribution()`. No tests.
 
 ### Partitions Tests
 
-**File:** [`test_grid_search_partitions.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_partitions.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_partitions.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_partitions.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                    | Purpose                         |
 | --------------------------------------- | ------------------------------- |
@@ -285,7 +361,9 @@ Helper file. Provides `make_dense_contribution()`. No tests.
 
 ### Coverage Tests
 
-**File:** [`test_grid_search_coverage.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_coverage.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                                  | Purpose                                                  |
 | --------------------------------------------------------------------- | -------------------------------------------------------- |
@@ -298,7 +376,7 @@ Helper file. Provides `make_dense_contribution()`. No tests.
 
 ### Support
 
-**File:** [`test_grid_search_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_support.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_grid_search/test_grid_search_support.rs)
 
 Helper file. Provides `make_dense_contribution()` and `grid_search()`. No tests.
 
@@ -312,7 +390,9 @@ Helper file. Provides `make_dense_contribution()` and `grid_search()`. No tests.
 
 ### Initial Tests
 
-**File:** [`test_dense_sparse_equivalence_initial.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                          | Purpose                      |
 | ------------------------------------------------------------- | ---------------------------- |
@@ -321,7 +401,9 @@ Helper file. Provides `make_dense_contribution()` and `grid_search()`. No tests.
 
 ### Convergence Tests
 
-**File:** [`test_dense_sparse_equivalence_convergence.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_convergence.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_convergence.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_convergence.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                 | Purpose               |
 | ------------------------------------ | --------------------- |
@@ -330,7 +412,9 @@ Helper file. Provides `make_dense_contribution()` and `grid_search()`. No tests.
 
 ### Bounds Tests
 
-**File:** [`test_dense_sparse_equivalence_bounds.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_bounds.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_bounds.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_bounds.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                             | Purpose                    |
 | ---------------------------------------------------------------- | -------------------------- |
@@ -339,7 +423,9 @@ Helper file. Provides `make_dense_contribution()` and `grid_search()`. No tests.
 
 ### Validity Tests
 
-**File:** [`test_dense_sparse_equivalence_validity.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_validity.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_validity.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_validity.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                              | Purpose                       |
 | ------------------------------------------------- | ----------------------------- |
@@ -348,7 +434,7 @@ Helper file. Provides `make_dense_contribution()` and `grid_search()`. No tests.
 
 ### Support
 
-**File:** [`test_dense_sparse_equivalence_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs)
 
 Helper file. Provides `setup_dense_only()`, `setup_sparse_only()`, `get_branch_lengths()`, `gap_free_alignment()`. No tests.
 
@@ -362,7 +448,9 @@ Helper file. Provides `setup_dense_only()`, `setup_sparse_only()`, `get_branch_l
 
 ### Iterations Tests
 
-**File:** [`test_convergence_iterations.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_iterations.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_iterations.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_iterations.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                 | Purpose                                                   | Notes                         |
 | ---------------------------------------------------- | --------------------------------------------------------- | ----------------------------- |
@@ -372,7 +460,9 @@ Helper file. Provides `setup_dense_only()`, `setup_sparse_only()`, `get_branch_l
 
 ### Edge Cases Tests
 
-**File:** [`test_convergence_edge_cases.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_edge_cases.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_edge_cases.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_edge_cases.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                            | Purpose                      |
 | ----------------------------------------------- | ---------------------------- |
@@ -382,7 +472,9 @@ Helper file. Provides `setup_dense_only()`, `setup_sparse_only()`, `get_branch_l
 
 ### Idempotence Tests
 
-**File:** [`test_convergence_idempotence.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_idempotence.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_idempotence.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_idempotence.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                    | Purpose                        |
 | ------------------------------------------------------- | ------------------------------ |
@@ -391,7 +483,7 @@ Helper file. Provides `setup_dense_only()`, `setup_sparse_only()`, `get_branch_l
 
 ### Support
 
-**File:** [`test_convergence_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs)
 
 Helper file. Provides `simple_alignment()`, `setup_partitions()`, `compute_total_lh()`. No tests.
 
@@ -401,7 +493,9 @@ Helper file. Provides `simple_alignment()`, `setup_partitions()`, `compute_total
 
 > **Note**: `test_damped_optimization_converges` and `test_damped_optimization_does_not_regress` are parameterized across 6 `BranchOptMethod` variants.
 
-**File:** [`test_damping.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_damping.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_damping.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_damping.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                                     | Purpose                                                                           |
 | -------------------------------------------------------- | --------------------------------------------------------------------------------- |
@@ -417,7 +511,12 @@ Helper file. Provides `simple_alignment()`, `setup_partitions()`, `compute_total
 
 ## v0 Parity and Damped vs Undamped (Golden Master)
 
-**File:** [`test_gm_optimize.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                  | Purpose                                                        | Notes                                          |
 | ------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------- |
@@ -434,7 +533,9 @@ Fixtures in `__fixtures__/`:
 
 ## Run Optimize Loop Contract
 
-**File:** [`test_run_optimize_loop.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_run_optimize_loop.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_run_optimize_loop.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_run_optimize_loop.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                              | Purpose                                                  |
 | ------------------------------------------------- | -------------------------------------------------------- |
@@ -448,7 +549,9 @@ Fixtures in `__fixtures__/`:
 
 ## Convergence Conditions
 
-**File:** [`test_convergence_conditions.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence_conditions.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_convergence_conditions.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence_conditions.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                                                    | Purpose                                                |
 | ----------------------------------------------------------------------- | ------------------------------------------------------ |
@@ -465,7 +568,12 @@ Fixtures in `__fixtures__/`:
 
 ## Convergence on Real Datasets
 
-**File:** [`test_convergence_sc2.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                                | Purpose                                              |
 | --------------------------------------------------- | ---------------------------------------------------- |
@@ -476,7 +584,9 @@ Fixtures in `__fixtures__/`:
 
 ## Optimization Metrics
 
-**File:** [`test_optimization_metrics.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimization_metrics.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_optimization_metrics.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimization_metrics.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                 | Purpose                       |
 | ---------------------------------------------------- | ----------------------------- |
@@ -492,7 +602,13 @@ Fixtures in `__fixtures__/`:
 
 ## Zero Branch Optimal
 
-**File:** [`test_is_zero_branch_optimal.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_is_zero_branch_optimal.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_is_zero_branch_optimal.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_is_zero_branch_optimal.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_sparse.rs`](../../packages/treetime/src/commands/optimize/optimize_sparse.rs)
 
 | Test                                                                    | Purpose                          |
 | ----------------------------------------------------------------------- | -------------------------------- |
@@ -514,7 +630,13 @@ Fixtures in `__fixtures__/`:
 
 ## Initial Guess Mode
 
-**File:** [`test_initial_guess_mode.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_mode.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_initial_guess_mode.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_mode.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
+- [`packages/treetime/src/commands/optimize/args.rs`](../../packages/treetime/src/commands/optimize/args.rs)
 
 | Test                                                            | Purpose                                                                 |
 | --------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -539,7 +661,9 @@ Fixtures in `__fixtures__/`:
 
 ## Initial Guess Indel Zero-BL
 
-**File:** [`test_initial_guess_indel_zero_bl.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_indel_zero_bl.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_initial_guess_indel_zero_bl.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_indel_zero_bl.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                                       | Purpose                                            |
 | ---------------------------------------------------------- | -------------------------------------------------- |
@@ -550,7 +674,9 @@ Fixtures in `__fixtures__/`:
 
 ## Initial Guess GTR Messages
 
-**File:** [`test_initial_guess_gtr_messages.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gtr_messages.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gtr_messages.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gtr_messages.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                             | Purpose                                                       |
 | ------------------------------------------------ | ------------------------------------------------------------- |
@@ -561,7 +687,12 @@ Fixtures in `__fixtures__/`:
 
 ## Initial Guess Formula
 
-**File:** [`test_initial_guess_formula.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/partition_ops.rs`](../../packages/treetime/src/commands/optimize/partition_ops.rs)
 
 | Test                                                                                 | Purpose                                                                                  |
 | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
@@ -574,7 +705,9 @@ Fixtures in `__fixtures__/`:
 
 ## Initial Guess Gaps
 
-**File:** [`test_initial_guess_gaps.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
 
 | Test                                           | Purpose                                                                     |
 | ---------------------------------------------- | --------------------------------------------------------------------------- |
@@ -590,7 +723,9 @@ Fixtures in `__fixtures__/`:
 
 ## Dense Edge Subs
 
-**File:** [`test_dense_edge_subs.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_edge_subs.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dense_edge_subs.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dense_edge_subs.rs)
+
+**Impl:** [`packages/treetime/src/representation/partition/marginal_dense.rs`](../../packages/treetime/src/representation/partition/marginal_dense.rs)
 
 | Test                                                                 | Purpose                                                                         |
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
@@ -604,7 +739,12 @@ Fixtures in `__fixtures__/`:
 
 ## Eval Zero-Branch Mismatch
 
-**File:** [`test_eval_zero_branch_mismatch.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                    | Purpose                                                                                 |
 | --------------------------------------- | --------------------------------------------------------------------------------------- |
@@ -616,7 +756,12 @@ Fixtures in `__fixtures__/`:
 
 > **Note**: `test_optimize_loop_with_topology_cleanup_sparse`, `test_optimize_loop_no_collapse_when_branches_nonzero`, and `test_optimize_loop_with_topology_cleanup_dense` are parameterized across 6 `BranchOptMethod` variants.
 
-**File:** [`test_topology_cleanup.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                                               | Purpose                                                    |
 | ------------------------------------------------------------------ | ---------------------------------------------------------- |
@@ -634,7 +779,7 @@ Fixtures in `__fixtures__/`:
 | `test_optimize_loop_with_topology_cleanup_dense`                   | Dense-mode full loop with topology cleanup                 |
 
 Direct coverage for `collapse_edge()` lives with the shared implementation in
-[`test_collapse_edge.rs`](../../packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs):
+[`packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs`](../../packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs):
 
 | Test                                                      | Purpose                                                             |
 | --------------------------------------------------------- | ------------------------------------------------------------------- |
@@ -651,7 +796,9 @@ Direct coverage for `collapse_edge()` lives with the shared implementation in
 
 ## Indel Contribution (Inline)
 
-**File:** [`optimize_indel.rs`](../../packages/treetime/src/commands/optimize/optimize_indel.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/commands/optimize/optimize_indel.rs`](../../packages/treetime/src/commands/optimize/optimize_indel.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/commands/optimize/optimize_indel.rs`](../../packages/treetime/src/commands/optimize/optimize_indel.rs)
 
 | Test                                                        | Purpose                                                           |
 | ----------------------------------------------------------- | ----------------------------------------------------------------- |
@@ -668,7 +815,14 @@ Direct coverage for `collapse_edge()` lives with the shared implementation in
 
 ## Indel Contribution (Integration)
 
-**File:** [`test_optimize_indel.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_indel.rs`](../../packages/treetime/src/commands/optimize/optimize_indel.rs)
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                                                  | Purpose                                                                        |
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
@@ -697,7 +851,15 @@ Direct coverage for `collapse_edge()` lives with the shared implementation in
 
 ## Optimization Method
 
-**File:** [`test_optimize_method.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_method.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/method_newton.rs`](../../packages/treetime/src/commands/optimize/method_newton.rs)
+- [`packages/treetime/src/commands/optimize/method_brent.rs`](../../packages/treetime/src/commands/optimize/method_brent.rs)
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/optimize_indel.rs`](../../packages/treetime/src/commands/optimize/optimize_indel.rs)
 
 Tests the 6 per-edge branch length optimization methods (Newton, NewtonSqrt, NewtonLog, Brent, BrentSqrt, BrentLog) against 5 verification criteria:
 
@@ -761,7 +923,15 @@ Tests the 6 per-edge branch length optimization methods (Newton, NewtonSqrt, New
 
 ## Dispatch Zero Boundary
 
-**File:** [`test_dispatch_zero_boundary.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/method_newton.rs`](../../packages/treetime/src/commands/optimize/method_newton.rs)
+- [`packages/treetime/src/commands/optimize/optimize_dense.rs`](../../packages/treetime/src/commands/optimize/optimize_dense.rs)
+- [`packages/treetime/src/commands/optimize/partition_ops.rs`](../../packages/treetime/src/commands/optimize/partition_ops.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 ### End-to-end dispatch
 
@@ -799,7 +969,9 @@ Tests the 6 per-edge branch length optimization methods (Newton, NewtonSqrt, New
 
 ## Optimization Method Step Clamping
 
-**File:** [`test_optimize_method_step_clamping.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_method_step_clamping.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_optimize_method_step_clamping.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_method_step_clamping.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/method_newton.rs`](../../packages/treetime/src/commands/optimize/method_newton.rs)
 
 | Test                                                                                | Purpose                                                 |
 | ----------------------------------------------------------------------------------- | ------------------------------------------------------- |
@@ -818,7 +990,9 @@ Tests the 6 per-edge branch length optimization methods (Newton, NewtonSqrt, New
 
 ## CLI Args
 
-**File:** [`test_args.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_args.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_args.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_args.rs)
+
+**Impl:** [`packages/treetime/src/commands/optimize/args.rs`](../../packages/treetime/src/commands/optimize/args.rs)
 
 | Test                                               | Purpose                                                 |
 | -------------------------------------------------- | ------------------------------------------------------- |
@@ -830,7 +1004,12 @@ Tests the 6 per-edge branch length optimization methods (Newton, NewtonSqrt, New
 
 ## Zero Sequence Length
 
-**File:** [`test_optimize_zero_sequence_length.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs)
+**Test:** [`packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs`](../../packages/treetime/src/commands/optimize/__tests__/test_optimize_zero_sequence_length.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packages/treetime/src/commands/optimize/optimize_unified.rs)
+- [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/src/commands/optimize/run.rs)
 
 | Test                                                     | Purpose                                                      |
 | -------------------------------------------------------- | ------------------------------------------------------------ |

--- a/docs/port-test-inventory/supporting.md
+++ b/docs/port-test-inventory/supporting.md
@@ -24,7 +24,9 @@
 
 ### BitSet128
 
-**File:** [`test_bitset128.rs`](../../packages/treetime-primitives/src/__tests__/test_bitset128.rs)
+**Test:** [`packages/treetime-primitives/src/__tests__/test_bitset128.rs`](../../packages/treetime-primitives/src/__tests__/test_bitset128.rs)
+
+**Impl:** [`packages/treetime-primitives/src/bitset128.rs`](../../packages/treetime-primitives/src/bitset128.rs)
 
 Unit and parameterized tests for all BitSet128 operations.
 
@@ -103,7 +105,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### AsciiChar
 
-**File:** [`test_ascii_char.rs`](../../packages/treetime-primitives/src/__tests__/test_ascii_char.rs)
+**Test:** [`packages/treetime-primitives/src/__tests__/test_ascii_char.rs`](../../packages/treetime-primitives/src/__tests__/test_ascii_char.rs)
+
+**Impl:** [`packages/treetime-primitives/src/seq_char.rs`](../../packages/treetime-primitives/src/seq_char.rs)
 
 | Test                               | Purpose                          |
 | ---------------------------------- | -------------------------------- |
@@ -117,7 +121,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Seq
 
-**File:** [`test_seq.rs`](../../packages/treetime-primitives/src/__tests__/test_seq.rs)
+**Test:** [`packages/treetime-primitives/src/__tests__/test_seq.rs`](../../packages/treetime-primitives/src/__tests__/test_seq.rs)
+
+**Impl:** [`packages/treetime-primitives/src/seq.rs`](../../packages/treetime-primitives/src/seq.rs)
 
 | Test                                  | Purpose                 |
 | ------------------------------------- | ----------------------- |
@@ -131,7 +137,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### interval/range_complement
 
-**File:** [`range_complement.rs`](../../packages/treetime-utils/src/interval/range_complement.rs) (inline)
+**Test:** [`packages/treetime-utils/src/interval/range_complement.rs`](../../packages/treetime-utils/src/interval/range_complement.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/interval/range_complement.rs`](../../packages/treetime-utils/src/interval/range_complement.rs)
 
 | Test                                           | Purpose                         |
 | ---------------------------------------------- | ------------------------------- |
@@ -144,7 +152,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### interval/range_difference
 
-**File:** [`range_difference.rs`](../../packages/treetime-utils/src/interval/range_difference.rs) (inline)
+**Test:** [`packages/treetime-utils/src/interval/range_difference.rs`](../../packages/treetime-utils/src/interval/range_difference.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/interval/range_difference.rs`](../../packages/treetime-utils/src/interval/range_difference.rs)
 
 | Test                                            | Purpose                       |
 | ----------------------------------------------- | ----------------------------- |
@@ -159,7 +169,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### interval/range_intersection
 
-**File:** [`range_intersection.rs`](../../packages/treetime-utils/src/interval/range_intersection.rs) (inline)
+**Test:** [`packages/treetime-utils/src/interval/range_intersection.rs`](../../packages/treetime-utils/src/interval/range_intersection.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/interval/range_intersection.rs`](../../packages/treetime-utils/src/interval/range_intersection.rs)
 
 | Test                                                                 | Purpose                            |
 | -------------------------------------------------------------------- | ---------------------------------- |
@@ -184,7 +196,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### interval/range_union
 
-**File:** [`range_union.rs`](../../packages/treetime-utils/src/interval/range_union.rs) (inline)
+**Test:** [`packages/treetime-utils/src/interval/range_union.rs`](../../packages/treetime-utils/src/interval/range_union.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/interval/range_union.rs`](../../packages/treetime-utils/src/interval/range_union.rs)
 
 | Test                                                  | Purpose                       |
 | ----------------------------------------------------- | ----------------------------- |
@@ -206,7 +220,13 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### interval/range_properties
 
-**File:** [`range_properties.rs`](../../packages/treetime-utils/src/interval/range_properties.rs) (inline)
+**Test:** [`packages/treetime-utils/src/interval/range_properties.rs`](../../packages/treetime-utils/src/interval/range_properties.rs) (inline)
+
+**Impl:**
+
+- [`packages/treetime-utils/src/interval/range_complement.rs`](../../packages/treetime-utils/src/interval/range_complement.rs)
+- [`packages/treetime-utils/src/interval/range_intersection.rs`](../../packages/treetime-utils/src/interval/range_intersection.rs)
+- [`packages/treetime-utils/src/interval/range_union.rs`](../../packages/treetime-utils/src/interval/range_union.rs)
 
 | Test                                                         | Purpose                                   |
 | ------------------------------------------------------------ | ----------------------------------------- |
@@ -219,7 +239,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### iterator/mean_by_key
 
-**File:** [`mean_by_key.rs`](../../packages/treetime-utils/src/iterator/mean_by_key.rs) (inline)
+**Test:** [`packages/treetime-utils/src/iterator/mean_by_key.rs`](../../packages/treetime-utils/src/iterator/mean_by_key.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/iterator/mean_by_key.rs`](../../packages/treetime-utils/src/iterator/mean_by_key.rs)
 
 | Test                                      | Purpose                     |
 | ----------------------------------------- | --------------------------- |
@@ -245,7 +267,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### datetime/parse_uncertain_date
 
-**File:** [`parse_uncertain_date.rs`](../../packages/treetime-utils/src/datetime/__tests__/parse_uncertain_date.rs)
+**Test:** [`packages/treetime-utils/src/datetime/__tests__/parse_uncertain_date.rs`](../../packages/treetime-utils/src/datetime/__tests__/parse_uncertain_date.rs)
+
+**Impl:** [`packages/treetime-utils/src/datetime/parse_uncertain_date.rs`](../../packages/treetime-utils/src/datetime/parse_uncertain_date.rs)
 
 | Test                              | Purpose                                         |
 | --------------------------------- | ----------------------------------------------- |
@@ -254,7 +278,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### datetime/format_to_regex
 
-**File:** [`format_to_regex.rs`](../../packages/treetime-utils/src/datetime/format_to_regex.rs) (inline)
+**Test:** [`packages/treetime-utils/src/datetime/format_to_regex.rs`](../../packages/treetime-utils/src/datetime/format_to_regex.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/datetime/format_to_regex.rs`](../../packages/treetime-utils/src/datetime/format_to_regex.rs)
 
 | Test                                  | Purpose                             |
 | ------------------------------------- | ----------------------------------- |
@@ -263,7 +289,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### datetime/year_fraction
 
-**File:** [`year_fraction.rs`](../../packages/treetime-utils/src/datetime/year_fraction.rs) (inline)
+**Test:** [`packages/treetime-utils/src/datetime/year_fraction.rs`](../../packages/treetime-utils/src/datetime/year_fraction.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/datetime/year_fraction.rs`](../../packages/treetime-utils/src/datetime/year_fraction.rs)
 
 | Test                         | Purpose                                        |
 | ---------------------------- | ---------------------------------------------- |
@@ -271,7 +299,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### fmt/string
 
-**File:** [`string.rs`](../../packages/treetime-utils/src/fmt/__tests__/string.rs)
+**Test:** [`packages/treetime-utils/src/fmt/__tests__/string.rs`](../../packages/treetime-utils/src/fmt/__tests__/string.rs)
+
+**Impl:** [`packages/treetime-utils/src/fmt/string.rs`](../../packages/treetime-utils/src/fmt/string.rs)
 
 | Test                                 | Purpose                                  |
 | ------------------------------------ | ---------------------------------------- |
@@ -285,7 +315,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### fmt/float
 
-**File:** [`float.rs`](../../packages/treetime-utils/src/fmt/float.rs) (inline)
+**Test:** [`packages/treetime-utils/src/fmt/float.rs`](../../packages/treetime-utils/src/fmt/float.rs) (inline)
+
+**Impl:** [`packages/treetime-utils/src/fmt/float.rs`](../../packages/treetime-utils/src/fmt/float.rs)
 
 | Test                               | Purpose                                   |
 | ---------------------------------- | ----------------------------------------- |
@@ -300,7 +332,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### array/ndarray
 
-**File:** [`ndarray.rs`](../../packages/treetime-utils/src/array/__tests__/ndarray.rs)
+**Test:** [`packages/treetime-utils/src/array/__tests__/ndarray.rs`](../../packages/treetime-utils/src/array/__tests__/ndarray.rs)
+
+**Impl:** [`packages/treetime-utils/src/array/ndarray.rs`](../../packages/treetime-utils/src/array/ndarray.rs)
 
 | Test                                         | Purpose                           |
 | -------------------------------------------- | --------------------------------- |
@@ -332,7 +366,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### dates_csv
 
-**File:** [`test_dates_csv.rs`](../../packages/treetime-io/src/__tests__/test_dates_csv.rs)
+**Test:** [`packages/treetime-io/src/__tests__/test_dates_csv.rs`](../../packages/treetime-io/src/__tests__/test_dates_csv.rs)
+
+**Impl:** [`packages/treetime-io/src/dates_csv.rs`](../../packages/treetime-io/src/dates_csv.rs)
 
 | Test                       | Purpose                                  |
 | -------------------------- | ---------------------------------------- |
@@ -342,7 +378,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### discrete_states_csv
 
-**File:** [`test_discrete_states_csv.rs`](../../packages/treetime-io/src/__tests__/test_discrete_states_csv.rs)
+**Test:** [`packages/treetime-io/src/__tests__/test_discrete_states_csv.rs`](../../packages/treetime-io/src/__tests__/test_discrete_states_csv.rs)
+
+**Impl:** [`packages/treetime-io/src/discrete_states_csv.rs`](../../packages/treetime-io/src/discrete_states_csv.rs)
 
 | Test                                                        | Purpose                                               |
 | ----------------------------------------------------------- | ----------------------------------------------------- |
@@ -355,7 +393,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### nwk_providers
 
-**File:** [`test_nwk_providers.rs`](../../packages/treetime-io/src/__tests__/test_nwk_providers.rs)
+**Test:** [`packages/treetime-io/src/__tests__/test_nwk_providers.rs`](../../packages/treetime-io/src/__tests__/test_nwk_providers.rs)
+
+**Impl:** [`packages/treetime-io/src/nwk.rs`](../../packages/treetime-io/src/nwk.rs)
 
 | Test                                        | Purpose                                                                    |
 | ------------------------------------------- | -------------------------------------------------------------------------- |
@@ -368,7 +408,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### concat
 
-**File:** [`test_concat.rs`](../../packages/treetime-io/src/__tests__/test_concat.rs)
+**Test:** [`packages/treetime-io/src/__tests__/test_concat.rs`](../../packages/treetime-io/src/__tests__/test_concat.rs)
+
+**Impl:** [`packages/treetime-io/src/concat.rs`](../../packages/treetime-io/src/concat.rs)
 
 | Test                                                              | Purpose                                |
 | ----------------------------------------------------------------- | -------------------------------------- |
@@ -384,7 +426,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### parse_delimited
 
-**File:** [`parse_delimited.rs`](../../packages/treetime-io/src/parse_delimited.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime-io/src/parse_delimited.rs`](../../packages/treetime-io/src/parse_delimited.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime-io/src/parse_delimited.rs`](../../packages/treetime-io/src/parse_delimited.rs)
 
 | Test                                                         | Purpose                                          |
 | ------------------------------------------------------------ | ------------------------------------------------ |
@@ -410,7 +454,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Grid
 
-**File:** [`grid.rs`](../../packages/treetime-grid/src/__tests__/grid.rs)
+**Test:** [`packages/treetime-grid/src/__tests__/grid.rs`](../../packages/treetime-grid/src/__tests__/grid.rs)
+
+**Impl:** [`packages/treetime-grid/src/grid.rs`](../../packages/treetime-grid/src/grid.rs)
 
 | Test                       | Purpose                                       |
 | -------------------------- | --------------------------------------------- |
@@ -418,7 +464,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### GridFn
 
-**File:** [`grid_fn.rs`](../../packages/treetime-grid/src/__tests__/grid_fn.rs)
+**Test:** [`packages/treetime-grid/src/__tests__/grid_fn.rs`](../../packages/treetime-grid/src/__tests__/grid_fn.rs)
+
+**Impl:** [`packages/treetime-grid/src/grid_fn.rs`](../../packages/treetime-grid/src/grid_fn.rs)
 
 | Test                                     | Purpose                                    |
 | ---------------------------------------- | ------------------------------------------ |
@@ -435,7 +483,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### interp_nonuniform
 
-**File:** [`interp_nonuniform.rs`](../../packages/treetime-grid/src/interp_nonuniform.rs) (inline)
+**Test:** [`packages/treetime-grid/src/interp_nonuniform.rs`](../../packages/treetime-grid/src/interp_nonuniform.rs) (inline)
+
+**Impl:** [`packages/treetime-grid/src/interp_nonuniform.rs`](../../packages/treetime-grid/src/interp_nonuniform.rs)
 
 | Test                                         | Purpose                                |
 | -------------------------------------------- | -------------------------------------- |
@@ -451,7 +501,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### convert/auspice
 
-**File:** [`auspice.rs`](../../packages/treetime-cli/src/convert/__tests__/auspice.rs)
+**Test:** [`packages/treetime-cli/src/convert/__tests__/auspice.rs`](../../packages/treetime-cli/src/convert/__tests__/auspice.rs)
+
+**Impl:** [`packages/treetime-cli/src/convert/auspice.rs`](../../packages/treetime-cli/src/convert/auspice.rs)
 
 | Test                                      | Purpose                            |
 | ----------------------------------------- | ---------------------------------- |
@@ -463,7 +515,13 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### convert/convert
 
-**File:** [`convert.rs`](../../packages/treetime-cli/src/convert/__tests__/convert.rs)
+**Test:** [`packages/treetime-cli/src/convert/__tests__/convert.rs`](../../packages/treetime-cli/src/convert/__tests__/convert.rs)
+
+**Impl:**
+
+- [`packages/treetime-cli/src/convert/convert.rs`](../../packages/treetime-cli/src/convert/convert.rs)
+- [`packages/treetime-cli/src/convert/auspice.rs`](../../packages/treetime-cli/src/convert/auspice.rs)
+- [`packages/treetime-cli/src/convert/usher.rs`](../../packages/treetime-cli/src/convert/usher.rs)
 
 | Test                                         | Purpose                            |
 | -------------------------------------------- | ---------------------------------- |
@@ -473,7 +531,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### convert/usher
 
-**File:** [`usher.rs`](../../packages/treetime-cli/src/convert/__tests__/usher.rs)
+**Test:** [`packages/treetime-cli/src/convert/__tests__/usher.rs`](../../packages/treetime-cli/src/convert/__tests__/usher.rs)
+
+**Impl:** [`packages/treetime-cli/src/convert/usher.rs`](../../packages/treetime-cli/src/convert/usher.rs)
 
 | Test                                       | Purpose                            |
 | ------------------------------------------ | ---------------------------------- |
@@ -482,7 +542,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### convert/mutation
 
-**File:** [`mutation.rs`](../../packages/treetime-cli/src/convert/mutation.rs) (inline)
+**Test:** [`packages/treetime-cli/src/convert/mutation.rs`](../../packages/treetime-cli/src/convert/mutation.rs) (inline)
+
+**Impl:** [`packages/treetime-cli/src/convert/mutation.rs`](../../packages/treetime-cli/src/convert/mutation.rs)
 
 | Test                        | Purpose                                   |
 | --------------------------- | ----------------------------------------- |
@@ -499,7 +561,12 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Alphabet
 
-**File:** [`test_alphabet.rs`](../../packages/treetime/src/alphabet/__tests__/test_alphabet.rs)
+**Test:** [`packages/treetime/src/alphabet/__tests__/test_alphabet.rs`](../../packages/treetime/src/alphabet/__tests__/test_alphabet.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/alphabet/alphabet.rs`](../../packages/treetime/src/alphabet/alphabet.rs)
+- [`packages/treetime/src/alphabet/alphabet_config.rs`](../../packages/treetime/src/alphabet/alphabet_config.rs)
 
 | Test                                             | Purpose                                      |
 | ------------------------------------------------ | -------------------------------------------- |
@@ -552,7 +619,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_alphabet_char_index_roundtrip`             | Char-to-index-to-char roundtrip              |
 | `test_alphabet_set_to_char_canonical_roundtrip`  | Char-to-set-to-char roundtrip                |
 
-**File:** [`test_alphabet_config.rs`](../../packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs)
+**Test:** [`packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs`](../../packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs)
+
+**Impl:** [`packages/treetime/src/alphabet/alphabet_config.rs`](../../packages/treetime/src/alphabet/alphabet_config.rs)
 
 | Test                                                                    | Purpose                                           |
 | ----------------------------------------------------------------------- | ------------------------------------------------- |
@@ -581,7 +650,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### I/O
 
-**File:** [`test_fasta.rs`](../../packages/treetime/src/io/__tests__/test_fasta.rs)
+**Test:** [`packages/treetime/src/io/__tests__/test_fasta.rs`](../../packages/treetime/src/io/__tests__/test_fasta.rs)
+
+**Impl:** [`packages/treetime-io/src/fasta.rs`](../../packages/treetime-io/src/fasta.rs)
 
 | Test                                                                  | Purpose                                       |
 | --------------------------------------------------------------------- | --------------------------------------------- |
@@ -604,7 +675,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_fasta_reader_dedent_aa`                                         | Multiple amino acid records                   |
 | `test_fasta_reader_multiline_and_skewed_indentation`                  | Case folding, multiline, indentation handling |
 
-**File:** [`test_nwk.rs`](../../packages/treetime/src/io/__tests__/test_nwk.rs)
+**Test:** [`packages/treetime/src/io/__tests__/test_nwk.rs`](../../packages/treetime/src/io/__tests__/test_nwk.rs)
+
+**Impl:** [`packages/treetime-io/src/nwk.rs`](../../packages/treetime-io/src/nwk.rs)
 
 | Test                                      | Purpose                              |
 | ----------------------------------------- | ------------------------------------ |
@@ -619,7 +692,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Sequence Operations
 
-**File:** [`test_composition.rs`](../../packages/treetime/src/seq/__tests__/test_composition.rs)
+**Test:** [`packages/treetime/src/seq/__tests__/test_composition.rs`](../../packages/treetime/src/seq/__tests__/test_composition.rs)
+
+**Impl:** [`packages/treetime/src/seq/composition.rs`](../../packages/treetime/src/seq/composition.rs)
 
 | Test                                          | Purpose                              |
 | --------------------------------------------- | ------------------------------------ |
@@ -632,7 +707,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_composition_add_deletion`               | Deletion updates gap counts          |
 | `test_composition_add_insertion`              | Insertion updates char counts        |
 
-**File:** [`test_div.rs`](../../packages/treetime/src/seq/__tests__/test_div.rs)
+**Test:** [`packages/treetime/src/seq/__tests__/test_div.rs`](../../packages/treetime/src/seq/__tests__/test_div.rs)
+
+**Impl:** [`packages/treetime/src/seq/div.rs`](../../packages/treetime/src/seq/div.rs)
 
 | Test                       | Purpose                              |
 | -------------------------- | ------------------------------------ |
@@ -644,7 +721,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_deep_tree`           | 20-level deep tree divergence        |
 | `test_zero_branch_lengths` | Zero branch lengths handled          |
 
-**File:** [`test_find_char_ranges.rs`](../../packages/treetime/src/seq/__tests__/test_find_char_ranges.rs)
+**Test:** [`packages/treetime/src/seq/__tests__/test_find_char_ranges.rs`](../../packages/treetime/src/seq/__tests__/test_find_char_ranges.rs)
+
+**Impl:** [`packages/treetime/src/seq/find_char_ranges.rs`](../../packages/treetime/src/seq/find_char_ranges.rs)
 
 | Test                                       | Purpose                                  |
 | ------------------------------------------ | ---------------------------------------- |
@@ -653,7 +732,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_find_gap_ranges` (7 cases)           | Gap range detection                      |
 | `test_find_undetermined_ranges` (12 cases) | Combined N+gap range detection and merge |
 
-**File:** [`test_mutation.rs`](../../packages/treetime/src/seq/__tests__/test_mutation.rs)
+**Test:** [`packages/treetime/src/seq/__tests__/test_mutation.rs`](../../packages/treetime/src/seq/__tests__/test_mutation.rs)
+
+**Impl:** [`packages/treetime/src/seq/mutation.rs`](../../packages/treetime/src/seq/mutation.rs)
 
 | Test                                                            | Purpose                                          |
 | --------------------------------------------------------------- | ------------------------------------------------ |
@@ -669,7 +750,13 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Graph
 
-**File:** [`graph.rs`](../../packages/treetime/src/graph/__tests__/graph.rs)
+**Test:** [`packages/treetime/src/graph/__tests__/graph.rs`](../../packages/treetime/src/graph/__tests__/graph.rs)
+
+**Impl:**
+
+- [`packages/treetime-graph/src/graph.rs`](../../packages/treetime-graph/src/graph.rs)
+- [`packages/treetime-graph/src/graph_traverse.rs`](../../packages/treetime-graph/src/graph_traverse.rs)
+- [`packages/treetime-graph/src/graph_ops.rs`](../../packages/treetime-graph/src/graph_ops.rs)
 
 | Test                                                  | Purpose                                |
 | ----------------------------------------------------- | -------------------------------------- |
@@ -689,7 +776,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_collapse_edge_multiple_inbound_edges`           | Collapse with multiple inbound edges   |
 | `test_collapse_edge_adjacency_consistency`            | Edge-node adjacency stays consistent   |
 
-**File:** [`test_edge.rs`](../../packages/treetime/src/graph/__tests__/test_edge.rs)
+**Test:** [`packages/treetime/src/graph/__tests__/test_edge.rs`](../../packages/treetime/src/graph/__tests__/test_edge.rs)
+
+**Impl:** [`packages/treetime-graph/src/edge.rs`](../../packages/treetime-graph/src/edge.rs)
 
 | Test           | Purpose                                |
 | -------------- | -------------------------------------- |
@@ -697,7 +786,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Representation
 
-**File:** [`test_partition_marginal_sparse.rs`](../../packages/treetime/src/representation/__tests__/test_partition_marginal_sparse.rs)
+**Test:** [`packages/treetime/src/representation/__tests__/test_partition_marginal_sparse.rs`](../../packages/treetime/src/representation/__tests__/test_partition_marginal_sparse.rs)
+
+**Impl:** [`packages/treetime/src/seq/mutation.rs`](../../packages/treetime/src/seq/mutation.rs)
 
 | Test                                                   | Purpose                                     |
 | ------------------------------------------------------ | ------------------------------------------- |
@@ -710,7 +801,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_compose_substitutions_mixed`                     | Chain, keep, add, cancel combined           |
 | `test_compose_substitutions_single_position` (4 cases) | Single-position chain and cancel variants   |
 
-**File:** [`discrete_states.rs`](../../packages/treetime/src/representation/discrete_states.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/discrete_states.rs`](../../packages/treetime/src/representation/discrete_states.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/discrete_states.rs`](../../packages/treetime/src/representation/discrete_states.rs)
 
 | Test                                            | Purpose                                                  |
 | ----------------------------------------------- | -------------------------------------------------------- |
@@ -723,14 +816,18 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_empty_values`                             | Empty input produces empty DiscreteStates                |
 | `test_missing_marker`                           | Custom missing marker stored and returned                |
 
-**File:** [`marginal_helpers.rs`](../../packages/treetime/src/representation/partition/marginal_helpers.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/partition/marginal_helpers.rs`](../../packages/treetime/src/representation/partition/marginal_helpers.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/partition/marginal_helpers.rs`](../../packages/treetime/src/representation/partition/marginal_helpers.rs)
 
 | Test                                   | Purpose                                                                    |
 | -------------------------------------- | -------------------------------------------------------------------------- |
 | `test_propagate_raw_per_site_forward`  | Forward propagation with per-site rates matches individual expQt_with_rate |
 | `test_propagate_raw_per_site_backward` | Backward propagation (transpose) with per-site rates matches individual    |
 
-**File:** [`ancestral.rs`](../../packages/treetime/src/representation/payload/ancestral.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/payload/ancestral.rs`](../../packages/treetime/src/representation/payload/ancestral.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/payload/ancestral.rs`](../../packages/treetime/src/representation/payload/ancestral.rs)
 
 | Test                                                       | Purpose                                              |
 | ---------------------------------------------------------- | ---------------------------------------------------- |
@@ -740,7 +837,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_annotate_branch_mutations_sorts_by_position`         | Multiple mutations sorted by position                |
 | `test_annotate_branch_mutations_multi_partition_merge`     | Mutations from multiple partitions merged and sorted |
 
-**File:** [`discrete.rs`](../../packages/treetime/src/representation/payload/discrete.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/payload/discrete.rs`](../../packages/treetime/src/representation/payload/discrete.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/payload/discrete.rs`](../../packages/treetime/src/representation/payload/discrete.rs)
 
 | Test                                         | Purpose                                             |
 | -------------------------------------------- | --------------------------------------------------- |
@@ -749,7 +848,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_default_node_data`                     | Default node data has empty profile and zero log_lh |
 | `test_default_edge_data`                     | Default edge data has empty arrays and zero log_lh  |
 
-**File:** [`timetree.rs`](../../packages/treetime/src/representation/payload/timetree.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/representation/payload/timetree.rs`](../../packages/treetime/src/representation/payload/timetree.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/representation/payload/timetree.rs`](../../packages/treetime/src/representation/payload/timetree.rs)
 
 | Test                                                           | Purpose                                                         |
 | -------------------------------------------------------------- | --------------------------------------------------------------- |
@@ -759,7 +860,9 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Commands: Prune
 
-**File:** [`test_run.rs`](../../packages/treetime/src/commands/prune/__tests__/test_run.rs)
+**Test:** [`packages/treetime/src/commands/prune/__tests__/test_run.rs`](../../packages/treetime/src/commands/prune/__tests__/test_run.rs)
+
+**Impl:** [`packages/treetime/src/commands/prune/run.rs`](../../packages/treetime/src/commands/prune/run.rs)
 
 | Test                                                                         | Purpose                                                      |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------ |
@@ -806,7 +909,9 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_collapse_edge_compose_cancellation`                                    | Cancellation (A->G + G->A = none) through edge collapse      |
 | `test_collapse_edge_compose_multiple_partitions`                             | Composition applied independently per partition              |
 
-**File:** [`test_merge_shared_mutations.rs`](../../packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs)
+**Test:** [`packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs`](../../packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs)
+
+**Impl:** [`packages/treetime/src/commands/prune/run.rs`](../../packages/treetime/src/commands/prune/run.rs)
 
 | Test                                                      | Purpose                                               |
 | --------------------------------------------------------- | ----------------------------------------------------- |

--- a/docs/port-test-inventory/timetree.md
+++ b/docs/port-test-inventory/timetree.md
@@ -26,7 +26,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Piecewise Constant Function
 
-**File:** [`test_piecewise_constant_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_constant_fn.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_constant_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_constant_fn.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/piecewise_constant_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/piecewise_constant_fn.rs)
 
 | Test                                | Purpose                                    |
 | ----------------------------------- | ------------------------------------------ |
@@ -37,7 +39,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Piecewise Linear Function
 
-**File:** [`test_piecewise_linear_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_linear_fn.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_linear_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_linear_fn.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/piecewise_linear_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/piecewise_linear_fn.rs)
 
 | Test                                           | Purpose                               |
 | ---------------------------------------------- | ------------------------------------- |
@@ -51,7 +55,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Event Collection
 
-**File:** [`test_events.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_events.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_events.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_events.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/events.rs`](../../packages/treetime/src/commands/timetree/coalescent/events.rs)
 
 | Test                                           | Purpose                      |
 | ---------------------------------------------- | ---------------------------- |
@@ -64,7 +70,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Lineage Dynamics
 
-**File:** [`test_lineage_dynamics.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_lineage_dynamics.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_lineage_dynamics.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_lineage_dynamics.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/lineage_dynamics.rs`](../../packages/treetime/src/commands/timetree/coalescent/lineage_dynamics.rs)
 
 | Test                                            | Purpose                                                       |
 | ----------------------------------------------- | ------------------------------------------------------------- |
@@ -82,7 +90,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Integration (Merger Rates)
 
-**File:** [`test_integration.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_integration.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_integration.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_integration.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/integration.rs`](../../packages/treetime/src/commands/timetree/coalescent/integration.rs)
 
 | Test                                                         | Purpose                                     |
 | ------------------------------------------------------------ | ------------------------------------------- |
@@ -99,7 +109,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Tc Optimization
 
-**File:** [`test_optimize_tc.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_optimize_tc.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_optimize_tc.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_optimize_tc.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/optimize_tc.rs`](../../packages/treetime/src/commands/timetree/coalescent/optimize_tc.rs)
 
 | Test                                                 | Purpose                                               |
 | ---------------------------------------------------- | ----------------------------------------------------- |
@@ -110,7 +122,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Skyline Optimization
 
-**File:** [`test_skyline.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_skyline.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_skyline.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_skyline.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/skyline.rs`](../../packages/treetime/src/commands/timetree/coalescent/skyline.rs)
 
 | Test                                               | Purpose                              |
 | -------------------------------------------------- | ------------------------------------ |
@@ -123,7 +137,9 @@ Parameterized tests use `#[case]` expansions via rstest.
 
 ### Golden-Master Coalescent
 
-**File:** [`test_gm_coalescent.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_gm_coalescent.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_gm_coalescent.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_gm_coalescent.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/coalescent.rs`](../../packages/treetime/src/commands/timetree/coalescent/coalescent.rs)
 
 | Test                 | Datasets and Tc values                                                                                                                                                               |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -135,7 +151,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ## Total Log-Likelihood
 
-**File:** [`test_total_lh.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_total_lh.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_total_lh.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_total_lh.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/total_lh.rs`](../../packages/treetime/src/commands/timetree/coalescent/total_lh.rs)
 
 | Test                                           | Purpose                                                      |
 | ---------------------------------------------- | ------------------------------------------------------------ |
@@ -147,7 +165,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 | `test_total_lh_matches_optimize_tc_likelihood` | compute_coalescent_total_lh matches optimize_tc output       |
 | `test_total_lh_with_formula_distribution`      | Constant Formula distribution matches Distribution::constant |
 
-**File:** [`test_gm_total_lh.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_gm_total_lh.rs)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_gm_total_lh.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_gm_total_lh.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/total_lh.rs`](../../packages/treetime/src/commands/timetree/coalescent/total_lh.rs)
 
 | Test                        | Purpose                                                            |
 | --------------------------- | ------------------------------------------------------------------ |
@@ -158,7 +178,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ## Time Coordinate
 
-**File:** [`time_coordinate.rs`](../../packages/treetime/src/commands/timetree/coalescent/time_coordinate.rs) (inline `#[cfg(test)]`)
+**Test:** [`packages/treetime/src/commands/timetree/coalescent/time_coordinate.rs`](../../packages/treetime/src/commands/timetree/coalescent/time_coordinate.rs) (inline `#[cfg(test)]`)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/time_coordinate.rs`](../../packages/treetime/src/commands/timetree/coalescent/time_coordinate.rs)
 
 | Test                             | Purpose                                                       |
 | -------------------------------- | ------------------------------------------------------------- |
@@ -173,7 +195,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Backward Pass
 
-**File:** [`test_backward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_backward_pass.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_backward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_backward_pass.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/backward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/backward_pass.rs)
 
 | Test                                                                  | Purpose                                          |
 | --------------------------------------------------------------------- | ------------------------------------------------ |
@@ -188,7 +212,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Runner (Input Mode)
 
-**File:** [`test_runner.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_runner.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_runner.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_runner.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
 
 | Test                                                           | Purpose                                              |
 | -------------------------------------------------------------- | ---------------------------------------------------- |
@@ -199,7 +225,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Branch-Length Likelihood Grid
 
-**File:** [`test_branch_length_likelihood.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs`](../../packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs)
 
 | Test                                                                  | Purpose                                                            | Notes            |
 | --------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------- |
@@ -218,11 +246,17 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 #### Support
 
-**File:** [`test_gm_runner_support.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_support.rs) - shared fixtures and helpers, no tests.
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_support.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_support.rs) - shared fixtures and helpers, no tests.
 
 #### Poisson Mode
 
-**File:** [`test_gm_runner_poisson.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_poisson.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_poisson.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_poisson.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/timetree/inference/backward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/backward_pass.rs)
+- [`packages/treetime/src/commands/timetree/inference/forward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/forward_pass.rs)
+- [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
 
 | Test                     | Datasets              | Tolerance | Notes                                                                      |
 | ------------------------ | --------------------- | --------- | -------------------------------------------------------------------------- |
@@ -230,7 +264,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 #### Dense Marginal
 
-**File:** [`test_gm_runner_marginal_dense.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
 
 | Test                            | Datasets    | Tolerance | Notes                                                                    |
 | ------------------------------- | ----------- | --------- | ------------------------------------------------------------------------ |
@@ -238,7 +274,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 #### Sparse Marginal
 
-**File:** [`test_gm_runner_marginal_sparse.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
 
 | Test                             | Datasets    | Tolerance | Notes               |
 | -------------------------------- | ----------- | --------- | ------------------- |
@@ -246,7 +284,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 #### ML Branch-Length Pre-Optimization
 
-**File:** [`test_gm_runner_pre_optimize.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
 
 | Test                                                 | Purpose                                                |
 | ---------------------------------------------------- | ------------------------------------------------------ |
@@ -255,7 +295,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 #### Coalescent Integration
 
-**File:** [`test_runner_coalescent.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_runner_coalescent.rs)
+**Test:** [`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_runner_coalescent.rs`](../../packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_runner_coalescent.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
 
 | Test                               | Datasets                        | Notes                                               |
 | ---------------------------------- | ------------------------------- | --------------------------------------------------- |
@@ -265,7 +307,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ## Convergence Tests
 
-**File:** [`test_metrics.rs`](../../packages/treetime/src/commands/timetree/convergence/__tests__/test_metrics.rs)
+**Test:** [`packages/treetime/src/commands/timetree/convergence/__tests__/test_metrics.rs`](../../packages/treetime/src/commands/timetree/convergence/__tests__/test_metrics.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/convergence/metrics.rs`](../../packages/treetime/src/commands/timetree/convergence/metrics.rs)
 
 | Test                                                     | Purpose                                        |
 | -------------------------------------------------------- | ---------------------------------------------- |
@@ -274,7 +318,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 | `test_metrics_optimizer_stops_at_max_iterations`         | Max iteration limit                            |
 | `test_metrics_optimizer_n_resolved_prevents_convergence` | Polytomy resolution prevents early convergence |
 
-**File:** [`test_pipeline.rs`](../../packages/treetime/src/commands/timetree/convergence/__tests__/test_pipeline.rs)
+**Test:** [`packages/treetime/src/commands/timetree/convergence/__tests__/test_pipeline.rs`](../../packages/treetime/src/commands/timetree/convergence/__tests__/test_pipeline.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/run.rs`](../../packages/treetime/src/commands/timetree/run.rs)
 
 | Test                                 | Purpose                                                                       | Type        |
 | ------------------------------------ | ----------------------------------------------------------------------------- | ----------- |
@@ -286,7 +332,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Confidence Extraction
 
-**File:** [`test_confidence_extract.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_confidence_extract.rs)
+**Test:** [`packages/treetime/src/commands/timetree/output/__tests__/test_confidence_extract.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_confidence_extract.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/output/confidence.rs`](../../packages/treetime/src/commands/timetree/output/confidence.rs)
 
 | Test                                                                 | Purpose                                            | Notes            |
 | -------------------------------------------------------------------- | -------------------------------------------------- | ---------------- |
@@ -303,7 +351,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Confidence Combination
 
-**File:** [`test_confidence_combine.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_confidence_combine.rs)
+**Test:** [`packages/treetime/src/commands/timetree/output/__tests__/test_confidence_combine.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_confidence_combine.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/output/confidence.rs`](../../packages/treetime/src/commands/timetree/output/confidence.rs)
 
 | Test                                          | Purpose                      |
 | --------------------------------------------- | ---------------------------- |
@@ -314,7 +364,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Rate Uncertainty
 
-**File:** [`test_confidence_rate.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_confidence_rate.rs)
+**Test:** [`packages/treetime/src/commands/timetree/output/__tests__/test_confidence_rate.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_confidence_rate.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/output/confidence.rs`](../../packages/treetime/src/commands/timetree/output/confidence.rs)
 
 | Test                                                            | Purpose                                             |
 | --------------------------------------------------------------- | --------------------------------------------------- |
@@ -329,7 +381,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Auspice Output
 
-**File:** [`test_auspice.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_auspice.rs)
+**Test:** [`packages/treetime/src/commands/timetree/output/__tests__/test_auspice.rs`](../../packages/treetime/src/commands/timetree/output/__tests__/test_auspice.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/output/auspice.rs`](../../packages/treetime/src/commands/timetree/output/auspice.rs)
 
 | Test                                             | Purpose                                           |
 | ------------------------------------------------ | ------------------------------------------------- |
@@ -350,7 +404,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Clock Filter
 
-**File:** [`test_clock_filter.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_clock_filter.rs)
+**Test:** [`packages/treetime/src/commands/timetree/optimization/__tests__/test_clock_filter.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_clock_filter.rs)
+
+**Impl:** [`packages/treetime/src/commands/clock/clock_filter.rs`](../../packages/treetime/src/commands/clock/clock_filter.rs)
 
 | Test                                       | Purpose                                |
 | ------------------------------------------ | -------------------------------------- |
@@ -363,7 +419,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Relaxed Clock
 
-**File:** [`test_relaxed_clock.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs)
+**Test:** [`packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/optimization/relaxed_clock.rs`](../../packages/treetime/src/commands/timetree/optimization/relaxed_clock.rs)
 
 | Test                                                         | Purpose                                     |
 | ------------------------------------------------------------ | ------------------------------------------- |
@@ -383,7 +441,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Polytomy Resolution
 
-**File:** [`test_polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs)
+**Test:** [`packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/optimization/polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/polytomy.rs)
 
 | Test                                                           | Purpose                               |
 | -------------------------------------------------------------- | ------------------------------------- |
@@ -400,7 +460,9 @@ Tolerance: 1e-5 max absolute error. Fixtures: [`gm_coalescent_*.json`](../../pac
 
 ### Rerooting
 
-**File:** [`test_reroot.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs)
+**Test:** [`packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/optimization/reroot.rs`](../../packages/treetime/src/commands/timetree/optimization/reroot.rs)
 
 | Test                                                 | Purpose                         | Type        |
 | ---------------------------------------------------- | ------------------------------- | ----------- |
@@ -435,4 +497,4 @@ Each `__tests__/mod.rs` contains only `mod` declarations.
 
 3. **Dense marginal**: `ebola_20` disabled due to gap character handling in alphabet.
 
-4. **Duplicate tests**: [`test_lineage_dynamics.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_lineage_dynamics.rs) contains 2 piecewise constant tests that duplicate those in [`test_piecewise_constant_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_constant_fn.rs).
+4. **Duplicate tests**: [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_lineage_dynamics.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_lineage_dynamics.rs) contains 2 piecewise constant tests that duplicate those in [`packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_constant_fn.rs`](../../packages/treetime/src/commands/timetree/coalescent/__tests__/test_piecewise_constant_fn.rs).

--- a/docs/port-test-inventory/validation.md
+++ b/docs/port-test-inventory/validation.md
@@ -60,7 +60,14 @@ Additional timetree-only: `mpox/clade-ii/20`
 
 ## Timetree Validation
 
-**File:** [`examples/timetree_validation.rs`](../../packages/treetime/examples/timetree_validation.rs)
+**Test:** [`packages/treetime/examples/timetree_validation.rs`](../../packages/treetime/examples/timetree_validation.rs)
+
+**Impl:**
+
+- [`packages/treetime/src/commands/timetree/inference/runner.rs`](../../packages/treetime/src/commands/timetree/inference/runner.rs)
+- [`packages/treetime/src/commands/timetree/inference/backward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/backward_pass.rs)
+- [`packages/treetime/src/commands/timetree/inference/forward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/forward_pass.rs)
+- [`packages/treetime/src/commands/timetree/utils.rs`](../../packages/treetime/src/commands/timetree/utils.rs)
 
 Golden-master comparison of v1 timetree inference against v0 Python outputs. Runs full timetree pipeline on `flu/h3n2/20` dataset and compares node dates, branch lengths, clock rate, and coalescent contributions.
 
@@ -78,7 +85,9 @@ Three execution modes:
 
 ## Coalescent Validation
 
-**File:** [`examples/coalescent_validation.rs`](../../packages/treetime/examples/coalescent_validation.rs)
+**Test:** [`packages/treetime/examples/coalescent_validation.rs`](../../packages/treetime/examples/coalescent_validation.rs)
+
+**Impl:** [`packages/treetime/src/commands/timetree/coalescent/coalescent.rs`](../../packages/treetime/src/commands/timetree/coalescent/coalescent.rs)
 
 Golden-master comparison of v1 coalescent model contributions against v0 Python golden outputs. Tests piecewise constant and skyline coalescent on multiple datasets with varying Tc parameters.
 
@@ -106,34 +115,44 @@ Support library for math operation validation. Provides test suites, runners, an
 
 ### Metrics Tests
 
-**File:** [`pointwise.rs`](../../packages/treetime-validation/src/testing/metrics/pointwise/pointwise.rs) (inline)
+**Test:** [`packages/treetime-validation/src/testing/metrics/pointwise/pointwise.rs`](../../packages/treetime-validation/src/testing/metrics/pointwise/pointwise.rs) (inline)
+
+**Impl:** [`packages/treetime-validation/src/testing/metrics/pointwise/pointwise.rs`](../../packages/treetime-validation/src/testing/metrics/pointwise/pointwise.rs)
 
 | Test                     | Purpose                            |
 | ------------------------ | ---------------------------------- |
 | `test_perfect_agreement` | Zero error on identical inputs     |
 | `test_constant_offset`   | Detects systematic constant offset |
 
-**File:** [`spatial.rs`](../../packages/treetime-validation/src/testing/metrics/spatial/spatial.rs) (inline)
+**Test:** [`packages/treetime-validation/src/testing/metrics/spatial/spatial.rs`](../../packages/treetime-validation/src/testing/metrics/spatial/spatial.rs) (inline)
+
+**Impl:** [`packages/treetime-validation/src/testing/metrics/spatial/spatial.rs`](../../packages/treetime-validation/src/testing/metrics/spatial/spatial.rs)
 
 | Test                                    | Purpose                         |
 | --------------------------------------- | ------------------------------- |
 | `test_perfect_agreement`                | Zero spatial error on identical |
 | `test_cumulative_error_systematic_bias` | Detects systematic spatial bias |
 
-**File:** [`metrics.rs`](../../packages/treetime-validation/src/testing/metrics/metrics.rs) (inline)
+**Test:** [`packages/treetime-validation/src/testing/metrics/metrics.rs`](../../packages/treetime-validation/src/testing/metrics/metrics.rs) (inline)
+
+**Impl:** [`packages/treetime-validation/src/testing/metrics/metrics.rs`](../../packages/treetime-validation/src/testing/metrics/metrics.rs)
 
 | Test                                  | Purpose                             |
 | ------------------------------------- | ----------------------------------- |
 | `test_comprehensive_metrics_creation` | Default metrics config construction |
 | `test_metrics_with_custom_config`     | Custom threshold metrics config     |
 
-**File:** [`statistics.rs`](../../packages/treetime-validation/src/testing/metrics/distribution/statistics.rs) (inline)
+**Test:** [`packages/treetime-validation/src/testing/metrics/distribution/statistics.rs`](../../packages/treetime-validation/src/testing/metrics/distribution/statistics.rs) (inline)
+
+**Impl:** [`packages/treetime-validation/src/testing/metrics/distribution/statistics.rs`](../../packages/treetime-validation/src/testing/metrics/distribution/statistics.rs)
 
 | Test                       | Purpose                       |
 | -------------------------- | ----------------------------- |
 | `test_statistical_metrics` | KS statistic, mean, std tests |
 
-**File:** [`histograms.rs`](../../packages/treetime-validation/src/testing/metrics/distribution/histograms.rs) (inline)
+**Test:** [`packages/treetime-validation/src/testing/metrics/distribution/histograms.rs`](../../packages/treetime-validation/src/testing/metrics/distribution/histograms.rs) (inline)
+
+**Impl:** [`packages/treetime-validation/src/testing/metrics/distribution/histograms.rs`](../../packages/treetime-validation/src/testing/metrics/distribution/histograms.rs)
 
 | Test                      | Purpose                      |
 | ------------------------- | ---------------------------- |


### PR DESCRIPTION
The test inventory documents in `docs/port-test-inventory/` listed tests by bare filename (e.g., `test_fitch.rs`) with no link to the implementation files they exercise. Navigation required knowing the codebase layout to find either the test or the production code.

This PR rewrites all 9 inventory files to show project-root-relative paths as visible link text and adds `**Impl:**` links for every test section. Each section now has both a `**Test:**` link pointing to the test file and an `**Impl:**` link (or bullet list for multi-file cases) pointing to the production source. Impl targets were determined by tracing imports in each test file.

### Work items

- [x] Rename `**File:**` to `**Test:**` with full paths as visible text (all 9 files)
- [x] Add `**Impl:**` links to production source files
- [x] Multi-file impl sections use markdown bullet list
- [x] Expand support file references to full paths
- [x] Normalize `**Tests:**` plural to `**Test:**` singular for consistency