### PR TITLE
test(utils): add negative infinity assertion helper

### DIFF
--- a/packages/treetime-utils/README.md
+++ b/packages/treetime-utils/README.md
@@ -97,6 +97,7 @@ Test assertion macros wrapping `pretty_assertions` and `approx`:
 - `pretty_assert_eq!()` - formatted equality assertion with newline normalization
 - `pretty_assert_ulps_eq!()` - ULP-based float comparison with pretty diff output
 - `pretty_assert_abs_diff_eq!()` - absolute difference float comparison
+- `pretty_assert_neg_inf!()` - exact scalar `f64` negative-infinity assertion without direct float equality
 - `assert_error!()` - assert error message content
 
 ## Memory Allocator

--- a/packages/treetime-utils/src/array/softmax_with_log_norm.rs
+++ b/packages/treetime-utils/src/array/softmax_with_log_norm.rs
@@ -119,6 +119,7 @@ pub fn softmax_with_log_norm(log_vec: ArrayView1<'_, f64>) -> (Array1<f64>, f64)
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::pretty_assert_neg_inf;
   use approx::assert_ulps_eq;
   use ndarray::array;
   use rstest::rstest;
@@ -189,7 +190,7 @@ mod tests {
 
     let expected_uniform = Array1::from_elem(n_states, 1.0 / n_states as f64);
     assert_ulps_eq!(normalized, expected_uniform, max_ulps = 0);
-    assert!(log_norm == NEG_INF, "expected NEG_INFINITY, got {log_norm}");
+    pretty_assert_neg_inf!(log_norm, "expected NEG_INFINITY, got {log_norm}");
   }
 
   /// Equal finite inputs produce exact uniform output.

--- a/packages/treetime-utils/src/testing/assert.rs
+++ b/packages/treetime-utils/src/testing/assert.rs
@@ -130,6 +130,29 @@ macro_rules! pretty_assert_abs_diff_eq {
   }};
 }
 
+#[macro_export]
+macro_rules! pretty_assert_neg_inf {
+  ($actual:expr $(,)?) => {{
+    let actual: f64 = $actual;
+    if !$crate::testing::assert::is_neg_inf(actual) {
+      pretty_assertions::assert_eq!(
+        $crate::testing::assert::format_scalar(format!("{actual:#?}")),
+        $crate::testing::assert::format_scalar(format!("{:#?}", f64::NEG_INFINITY)),
+      );
+    }
+  }};
+  ($actual:expr, $msg:literal $(, $arg:expr)* $(,)?) => {{
+    let actual: f64 = $actual;
+    if !$crate::testing::assert::is_neg_inf(actual) {
+      pretty_assertions::assert_eq!(
+        $crate::testing::assert::format_scalar(format!("{actual:#?}")),
+        $crate::testing::assert::format_scalar(format!("{:#?}", f64::NEG_INFINITY)),
+        $msg $(, $arg)*
+      );
+    }
+  }};
+}
+
 /// Replace newlines with NEL (U+0085) to keep multi-line Debug output on one diff line in pretty_assertions.
 pub fn format_newlines(s: impl AsRef<str>) -> String {
   s.as_ref().replace('\n', "\u{0085}")
@@ -137,6 +160,14 @@ pub fn format_newlines(s: impl AsRef<str>) -> String {
 
 pub fn format_array(s: impl AsRef<str>) -> String {
   strip_ndarray_metadata(&format_newlines(s))
+}
+
+pub fn format_scalar(s: impl AsRef<str>) -> String {
+  format_newlines(s)
+}
+
+pub fn is_neg_inf(actual: f64) -> bool {
+  actual.is_infinite() && actual.is_sign_negative()
 }
 
 #[macro_export]
@@ -174,4 +205,54 @@ macro_rules! assert_error {
     let actual_message = $crate::error::report_to_string(&error);
     pretty_assertions::assert_eq!(actual_message, $expected_message);
   }};
+}
+
+#[cfg(test)]
+mod tests {
+  use std::panic::{AssertUnwindSafe, catch_unwind, set_hook, take_hook};
+  use std::sync::{LazyLock, Mutex};
+
+  use crate::testing::assert::is_neg_inf;
+
+  static PANIC_HOOK_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+  #[test]
+  fn test_is_neg_inf_accepts_only_negative_infinity() {
+    assert!(is_neg_inf(f64::NEG_INFINITY));
+    assert!(!is_neg_inf(f64::INFINITY));
+    assert!(!is_neg_inf(f64::NAN));
+    assert!(!is_neg_inf(-1.0));
+    assert!(!is_neg_inf(-0.0));
+    assert!(!is_neg_inf(0.0));
+  }
+
+  #[test]
+  fn test_pretty_assert_neg_inf_accepts_negative_infinity() {
+    let result = catch_unwind(|| pretty_assert_neg_inf!(f64::NEG_INFINITY));
+    result.unwrap();
+  }
+
+  #[test]
+  fn test_pretty_assert_neg_inf_rejects_positive_infinity() {
+    let result = catch_panic_silent(|| pretty_assert_neg_inf!(f64::INFINITY));
+    assert!(result.is_err());
+  }
+
+  #[test]
+  fn test_pretty_assert_neg_inf_rejects_nan() {
+    let result = catch_panic_silent(|| pretty_assert_neg_inf!(f64::NAN));
+    assert!(result.is_err());
+  }
+
+  fn catch_panic_silent(f: impl FnOnce()) -> std::thread::Result<()> {
+    let _guard = match PANIC_HOOK_LOCK.lock() {
+      Ok(guard) => guard,
+      Err(err) => err.into_inner(),
+    };
+    let original_hook = take_hook();
+    set_hook(Box::new(|_| {}));
+    let result = catch_unwind(AssertUnwindSafe(f));
+    set_hook(original_hook);
+    result
+  }
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_optimize_indel.rs
@@ -15,6 +15,7 @@ mod tests {
   };
   use crate::commands::optimize::run::collect_optimize_partitions;
   use crate::gtr::get_gtr::{JC69Params, jc69};
+  use crate::pretty_assert_neg_inf;
   use crate::representation::partition::marginal_dense::PartitionMarginalDense;
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
   use crate::representation::payload::ancestral::GraphAncestral;
@@ -188,7 +189,7 @@ mod tests {
     let indel_rate = estimate_indel_rate(&graph, &mixed_partitions);
     let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate);
 
-    assert!(total_lh.is_infinite() && total_lh.is_sign_negative());
+    pretty_assert_neg_inf!(total_lh);
     Ok(())
   }
 

