### PR TITLE
refactor: codebase import and slop cleanup

### DIFF
--- a/packages/phyloxml/src/lib.rs
+++ b/packages/phyloxml/src/lib.rs
@@ -3,27 +3,29 @@ pub mod types;
 pub use crate::types::*;
 use quick_xml::DeError;
 use quick_xml::de::from_reader;
+use std::io;
 
-pub fn phyloxml_read(reader: impl std::io::Read) -> Result<Phyloxml, DeError> {
-  let reader = std::io::BufReader::new(reader);
+pub fn phyloxml_read(reader: impl io::Read) -> Result<Phyloxml, DeError> {
+  let reader = io::BufReader::new(reader);
   from_reader(reader)
 }
 
-pub fn phyloxml_write(writer: impl std::io::Write, phyloxml: &Phyloxml) -> std::io::Result<()> {
+pub fn phyloxml_write(writer: impl io::Write, phyloxml: &Phyloxml) -> io::Result<()> {
   details::to_writer_pretty(writer, "phyloxml", phyloxml)
 }
 
 mod details {
   use quick_xml::se::to_string_with_root;
   use serde::Serialize;
+  use std::io;
   use std::io::Cursor;
 
-  pub fn to_writer_pretty<W, T>(writer: W, root_tag: &str, data: &T) -> std::io::Result<()>
+  pub fn to_writer_pretty<W, T>(writer: W, root_tag: &str, data: &T) -> io::Result<()>
   where
-    W: std::io::Write,
+    W: io::Write,
     T: Serialize,
   {
-    let s = to_string_with_root(root_tag, data).map_err(std::io::Error::other)?;
+    let s = to_string_with_root(root_tag, data).map_err(io::Error::other)?;
 
     let reader = xml::ParserConfig::new()
       .trim_whitespace(true)
@@ -44,10 +46,10 @@ mod details {
     Ok(())
   }
 
-  fn to_io<E>(e: E) -> std::io::Error
+  fn to_io<E>(e: E) -> io::Error
   where
     E: Into<Box<dyn std::error::Error + Send + Sync>>,
   {
-    std::io::Error::other(e)
+    io::Error::other(e)
   }
 }

--- a/packages/phyloxml/src/types.rs
+++ b/packages/phyloxml/src/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use Value;
+use serde_json::Value;
 use std::collections::BTreeMap;
 
 /// (Incomplete) representation of PhyloXML format, according to schema at http://www.phyloxml.org/1.20/phyloxml.xsd

--- a/packages/phyloxml/src/types.rs
+++ b/packages/phyloxml/src/types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use Value;
 use std::collections::BTreeMap;
 
 /// (Incomplete) representation of PhyloXML format, according to schema at http://www.phyloxml.org/1.20/phyloxml.xsd
@@ -6,7 +7,7 @@ use std::collections::BTreeMap;
 pub struct Phyloxml {
   pub phylogeny: Vec<PhyloxmlPhylogeny>,
   #[serde(flatten)]
-  pub other: BTreeMap<String, serde_json::Value>,
+  pub other: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -39,7 +40,7 @@ pub struct PhyloxmlPhylogeny {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub property: Vec<PhyloxmlProperty>,
   #[serde(flatten)]
-  pub other: BTreeMap<String, serde_json::Value>,
+  pub other: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -79,7 +80,7 @@ pub struct PhyloxmlClade {
   #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub clade: Vec<PhyloxmlClade>,
   #[serde(flatten)]
-  pub other: BTreeMap<String, serde_json::Value>,
+  pub other: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -101,7 +102,7 @@ pub struct PhyloxmlTaxonomy {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub uri: Option<PhyloxmlUri>,
   #[serde(flatten)]
-  pub other: BTreeMap<String, serde_json::Value>,
+  pub other: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -123,7 +124,7 @@ pub struct PhyloxmlSequence {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub domain_architecture: Option<PhyloxmlDomainArchitecture>,
   #[serde(flatten)]
-  pub other: BTreeMap<String, serde_json::Value>,
+  pub other: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/packages/treetime-cli/src/convert/mutation.rs
+++ b/packages/treetime-cli/src/convert/mutation.rs
@@ -2,6 +2,7 @@ use eyre::Report;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::str::from_utf8;
 use treetime::make_error;
 
 pub type MutationList = Vec<Mutation>;
@@ -40,7 +41,7 @@ impl Mutation {
       return make_error!("Invalid alternative character in mutation: '{s}'");
     }
 
-    let position_str = std::str::from_utf8(&bytes[1..bytes.len() - 1])
+    let position_str = from_utf8(&bytes[1..bytes.len() - 1])
       .map_err(|e| treetime::make_report!("Invalid UTF-8 in mutation '{s}': {e}"))?;
     let position = position_str
       .parse::<usize>()

--- a/packages/treetime-distribution/src/__tests__/test_gaussian_product.rs
+++ b/packages/treetime-distribution/src/__tests__/test_gaussian_product.rs
@@ -8,6 +8,7 @@ mod tests {
   use eyre::Report;
   use ndarray::Array1;
   use ordered_float::OrderedFloat;
+  use treetime_analytical::{GaussianParams, gaussian_product_params};
 
   const GAUSSIAN_GRID_HALF_WIDTH_SIGMAS: f64 = 5.0;
 
@@ -221,8 +222,6 @@ mod tests {
 
   #[test]
   fn test_gaussian_analytical_formula() {
-    use treetime_analytical::{GaussianParams, gaussian_product_params};
-
     let params = vec![
       GaussianParams {
         mu: -1.0,

--- a/packages/treetime-distribution/src/distribution_core/formula.rs
+++ b/packages/treetime-distribution/src/distribution_core/formula.rs
@@ -3,6 +3,7 @@ use eyre::Result;
 use ndarray::Array1;
 use ndarray_stats::QuantileExt;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::sync::Arc;
 
 const FORMULA_GRID_SIZE: usize = 200;
@@ -89,8 +90,8 @@ impl<Y: YAxisPolicy> Clone for DistributionFormula<Y> {
   }
 }
 
-impl<Y: YAxisPolicy> std::fmt::Debug for DistributionFormula<Y> {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<Y: YAxisPolicy> fmt::Debug for DistributionFormula<Y> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.write_str("DistributionFormula")
   }
 }

--- a/packages/treetime-distribution/src/distribution_ops/scalar_multiply.rs
+++ b/packages/treetime-distribution/src/distribution_ops/scalar_multiply.rs
@@ -24,9 +24,7 @@ pub fn distribution_scalar_multiplication<Y: YAxisPolicy>(
       let amplitude = Y::multiply(r.amplitude(), Y::from_plain(scalar));
       Ok(Distribution::range((r.start(), r.end()), amplitude))
     },
-    Distribution::Empty => {
-      Ok(Distribution::empty())
-    },
+    Distribution::Empty => Ok(Distribution::empty()),
     Distribution::Formula(_) => {
       panic!("Scalar multiplication not implemented for Formula distributions")
     },

--- a/packages/treetime-distribution/src/distribution_ops/scalar_multiply.rs
+++ b/packages/treetime-distribution/src/distribution_ops/scalar_multiply.rs
@@ -18,17 +18,17 @@ pub fn distribution_scalar_multiplication<Y: YAxisPolicy>(
     },
     Distribution::Point(p) => {
       let amplitude = Y::multiply(p.amplitude(), Y::from_plain(scalar));
-      Ok(Distribution::point(p.t(), amplitude)) //
+      Ok(Distribution::point(p.t(), amplitude))
     },
     Distribution::Range(r) => {
       let amplitude = Y::multiply(r.amplitude(), Y::from_plain(scalar));
-      Ok(Distribution::range((r.start(), r.end()), amplitude)) //
+      Ok(Distribution::range((r.start(), r.end()), amplitude))
     },
     Distribution::Empty => {
-      Ok(Distribution::empty()) //
+      Ok(Distribution::empty())
     },
     Distribution::Formula(_) => {
-      panic!("Scalar multiplication not implemented for Formula distributions") //
+      panic!("Scalar multiplication not implemented for Formula distributions")
     },
   }
 }

--- a/packages/treetime-utils/src/array/__tests__/ndarray.rs
+++ b/packages/treetime-utils/src/array/__tests__/ndarray.rs
@@ -6,7 +6,7 @@ mod tests {
 
   use crate::array::ndarray::*;
   use crate::pretty_assert_ulps_eq;
-  use ::ndarray::{Array0, Array1, Array2, Axis, arr0, array};
+  use ndarray::{Array0, Array1, Array2, Axis, arr0, array};
   use eyre::Report;
   use rand::SeedableRng;
   use rand_isaac::Isaac64Rng;

--- a/packages/treetime-utils/src/array/__tests__/ndarray.rs
+++ b/packages/treetime-utils/src/array/__tests__/ndarray.rs
@@ -6,8 +6,8 @@ mod tests {
 
   use crate::array::ndarray::*;
   use crate::pretty_assert_ulps_eq;
-  use ndarray::{Array0, Array1, Array2, Axis, arr0, array};
   use eyre::Report;
+  use ndarray::{Array0, Array1, Array2, Axis, arr0, array};
   use rand::SeedableRng;
   use rand_isaac::Isaac64Rng;
   use rstest::rstest;

--- a/packages/treetime-utils/src/datetime/year_fraction.rs
+++ b/packages/treetime-utils/src/datetime/year_fraction.rs
@@ -69,7 +69,7 @@ mod tests {
   #[case::half_century                                (iso("1950-07-02T12:00:00.000Z"),  1950.5000000000)]
   #[case::quarter_century                             (iso("2025-04-01T12:00:00.000Z"),  2025.2479452054)]
   #[case::three_quarters_century                      (iso("2075-09-30T12:00:00.000Z"),  2075.7465753424)]
-  #[case::hapl_millennium                             (iso("2500-12-31T12:00:00.000Z"),  2500.9986301369)]
+  #[case::half_millennium                              (iso("2500-12-31T12:00:00.000Z"),  2500.9986301369)]
   #[case::halfway_non_leap_year                       (iso("2023-07-02T12:00:00.000Z"),  2023.5000000000)]
   //
   #[case::leap_year_2024_day_before                   (iso("2024-02-28T12:00:00.000Z"),  2024.15983606553)]

--- a/packages/treetime-utils/src/error.rs
+++ b/packages/treetime-utils/src/error.rs
@@ -32,7 +32,7 @@ pub fn keep_ok<T, E>(results: &[Result<T, E>]) -> impl Iterator<Item = &T> {
 macro_rules! make_error {
   ($($arg:tt)*) => {
     {
-      Err(eyre::eyre!(std::format!($($arg)*)))
+      Err(eyre::eyre!(format!($($arg)*)))
     }
   };
 }
@@ -54,8 +54,8 @@ pub use make_report;
 macro_rules! make_internal_error {
   ($($arg:tt)*) => {
     {
-      let msg_external = std::format!($($arg)*);
-      let msg = std::format!("{msg_external}. This is an internal error. Please report it to developers.");
+      let msg_external = format!($($arg)*);
+      let msg = format!("{msg_external}. This is an internal error. Please report it to developers.");
       Err(eyre::eyre!(msg))
     }
   };
@@ -67,8 +67,8 @@ pub use make_internal_error;
 macro_rules! make_internal_report {
   ($($arg:tt)*) => {
     {
-      let msg_external = std::format!($($arg)*);
-      let msg = std::format!("{msg_external}. This is an internal error. Please report it to developers.");
+      let msg_external = format!($($arg)*);
+      let msg = format!("{msg_external}. This is an internal error. Please report it to developers.");
       eyre::eyre!(msg)
     }
   };

--- a/packages/treetime-utils/src/error.rs
+++ b/packages/treetime-utils/src/error.rs
@@ -32,7 +32,7 @@ pub fn keep_ok<T, E>(results: &[Result<T, E>]) -> impl Iterator<Item = &T> {
 macro_rules! make_error {
   ($($arg:tt)*) => {
     {
-      Err(eyre::eyre!(format!($($arg)*)))
+      Err(eyre::eyre!(std::format!($($arg)*)))
     }
   };
 }
@@ -54,8 +54,8 @@ pub use make_report;
 macro_rules! make_internal_error {
   ($($arg:tt)*) => {
     {
-      let msg_external = format!($($arg)*);
-      let msg = format!("{msg_external}. This is an internal error. Please report it to developers.");
+      let msg_external = std::format!($($arg)*);
+      let msg = std::format!("{msg_external}. This is an internal error. Please report it to developers.");
       Err(eyre::eyre!(msg))
     }
   };
@@ -67,8 +67,8 @@ pub use make_internal_error;
 macro_rules! make_internal_report {
   ($($arg:tt)*) => {
     {
-      let msg_external = format!($($arg)*);
-      let msg = format!("{msg_external}. This is an internal error. Please report it to developers.");
+      let msg_external = std::format!($($arg)*);
+      let msg = std::format!("{msg_external}. This is an internal error. Please report it to developers.");
       eyre::eyre!(msg)
     }
   };

--- a/packages/treetime-utils/src/interval/range_properties.rs
+++ b/packages/treetime-utils/src/interval/range_properties.rs
@@ -5,6 +5,7 @@ mod tests {
   use crate::interval::range_intersection::range_intersection;
   use crate::interval::range_union::range_union;
   use rstest::rstest;
+  use std::slice::from_ref;
 
   #[rstest]
   fn test_range_properties_union_distribution_over_intersection() {
@@ -62,7 +63,7 @@ mod tests {
     let universe = vec![(0, 20)]; // Universal set
 
     // A ∪ ¬A
-    let actual = range_union(&[set_a.clone(), range_complement(&universe, std::slice::from_ref(&set_a))]);
+    let actual = range_union(&[set_a.clone(), range_complement(&universe, from_ref(&set_a))]);
 
     assert_eq!(actual, universe);
   }

--- a/packages/treetime-utils/src/io/compression.rs
+++ b/packages/treetime-utils/src/io/compression.rs
@@ -30,7 +30,6 @@ use xz2::read::XzDecoder;
 #[cfg(not(target_arch = "wasm32"))]
 use xz2::write::XzEncoder;
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(target_arch = "wasm32"))]
 use zstd::Decoder as ZstdDecoder;
 #[cfg(not(target_arch = "wasm32"))]
 use zstd::Encoder as ZstdEncoder;

--- a/packages/treetime-utils/src/io/file.rs
+++ b/packages/treetime-utils/src/io/file.rs
@@ -72,13 +72,13 @@ mod non_wasm {
 
   const TTY_WARNING: &str = r#"Reading from standard input which is a TTY (e.g. an interactive terminal). This is likely not what you meant. Instead:
 
- - if you want to read fasta from the output of another program, try:
+ - if you want to read from the output of another program, try:
 
-    cat /path/to/file | nextclade <your other flags>
+    cat /path/to/file | treetime <your other flags>
 
  - if you want to read from file(s), don't forget to provide a path:
 
-    nextclade /path/to/file
+    treetime /path/to/file
 "#;
 
   pub fn warn_if_tty() {

--- a/packages/treetime-validation/src/testing/metrics/pointwise/tolerance.rs
+++ b/packages/treetime-validation/src/testing/metrics/pointwise/tolerance.rs
@@ -1,5 +1,6 @@
 use crate::testing::metrics::config::PointwiseConfig;
 use ndarray::Array1;
+use serde::ser::SerializeSeq;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use treetime_utils::array::serde::{array1_as_vec, array1_from_vec};
 
@@ -7,7 +8,6 @@ fn serialize_array_of_array1<S>(arrays: &[Array1<f64>; 3], serializer: S) -> Res
 where
   S: Serializer,
 {
-  use serde::ser::SerializeSeq;
   let mut seq = serializer.serialize_seq(Some(3))?;
   for array in arrays {
     let vec: Vec<f64> = array.to_vec();

--- a/packages/treetime-validation/src/testing/plots/pointwise_plots.rs
+++ b/packages/treetime-validation/src/testing/plots/pointwise_plots.rs
@@ -3,6 +3,7 @@ use crate::testing::framework::test_case::TestCase;
 use crate::testing::plots::utils::expand_range;
 use eyre::Report;
 use plotters::prelude::*;
+use std::iter::once;
 
 pub fn plot_pointwise_error_profiles<T>(result: &TestResult<T>, output_dir: &str) -> Result<(), Report>
 where
@@ -82,7 +83,7 @@ where
       x.iter().zip(pw.errors.signed.iter()).map(|(&x, &y)| (x, y)),
       GREEN.stroke_width(2),
     ))?;
-    chart.draw_series(std::iter::once(PathElement::new(
+    chart.draw_series(once(PathElement::new(
       vec![(x_min, 0.0), (x_max, 0.0)],
       BLACK.stroke_width(1),
     )))?;

--- a/packages/treetime-validation/src/testing/plots/spatial_plots.rs
+++ b/packages/treetime-validation/src/testing/plots/spatial_plots.rs
@@ -3,6 +3,7 @@ use crate::testing::framework::test_case::TestCase;
 use crate::testing::plots::utils::expand_range;
 use eyre::Report;
 use plotters::prelude::*;
+use std::iter::once;
 
 pub fn plot_spatial_profiles<T>(result: &TestResult<T>, output_dir: &str) -> Result<(), Report>
 where
@@ -79,7 +80,7 @@ where
         .map(|(&x, &y)| (x, y)),
       GREEN.stroke_width(2),
     ))?;
-    chart.draw_series(std::iter::once(PathElement::new(
+    chart.draw_series(once(PathElement::new(
       vec![(x_min, 0.0), (x_max, 0.0)],
       BLACK.stroke_width(1),
     )))?;

--- a/packages/treetime-validation/src/testing/runners/convolution.rs
+++ b/packages/treetime-validation/src/testing/runners/convolution.rs
@@ -9,9 +9,10 @@ use crate::testing::runners::runner::TestRunner;
 use crate::testing::test_suites::test_suites::ConvolutionTestSuite;
 use eyre::Report;
 use ndarray::Array1;
+use std::marker::PhantomData;
 use std::time::Instant;
 
-pub struct ConvolutionRunner<S: ConvolutionTestSuite>(std::marker::PhantomData<S>);
+pub struct ConvolutionRunner<S: ConvolutionTestSuite>(PhantomData<S>);
 
 impl<S: ConvolutionTestSuite + Default> TestRunner for ConvolutionRunner<S> {
   type TestCase = S::TestCase;

--- a/packages/treetime/examples/timetree_validation.rs
+++ b/packages/treetime/examples/timetree_validation.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
+use std::slice::from_ref;
 use std::sync::Arc;
 use treetime::alphabet::alphabet::Alphabet;
 use treetime::commands::ancestral::fitch::compress_sequences;
@@ -305,7 +306,7 @@ fn run_marginal_sparse_test(config: &DatasetConfig, args: &Args) -> Result<TestR
     edges: btreemap! {},
   }));
 
-  compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+  compress_sequences(&graph, from_ref(&sparse_partition), &aln)?;
   dump_graph(&graph, &output_dir_str, "001_after_compress_sequences.json")?;
 
   let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];

--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
@@ -15,9 +15,9 @@ mod tests {
   use parking_lot::RwLock;
   use std::collections::BTreeMap;
   use std::sync::{Arc, LazyLock};
+  use treetime_graph::node::GraphNodeKey;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::json::{JsonPretty, json_write_str};
-  use treetime_graph::node::GraphNodeKey;
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::vec_of_owned;
 

--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
@@ -17,11 +17,12 @@ mod tests {
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::json::{JsonPretty, json_write_str};
+  use treetime_graph::node::GraphNodeKey;
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::vec_of_owned;
 
   /// Retrieve the name of a graph node by its key. Panics if the node is missing or unnamed.
-  fn get_node_name(graph: &GraphAncestral, key: treetime_graph::node::GraphNodeKey) -> String {
+  fn get_node_name(graph: &GraphAncestral, key: GraphNodeKey) -> String {
     let node = graph.get_node(key).expect("node exists");
     node
       .read_arc()

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -18,6 +18,7 @@ mod tests {
   use ndarray::{Array1, array};
   use parking_lot::RwLock;
   use std::collections::BTreeMap;
+  use std::slice::from_ref;
   use std::sync::{Arc, LazyLock};
   use treetime_graph::node::Named;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
@@ -334,8 +335,8 @@ mod tests {
 
     assert_ulps_eq!(log_lh_dense, log_lh_sparse, epsilon = 1e-10);
 
-    let dense_sequences = reconstruct_named_sequences(&graph, std::slice::from_ref(&dense_partition))?;
-    let sparse_sequences = reconstruct_named_sequences(&graph, std::slice::from_ref(&sparse_partition))?;
+    let dense_sequences = reconstruct_named_sequences(&graph, from_ref(&dense_partition))?;
+    let sparse_sequences = reconstruct_named_sequences(&graph, from_ref(&sparse_partition))?;
     assert_eq!(dense_sequences, sparse_sequences);
 
     let dense_branch_subs = edge_subs_by_edge_name(&graph, &*dense_partition.read_arc())?;

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs
@@ -15,7 +15,7 @@ mod tests {
   use eyre::Report;
   use indoc::indoc;
   use maplit::btreemap;
-  use ndarray::array;
+  use ndarray::{Array1, array};
   use parking_lot::RwLock;
   use std::collections::BTreeMap;
   use std::sync::{Arc, LazyLock};
@@ -487,8 +487,6 @@ mod tests {
   /// divergence beyond the existing dense-sparse gap.
   #[test]
   fn test_marginal_sparse_uniform_site_rates_matches_scalar() -> Result<(), Report> {
-    use ndarray::Array1;
-
     let aln = gap_free_alignment()?;
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let seq_len = get_common_length(&aln)?;
@@ -516,8 +514,6 @@ mod tests {
   /// G3b: Dense with uniform per-site rates matches dense with scalar mu.
   #[test]
   fn test_marginal_dense_uniform_site_rates_matches_scalar() -> Result<(), Report> {
-    use ndarray::Array1;
-
     let aln = gap_free_alignment()?;
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let seq_len = get_common_length(&aln)?;

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
@@ -21,6 +21,7 @@ mod tests {
   use pretty_assertions::assert_eq;
   use std::collections::BTreeMap;
   use std::sync::{Arc, LazyLock};
+  use treetime_graph::node::GraphNodeKey;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::json::{JsonPretty, json_write_str};
   use treetime_io::nwk::nwk_read_str;
@@ -609,7 +610,7 @@ mod tests {
     fn get_reconstructed_seq<'a>(
       graph: &GraphAncestral,
       seqs_by_name: &'a BTreeMap<String, Seq>,
-      node_key: treetime_graph::node::GraphNodeKey,
+      node_key: GraphNodeKey,
     ) -> &'a Seq {
       let node = graph.get_node(node_key).expect("node should exist");
       let node = node.read_arc();

--- a/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs
@@ -16,6 +16,7 @@ mod tests {
   use parking_lot::RwLock;
   use pretty_assertions::assert_eq;
   use std::path::PathBuf;
+  use std::slice::from_ref;
   use std::sync::{Arc, LazyLock};
   use treetime_io::fasta::{read_many_fasta, read_many_fasta_str};
   use treetime_io::nwk::{nwk_read_file, nwk_read_str};
@@ -513,7 +514,7 @@ mod tests {
       edges: btreemap! {},
     }));
 
-    let dense_log_lh = initialize_marginal(&graph, std::slice::from_ref(&dense_partition), &aln)?;
+    let dense_log_lh = initialize_marginal(&graph, from_ref(&dense_partition), &aln)?;
 
     // Sparse partition
     let sparse_partition = Arc::new(RwLock::new(PartitionMarginalSparse {
@@ -526,8 +527,8 @@ mod tests {
       root_sequence: seq![],
     }));
 
-    compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
-    let sparse_log_lh = update_marginal(&graph, std::slice::from_ref(&sparse_partition))?;
+    compress_sequences(&graph, from_ref(&sparse_partition), &aln)?;
+    let sparse_log_lh = update_marginal(&graph, from_ref(&sparse_partition))?;
 
     // Log-likelihoods should match for clean sequences
     pretty_assert_ulps_eq!(dense_log_lh, sparse_log_lh, epsilon = 1e-10);

--- a/packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs
+++ b/packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs
@@ -4,6 +4,7 @@ mod tests {
   use eyre::Report;
   use pretty_assertions::assert_eq;
   use rstest::rstest;
+  use std::collections::BTreeMap;
 
   use helpers::{load_gm_mugration_inputs, load_gm_mugration_outputs, run_gm_mugration_case};
 
@@ -38,7 +39,7 @@ mod tests {
     assert_eq!(expected_n_states, actual_n_states);
 
     let expected_trait_assignments = expected.trait_assignments.clone();
-    let actual_trait_assignments: std::collections::BTreeMap<String, String> =
+    let actual_trait_assignments: BTreeMap<String, String> =
       actual.trait_assignments().iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     assert_eq!(expected_trait_assignments, actual_trait_assignments);
 

--- a/packages/treetime/src/commands/mugration/__tests__/test_run.rs
+++ b/packages/treetime/src/commands/mugration/__tests__/test_run.rs
@@ -8,11 +8,11 @@ mod tests {
   use approx::assert_abs_diff_eq;
   use eyre::Report;
   use indexmap::IndexSet;
-  use std::iter::once;
   use itertools::Itertools;
   use maplit::btreemap;
   use ndarray::array;
   use pretty_assertions::assert_eq;
+  use std::iter::once;
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::{o, vec_of_owned};
 

--- a/packages/treetime/src/commands/mugration/__tests__/test_run.rs
+++ b/packages/treetime/src/commands/mugration/__tests__/test_run.rs
@@ -8,6 +8,7 @@ mod tests {
   use approx::assert_abs_diff_eq;
   use eyre::Report;
   use indexmap::IndexSet;
+  use std::iter::once;
   use itertools::Itertools;
   use maplit::btreemap;
   use ndarray::array;
@@ -20,7 +21,7 @@ mod tests {
     let unique_values: IndexSet<String> = [o!("usa"), o!("germany"), o!("france"), o!("italy")]
       .into_iter()
       .collect();
-    let weights_keys: IndexSet<String> = std::iter::once(o!("usa")).collect();
+    let weights_keys: IndexSet<String> = once(o!("usa")).collect();
     let missing_data = "?";
     let threshold = 0.5;
 
@@ -34,12 +35,12 @@ mod tests {
   #[test]
   fn test_run_validate_weight_coverage_accepts_at_threshold() {
     let unique_values: IndexSet<String> = [o!("usa"), o!("germany")].into_iter().collect();
-    let weights_keys: IndexSet<String> = std::iter::once(o!("usa")).collect();
+    let weights_keys: IndexSet<String> = once(o!("usa")).collect();
     let missing_data = "?";
     let threshold = 0.5;
 
     let coverage = validate_weight_coverage(&unique_values, &weights_keys, missing_data, threshold).unwrap();
-    let expected_missing: IndexSet<String> = std::iter::once(o!("germany")).collect();
+    let expected_missing: IndexSet<String> = once(o!("germany")).collect();
     assert_eq!(expected_missing, coverage.missing_values);
     assert_abs_diff_eq!(0.5, coverage.missing_ratio, epsilon = 1e-10);
   }
@@ -47,7 +48,7 @@ mod tests {
   #[test]
   fn test_run_validate_weight_coverage_excludes_missing_data_marker() {
     let unique_values: IndexSet<String> = [o!("usa"), o!("?")].into_iter().collect();
-    let weights_keys: IndexSet<String> = std::iter::once(o!("usa")).collect();
+    let weights_keys: IndexSet<String> = once(o!("usa")).collect();
     let missing_data = "?";
     let threshold = 0.5;
 

--- a/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
@@ -4,6 +4,7 @@ mod tests {
   use approx::assert_relative_eq;
   use eyre::Report;
   use rstest::rstest;
+  use std::collections::BTreeMap;
 
   use crate::commands::optimize::args::BranchOptMethod;
   use std::path::Path;
@@ -82,7 +83,7 @@ mod tests {
 
     let result = setup_and_run(workspace_root, case, BranchOptMethod::BrentSqrt)?;
 
-    let v1_branch_lengths: std::collections::BTreeMap<String, f64> = result
+    let v1_branch_lengths: BTreeMap<String, f64> = result
       .graph
       .get_edges()
       .iter()

--- a/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_gm_optimize.rs
@@ -185,6 +185,7 @@ mod tests {
     use parking_lot::RwLock;
     use serde::Deserialize;
     use std::collections::BTreeMap;
+    use std::fs::read_to_string;
     use std::path::Path;
     use std::sync::Arc;
     use treetime_io::fasta::read_many_fasta;
@@ -214,14 +215,14 @@ mod tests {
     pub fn load_gm_inputs() -> BTreeMap<String, GmOptimizeCase> {
       let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("src/commands/optimize/__tests__/__fixtures__/gm_optimize_inputs.json");
-      let content = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
+      let content = read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
       serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {}: {e}", path.display()))
     }
 
     pub fn load_gm_outputs() -> BTreeMap<String, GmOptimizeExpected> {
       let path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("src/commands/optimize/__tests__/__fixtures__/gm_optimize_outputs.json");
-      let content = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
+      let content = read_to_string(&path).unwrap_or_else(|e| panic!("Failed to read {}: {e}", path.display()));
       serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {}: {e}", path.display()))
     }
 

--- a/packages/treetime/src/commands/optimize/args.rs
+++ b/packages/treetime/src/commands/optimize/args.rs
@@ -109,15 +109,17 @@ pub struct TreetimeOptimizeArgs {
 
   /// GTR model to use
   ///
-  /// '--model infer' will infer a model from the data.
-  ///
-  /// TODO: Alternatively, specify the model type. If the specified model requires additional options, use '--gtr-params' to specify those.
+  /// '--model infer' will infer a model from the data. Alternatively, specify the model
+  /// type. If the specified model requires additional options, use '--gtr-params' to
+  /// specify those.
   #[clap(long = "model", short = 'g', value_enum, default_value_t = GtrModelName::Infer)]
   pub model_name: GtrModelName,
 
-  /// Use dense representation of sequences on the tree, useful if branches are long.
+  /// Use dense representation of sequences on the tree
   ///
-  /// TODO: explain this better
+  /// Dense mode stores full probability vectors at every alignment position for each
+  /// node. Sparse mode stores only variable positions. Dense is more accurate when
+  /// branches are long and many sites change, but uses more memory.
   #[clap(long)]
   pub dense: Option<bool>,
 

--- a/packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs
+++ b/packages/treetime/src/commands/prune/__tests__/test_merge_shared_mutations.rs
@@ -14,6 +14,7 @@ mod tests {
   use parking_lot::RwLock;
   use pretty_assertions::assert_eq;
   use std::sync::Arc;
+  use treetime_graph::node::GraphNodeKey;
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::AsciiChar;
   use treetime_primitives::seq;
@@ -79,7 +80,7 @@ mod tests {
   }
 
   /// Find the new internal node (unnamed, non-root, non-leaf).
-  fn find_unnamed_internal_nodes(graph: &GraphAncestral) -> Vec<treetime_graph::node::GraphNodeKey> {
+  fn find_unnamed_internal_nodes(graph: &GraphAncestral) -> Vec<GraphNodeKey> {
     graph
       .get_nodes()
       .iter()

--- a/packages/treetime/src/commands/timetree/coalescent/lineage_dynamics.rs
+++ b/packages/treetime/src/commands/timetree/coalescent/lineage_dynamics.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use ndarray::Array1;
 use ordered_float::OrderedFloat;
 use std::collections::BTreeMap;
+use std::iter::once;
 use treetime_utils::make_error;
 
 /// Computes k(t) distribution from tree events in TBP coordinates.
@@ -35,7 +36,7 @@ pub fn compute_lineage_count_distribution(events: &[(Tbp, i32)]) -> Result<Piece
     .unzip();
 
   let breakpoints = Array1::from_vec(breakpoints);
-  let values = std::iter::once(0.0).chain(values).collect_vec();
+  let values = once(0.0).chain(values).collect_vec();
   let values = Array1::from_vec(values);
 
   Ok(PiecewiseConstantFn::new(breakpoints, values))

--- a/packages/treetime/src/commands/timetree/convergence/__tests__/test_pipeline.rs
+++ b/packages/treetime/src/commands/timetree/convergence/__tests__/test_pipeline.rs
@@ -3,6 +3,7 @@ mod tests {
   use crate::commands::timetree::args::TreetimeTimetreeArgs;
   use crate::commands::timetree::run::run_timetree_estimation;
   use eyre::Report;
+  use std::fs::read_to_string;
   use std::path::PathBuf;
 
   #[test]
@@ -25,7 +26,7 @@ mod tests {
     run_timetree_estimation(&args)?;
 
     // Verify tracelog was written and contains data
-    let csv_content = std::fs::read_to_string(&tracelog_path)?;
+    let csv_content = read_to_string(&tracelog_path)?;
     let lines: Vec<&str> = csv_content.lines().collect();
     assert!(lines.len() >= 2, "Tracelog must have header + at least 1 data row");
 

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
@@ -21,6 +21,7 @@ mod tests {
   use maplit::btreemap;
   use parking_lot::RwLock;
   use rstest::rstest;
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_io::nwk::nwk_read_str;
   use treetime_primitives::seq;
@@ -58,7 +59,7 @@ mod tests {
       root_sequence: seq![],
     }));
 
-    compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    compress_sequences(&graph, from_ref(&sparse_partition), &aln)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> = vec![sparse_partition];
     initialize_marginal(&graph, &partitions, &aln)?;

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
@@ -25,6 +25,7 @@ mod tests {
   use maplit::btreemap;
   use parking_lot::RwLock;
   use rstest::rstest;
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_graph::edge::HasBranchLength;
   use treetime_io::nwk::nwk_read_str;
@@ -62,7 +63,7 @@ mod tests {
       root_sequence: seq![],
     }));
 
-    compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    compress_sequences(&graph, from_ref(&sparse_partition), &aln)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];
@@ -122,7 +123,7 @@ mod tests {
       root_sequence: seq![],
     }));
 
-    compress_sequences(&graph, std::slice::from_ref(&sparse_partition), &aln)?;
+    compress_sequences(&graph, from_ref(&sparse_partition), &aln)?;
 
     let partitions: Vec<Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>> =
       vec![sparse_partition];

--- a/packages/treetime/src/commands/timetree/initialization.rs
+++ b/packages/treetime/src/commands/timetree/initialization.rs
@@ -1,5 +1,5 @@
 use crate::alphabet::alphabet::Alphabet;
-use crate::commands::ancestral::fitch::get_common_length;
+use crate::commands::ancestral::fitch::{compress_sequences, get_common_length};
 use crate::commands::ancestral::marginal::update_marginal;
 use crate::commands::clock::date_constraints::load_date_constraints;
 use crate::commands::timetree::args::{BranchLengthMode, TreetimeTimetreeArgs};
@@ -112,7 +112,7 @@ pub fn initialize_partitions(
       edges: btreemap! {},
     }));
 
-    crate::commands::ancestral::fitch::compress_sequences(graph, from_ref(&sparse_partition), aln_data)?;
+    compress_sequences(graph, from_ref(&sparse_partition), aln_data)?;
 
     // For Infer: Fitch compression populated mutation counts, infer real GTR
     if model_name == GtrModelName::Infer {

--- a/packages/treetime/src/commands/timetree/initialization.rs
+++ b/packages/treetime/src/commands/timetree/initialization.rs
@@ -21,6 +21,7 @@ use eyre::{Report, WrapErr};
 use log::info;
 use maplit::btreemap;
 use parking_lot::RwLock;
+use std::slice::from_ref;
 use std::sync::Arc;
 use treetime_io::dates_csv::read_dates;
 use treetime_io::fasta::{FastaRecord, read_many_fasta};
@@ -111,7 +112,7 @@ pub fn initialize_partitions(
       edges: btreemap! {},
     }));
 
-    crate::commands::ancestral::fitch::compress_sequences(graph, std::slice::from_ref(&sparse_partition), aln_data)?;
+    crate::commands::ancestral::fitch::compress_sequences(graph, from_ref(&sparse_partition), aln_data)?;
 
     // For Infer: Fitch compression populated mutation counts, infer real GTR
     if model_name == GtrModelName::Infer {
@@ -140,7 +141,7 @@ pub fn initialize_partitions(
     if model_name == GtrModelName::Infer {
       let aln_data = aln.ok_or_else(|| make_report!("Alignment required for dense GTR inference"))?;
       dense_partition.write_arc().attach_sequences(graph, aln_data)?;
-      update_marginal(graph, std::slice::from_ref(&dense_partition))?;
+      update_marginal(graph, from_ref(&dense_partition))?;
       let gtr = get_gtr_dense(&model_name, &dense_partition, graph)
         .wrap_err("When inferring GTR model from dense partition")?;
       dense_partition.write_arc().gtr = gtr;

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_clock_filter.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_clock_filter.rs
@@ -6,6 +6,7 @@ mod tests {
   use eyre::Report;
   use maplit::btreemap;
   use pretty_assertions::assert_eq;
+  use std::collections::BTreeMap;
   use std::sync::Arc;
   use treetime_distribution::Distribution;
   use treetime_graph::node::{Named, Outlier, TimeConstraint};
@@ -13,7 +14,7 @@ mod tests {
 
   const TREE_NEWICK: &str = "((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;";
 
-  fn setup_dates(graph: &GraphTimetree, dates: &std::collections::BTreeMap<String, f64>) {
+  fn setup_dates(graph: &GraphTimetree, dates: &BTreeMap<String, f64>) {
     for n in graph.get_leaves() {
       let name = n.read_arc().payload().read_arc().name().map(|s| s.as_ref().to_owned());
       if let Some(name) = name {

--- a/packages/treetime/src/commands/timetree/output/confidence.rs
+++ b/packages/treetime/src/commands/timetree/output/confidence.rs
@@ -14,6 +14,7 @@ use parking_lot::RwLock;
 use serde::Serialize;
 use statrs::function::erf::erf_inv;
 use std::collections::BTreeMap;
+use std::f64::consts::SQRT_2;
 use std::path::Path;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
@@ -336,7 +337,7 @@ pub(crate) fn quantile_to_zscore(p: f64) -> f64 {
   if p * (1.0 - p) == 0.0 {
     return 0.0;
   }
-  std::f64::consts::SQRT_2 * erf_inv(2.0 * p - 1.0)
+  SQRT_2 * erf_inv(2.0 * p - 1.0)
 }
 
 /// Save per-edge gamma values for later restoration.

--- a/packages/treetime/src/gtr/__tests__/test_gm_gtr.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gm_gtr.rs
@@ -7,7 +7,6 @@ mod tests {
   use crate::gtr::gtr::{GTR, GTRParams};
   use eyre::Report;
   use rstest::rstest;
-  use std::fs::read_to_string;
 
   use helpers::{compare_gtr, load_gm_gtr_inputs, load_gm_gtr_outputs};
 
@@ -169,6 +168,7 @@ mod tests {
   mod helpers {
     use crate::gtr::gtr::GTR;
     use approx::assert_abs_diff_eq;
+    use std::fs::read_to_string;
     use indexmap::IndexMap;
     use ndarray::{Array1, Array2};
     use serde::Deserialize;

--- a/packages/treetime/src/gtr/__tests__/test_gm_gtr.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gm_gtr.rs
@@ -7,6 +7,7 @@ mod tests {
   use crate::gtr::gtr::{GTR, GTRParams};
   use eyre::Report;
   use rstest::rstest;
+  use std::fs::read_to_string;
 
   use helpers::{compare_gtr, load_gm_gtr_inputs, load_gm_gtr_outputs};
 
@@ -274,7 +275,7 @@ mod tests {
         "{}/src/gtr/__tests__/__fixtures__/gm_gtr_inputs.json",
         env!("CARGO_MANIFEST_DIR")
       );
-      let content = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
+      let content = read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
       serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {path}: {e}"))
     }
 
@@ -283,7 +284,7 @@ mod tests {
         "{}/src/gtr/__tests__/__fixtures__/gm_gtr_outputs.json",
         env!("CARGO_MANIFEST_DIR")
       );
-      let content = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
+      let content = read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
       serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {path}: {e}"))
     }
 

--- a/packages/treetime/src/gtr/__tests__/test_gm_gtr.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gm_gtr.rs
@@ -168,10 +168,10 @@ mod tests {
   mod helpers {
     use crate::gtr::gtr::GTR;
     use approx::assert_abs_diff_eq;
-    use std::fs::read_to_string;
     use indexmap::IndexMap;
     use ndarray::{Array1, Array2};
     use serde::Deserialize;
+    use std::fs::read_to_string;
     use treetime_utils::array::ndarray::sorted;
     use treetime_utils::array::serde::{array1_from_vec, array2_from_vec, option_array1_from_vec};
 

--- a/packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs
@@ -6,7 +6,6 @@ mod tests {
   use eyre::Report;
   use ndarray::prelude::*;
   use rstest::rstest;
-  use std::fs::read_to_string;
 
   use crate::gtr::__tests__::site_specific_support::{simulate_counts, value_to_array2, value_to_array3};
   use helpers::{load_gm_inputs, load_gm_outputs};
@@ -209,6 +208,7 @@ mod tests {
   mod helpers {
     use indexmap::IndexMap;
     use serde::Deserialize;
+    use std::fs::read_to_string;
 
     #[derive(Debug, Deserialize)]
     pub struct ExpQtEntry {

--- a/packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs
@@ -5,8 +5,8 @@ mod tests {
   use approx::assert_abs_diff_eq;
   use eyre::Report;
   use ndarray::prelude::*;
-
   use rstest::rstest;
+  use std::fs::read_to_string;
 
   use crate::gtr::__tests__::site_specific_support::{simulate_counts, value_to_array2, value_to_array3};
   use helpers::{load_gm_inputs, load_gm_outputs};
@@ -263,7 +263,7 @@ mod tests {
         "{}/src/gtr/__tests__/__fixtures__/gm_gtr_site_specific_inputs.json",
         env!("CARGO_MANIFEST_DIR")
       );
-      let content = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
+      let content = read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
       serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {path}: {e}"))
     }
 
@@ -272,7 +272,7 @@ mod tests {
         "{}/src/gtr/__tests__/__fixtures__/gm_gtr_site_specific_outputs.json",
         env!("CARGO_MANIFEST_DIR")
       );
-      let content = std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
+      let content = read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read: {path}"));
       serde_json::from_str(&content).unwrap_or_else(|e| panic!("Failed to parse {path}: {e}"))
     }
   }

--- a/packages/treetime/src/gtr/__tests__/test_prop_gtr_site_rates.rs
+++ b/packages/treetime/src/gtr/__tests__/test_prop_gtr_site_rates.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
   use crate::gtr::__tests__::generators::tests::generators::{arb_branch_len, arb_gtr_nuc, arb_profile_nuc};
+  use crate::gtr::get_gtr::{JC69Params, jc69};
   use approx::assert_abs_diff_eq;
   use ndarray::{Array1, Array2};
   use proptest::prelude::*;
@@ -193,8 +194,6 @@ mod tests {
   /// Higher site rate produces more divergence from initial state
   #[test]
   fn test_higher_rate_more_divergence() {
-    use crate::gtr::get_gtr::{JC69Params, jc69};
-
     let gtr = jc69(JC69Params::default()).unwrap();
     let t = 0.5;
 
@@ -213,8 +212,6 @@ mod tests {
   /// Rate 0 means no evolution (identity matrix)
   #[test]
   fn test_rate_zero_is_identity() {
-    use crate::gtr::get_gtr::{JC69Params, jc69};
-
     let gtr = jc69(JC69Params::default()).unwrap();
     let p = gtr.expQt_with_rate(1.0, 0.0);
     pretty_assert_abs_diff_eq!(p, Array2::eye(4), epsilon = 1e-14);
@@ -223,8 +220,6 @@ mod tests {
   /// set_site_rates / clear_site_rates / has_site_rates lifecycle
   #[test]
   fn test_site_rates_lifecycle() {
-    use crate::gtr::get_gtr::{JC69Params, jc69};
-
     let mut gtr = jc69(JC69Params::default()).unwrap();
     assert!(!gtr.has_site_rates());
 

--- a/packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs
+++ b/packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+  use crate::gtr::gtr::{GTR, GTRParams};
   use crate::gtr::gtr_site_specific::{GTRSiteSpecific, GTRSiteSpecificParams};
   use ndarray::prelude::*;
   use proptest::prelude::*;
@@ -534,8 +535,6 @@ mod tests {
   /// When all sites have the same pi, site-specific model matches standard GTR.
   #[test]
   fn test_gtr_site_specific_uniform_matches_standard() {
-    use crate::gtr::gtr::{GTR, GTRParams};
-
     let pi = array![0.1, 0.2, 0.3, 0.4];
     let W = {
       let mut w = Array2::<f64>::ones([4, 4]);

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
@@ -24,6 +24,7 @@ mod tests {
   use maplit::btreemap;
   use parking_lot::RwLock;
   use rstest::rstest;
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
@@ -57,7 +58,7 @@ mod tests {
       nodes: btreemap! {},
       edges: btreemap! {},
     }));
-    initialize_marginal(&graph, std::slice::from_ref(&partition), aln)?;
+    initialize_marginal(&graph, from_ref(&partition), aln)?;
     Ok((graph, partition))
   }
 
@@ -76,8 +77,8 @@ mod tests {
       edges: btreemap! {},
       root_sequence: seq![],
     }));
-    compress_sequences(&graph, std::slice::from_ref(&partition), aln)?;
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    compress_sequences(&graph, from_ref(&partition), aln)?;
+    update_marginal(&graph, from_ref(&partition))?;
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
@@ -47,6 +47,7 @@ mod tests {
   use parking_lot::RwLock;
   use rstest::rstest;
   use std::path::PathBuf;
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_io::fasta::read_many_fasta;
   use treetime_io::nwk::nwk_read_file;
@@ -130,7 +131,7 @@ mod tests {
         nodes: btreemap! {},
         edges: btreemap! {},
       }));
-      initialize_marginal(&graph, std::slice::from_ref(&partition), &aln)?;
+      initialize_marginal(&graph, from_ref(&partition), &aln)?;
       infer_gtr_dense(&partition, &graph)?
     };
 
@@ -148,8 +149,8 @@ mod tests {
         edges: btreemap! {},
         root_sequence: seq![],
       }));
-      compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-      update_marginal(&graph, std::slice::from_ref(&partition))?;
+      compress_sequences(&graph, from_ref(&partition), &aln)?;
+      update_marginal(&graph, from_ref(&partition))?;
       infer_gtr_sparse(&partition, &graph)?
     };
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs
@@ -18,6 +18,7 @@ mod tests {
   use maplit::btreemap;
   use ndarray::{Array1, Array2, array};
   use parking_lot::RwLock;
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
@@ -47,7 +48,7 @@ mod tests {
       edges: btreemap! {},
     }));
 
-    initialize_marginal(&graph, std::slice::from_ref(&partition), aln)?;
+    initialize_marginal(&graph, from_ref(&partition), aln)?;
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs
@@ -24,6 +24,7 @@ mod tests {
   use std::collections::BTreeMap;
   use std::fs;
   use std::path::{Path, PathBuf};
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_io::fasta::{FastaRecord, read_many_fasta, read_many_fasta_str};
   use treetime_io::nwk::{nwk_read_file, nwk_read_str};
@@ -142,7 +143,7 @@ mod tests {
       edges: btreemap! {},
     }));
 
-    initialize_marginal(&graph, std::slice::from_ref(&partition), aln)?;
+    initialize_marginal(&graph, from_ref(&partition), aln)?;
     Ok((graph, partition))
   }
 
@@ -170,7 +171,7 @@ mod tests {
       edges: btreemap! {},
     }));
 
-    initialize_marginal(&graph, std::slice::from_ref(&partition), &aln)?;
+    initialize_marginal(&graph, from_ref(&partition), &aln)?;
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_sparse.rs
@@ -17,6 +17,7 @@ mod tests {
   use maplit::btreemap;
   use ndarray::array;
   use parking_lot::RwLock;
+  use std::slice::from_ref;
   use std::sync::Arc;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
@@ -55,8 +56,8 @@ mod tests {
       root_sequence: seq![],
     }));
 
-    compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    compress_sequences(&graph, from_ref(&partition), &aln)?;
+    update_marginal(&graph, from_ref(&partition))?;
 
     let counts_actual = get_mutation_counts_sparse(&graph, &partition)?;
     // Expected values reflect MAP-derived mutations from marginal posteriors
@@ -105,8 +106,8 @@ mod tests {
       root_sequence: seq![],
     }));
 
-    compress_sequences(&graph, std::slice::from_ref(&partition), &aln)?;
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    compress_sequences(&graph, from_ref(&partition), &aln)?;
+    update_marginal(&graph, from_ref(&partition))?;
 
     let counts = get_mutation_counts_sparse(&graph, &partition)?;
     let actual = infer_gtr_impl(

--- a/packages/treetime/src/io/__tests__/test_nwk.rs
+++ b/packages/treetime/src/io/__tests__/test_nwk.rs
@@ -3,6 +3,7 @@ mod tests {
   use crate::graph::__tests__::graph::tests::{TestEdge, TestNode};
   use approx::assert_abs_diff_eq;
   use eyre::Report;
+  use std::collections::BTreeMap;
   use pretty_assertions::assert_eq;
   use treetime_graph::edge::HasBranchLength;
   use treetime_graph::node::Named;
@@ -142,7 +143,7 @@ mod tests {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>(input)?;
 
     // Collect branch lengths by finding edges to specific nodes
-    let mut branch_lengths = std::collections::BTreeMap::new();
+    let mut branch_lengths = BTreeMap::new();
     for edge in graph.get_edges() {
       let edge_ref = edge.read_arc();
       let target_key = edge_ref.target();

--- a/packages/treetime/src/io/__tests__/test_nwk.rs
+++ b/packages/treetime/src/io/__tests__/test_nwk.rs
@@ -3,8 +3,8 @@ mod tests {
   use crate::graph::__tests__::graph::tests::{TestEdge, TestNode};
   use approx::assert_abs_diff_eq;
   use eyre::Report;
-  use std::collections::BTreeMap;
   use pretty_assertions::assert_eq;
+  use std::collections::BTreeMap;
   use treetime_graph::edge::HasBranchLength;
   use treetime_graph::node::Named;
   use treetime_io::nwk::{NwkWriteOptions, nwk_read_str, nwk_write_str};

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -13,7 +13,7 @@ use crate::seq::mutation::Sub;
 use eyre::Report;
 use itertools::{Itertools, izip};
 use ndarray::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
@@ -147,9 +147,9 @@ where
   E: EdgeOptimizeOps,
 {
   fn reconcile_topology(&mut self, graph: &Graph<N, E, ()>) {
-    let graph_node_keys: std::collections::BTreeSet<GraphNodeKey> =
+    let graph_node_keys: BTreeSet<GraphNodeKey> =
       graph.get_nodes().into_iter().map(|n| n.read_arc().key()).collect();
-    let graph_edge_keys: std::collections::BTreeSet<GraphEdgeKey> =
+    let graph_edge_keys: BTreeSet<GraphEdgeKey> =
       graph.get_edges().into_iter().map(|e| e.read_arc().key()).collect();
 
     // Add missing nodes with default partition data (backward pass will recompute)

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -147,10 +147,8 @@ where
   E: EdgeOptimizeOps,
 {
   fn reconcile_topology(&mut self, graph: &Graph<N, E, ()>) {
-    let graph_node_keys: BTreeSet<GraphNodeKey> =
-      graph.get_nodes().into_iter().map(|n| n.read_arc().key()).collect();
-    let graph_edge_keys: BTreeSet<GraphEdgeKey> =
-      graph.get_edges().into_iter().map(|e| e.read_arc().key()).collect();
+    let graph_node_keys: BTreeSet<GraphNodeKey> = graph.get_nodes().into_iter().map(|n| n.read_arc().key()).collect();
+    let graph_edge_keys: BTreeSet<GraphEdgeKey> = graph.get_edges().into_iter().map(|e| e.read_arc().key()).collect();
 
     // Add missing nodes with default partition data (backward pass will recompute)
     for &key in &graph_node_keys {

--- a/packages/treetime/src/representation/partition/marginal_helpers.rs
+++ b/packages/treetime/src/representation/partition/marginal_helpers.rs
@@ -200,14 +200,13 @@ fn is_site_resolved(dis: &Array1<f64>, epsilon: f64) -> bool {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::seq::composition::Composition;
   use approx::assert_abs_diff_eq;
   use ndarray::array;
 
   #[test]
   fn test_propagate_raw_per_site_forward() {
-    use crate::gtr::get_gtr::{JC69Params, jc69};
-
     let a = AsciiChar::from_byte_unchecked(b'A');
     let c = AsciiChar::from_byte_unchecked(b'C');
     let g = AsciiChar::from_byte_unchecked(b'G');
@@ -244,8 +243,6 @@ mod tests {
 
   #[test]
   fn test_propagate_raw_per_site_backward() {
-    use crate::gtr::get_gtr::{JC69Params, jc69};
-
     let a = AsciiChar::from_byte_unchecked(b'A');
     let c = AsciiChar::from_byte_unchecked(b'C');
     let g = AsciiChar::from_byte_unchecked(b'G');

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -14,7 +14,7 @@ use crate::representation::payload::sparse::{MarginalSparseSeqDistribution, Spar
 use crate::seq::mutation::{Sub, compose_substitutions};
 use eyre::Report;
 use itertools::Itertools;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey};
 use treetime_graph::graph::Graph;
@@ -405,9 +405,9 @@ where
   E: EdgeOptimizeOps,
 {
   fn reconcile_topology(&mut self, graph: &Graph<N, E, ()>) {
-    let graph_node_keys: std::collections::BTreeSet<GraphNodeKey> =
+    let graph_node_keys: BTreeSet<GraphNodeKey> =
       graph.get_nodes().into_iter().map(|n| n.read_arc().key()).collect();
-    let graph_edge_keys: std::collections::BTreeSet<GraphEdgeKey> =
+    let graph_edge_keys: BTreeSet<GraphEdgeKey> =
       graph.get_edges().into_iter().map(|e| e.read_arc().key()).collect();
 
     // Add missing nodes with empty partition data

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -405,10 +405,8 @@ where
   E: EdgeOptimizeOps,
 {
   fn reconcile_topology(&mut self, graph: &Graph<N, E, ()>) {
-    let graph_node_keys: BTreeSet<GraphNodeKey> =
-      graph.get_nodes().into_iter().map(|n| n.read_arc().key()).collect();
-    let graph_edge_keys: BTreeSet<GraphEdgeKey> =
-      graph.get_edges().into_iter().map(|e| e.read_arc().key()).collect();
+    let graph_node_keys: BTreeSet<GraphNodeKey> = graph.get_nodes().into_iter().map(|n| n.read_arc().key()).collect();
+    let graph_edge_keys: BTreeSet<GraphEdgeKey> = graph.get_edges().into_iter().map(|e| e.read_arc().key()).collect();
 
     // Add missing nodes with empty partition data
     for &key in &graph_node_keys {


### PR DESCRIPTION
Import hygiene and copy-paste artifact cleanup across 45 files, driven by three independent code quality audits.

- Replace `nextclade` with `treetime` in TTY warning text copied from another project
- Fix `hapl_millennium` typo to `half_millennium` in test case name
- Remove trailing empty `//` comments, duplicate `#[cfg]` attribute, leading `::` in import
- Move function-body `use` statements to module scope in 7 files
- Replace ~50 inline fully-qualified paths with top-level imports across ~30 files
- Replace TODO placeholder doc comments on CLI arguments with proper descriptions