### PR TITLE
refactor(sparse): store root sequence off-tree

### DIFF
--- a/docs/port-known-issues/M-timetree-sparse-convergence-empty-sequences.md
+++ b/docs/port-known-issues/M-timetree-sparse-convergence-empty-sequences.md
@@ -1,0 +1,21 @@
+# Sparse timetree convergence tracking compares empty sequences
+
+Severity: medium
+
+## Problem
+
+`capture_ancestral_states()` snapshots ancestral sequences for convergence tracking via `extract_ancestral_sequence()`. After `extract_root_sequence()` clears internal node sequences, `extract_ancestral_sequence()` returns empty `Seq` for non-root internal nodes. Both pre- and post-iteration snapshots are empty, so `count_sequence_changes()` returns 0, and the refinement loop may declare convergence prematurely.
+
+## Affected paths
+
+- `packages/treetime/src/commands/timetree/refinement.rs`: `capture_ancestral_states` at lines 51 and 92
+- `packages/treetime/src/commands/timetree/convergence/sequence_changes.rs`: `capture_ancestral_states` reads `extract_ancestral_sequence` per internal node
+- `packages/treetime/src/representation/partition/marginal_sparse.rs`: `extract_ancestral_sequence` returns empty when `seq.sequence` is cleared
+
+## Context
+
+Before the off-tree root sequence refactoring, internal node sequences were retained from Fitch compression. Convergence tracking compared these Fitch-era sequences across iterations. Since marginal passes do not update `seq.sequence`, the compared sequences were already stale (reflecting Fitch resolution, not current marginal posteriors). The refactoring changed the symptom from "stale but nonzero diffs" to "empty = zero diffs".
+
+## Fix direction
+
+`capture_ancestral_states` should reconstruct sequences from current marginal profiles (via `ancestral_reconstruction_marginal` or `node_state_at`) instead of reading stored `seq.sequence`. This makes convergence tracking reflect actual marginal state changes between iterations.

--- a/docs/port-known-issues/M-timetree-sparse-convergence-empty-sequences.md
+++ b/docs/port-known-issues/M-timetree-sparse-convergence-empty-sequences.md
@@ -4,13 +4,13 @@ Severity: medium
 
 ## Problem
 
-`capture_ancestral_states()` snapshots ancestral sequences for convergence tracking via `extract_ancestral_sequence()`. After `extract_root_sequence()` clears internal node sequences, `extract_ancestral_sequence()` returns empty `Seq` for non-root internal nodes. Both pre- and post-iteration snapshots are empty, so `count_sequence_changes()` returns 0, and the refinement loop may declare convergence prematurely.
+`capture_ancestral_states()` snapshots ancestral sequences for convergence tracking via `extract_ancestral_sequence()`. After `compress_sequences()` finalizes sparse partitions (clearing internal node sequences and storing the root sequence off-tree), `extract_ancestral_sequence()` returns empty `Seq` for non-root internal nodes. Both pre- and post-iteration snapshots are empty, so `count_sequence_changes()` returns 0, and the refinement loop may declare convergence prematurely.
 
 ## Affected paths
 
 - `packages/treetime/src/commands/timetree/refinement.rs`: `capture_ancestral_states` at lines 51 and 92
 - `packages/treetime/src/commands/timetree/convergence/sequence_changes.rs`: `capture_ancestral_states` reads `extract_ancestral_sequence` per internal node
-- `packages/treetime/src/representation/partition/marginal_sparse.rs`: `extract_ancestral_sequence` returns empty when `seq.sequence` is cleared
+- `packages/treetime/src/representation/partition/marginal_sparse.rs`: `extract_ancestral_sequence` returns empty when `seq.sequence` is cleared by `finalize_fitch`
 
 ## Context
 

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -97,6 +97,7 @@ exactly.
 | Medium     | Timetree     | [Skyline coalescent uses Nelder-Mead instead of SLSQP](M-timetree-skyline-nelder-mead-optimizer.md)                                   |
 | Medium     | Timetree     | [Marginal dense golden master node key mismatch on ebola_20](M-timetree-dense-golden-master-node-mismatch.md)                         |
 | Medium     | Timetree     | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)                  |
+| Medium     | Timetree     | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                     |
 | Negligible | Ancestral    | [Sparse marginal passes still use remove/insert pattern](N-ancestral-sparse-remove-insert-pattern.md)                                 |
 | Negligible | Clock        | [assign_dates fails for small trees](N-clock-small-trees.md)                                                                          |
 | Negligible | Core         | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                       |

--- a/packages/treetime/examples/timetree_validation.rs
+++ b/packages/treetime/examples/timetree_validation.rs
@@ -33,6 +33,7 @@ use treetime_io::dates_csv::read_dates;
 use treetime_io::fasta::read_many_fasta;
 use treetime_io::json::{JsonPretty, json_write_file};
 use treetime_io::nwk::nwk_read_str;
+use treetime_primitives::seq;
 use treetime_utils::fmt::string::truncate_right_with_ellipsis;
 use treetime_utils::init::global::global_init;
 
@@ -299,11 +300,13 @@ fn run_marginal_sparse_test(config: &DatasetConfig, args: &Args) -> Result<TestR
     gtr: jc69(JC69Params::default())?,
     alphabet,
     length: config.sequence_length,
+    root_sequence: seq![],
     nodes: btreemap! {},
     edges: btreemap! {},
   }));
 
   compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+  sparse_partition.write_arc().extract_root_sequence(&graph);
   dump_graph(&graph, &output_dir_str, "001_after_compress_sequences.json")?;
 
   let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];

--- a/packages/treetime/examples/timetree_validation.rs
+++ b/packages/treetime/examples/timetree_validation.rs
@@ -306,7 +306,7 @@ fn run_marginal_sparse_test(config: &DatasetConfig, args: &Args) -> Result<TestR
   }));
 
   compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-  sparse_partition.write_arc().extract_root_sequence(&graph);
+  sparse_partition.write_arc().extract_root_sequence(&graph)?;
   dump_graph(&graph, &output_dir_str, "001_after_compress_sequences.json")?;
 
   let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];

--- a/packages/treetime/examples/timetree_validation.rs
+++ b/packages/treetime/examples/timetree_validation.rs
@@ -306,7 +306,6 @@ fn run_marginal_sparse_test(config: &DatasetConfig, args: &Args) -> Result<TestR
   }));
 
   compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-  sparse_partition.write_arc().extract_root_sequence(&graph)?;
   dump_graph(&graph, &output_dir_str, "001_after_compress_sequences.json")?;
 
   let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];

--- a/packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs
@@ -92,9 +92,6 @@ pub mod tests {
     }))];
 
     compress_sequences(&graph, &partitions, &input.alignment)?;