--- a/packages/treetime/src/commands/optimize/optimize_indel.rs
+++ b/packages/treetime/src/commands/optimize/optimize_indel.rs
@@ -109,12 +109,13 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::pretty_assert_neg_inf;
   use approx::assert_abs_diff_eq;
 
   #[test]
   fn test_optimize_indel_poisson_zero_rate() {
     let metrics = poisson_indel_log_lh(3, 0.0, 0.1);
-    assert!(metrics.log_lh.is_infinite() && metrics.log_lh.is_sign_negative());
+    pretty_assert_neg_inf!(metrics.log_lh);
     assert_abs_diff_eq!(metrics.derivative, 0.0, epsilon = 1e-15);
     assert_abs_diff_eq!(metrics.second_derivative, 0.0, epsilon = 1e-15);
   }

--- a/packages/treetime/src/lib.rs
+++ b/packages/treetime/src/lib.rs
@@ -17,7 +17,7 @@ pub use treetime_io;
 pub use treetime_primitives;
 pub use treetime_utils::{
   make_error, make_internal_error, make_internal_report, make_report, o, pretty_assert_abs_diff_eq,
-  pretty_assert_ulps_eq, vec_of_owned, vec_u8,
+  pretty_assert_neg_inf, pretty_assert_ulps_eq, vec_of_owned, vec_u8,
 };
 
 #[cfg(test)]

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -424,6 +424,7 @@ fn normalize_from_log(log_dis: &Array2<f64>) -> (Array2<f64>, f64) {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::pretty_assert_neg_inf;
   use approx::assert_abs_diff_eq;
   use ndarray::array;
 
@@ -472,10 +473,7 @@ mod tests {
 
     assert_valid_rows(&dis);
     assert_abs_diff_eq!(dis, Array2::from_elem((1, 4), 0.25), epsilon = 1e-10);
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY, got {log_lh}");
   }
 
   #[test]
@@ -485,10 +483,7 @@ mod tests {
 
     assert_valid_rows(&dis);
     assert_abs_diff_eq!(dis, Array2::from_elem((3, 4), 0.25), epsilon = 1e-10);
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY, got {log_lh}");
   }
 
   #[test]
@@ -515,10 +510,7 @@ mod tests {
     ];
     assert_abs_diff_eq!(dis.row(1), expected_row1, epsilon = 1e-10);
     // total_log_lh is -inf because one row was degenerate
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY, got {log_lh}");
   }
 
   #[test]
@@ -556,10 +548,7 @@ mod tests {
 
     assert_valid_rows(&dis);
     assert_abs_diff_eq!(dis, Array2::from_elem((1, 3), 1.0 / 3.0), epsilon = 1e-10);
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY, got {log_lh}");
   }
 
   #[test]
@@ -580,10 +569,7 @@ mod tests {
 
     assert_valid_rows(&dis);
     assert_abs_diff_eq!(dis.row(0), array![0.25, 0.25, 0.25, 0.25], epsilon = 1e-10);
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY for all-zero row, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY for all-zero row, got {log_lh}");
   }
 
   #[test]
@@ -597,8 +583,8 @@ mod tests {
     // Normal row is normalized
     assert_abs_diff_eq!(dis.row(1), array![0.2, 0.4, 0.2, 0.2], epsilon = 1e-10);
     // log_lh is NEG_INFINITY because one row was degenerate
-    assert!(
-      log_lh == f64::NEG_INFINITY,
+    pretty_assert_neg_inf!(
+      log_lh,
       "log_lh should be NEG_INFINITY when any row is zero, got {log_lh}"
     );
   }
@@ -610,10 +596,7 @@ mod tests {
 
     assert_valid_rows(&dis);
     assert_abs_diff_eq!(dis.row(0), array![0.25, 0.25, 0.25, 0.25], epsilon = 1e-10);
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY for NaN row, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY for NaN row, got {log_lh}");
   }
 
   #[test]
@@ -623,9 +606,6 @@ mod tests {
 
     assert_valid_rows(&dis);
     assert_abs_diff_eq!(dis.row(0), array![0.25, 0.25, 0.25, 0.25], epsilon = 1e-10);
-    assert!(
-      log_lh == f64::NEG_INFINITY,
-      "log_lh should be NEG_INFINITY for inf row, got {log_lh}"
-    );
+    pretty_assert_neg_inf!(log_lh, "log_lh should be NEG_INFINITY for inf row, got {log_lh}");
   }
 }


### PR DESCRIPTION
Exact scalar `-inf` assertions scattered across tests used verbose `is_infinite() && is_sign_negative()` patterns. This PR adds a `pretty_assert_neg_inf!` helper with direct self-tests and migrates existing assertions to use it.

### Work items

- [x] Add `pretty_assert_neg_inf!` macro to `treetime-utils/src/testing/assert.rs`
- [x] Add self-tests for negative infinity, positive infinity, and NaN handling
- [x] Migrate assertions in optimize, softmax, and marginal dense tests
- [x] Document and re-export the helper