### PR TITLE
fix: correct match arm and validation condition

### DIFF
--- a/packages/treetime-cli/src/convert/args.rs
+++ b/packages/treetime-cli/src/convert/args.rs
@@ -77,7 +77,7 @@ pub fn guess_tree_format_from_filename(filepath: impl AsRef<Path>) -> Option<Tre
     Some("graph.json") => Some(TreeFormat::PhyloGraph),
     Some("mat.json") => Some(TreeFormat::MatPb),
     Some("mat.pb") => Some(TreeFormat::MatPb),
-    Some("nex | nexus") => Some(TreeFormat::Nexus),
+    Some("nex" | "nexus") => Some(TreeFormat::Nexus),
     Some("nwk" | "newick") => Some(TreeFormat::Newick),
     Some("phylo.xml") => Some(TreeFormat::Phyloxml),
     _ => None,

--- a/packages/treetime/src/alphabet/alphabet_config.rs
+++ b/packages/treetime/src/alphabet/alphabet_config.rs
@@ -139,7 +139,7 @@ impl AlphabetConfig {
       return make_error!("Ambiguous set contains 'gap' character: {msg}");
     }
 
-    if ambiguous_keys.contains(*gap) {
+    if ambiguous_keys.contains(*unknown) {
       let msg = ambiguous.keys().map(quote).join(", ");
       return make_error!("Ambiguous set contains 'unknown' character: {msg}");
     }


### PR DESCRIPTION
Two correctness bugs found by code quality audits.

- Fix match arm `Some("nex | nexus")` that matched a literal string instead of either extension
- Fix duplicate-if condition in alphabet validation that checked `gap` twice instead of `gap` then `unknown`