-    for p in &partitions {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
     let log_lh = update_marginal(&graph, &partitions)?;
     Ok((log_lh, partitions))
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs
@@ -93,7 +93,7 @@ pub mod tests {
 
     compress_sequences(&graph, &partitions, &input.alignment)?;
     for p in &partitions {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
     let log_lh = update_marginal(&graph, &partitions)?;
     Ok((log_lh, partitions))

--- a/packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/prop_marginal_support.rs
@@ -12,6 +12,7 @@ pub mod tests {
   use parking_lot::RwLock;
   use std::sync::Arc;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   /// Run marginal ancestral reconstruction using dense representation.
   ///
@@ -87,9 +88,13 @@ pub mod tests {
       length,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &partitions, &input.alignment)?;
+    for p in &partitions {
+      p.write_arc().extract_root_sequence(&graph);
+    }
     let log_lh = update_marginal(&graph, &partitions)?;
     Ok((log_lh, partitions))
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -22,6 +22,7 @@ mod tests {
   use treetime_graph::node::Named;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
   use treetime_utils::make_report;
 
   static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
@@ -127,10 +128,14 @@ mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
     let partitions = [Arc::clone(&partition)];
 
     compress_sequences(graph, &partitions, aln)?;
+    for p in &partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     let log_lh = update_marginal(graph, &partitions)?;
     Ok((log_lh, partition))
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -133,9 +133,6 @@ mod tests {
     let partitions = [Arc::clone(&partition)];
 
     compress_sequences(graph, &partitions, aln)?;
-    for p in &partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     let log_lh = update_marginal(graph, &partitions)?;
     Ok((log_lh, partition))
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -134,7 +134,7 @@ mod tests {
 
     compress_sequences(graph, &partitions, aln)?;
     for p in &partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     let log_lh = update_marginal(graph, &partitions)?;
     Ok((log_lh, partition))

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
@@ -129,7 +129,6 @@ mod tests {
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
-    partitions[0].write_arc().extract_root_sequence(graph);
     let log_lh = update_marginal(graph, &partitions)?;
     Ok((log_lh, partitions))
   }
@@ -204,7 +203,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
-    partitions_marginal_sparse[0].write_arc().extract_root_sequence(&graph);
 
     let log_lh = update_marginal(&graph, &partitions_marginal_sparse)?;
 
@@ -530,7 +528,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
-    partitions[0].write_arc().extract_root_sequence(&graph);
     update_marginal(&graph, &partitions)?;
 
     let actual_by_edge = {

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
@@ -25,6 +25,7 @@ mod tests {
   use treetime_io::json::{JsonPretty, json_write_str};
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::Seq;
+  use treetime_primitives::seq;
 
   /// Lazily initialized default nucleotide alphabet (A, C, G, T with gap handling).
   static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
@@ -124,9 +125,11 @@ mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
+    partitions[0].write_arc().extract_root_sequence(graph);
     let log_lh = update_marginal(graph, &partitions)?;
     Ok((log_lh, partitions))
   }
@@ -197,9 +200,11 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
+    partitions_marginal_sparse[0].write_arc().extract_root_sequence(&graph);
 
     let log_lh = update_marginal(&graph, &partitions_marginal_sparse)?;
 
@@ -300,6 +305,7 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
@@ -472,6 +478,7 @@ mod tests {
             length: get_common_length(&aln)?,
             nodes: btreemap! {},
             edges: btreemap! {},
+            root_sequence: seq![],
           }))];
 
           compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
@@ -519,9 +526,11 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
+    partitions[0].write_arc().extract_root_sequence(&graph);
     update_marginal(&graph, &partitions)?;
 
     let actual_by_edge = {

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
@@ -124,9 +124,6 @@ pub mod tests {
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
-    for p in &partitions {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
     let log_lh = update_marginal(&graph, &partitions)?;
     Ok((log_lh, partitions))
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
@@ -125,7 +125,7 @@ pub mod tests {
 
     compress_sequences(&graph, &partitions, &aln)?;
     for p in &partitions {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
     let log_lh = update_marginal(&graph, &partitions)?;
     Ok((log_lh, partitions))

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
@@ -16,6 +16,7 @@ pub mod tests {
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
 
@@ -119,9 +120,13 @@ pub mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
+    for p in &partitions {
+      p.write_arc().extract_root_sequence(&graph);
+    }
     let log_lh = update_marginal(&graph, &partitions)?;
     Ok((log_lh, partitions))
   }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
@@ -527,6 +527,7 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    sparse_partition.write_arc().extract_root_sequence(&graph)?;
     let sparse_log_lh = update_marginal(&graph, std::slice::from_ref(&sparse_partition))?;
 
     // Log-likelihoods should match for clean sequences

--- a/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
@@ -19,6 +19,7 @@ mod tests {
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::{read_many_fasta, read_many_fasta_str};
   use treetime_io::nwk::{nwk_read_file, nwk_read_str};
+  use treetime_primitives::seq;
   use treetime_utils::make_report;
 
   /// Resolve the workspace root directory by walking up from the crate's manifest directory.
@@ -522,6 +523,7 @@ mod tests {
       length,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;

--- a/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
@@ -527,7 +527,6 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    sparse_partition.write_arc().extract_root_sequence(&graph)?;
     let sparse_log_lh = update_marginal(&graph, std::slice::from_ref(&sparse_partition))?;
 
     // Log-likelihoods should match for clean sequences

--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -537,6 +537,9 @@ where
   fitch_backward(graph, partitions);
   fitch_forward(graph, partitions)?;
   fitch_cleanup(graph, partitions);
+  for partition in partitions {
+    partition.write_arc().finalize_fitch(graph)?;
+  }
   Ok(())
 }
 

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -117,7 +117,7 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
         if !partitions_marginal_sparse.is_empty() {
           compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
           for partition in &partitions_marginal_sparse {
-            partition.write_arc().extract_root_sequence(&graph);
+            partition.write_arc().extract_root_sequence(&graph)?;
           }
 
           // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -116,9 +116,6 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
 
         if !partitions_marginal_sparse.is_empty() {
           compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
-          for partition in &partitions_marginal_sparse {
-            partition.write_arc().extract_root_sequence(&graph)?;
-          }
 
           // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr
           // FIXME: spaghetti code: dummy gtr is replaced by real gtr here

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -24,6 +24,7 @@ use treetime_graph::node::GraphNode;
 use treetime_io::fasta::{FastaReader, FastaRecord, FastaWriter, read_many_fasta};
 use treetime_io::nex::{NexWriteOptions, nex_write_file};
 use treetime_io::nwk::{EdgeToNwk, NodeToNwk, NwkWriteOptions, nwk_read_file, nwk_write_file};
+use treetime_primitives::seq;
 use treetime_utils::io::file::{create_file_or_stdout, open_stdin};
 
 #[derive(Clone, Debug, Default)]
@@ -105,6 +106,7 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
           gtr: jc69(JC69Params::default())?, // FIXME: dummy temporary gtr should not be needed here
           alphabet,
           length: get_common_length(&aln)?,
+          root_sequence: seq![],
           nodes: btreemap! {},
           edges: btreemap! {},
         }]
@@ -114,6 +116,9 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
 
         if !partitions_marginal_sparse.is_empty() {
           compress_sequences(&graph, &partitions_marginal_sparse, &aln)?;
+          for partition in &partitions_marginal_sparse {
+            partition.write_arc().extract_root_sequence(&graph);
+          }
 
           // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr
           // FIXME: spaghetti code: dummy gtr is replaced by real gtr here

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs
@@ -73,9 +73,6 @@ pub mod tests {
     }))];
 
     compress_sequences(graph, &sparse_partitions, aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     initialize_marginal(graph, &dense_partitions, aln)?;
     update_marginal(graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs
@@ -74,7 +74,7 @@ pub mod tests {
 
     compress_sequences(graph, &sparse_partitions, aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     initialize_marginal(graph, &dense_partitions, aln)?;
     update_marginal(graph, &sparse_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence/test_convergence_support.rs
@@ -16,6 +16,7 @@ pub mod tests {
   use parking_lot::RwLock;
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
+  use treetime_primitives::seq;
 
   pub static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
 
@@ -68,9 +69,13 @@ pub mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &sparse_partitions, aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     initialize_marginal(graph, &dense_partitions, aln)?;
     update_marginal(graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs
@@ -49,7 +49,7 @@ mod tests {
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
     update_marginal(&graph, &sparse_partitions)?;
 
@@ -113,7 +113,7 @@ mod tests {
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
     update_marginal(&graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs
@@ -48,9 +48,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
     update_marginal(&graph, &sparse_partitions)?;
 
     // Infer GTR from data (matches production flow)
@@ -112,9 +109,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
     update_marginal(&graph, &sparse_partitions)?;
 
     for partition in &sparse_partitions {

--- a/packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_convergence_sc2.rs
@@ -15,6 +15,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_io::fasta::read_many_fasta;
   use treetime_io::nwk::nwk_read_file;
+  use treetime_primitives::seq;
 
   /// Regression test: sparse optimize loop converges on sc2/2844 (dataset with indels).
   ///
@@ -43,9 +44,13 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(&graph);
+    }
     update_marginal(&graph, &sparse_partitions)?;
 
     // Infer GTR from data (matches production flow)
@@ -103,9 +108,13 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(&graph);
+    }
     update_marginal(&graph, &sparse_partitions)?;
 
     for partition in &sparse_partitions {

--- a/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
@@ -84,9 +84,6 @@ pub mod tests {
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
-    for p in &partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)

--- a/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
@@ -27,6 +27,7 @@ pub mod tests {
   use std::sync::{Arc, LazyLock};
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
+  use treetime_primitives::seq;
 
   pub static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
 
@@ -79,9 +80,13 @@ pub mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
+    for p in &partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)

--- a/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
@@ -85,7 +85,7 @@ pub mod tests {
 
     compress_sequences(graph, &partitions, aln)?;
     for p in &partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     update_marginal(graph, &partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
@@ -26,6 +26,7 @@ mod tests {
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   /// 4-taxon tree with positive initial branch lengths on every edge.
   ///
@@ -82,9 +83,13 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     initialize_marginal(graph, &dense_partitions, &aln)?;
     update_marginal(graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
@@ -87,9 +87,6 @@ mod tests {
     }))];
 
     compress_sequences(graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     initialize_marginal(graph, &dense_partitions, &aln)?;
     update_marginal(graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_dispatch_zero_boundary.rs
@@ -88,7 +88,7 @@ mod tests {
 
     compress_sequences(graph, &sparse_partitions, &aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     initialize_marginal(graph, &dense_partitions, &aln)?;
     update_marginal(graph, &sparse_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs
@@ -18,6 +18,7 @@ mod tests {
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   // Regression: run_optimize_mixed must not produce -inf/NaN when entering
   // with branch_length=0 and mismatched certain states. Before the fix,
@@ -64,9 +65,13 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(&graph);
+    }
     initialize_marginal(&graph, &dense_partitions, &aln)?;
     update_marginal(&graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs
@@ -70,7 +70,7 @@ mod tests {
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
     initialize_marginal(&graph, &dense_partitions, &aln)?;
     update_marginal(&graph, &sparse_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_eval_zero_branch_mismatch.rs
@@ -69,9 +69,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
     initialize_marginal(&graph, &dense_partitions, &aln)?;
     update_marginal(&graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
@@ -259,7 +259,7 @@ mod tests {
 
       compress_sequences(&graph, &sparse_partitions, &aln)?;
       for p in &sparse_partitions {
-        p.write_arc().extract_root_sequence(&graph);
+        p.write_arc().extract_root_sequence(&graph)?;
       }
       initialize_marginal(&graph, &dense_partitions, &aln)?;
       update_marginal(&graph, &sparse_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
@@ -189,6 +189,7 @@ mod tests {
     use std::sync::Arc;
     use treetime_io::fasta::read_many_fasta;
     use treetime_io::nwk::nwk_read_file;
+    use treetime_primitives::seq;
 
     #[derive(Clone, Deserialize)]
     pub struct GmOptimizeCase {
@@ -242,6 +243,7 @@ mod tests {
         gtr: jc69(JC69Params::default())?,
         alphabet: alphabet_sparse,
         length: get_common_length(&aln)?,
+        root_sequence: seq![],
         nodes: btreemap! {},
         edges: btreemap! {},
       }))];
@@ -256,6 +258,9 @@ mod tests {
       }))];
 
       compress_sequences(&graph, &sparse_partitions, &aln)?;
+      for p in &sparse_partitions {
+        p.write_arc().extract_root_sequence(&graph);
+      }
       initialize_marginal(&graph, &dense_partitions, &aln)?;
       update_marginal(&graph, &sparse_partitions)?;
       update_marginal(&graph, &dense_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
@@ -258,9 +258,6 @@ mod tests {
       }))];
 
       compress_sequences(&graph, &sparse_partitions, &aln)?;
-      for p in &sparse_partitions {
-        p.write_arc().extract_root_sequence(&graph)?;
-      }
       initialize_marginal(&graph, &dense_partitions, &aln)?;
       update_marginal(&graph, &sparse_partitions)?;
       update_marginal(&graph, &dense_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
@@ -178,9 +178,6 @@ mod tests {
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
-    for p in &partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
@@ -179,7 +179,7 @@ mod tests {
 
     compress_sequences(graph, &partitions, aln)?;
     for p in &partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     update_marginal(graph, &partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs
@@ -22,6 +22,7 @@ mod tests {
   use treetime_graph::node::Named;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   const TREE_NEWICK: &str = "((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;";
 
@@ -173,9 +174,13 @@ mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
+    for p in &partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs
@@ -19,6 +19,7 @@ mod tests {
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   const TREE_NEWICK: &str = "((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;";
 
@@ -88,9 +89,13 @@ mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
+    for p in &partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs
@@ -93,9 +93,6 @@ mod tests {
     }))];
 
     compress_sequences(graph, &partitions, aln)?;
-    for p in &partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     update_marginal(graph, &partitions)?;
 
     Ok(partitions)

--- a/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_initial_guess_gaps.rs
@@ -94,7 +94,7 @@ mod tests {
 
     compress_sequences(graph, &partitions, aln)?;
     for p in &partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     update_marginal(graph, &partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
@@ -95,9 +95,6 @@ mod tests {
     }))];
 
     compress_sequences(graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(graph)?;
-    }
     initialize_marginal(graph, &dense_partitions, &aln)?;
     update_marginal(graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
@@ -30,6 +30,7 @@ mod tests {
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::Seq;
+  use treetime_primitives::seq;
 
   /// Inject indels onto the first edge in each partition (both dense and sparse).
   fn inject_indels_on_first_edge(
@@ -90,9 +91,13 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(graph);
+    }
     initialize_marginal(graph, &dense_partitions, &aln)?;
     update_marginal(graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
@@ -96,7 +96,7 @@ mod tests {
 
     compress_sequences(graph, &sparse_partitions, &aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(graph);
+      p.write_arc().extract_root_sequence(graph)?;
     }
     initialize_marginal(graph, &dense_partitions, &aln)?;
     update_marginal(graph, &sparse_partitions)?;

--- a/packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs
@@ -247,7 +247,7 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph); }
+    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph)?; }
     update_marginal(&graph, &sparse_partitions)?;
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
@@ -335,7 +335,7 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph); }
+    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph)?; }
     update_marginal(&graph, &sparse_partitions)?;
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
@@ -410,7 +410,7 @@ mod tests {
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
     for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
     update_marginal(&graph, &sparse_partitions)?;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs
@@ -28,6 +28,7 @@ mod tests {
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::AsciiChar;
+  use treetime_primitives::seq;
 
   fn c(b: u8) -> AsciiChar {
     AsciiChar::from_byte_unchecked(b)
@@ -38,11 +39,15 @@ mod tests {
   }
 
   fn populate_test_nodes(partition: &mut PartitionMarginalSparse, graph: &GraphAncestral) {
+    let ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(partition.length).collect();
+    if partition.root_sequence.is_empty() {
+      partition.root_sequence = ref_seq.clone();
+    }
     for node in graph.get_nodes() {
       let key = node.read_arc().key();
       partition.nodes.entry(key).or_insert_with(|| {
         let mut node_part = SparseNodePartition::empty(&partition.alphabet);
-        node_part.seq.sequence = std::iter::repeat_with(|| c(b'A')).take(partition.length).collect();
+        node_part.seq.sequence = ref_seq.clone();
         node_part
       });
     }
@@ -134,6 +139,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     populate_test_nodes(&mut partition, &graph);
@@ -237,9 +243,11 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph); }
     update_marginal(&graph, &sparse_partitions)?;
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
@@ -323,9 +331,11 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph); }
     update_marginal(&graph, &sparse_partitions)?;
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
@@ -395,9 +405,13 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
+    for p in &sparse_partitions {
+      p.write_arc().extract_root_sequence(&graph);
+    }
     update_marginal(&graph, &sparse_partitions)?;
 
     let initial_node_count = graph.get_nodes().len();

--- a/packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_topology_cleanup.rs
@@ -247,7 +247,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph)?; }
     update_marginal(&graph, &sparse_partitions)?;
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
@@ -335,7 +334,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions { p.write_arc().extract_root_sequence(&graph)?; }
     update_marginal(&graph, &sparse_partitions)?;
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
@@ -409,9 +407,6 @@ mod tests {
     }))];
 
     compress_sequences(&graph, &sparse_partitions, &aln)?;
-    for p in &sparse_partitions {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
     update_marginal(&graph, &sparse_partitions)?;
 
     let initial_node_count = graph.get_nodes().len();

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -27,6 +27,7 @@ use treetime_graph::node::GraphNode;
 use treetime_io::fasta::read_many_fasta;
 use treetime_io::nex::{NexWriteOptions, nex_write_file};
 use treetime_io::nwk::{EdgeToNwk, NodeToNwk, NwkWriteOptions, nwk_read_file, nwk_write_file};
+use treetime_primitives::seq;
 use treetime_utils::fmt::float::float_to_significant_digits;
 use treetime_utils::make_error;
 
@@ -126,6 +127,7 @@ pub fn run_optimize(args: &TreetimeOptimizeArgs) -> Result<(), Report> {
       gtr: jc69(JC69Params::default())?, // FIXME: dummy temporary gtr should not be needed here
       alphabet: alphabet.clone(),
       length: get_common_length(&aln)?,
+      root_sequence: seq![],
       nodes: btreemap! {},
       edges: btreemap! {},
     }]
@@ -134,6 +136,9 @@ pub fn run_optimize(args: &TreetimeOptimizeArgs) -> Result<(), Report> {
     .collect_vec();
 
     compress_sequences(&graph, &partitions, &aln)?;
+    for partition in &partitions {
+      partition.write_arc().extract_root_sequence(&graph);
+    }
 
     // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr
     // FIXME: spaghetti code: dummy gtr is replaced by real gtr here

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -137,7 +137,7 @@ pub fn run_optimize(args: &TreetimeOptimizeArgs) -> Result<(), Report> {
 
     compress_sequences(&graph, &partitions, &aln)?;
     for partition in &partitions {
-      partition.write_arc().extract_root_sequence(&graph);
+      partition.write_arc().extract_root_sequence(&graph)?;
     }
 
     // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -136,9 +136,6 @@ pub fn run_optimize(args: &TreetimeOptimizeArgs) -> Result<(), Report> {
     .collect_vec();
 
     compress_sequences(&graph, &partitions, &aln)?;
-    for partition in &partitions {
-      partition.write_arc().extract_root_sequence(&graph)?;
-    }
 
     // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr
     // FIXME: spaghetti code: dummy gtr is replaced by real gtr here

--- a/packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs
+++ b/packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs
@@ -16,6 +16,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::AsciiChar;
+  use treetime_primitives::seq;
 
   fn c(b: u8) -> AsciiChar {
     AsciiChar::from_byte_unchecked(b)
@@ -37,6 +38,7 @@ mod tests {
       length,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     // Build root reference sequence consistent with edge subs.
@@ -50,6 +52,8 @@ mod tests {
         }
       }
     }
+
+    partition.root_sequence = ref_seq.clone();
 
     // Populate node entries so edge_subs() can reconstruct states
     for node in graph.get_nodes() {
@@ -388,10 +392,11 @@ mod tests {
       length: 200,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
-    // Populate nodes for p2 with a reference sequence matching the sub ref chars
     let mut p2_ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(200).collect();
     p2_ref_seq[50] = c(b'C'); // sub C50G uses ref='C'
+    p2_inner.root_sequence = p2_ref_seq.clone();
     for node in graph.get_nodes() {
       let key = node.read_arc().key();
       let mut node_part = SparseNodePartition::empty(&p2_inner.alphabet);

--- a/packages/treetime/src/commands/prune/__tests__/test_run.rs
+++ b/packages/treetime/src/commands/prune/__tests__/test_run.rs
@@ -23,6 +23,7 @@ mod tests {
   use treetime_graph::graph::Graph;
   use treetime_io::nwk::{NwkWriteOptions, nwk_read_str, nwk_write_str};
   use treetime_primitives::AsciiChar;
+  use treetime_primitives::seq;
   use treetime_utils::make_report;
 
   fn c(b: u8) -> AsciiChar {
@@ -32,11 +33,15 @@ mod tests {
   /// Populate partition node entries for all graph nodes with dummy reference sequences.
   /// Required for `edge_subs()` to work (it accesses node data to reconstruct states).
   fn populate_test_nodes(partition: &mut PartitionMarginalSparse, graph: &GraphAncestral) {
+    let ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(partition.length).collect();
+    if partition.root_sequence.is_empty() {
+      partition.root_sequence = ref_seq.clone();
+    }
     for node in graph.get_nodes() {
       let key = node.read_arc().key();
       partition.nodes.entry(key).or_insert_with(|| {
         let mut node_part = SparseNodePartition::empty(&partition.alphabet);
-        node_part.seq.sequence = std::iter::repeat_with(|| c(b'A')).take(partition.length).collect();
+        node_part.seq.sequence = ref_seq.clone();
         node_part
       });
     }
@@ -58,6 +63,7 @@ mod tests {
         length: 100, // dummy length
         nodes: btreemap! {},
         edges: btreemap! {},
+        root_sequence: seq![],
       };
 
       populate_test_nodes(&mut partition, &graph);
@@ -103,6 +109,7 @@ mod tests {
         length: 100,
         nodes: btreemap! {},
         edges: btreemap! {},
+        root_sequence: seq![],
       };
 
       populate_test_nodes(&mut partition, &graph);
@@ -627,6 +634,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     // Root -> internal has mutations at positions 0, 1
@@ -714,6 +722,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     // Parent edge: A->G at pos 0
@@ -783,6 +792,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     // Parent edge: A->G at pos 0
@@ -851,6 +861,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
     partition1.edges.insert(
       root_internal_edge_key,
@@ -877,6 +888,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
     partition2.edges.insert(
       root_internal_edge_key,
@@ -1234,6 +1246,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     populate_test_nodes(&mut partition, &graph);
@@ -1324,6 +1337,7 @@ mod tests {
       length: 100,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     };
 
     let parent_indel = InDel::del((10, 15), [c(b'A'), c(b'C'), c(b'G'), c(b'T'), c(b'A')].as_slice());

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -28,6 +28,7 @@ use treetime_io::fasta::read_many_fasta;
 use treetime_io::nex::{NexWriteOptions, nex_write_file};
 use treetime_io::nwk::{EdgeToNwk, NodeToNwk, NwkWriteOptions, nwk_read_file, nwk_write_file};
 use treetime_io::parse_delimited::{parse_delimited_file, parse_delimited_str};
+use treetime_primitives::seq;
 use treetime_utils::iterator::difference::iterator_difference;
 use treetime_utils::iterator::intersection::iterator_intersection;
 
@@ -76,11 +77,15 @@ pub fn run_prune(args: &TreetimePruneArgs) -> Result<(), Report> {
       gtr: jc69(JC69Params::default())?, // FIXME: dummy temporary gtr should not be needed here
       alphabet,
       length: get_common_length(&aln)?,
+      root_sequence: seq![],
       nodes: btreemap! {},
       edges: btreemap! {},
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
+    for partition in &partitions {
+      partition.write_arc().extract_root_sequence(&graph);
+    }
 
     // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr
     // FIXME: spaghetti code: dummy gtr is replaced by real gtr here

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -83,9 +83,6 @@ pub fn run_prune(args: &TreetimePruneArgs) -> Result<(), Report> {
     }))];
 
     compress_sequences(&graph, &partitions, &aln)?;
-    for partition in &partitions {
-      partition.write_arc().extract_root_sequence(&graph)?;
-    }
 
     // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr
     // FIXME: spaghetti code: dummy gtr is replaced by real gtr here

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -84,7 +84,7 @@ pub fn run_prune(args: &TreetimePruneArgs) -> Result<(), Report> {
 
     compress_sequences(&graph, &partitions, &aln)?;
     for partition in &partitions {
-      partition.write_arc().extract_root_sequence(&graph);
+      partition.write_arc().extract_root_sequence(&graph)?;
     }
 
     // FIXME: chicken & egg problem: to get a gtr we need partitions, to get partitions we need a gtr

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
@@ -59,7 +59,6 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    sparse_partition.write_arc().extract_root_sequence(&graph);
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];
     initialize_marginal(&graph, &partitions, &aln)?;

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
@@ -23,6 +23,7 @@ mod tests {
   use rstest::rstest;
   use std::sync::Arc;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
   use treetime_utils::pretty_assert_map_abs_diff_eq;
 
   // --- Marginal sparse tests ---
@@ -54,9 +55,11 @@ mod tests {
       length: case.sequence_length(),
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    sparse_partition.write_arc().extract_root_sequence(&graph);
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];
     initialize_marginal(&graph, &partitions, &aln)?;

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
@@ -63,7 +63,7 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    sparse_partition.write_arc().extract_root_sequence(&graph);
+    sparse_partition.write_arc().extract_root_sequence(&graph)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];
@@ -124,7 +124,7 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    sparse_partition.write_arc().extract_root_sequence(&graph);
+    sparse_partition.write_arc().extract_root_sequence(&graph)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
@@ -63,7 +63,6 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    sparse_partition.write_arc().extract_root_sequence(&graph)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];
@@ -124,7 +123,6 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    sparse_partition.write_arc().extract_root_sequence(&graph)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
@@ -28,6 +28,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   fn extract_branch_lengths(graph: &GraphTimetree) -> Vec<f64> {
     graph
@@ -58,9 +59,11 @@ mod tests {
       length: case.sequence_length(),
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    sparse_partition.write_arc().extract_root_sequence(&graph);
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];
@@ -117,9 +120,11 @@ mod tests {
       length: case.sequence_length(),
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    sparse_partition.write_arc().extract_root_sequence(&graph);
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];

--- a/packages/treetime/src/commands/timetree/initialization.rs
+++ b/packages/treetime/src/commands/timetree/initialization.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use treetime_io::dates_csv::read_dates;
 use treetime_io::fasta::{FastaRecord, read_many_fasta};
 use treetime_io::nwk::nwk_read_file;
+use treetime_primitives::seq;
 
 pub struct InputData {
   pub graph: GraphTimetree,
@@ -105,11 +106,13 @@ pub fn initialize_partitions(
       gtr: initial_gtr,
       alphabet,
       length,
+      root_sequence: seq![],
       nodes: btreemap! {},
       edges: btreemap! {},
     }));
 
     crate::commands::ancestral::fitch::compress_sequences(graph, std::slice::from_ref(&sparse_partition), aln_data)?;
+    sparse_partition.write_arc().extract_root_sequence(graph);
 
     // For Infer: Fitch compression populated mutation counts, infer real GTR
     if model_name == GtrModelName::Infer {

--- a/packages/treetime/src/commands/timetree/initialization.rs
+++ b/packages/treetime/src/commands/timetree/initialization.rs
@@ -112,7 +112,6 @@ pub fn initialize_partitions(
     }));
 
     crate::commands::ancestral::fitch::compress_sequences(graph, std::slice::from_ref(&sparse_partition), aln_data)?;
-    sparse_partition.write_arc().extract_root_sequence(graph)?;
 
     // For Infer: Fitch compression populated mutation counts, infer real GTR
     if model_name == GtrModelName::Infer {

--- a/packages/treetime/src/commands/timetree/initialization.rs
+++ b/packages/treetime/src/commands/timetree/initialization.rs
@@ -112,7 +112,7 @@ pub fn initialize_partitions(
     }));
 
     crate::commands::ancestral::fitch::compress_sequences(graph, std::slice::from_ref(&sparse_partition), aln_data)?;
-    sparse_partition.write_arc().extract_root_sequence(graph);
+    sparse_partition.write_arc().extract_root_sequence(graph)?;
 
     // For Infer: Fitch compression populated mutation counts, infer real GTR
     if model_name == GtrModelName::Infer {

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
@@ -100,9 +100,6 @@ mod tests {
 
     let partitions_for_compress: [Arc<RwLock<PartitionMarginalSparse>>; 1] = [Arc::clone(&sparse_partition)];
     compress_sequences(&graph, &partitions_for_compress, &aln)?;
-    for p in &partitions_for_compress {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
 
     let clock_params = ClockParams::default();
     clock_regression_backward(&graph, &clock_params, None);
@@ -539,9 +536,6 @@ mod tests {
 
     let partitions_for_compress: [Arc<RwLock<PartitionMarginalSparse>>; 1] = [Arc::clone(&sparse_partition)];
     compress_sequences(&graph, &partitions_for_compress, &aln)?;
-    for p in &partitions_for_compress {
-      p.write_arc().extract_root_sequence(&graph)?;
-    }
 
     let clock_params = ClockParams::default();
     clock_regression_backward(&graph, &clock_params, None);

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
@@ -95,10 +95,14 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     let partitions_for_compress: [Arc<RwLock<PartitionMarginalSparse>>; 1] = [Arc::clone(&sparse_partition)];
     compress_sequences(&graph, &partitions_for_compress, &aln)?;
+    for p in &partitions_for_compress {
+      p.write_arc().extract_root_sequence(&graph);
+    }
 
     let clock_params = ClockParams::default();
     clock_regression_backward(&graph, &clock_params, None);
@@ -208,6 +212,7 @@ mod tests {
       gtr,
       alphabet: alphabet.clone(),
       length: 16,
+      root_sequence: seq![AsciiChar::from_byte_unchecked(b'A'); 16],
       nodes: btreemap! {
         root_key => SparseNodePartition::new(&seq![AsciiChar::from_byte_unchecked(b'A'); 16], &alphabet)?,
         a_key => SparseNodePartition::new(&seq![AsciiChar::from_byte_unchecked(b'A'); 16], &alphabet)?,
@@ -226,11 +231,6 @@ mod tests {
         },
       },
     };
-
-    // Manually set root sequence
-    if let Some(n) = sparse_partition.nodes.get_mut(&root_key) {
-      n.seq.sequence = seq![AsciiChar::from_byte_unchecked(b'A'); 16];
-    }
 
     // Build RerootChanges with inverted edge keys (simulating reroot from root to A)
     let changes = RerootChanges {
@@ -306,6 +306,7 @@ mod tests {
       gtr,
       alphabet: alphabet.clone(),
       length: 8,
+      root_sequence: root_seq.clone(),
       nodes: btreemap! {
         root_key => SparseNodePartition::new(&root_seq, &alphabet)?,
         a_key => SparseNodePartition::new(&seq![AsciiChar::from_byte_unchecked(b'A'); 8], &alphabet)?,
@@ -371,10 +372,14 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     let partitions_for_compress: [Arc<RwLock<PartitionMarginalSparse>>; 1] = [Arc::clone(&sparse_partition)];
     compress_sequences(&graph, &partitions_for_compress, &aln)?;
+    for p in &partitions_for_compress {
+      p.write_arc().extract_root_sequence(&graph);
+    }
 
     let clock_params = ClockParams::default();
     clock_regression_backward(&graph, &clock_params, None);

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
@@ -348,6 +348,18 @@ mod tests {
     );
     assert_eq!(inverted_sub.pos(), 2, "Position should remain unchanged");
 
+    // Verify root_sequence is updated: original root had G at pos 2,
+    // child A had T. After reroot to A, new root_sequence should have T at pos 2.
+    let expected_new_root_seq = {
+      let mut s = root_seq;
+      s[2] = c(b'T');
+      s
+    };
+    assert_eq!(
+      sparse_partition.root_sequence, expected_new_root_seq,
+      "root_sequence should reflect the new root's state after edge inversion"
+    );
+
     Ok(())
   }
 

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_reroot.rs
@@ -101,7 +101,7 @@ mod tests {
     let partitions_for_compress: [Arc<RwLock<PartitionMarginalSparse>>; 1] = [Arc::clone(&sparse_partition)];
     compress_sequences(&graph, &partitions_for_compress, &aln)?;
     for p in &partitions_for_compress {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
 
     let clock_params = ClockParams::default();
@@ -364,6 +364,156 @@ mod tests {
   }
 
   #[test]
+  fn test_reroot_root_sequence_updated_with_indel() -> Result<(), Report> {
+    let graph: GraphTimetree = nwk_read_str("(A:0.1,B:0.2)root;")?;
+    let alphabet = Alphabet::new(AlphabetName::Nuc)?;
+    let gtr = jc69(JC69Params::default())?;
+
+    let root_key = find_node_key_by_name(&graph, "root").ok_or_else(|| make_report!("root not found"))?;
+    let a_key = find_node_key_by_name(&graph, "A").ok_or_else(|| make_report!("A not found"))?;
+    let edge_to_a_key = graph
+      .get_edges()
+      .iter()
+      .find(|e| {
+        let e = e.read_arc();
+        e.source() == root_key && e.target() == a_key
+      })
+      .map(|e| e.read_arc().key())
+      .ok_or_else(|| make_report!("Edge to A not found"))?;
+
+    let root_seq = Seq::try_from_slice(b"ACGTACGT")?;
+    let indel = InDel::del((2, 4), seq![c(b'G'), c(b'T')]);
+
+    let mut sparse_partition = PartitionMarginalSparse {
+      index: 0,
+      gtr,
+      alphabet: alphabet.clone(),
+      length: 8,
+      root_sequence: root_seq.clone(),
+      nodes: btreemap! {
+        root_key => SparseNodePartition::new(&root_seq, &alphabet)?,
+        a_key => SparseNodePartition::new(&seq![c(b'A'); 8], &alphabet)?,
+      },
+      edges: btreemap! {
+        edge_to_a_key => SparseEdgePartition {
+          subs: vec![],
+          indels: vec![indel],
+          msg_to_parent: MarginalSparseSeqDistribution::default(),
+          msg_to_child: MarginalSparseSeqDistribution::default(),
+          msg_from_child: MarginalSparseSeqDistribution::default(),
+          transmission: None,
+        },
+      },
+    };
+
+    let changes = RerootChanges {
+      inverted_edge_keys: vec![edge_to_a_key],
+      ..RerootChanges::default()
+    };
+
+    sparse_partition.apply_reroot(&changes)?;
+
+    // Original: root has "ACGTACGT", edge to A has deletion at [2,4) (G,T -> gap).
+    // After inversion the indel becomes an insertion. Going from old root to new
+    // root in original direction, the child had gaps at [2,4).
+    let mut expected = root_seq;
+    expected[2] = alphabet.gap();
+    expected[3] = alphabet.gap();
+    assert_eq!(
+      sparse_partition.root_sequence, expected,
+      "root_sequence should have gaps at positions 2-3 after indel-based reroot"
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_reroot_root_sequence_multi_hop() -> Result<(), Report> {
+    let graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2)AB:0.1,C:0.3)root;")?;
+    let alphabet = Alphabet::new(AlphabetName::Nuc)?;
+    let gtr = jc69(JC69Params::default())?;
+
+    let root_key = find_node_key_by_name(&graph, "root").ok_or_else(|| make_report!("root not found"))?;
+    let ab_key = find_node_key_by_name(&graph, "AB").ok_or_else(|| make_report!("AB not found"))?;
+    let a_key = find_node_key_by_name(&graph, "A").ok_or_else(|| make_report!("A not found"))?;
+
+    let edge_root_ab = graph
+      .get_edges()
+      .iter()
+      .find(|e| {
+        let e = e.read_arc();
+        e.source() == root_key && e.target() == ab_key
+      })
+      .map(|e| e.read_arc().key())
+      .ok_or_else(|| make_report!("Edge root->AB not found"))?;
+    let edge_ab_a = graph
+      .get_edges()
+      .iter()
+      .find(|e| {
+        let e = e.read_arc();
+        e.source() == ab_key && e.target() == a_key
+      })
+      .map(|e| e.read_arc().key())
+      .ok_or_else(|| make_report!("Edge AB->A not found"))?;
+
+    let root_seq = Seq::try_from_slice(b"ACGTACGT")?;
+    let sub1 = Sub::new(c(b'A'), 0_usize, c(b'G'))?; // root->AB: A0G
+    let sub2 = Sub::new(c(b'G'), 0_usize, c(b'T'))?; // AB->A: G0T (cumulative at pos 0)
+    let sub3 = Sub::new(c(b'C'), 1_usize, c(b'A'))?; // AB->A: C1A
+
+    let mut sparse_partition = PartitionMarginalSparse {
+      index: 0,
+      gtr,
+      alphabet: alphabet.clone(),
+      length: 8,
+      root_sequence: root_seq.clone(),
+      nodes: btreemap! {
+        root_key => SparseNodePartition::new(&root_seq, &alphabet)?,
+        ab_key => SparseNodePartition::new(&seq![c(b'A'); 8], &alphabet)?,
+        a_key => SparseNodePartition::new(&seq![c(b'A'); 8], &alphabet)?,
+      },
+      edges: btreemap! {
+        edge_root_ab => SparseEdgePartition {
+          subs: vec![sub1],
+          indels: vec![],
+          msg_to_parent: MarginalSparseSeqDistribution::default(),
+          msg_to_child: MarginalSparseSeqDistribution::default(),
+          msg_from_child: MarginalSparseSeqDistribution::default(),
+          transmission: None,
+        },
+        edge_ab_a => SparseEdgePartition {
+          subs: vec![sub2, sub3],
+          indels: vec![],
+          msg_to_parent: MarginalSparseSeqDistribution::default(),
+          msg_to_child: MarginalSparseSeqDistribution::default(),
+          msg_from_child: MarginalSparseSeqDistribution::default(),
+          transmission: None,
+        },
+      },
+    };
+
+    // Reroot from root through AB to A: two inverted edges
+    let changes = RerootChanges {
+      inverted_edge_keys: vec![edge_root_ab, edge_ab_a],
+      ..RerootChanges::default()
+    };
+
+    sparse_partition.apply_reroot(&changes)?;
+
+    // Original path: root(ACGTACGT) -> AB (pos0: A->G) -> A (pos0: G->T, pos1: C->A)
+    // New root = A: pos0 = T, pos1 = A, rest unchanged from root
+    let mut expected = root_seq;
+    expected[0] = c(b'T');
+    expected[1] = c(b'A');
+    assert_eq!(
+      sparse_partition.root_sequence, expected,
+      "root_sequence should reflect cumulative subs across multi-hop reroot"
+    );
+
+    Ok(())
+  }
+
+  #[test]
   fn test_reroot_tree_sparse_flow_does_not_panic() -> Result<(), Report> {
     // Regression test: verify reroot_tree completes without panicking
     // when keep_root=false (reroot enabled) with sparse partitions
@@ -390,7 +540,7 @@ mod tests {
     let partitions_for_compress: [Arc<RwLock<PartitionMarginalSparse>>; 1] = [Arc::clone(&sparse_partition)];
     compress_sequences(&graph, &partitions_for_compress, &aln)?;
     for p in &partitions_for_compress {
-      p.write_arc().extract_root_sequence(&graph);
+      p.write_arc().extract_root_sequence(&graph)?;
     }
 
     let clock_params = ClockParams::default();

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
@@ -77,6 +77,7 @@ mod tests {
       root_sequence: seq![],
     }));
     compress_sequences(&graph, std::slice::from_ref(&partition), aln)?;
+    partition.write_arc().extract_root_sequence(&graph)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;
     Ok((graph, partition))
   }

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
@@ -77,7 +77,6 @@ mod tests {
       root_sequence: seq![],
     }));
     compress_sequences(&graph, std::slice::from_ref(&partition), aln)?;
-    partition.write_arc().extract_root_sequence(&graph)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;
     Ok((graph, partition))
   }

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
@@ -27,6 +27,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   lazy_static! {
     static ref NUC_ALPHABET: Alphabet = Alphabet::default();
@@ -73,6 +74,7 @@ mod tests {
       length: get_common_length(aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
     compress_sequences(&graph, std::slice::from_ref(&partition), aln)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
@@ -50,6 +50,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_io::fasta::read_many_fasta;
   use treetime_io::nwk::nwk_read_file;
+  use treetime_primitives::seq;
 
   #[rustfmt::skip]
   #[rstest]
@@ -145,8 +146,10 @@ mod tests {
         length: get_common_length(&aln)?,
         nodes: btreemap! {},
         edges: btreemap! {},
+        root_sequence: seq![],
       }));
       compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
+      partition.write_arc().extract_root_sequence(&graph);
       update_marginal(&graph, std::slice::from_ref(&partition))?;
       infer_gtr_sparse(&partition, &graph)?
     };

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
@@ -149,7 +149,6 @@ mod tests {
         root_sequence: seq![],
       }));
       compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-      partition.write_arc().extract_root_sequence(&graph)?;
       update_marginal(&graph, std::slice::from_ref(&partition))?;
       infer_gtr_sparse(&partition, &graph)?
     };

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
@@ -149,7 +149,7 @@ mod tests {
         root_sequence: seq![],
       }));
       compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-      partition.write_arc().extract_root_sequence(&graph);
+      partition.write_arc().extract_root_sequence(&graph)?;
       update_marginal(&graph, std::slice::from_ref(&partition))?;
       infer_gtr_sparse(&partition, &graph)?
     };

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
@@ -20,6 +20,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
 
   lazy_static! {
     static ref NUC_ALPHABET: Alphabet = Alphabet::default();
@@ -51,6 +52,7 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
@@ -100,6 +102,7 @@ mod tests {
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
@@ -56,7 +56,6 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-    partition.write_arc().extract_root_sequence(&graph)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;
 
     let counts_actual = get_mutation_counts_sparse(&graph, &partition)?;
@@ -107,7 +106,6 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-    partition.write_arc().extract_root_sequence(&graph)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;
 
     let counts = get_mutation_counts_sparse(&graph, &partition)?;

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
@@ -56,6 +56,7 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
+    partition.write_arc().extract_root_sequence(&graph)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;
 
     let counts_actual = get_mutation_counts_sparse(&graph, &partition)?;
@@ -106,6 +107,7 @@ mod tests {
     }));
 
     compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
+    partition.write_arc().extract_root_sequence(&graph)?;
     update_marginal(&graph, std::slice::from_ref(&partition))?;
 
     let counts = get_mutation_counts_sparse(&graph, &partition)?;

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs
@@ -19,6 +19,7 @@ mod tests {
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::AsciiChar;
+  use treetime_primitives::seq;
 
   fn c(b: u8) -> AsciiChar {
     AsciiChar::from_byte_unchecked(b)
@@ -29,11 +30,15 @@ mod tests {
   }
 
   fn populate_test_nodes(partition: &mut PartitionMarginalSparse, graph: &GraphAncestral) {
+    let ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(partition.length).collect();
+    if partition.root_sequence.is_empty() {
+      partition.root_sequence = ref_seq.clone();
+    }
     for node in graph.get_nodes() {
       let key = node.read_arc().key();
       partition.nodes.entry(key).or_insert_with(|| {
         let mut node_part = SparseNodePartition::empty(&partition.alphabet);
-        node_part.seq.sequence = std::iter::repeat_with(|| c(b'A')).take(partition.length).collect();
+        node_part.seq.sequence = ref_seq.clone();
         node_part
       });
     }
@@ -47,6 +52,7 @@ mod tests {
       length,
       nodes: btreemap! {},
       edges: btreemap! {},
+      root_sequence: seq![],
     })
   }
 

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -16,7 +16,7 @@ use eyre::Report;
 use itertools::Itertools;
 use std::collections::BTreeMap;
 use std::mem;
-use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
+use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey};
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
@@ -33,6 +33,7 @@ pub struct PartitionMarginalSparse {
   pub gtr: GTR,
   pub alphabet: Alphabet,
   pub length: usize,
+  pub root_sequence: Seq,
   pub nodes: BTreeMap<GraphNodeKey, SparseNodePartition>,
   pub edges: BTreeMap<GraphEdgeKey, SparseEdgePartition>,
 }
@@ -71,6 +72,31 @@ impl PartitionMarginalSparse {
   #[allow(clippy::same_name_method)]
   pub fn get_sequence_length(&self) -> usize {
     self.length
+  }
+
+  /// Extract root sequence from the root node and clear internal node sequences.
+  ///
+  /// After Fitch compression, every node carries a full resolved sequence. Only
+  /// the root sequence is needed for downstream reconstruction (node_state_at,
+  /// reconstruct_node_sequence cascade from it via edge subs). Clearing internal
+  /// sequences saves memory and removes stale data that would otherwise persist
+  /// across reroots.
+  pub fn extract_root_sequence<N, E>(&mut self, graph: &Graph<N, E, ()>)
+  where
+    N: GraphNode,
+    E: GraphEdge,
+  {
+    let root_key = graph
+      .get_exactly_one_root()
+      .expect("Tree must have exactly one root")
+      .read_arc()
+      .key();
+    self.root_sequence = self.nodes[&root_key].seq.sequence.clone();
+    for (key, node_data) in &mut self.nodes {
+      if *key != root_key && !graph.is_leaf(*key) {
+        node_data.seq.sequence = seq![];
+      }
+    }
   }
 
   /// Return positions that can change the reconstructed mutation set for one edge.
@@ -137,14 +163,11 @@ impl PartitionMarginalSparse {
     // Root must have partition data (populated by Fitch compression).
     // Non-root nodes may be absent during topology changes.
     let base_state = match graph.node_parent(node_key)? {
-      None => {
-        let d = node_data.ok_or_else(|| make_internal_report!("Root node {node_key} has no partition data"))?;
-        d.seq
-          .sequence
-          .get(pos)
-          .copied()
-          .unwrap_or_else(|| self.alphabet.char(0))
-      },
+      None => self
+        .root_sequence
+        .get(pos)
+        .copied()
+        .unwrap_or_else(|| self.alphabet.char(0)),
       Some((parent_key, parent_edge_key)) => {
         let parent_state = self.node_state_at(graph, parent_key, pos, cache)?;
 
@@ -402,7 +425,7 @@ where
     let mut node_data = self.nodes.remove(&node.key)?;
 
     let mut seq = if node.is_root {
-      node_data.seq.sequence.clone()
+      self.root_sequence.clone()
     } else {
       let (parent_key, edge_key) = get_exactly_one(&node.parent_keys).ok()?;
       let parent_data = self.nodes.get(parent_key)?;

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -292,6 +292,38 @@ impl PartitionRerootOps for PartitionMarginalSparse {
       edge_data.msg_from_child = MarginalSparseSeqDistribution::default();
     }
 
+    // Derive root sequence for the new root from the old root sequence.
+    // Walk inverted edges (listed in old_root->new_root order). After sub
+    // inversion, each sub's ref() holds the new-root-ward state (was the
+    // original child qry). Applying ref() at each position advances the
+    // sequence one step toward the new root.
+    if !changes.inverted_edge_keys.is_empty() {
+      let mut new_root_seq = self.root_sequence.clone();
+      for edge_key in &changes.inverted_edge_keys {
+        if let Some(edge_data) = self.edges.get(edge_key) {
+          for sub in &edge_data.subs {
+            if sub.pos() < new_root_seq.len() {
+              new_root_seq[sub.pos()] = sub.reff();
+            }
+          }
+          for indel in &edge_data.indels {
+            if indel.range.0 < new_root_seq.len() && indel.range.1 <= new_root_seq.len() {
+              // After inversion, deletion flag is flipped. To go in the
+              // original (old_root->new_root) direction:
+              // - current deletion (was insertion): child had `seq`
+              // - current insertion (was deletion): child had gaps
+              if indel.deletion {
+                new_root_seq[indel.range.0..indel.range.1].copy_from_slice(&indel.seq);
+              } else {
+                new_root_seq[indel.range.0..indel.range.1].fill(self.alphabet.gap());
+              }
+            }
+          }
+        }
+      }
+      self.root_sequence = new_root_seq;
+    }
+
     Ok(())
   }
 }

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -81,22 +81,19 @@ impl PartitionMarginalSparse {
   /// reconstruct_node_sequence cascade from it via edge subs). Clearing internal
   /// sequences saves memory and removes stale data that would otherwise persist
   /// across reroots.
-  pub fn extract_root_sequence<N, E>(&mut self, graph: &Graph<N, E, ()>)
+  pub fn extract_root_sequence<N, E>(&mut self, graph: &Graph<N, E, ()>) -> Result<(), Report>
   where
     N: GraphNode,
     E: GraphEdge,
   {
-    let root_key = graph
-      .get_exactly_one_root()
-      .expect("Tree must have exactly one root")
-      .read_arc()
-      .key();
+    let root_key = graph.get_exactly_one_root()?.read_arc().key();
     self.root_sequence = self.nodes[&root_key].seq.sequence.clone();
     for (key, node_data) in &mut self.nodes {
       if *key != root_key && !graph.is_leaf(*key) {
         node_data.seq.sequence = seq![];
       }
     }
+    Ok(())
   }
 
   /// Return positions that can change the reconstructed mutation set for one edge.
@@ -159,9 +156,11 @@ impl PartitionMarginalSparse {
 
     let node_data = self.nodes.get(&node_key);
 
-    // Compute base state from tree structure.
-    // Root must have partition data (populated by Fitch compression).
-    // Non-root nodes may be absent during topology changes.
+    debug_assert!(
+      !self.root_sequence.is_empty(),
+      "root_sequence is empty: call extract_root_sequence() after compress_sequences()"
+    );
+
     let base_state = match graph.node_parent(node_key)? {
       None => self
         .root_sequence
@@ -239,10 +238,12 @@ impl PartitionRerootOps for PartitionMarginalSparse {
         .insert(info.parent_side_edge_key, SparseEdgePartition::default());
     }
 
-    // Handle edge merge: compose mutations from two edges
+    // Handle edge merge: compose mutations from two edges.
+    // When the removed node is the old root (trivial root removal), update
+    // root_sequence using the parent_edge subs before discarding them.
+    // The parent_edge goes from the new-root side toward the removed node:
+    // sub.reff() = new-root-side state, sub.qry() = removed-node state.
     if let Some(info) = &changes.edge_merge {
-      self.nodes.remove(&info.removed_node_key);
-
       let parent_edge = self
         .edges
         .remove(&info.parent_edge_key)
@@ -252,10 +253,27 @@ impl PartitionRerootOps for PartitionMarginalSparse {
         .remove(&info.child_edge_key)
         .ok_or_else(|| make_internal_report!("Child edge {:?} must exist for merge", info.child_edge_key))?;
 
-      // Compose substitutions: parent then child
+      if changes.inverted_edge_keys.is_empty() {
+        for sub in &parent_edge.subs {
+          if sub.pos() < self.root_sequence.len() {
+            self.root_sequence[sub.pos()] = sub.reff();
+          }
+        }
+        for indel in &parent_edge.indels {
+          if indel.range.0 < self.root_sequence.len() && indel.range.1 <= self.root_sequence.len() {
+            if indel.deletion {
+              self.root_sequence[indel.range.0..indel.range.1].fill(self.alphabet.gap());
+            } else {
+              self.root_sequence[indel.range.0..indel.range.1].copy_from_slice(&indel.seq);
+            }
+          }
+        }
+      }
+
+      self.nodes.remove(&info.removed_node_key);
+
       let merged_subs = compose_substitutions(&parent_edge.subs, &child_edge.subs)?;
 
-      // Compose indels: concatenate (parent indels first, then child indels)
       let mut merged_indels = parent_edge.indels;
       merged_indels.extend(child_edge.indels);
 

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -66,22 +66,8 @@ impl PartitionCompressed for PartitionMarginalSparse {
   fn edges_mut(&mut self) -> &mut BTreeMap<GraphEdgeKey, SparseEdgePartition> {
     &mut self.edges
   }
-}
 
-impl PartitionMarginalSparse {
-  #[allow(clippy::same_name_method)]
-  pub fn get_sequence_length(&self) -> usize {
-    self.length
-  }
-
-  /// Extract root sequence from the root node and clear internal node sequences.
-  ///
-  /// After Fitch compression, every node carries a full resolved sequence. Only
-  /// the root sequence is needed for downstream reconstruction (node_state_at,
-  /// reconstruct_node_sequence cascade from it via edge subs). Clearing internal
-  /// sequences saves memory and removes stale data that would otherwise persist
-  /// across reroots.
-  pub fn extract_root_sequence<N, E>(&mut self, graph: &Graph<N, E, ()>) -> Result<(), Report>
+  fn finalize_fitch<N, E>(&mut self, graph: &Graph<N, E, ()>) -> Result<(), Report>
   where
     N: GraphNode,
     E: GraphEdge,
@@ -94,6 +80,13 @@ impl PartitionMarginalSparse {
       }
     }
     Ok(())
+  }
+}
+
+impl PartitionMarginalSparse {
+  #[allow(clippy::same_name_method)]
+  pub fn get_sequence_length(&self) -> usize {
+    self.length
   }
 
   /// Return positions that can change the reconstructed mutation set for one edge.
@@ -158,7 +151,7 @@ impl PartitionMarginalSparse {
 
     debug_assert!(
       !self.root_sequence.is_empty(),
-      "root_sequence is empty: call extract_root_sequence() after compress_sequences()"
+      "root_sequence is empty: compress_sequences() was not called or finalize_fitch() failed"
     );
 
     let base_state = match graph.node_parent(node_key)? {

--- a/packages/treetime/src/representation/partition/traits.rs
+++ b/packages/treetime/src/representation/partition/traits.rs
@@ -154,6 +154,18 @@ pub trait PartitionCompressed: Sync + Send {
   fn edge_mut(&mut self, key: &GraphEdgeKey) -> &mut SparseEdgePartition {
     self.edges_mut().get_mut(key).expect("Edge not found")
   }
+
+  /// Post-Fitch finalization hook called at the end of `compress_sequences`.
+  ///
+  /// Default is a no-op. `PartitionMarginalSparse` overrides this to extract
+  /// the root sequence off-tree and clear internal node sequences.
+  fn finalize_fitch<N, E>(&mut self, _graph: &Graph<N, E, ()>) -> Result<(), Report>
+  where
+    N: GraphNode,
+    E: GraphEdge,
+  {
+    Ok(())
+  }
 }
 
 pub trait HasLogLh {

--- a/packages/treetime/src/representation/payload/ancestral.rs
+++ b/packages/treetime/src/representation/payload/ancestral.rs
@@ -212,15 +212,6 @@ mod tests {
     edge_subs: &[(usize, Vec<Sub>)],
   ) -> Result<Arc<RwLock<PartitionMarginalSparse>>, Report> {
     let alphabet = Alphabet::default();
-    let mut partition = PartitionMarginalSparse {
-      index: 0,
-      gtr: jc69(JC69Params::default())?,
-      alphabet: alphabet.clone(),
-      length,
-      nodes: btreemap! {},
-      edges: btreemap! {},
-    };
-
     // Build reference sequence consistent with sub ref chars
     let mut ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(length).collect();
     for (_, subs) in edge_subs {
@@ -230,6 +221,16 @@ mod tests {
         }
       }
     }
+
+    let mut partition = PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: alphabet.clone(),
+      length,
+      root_sequence: ref_seq.clone(),
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    };
 
     for node in graph.get_nodes() {
       let key = node.read_arc().key();

--- a/packages/treetime/src/representation/payload/timetree.rs
+++ b/packages/treetime/src/representation/payload/timetree.rs
@@ -313,15 +313,6 @@ mod tests {
     edge_subs: &[(usize, Vec<Sub>)],
   ) -> Result<Arc<RwLock<PartitionMarginalSparse>>, Report> {
     let alphabet = Alphabet::default();
-    let mut partition = PartitionMarginalSparse {
-      index: 0,
-      gtr: jc69(JC69Params::default())?,
-      alphabet: alphabet.clone(),
-      length,
-      nodes: btreemap! {},
-      edges: btreemap! {},
-    };
-
     // Build reference sequence consistent with sub ref chars so node_state_at
     // returns the expected parent state at each mutated position.
     let mut ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(length).collect();
@@ -332,6 +323,16 @@ mod tests {
         }
       }
     }
+
+    let mut partition = PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: alphabet.clone(),
+      length,
+      root_sequence: ref_seq.clone(),
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    };
 
     for node in graph.get_nodes() {
       let key = node.read_arc().key();

--- a/packages/treetime/src/test_utils.rs
+++ b/packages/treetime/src/test_utils.rs
@@ -61,9 +61,6 @@ pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) ->
   }))];
 
   compress_sequences(&graph, &partitions, &aln)?;
-  for p in &partitions {
-    p.write_arc().extract_root_sequence(&graph)?;
-  }
   update_marginal(&graph, &partitions)
 }
 

--- a/packages/treetime/src/test_utils.rs
+++ b/packages/treetime/src/test_utils.rs
@@ -17,6 +17,7 @@ use treetime_graph::node::GraphNodeKey;
 use treetime_graph::node::Named;
 use treetime_io::fasta::read_many_fasta_str;
 use treetime_io::nwk::nwk_read_str;
+use treetime_primitives::seq;
 
 /// Default nucleotide alphabet for test helpers.
 pub static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
@@ -56,9 +57,13 @@ pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) ->
     length: get_common_length(&aln)?,
     nodes: btreemap! {},
     edges: btreemap! {},
+    root_sequence: seq![],
   }))];
 
   compress_sequences(&graph, &partitions, &aln)?;
+  for p in &partitions {
+    p.write_arc().extract_root_sequence(&graph);
+  }
   update_marginal(&graph, &partitions)
 }
 

--- a/packages/treetime/src/test_utils.rs
+++ b/packages/treetime/src/test_utils.rs
@@ -62,7 +62,7 @@ pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) ->
 
   compress_sequences(&graph, &partitions, &aln)?;
   for p in &partitions {
-    p.write_arc().extract_root_sequence(&graph);
+    p.write_arc().extract_root_sequence(&graph)?;
   }
   update_marginal(&graph, &partitions)
 }


### PR DESCRIPTION
After Fitch compression, every node retained a full resolved sequence in `seq.sequence`. In sparse mode, only edge deltas relative to a reference are needed for reconstruction. Storing full sequences on internal nodes wasted memory and left stale data that persisted across reroots.

`apply_reroot()` also never derived the new root sequence from the old one. After rerooting, reconstruction functions used the pre-reroot root sequence, producing wrong ancestral states at every internal node.

This PR stores the root sequence in a dedicated `root_sequence` field on `PartitionMarginalSparse`, clears internal node sequences after extraction, and derives the new root sequence during reroot. A `finalize_fitch()` hook in `compress_sequences()` eliminates the error-prone two-step protocol where callers had to remember a separate extraction call.

### Work items

- [x] Add `root_sequence: Seq` field to `PartitionMarginalSparse`
- [x] Modify `node_state_at()` and `reconstruct_node_sequence()` to read from `root_sequence`
- [x] Derive new root sequence in `apply_reroot()` by walking inverted edges
- [x] Handle trivial root removal case where parent edge subs must be applied before merge
- [x] Add `finalize_fitch()` trait method to auto-extract root sequence
- [x] Remove all 34 explicit `extract_root_sequence()` calls
- [x] File issue: [M-timetree-sparse-convergence-empty-sequences.md](https://github.com/neherlab/treetime/blob/2ccb3a4bc62fd75cc37fdd80b70aa4bf11edc534/docs/port-known-issues/M-timetree-sparse-convergence-empty-sequences.md): sparse convergence tracking compares empty sequences