### PR TITLE
test: GTR inference and topology test improvements

### DIFF
--- a/docs/port-known-issues/L-representation-infer-dense-stub.md
+++ b/docs/port-known-issues/L-representation-infer-dense-stub.md
@@ -1,0 +1,20 @@
+# `infer_dense()` stub always returns false
+
+`representation/algo/infer_dense.rs` exports `infer_dense()` as the shared dense-vs-sparse selector, but the function always returns `false`. Three user-facing commands use it as the default when `--dense` is omitted: `ancestral`, `optimize`, and `timetree`.
+
+## Impact
+
+Omitting `--dense` always selects sparse mode. On long-branch datasets where dense representation would be more appropriate, users must explicitly pass `--dense=true`. No correctness issue: sparse mode produces valid results on all inputs.
+
+## Root cause
+
+The heuristic for automatic selection has not been implemented. The stub was created as a placeholder during initial command wiring.
+
+## Fix
+
+Implement a heuristic based on branch lengths, sequence length, or both. Alternatively, remove the shared abstraction and make the default explicit at each command until a real heuristic exists.
+
+## Locations
+
+- Stub: `packages/treetime/src/representation/algo/infer_dense.rs`
+- Consumers: `packages/treetime/src/commands/ancestral/run.rs`, `packages/treetime/src/commands/optimize/run.rs`, `packages/treetime/src/commands/timetree/initialization.rs`

--- a/docs/port-known-issues/M-gtr-sparse-composition-stale-after-marginal.md
+++ b/docs/port-known-issues/M-gtr-sparse-composition-stale-after-marginal.md
@@ -20,6 +20,15 @@ Recompute `seq.composition` from `seq.sequence` after marginal reconstruction, o
 
 v0 overwrites `node.cseq` (compressed sequence) after each marginal pass. The `mutations` property dynamically compares current `node.up.cseq` vs `node.cseq`, so composition data always reflects the current reconstruction state. The stale-composition problem does not exist in v0.
 
+## Test co-dependency
+
+Fixing this issue requires updating tests that encode the stale behavior:
+
+- `gtr/infer_gtr/__tests__/test_contract.rs`: `test_root_state_sparse()` asserts Fitch-consensus counts after `update_marginal`
+- `gtr/infer_gtr/__tests__/test_sparse.rs`: `test_get_mutation_counts_sparse()` hard-codes `root_state` without deriving from reconstructed MAP root sequence
+
+Both tests will fail when composition is refreshed and must be rewritten to assert post-marginal state.
+
 ## Related
 
 - [M-gtr-per-site-rate-variation](M-gtr-per-site-rate-variation.md) - per-site rate variation, another GTR inference gap

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -52,105 +52,106 @@ exactly.
 
 ## Summary
 
-| Severity   | Scope        | Issue                                                                                                                                 |
-| ---------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| High       | Ancestral    | [Ancestral joint method default panics](H-ancestral-joint-default-panics.md)                                                          |
-| High       | Clock        | [ClockSet dateless-leaf contribution biases regression](H-clock-clockset-dateless-leaf-bias.md)                                       |
-| High       | Clock        | [Clock filter panics on trees with fewer than four dated leaves](H-clock-filter-panic-small-trees.md)                                 |
-| High       | Clock        | [Clock covariation divides by zero when sequence length is absent](H-clock-covariation-divide-by-zero.md)                             |
-| High       | Homoplasy    | [Homoplasy command is unimplemented](H-homoplasy-command-unimplemented.md)                                                            |
-| High       | Timetree     | [Coalescent backward pass grid explosion](H-timetree-coalescent-grid-explosion.md)                                                    |
-| High       | Timetree     | [Skyline optimizer uses a different objective than the reported coalescent cost](H-timetree-skyline-objective-mismatch.md)            |
-| High       | Timetree     | [No tree inference from alignment](H-timetree-tree-inference-unimplemented.md)                                                        |
-| Medium     | Timetree     | [Golden master runner missing internal node times](M-timetree-gm-runner-missing-internal-times.md)                                    |
-| Medium     | Clock        | [Clock filter residual parity](M-clock-filter-residual-parity.md)                                                                     |
-| Negligible | Clock        | [Clock regression all-negative-rate divergence](N-clock-regression-all-negative-rate.md)                                              |
-| Negligible | Clock        | [Clock chisq near-zero determinant](N-clock-chisq-near-zero-determinant.md)                                                           |
-| Medium     | Ancestral    | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                      |
-| Medium     | Ancestral    | [Marginal reconstruction uses plain probability space](M-ancestral-marginal-probability-space.md)                                     |
-| Medium     | Ancestral    | [Sparse root invariance violation](M-ancestral-sparse-root-invariance.md)                                                             |
-| Medium     | Ancestral    | [Sparse variable-site alphabet mismatch](M-ancestral-sparse-alphabet-mismatch.md)                                                     |
-| Medium     | Core         | [Dummy GTR initialization pattern across commands](M-core-dummy-gtr-initialization.md)                                                |
-| Medium     | Clock        | [Clock covariation overdispersion hardcoded](M-clock-covariation-overdispersion.md)                                                   |
-| Medium     | Dates        | [Column auto-detection gaps in CSV readers](M-dates-column-auto-detection-gaps.md)                                                    |
-| Medium     | GTR          | [Per-site rate variation not implemented](M-gtr-per-site-rate-variation.md)                                                           |
-| Medium     | I/O          | [Sequence attachment has O(n squared) complexity](M-io-sequence-attachment-quadratic.md)                                              |
-| Medium     | I/O          | [Sequence-to-node name matching is unreliable](M-io-sequence-name-matching-unreliable.md)                                             |
-| Medium     | Mugration    | [Iterative GTR inference not implemented for mugration](M-mugration-iterative-gtr.md)                                                 |
-| Medium     | Optimize     | [Negative branch lengths not validated or reported across optimizer modes](M-optimize-negative-branch-length-validation.md)           |
-| Medium     | Optimize     | [Optimizer and marginal propagation use incompatible branch-length scales when GTR mu != 1](M-optimize-gtr-mu-coordinate-mismatch.md) |
-| Low        | Core         | [Duplicate `write_graph()` across commands](L-core-duplicate-write-graph.md)                                                          |
-| Low        | Topology     | [Move `merge_shared_mutation_branches()` to shared topology_cleanup module](L-topology-cleanup-move-merge-shared-mutations.md)        |
-| Low        | GTR          | [Site-specific GTR partition integration pending](L-gtr-site-specific-partition-integration.md)                                       |
-| Low        | GTR          | [Site-specific GTR end-to-end inference test pending](L-gtr-site-specific-e2e-inference-test.md)                                      |
-| Medium     | Optimize     | [Optimize per-branch lengths diverge from v0 fixture beyond 10% relative tolerance](M-optimize-gm-per-branch-divergence.md)           |
-| Medium     | Optimize     | [Optimize outer loop enters persistent likelihood 2-cycle (sparse)](M-optimize-sparse-em-2-cycle.md) (**fixed**)                      |
-| Medium     | GTR          | [Sparse GTR inference mixes MAP mutations with Fitch-era compositions](M-gtr-sparse-composition-stale-after-marginal.md)              |
-| Medium     | Timetree     | [--aln flag silently ignored](M-timetree-aln-flag-ignored.md)                                                                         |
-| Medium     | Timetree     | [Coalescent backward pass missing leaf and root contributions](M-timetree-coalescent-missing-leaf-and-root-contributions.md)          |
-| Medium     | Timetree     | [--coalescent-opt alone skips initial Tc pass](M-timetree-coalescent-opt-skips-initial.md)                                            |
-| Medium     | Timetree     | [Date column header matching breaks on hash](M-timetree-date-header-hash.md)                                                          |
-| Medium     | Timetree     | [Internal node dates missing in nexus for input branch length mode](M-timetree-internal-dates-missing-input-bl.md)                    |
-| Medium     | Timetree     | [--method-anc ignored in timetree](M-timetree-method-anc-ignored.md)                                                                  |
-| Medium     | Timetree     | [Positional likelihood metric differs from v0](M-timetree-positional-likelihood-metric.md)                                            |
-| Medium     | Timetree     | [Skyline coalescent uses Nelder-Mead instead of SLSQP](M-timetree-skyline-nelder-mead-optimizer.md)                                   |
-| Medium     | Timetree     | [Marginal dense golden master node key mismatch on ebola_20](M-timetree-dense-golden-master-node-mismatch.md)                         |
-| Medium     | Timetree     | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)                  |
-| Medium     | Timetree     | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                     |
-| Negligible | Ancestral    | [Sparse marginal passes still use remove/insert pattern](N-ancestral-sparse-remove-insert-pattern.md)                                 |
-| Negligible | Clock        | [assign_dates fails for small trees](N-clock-small-trees.md)                                                                          |
-| Negligible | Core         | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                       |
-| Negligible | Dates        | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                       |
-| Negligible | Distribution | [Formula discretization errors silently swallowed](N-distribution-formula-silent-discretization.md)                                   |
-| Negligible | I/O          | [Large datasets require all sequences in memory simultaneously](N-io-large-dataset-memory-constraint.md)                              |
-| Negligible | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                            |
-| Negligible | Optimize     | [initial_guess_mixed allocates Vec\<Sub\> per edge for count only](L-optimize-initial-guess-alloc.md)                                 |
-| Negligible | Optimize     | [Dense/sparse equivalence test bounds undocumented](N-optimize-equivalence-bounds-undocumented.md)                                    |
-| Negligible | Optimize     | [Optimize command accepts only a single alignment](N-optimize-multi-alignment-input.md)                                               |
-| Negligible | Optimize     | [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md)                                                                |
-| Negligible | Optimize     | [Multi-modal surface counterexample with $\ell'(0) < 0$ not constructed](N-optimize-multimodal-counterexample-unreproduced.md)        |
-| Negligible | Optimize     | [Grid search resolution (100 points) is unverified](N-optimize-grid-search-resolution-unverified.md)                                  |
-| Negligible | Optimize     | [Grid search upper bound caps at 0.5 subs/site](N-optimize-grid-search-upper-bound-capped.md)                                         |
-| Negligible | Optimize     | [`reconcile_zero_boundary` grid extent argument is unverified](N-optimize-reconcile-grid-extent-unverified.md)                        |
-| Negligible | Optimize     | [Optimize pre-step uses default Brent tolerance instead of v0's coarse tolerance](N-optimize-pre-step-coarse-tolerance.md)            |
-| Negligible | Optimize     | [Optimize writes gtr.json before rate normalization](N-optimize-gtr-json-before-normalization.md)                                     |
-| Negligible | Timetree     | [--dates not required, misleading error when omitted](N-timetree-dates-not-required.md)                                               |
-| Negligible | Timetree     | [Dead CLI flags in timetree](N-timetree-dead-cli-flags.md)                                                                            |
-| Negligible | Timetree     | [gtr.json missing for --branch-length-mode=input](N-timetree-gtr-json-missing-input-bl.md)                                            |
-| Negligible | Timetree     | [timetree.json missing coalescent and skyline parameters](N-timetree-json-missing-coalescent.md)                                      |
-| Negligible | Timetree     | [Missing output files compared to v0](N-timetree-missing-output-files.md)                                                             |
-| Negligible | Timetree     | [Missing skyline output files](N-timetree-missing-skyline-output.md)                                                                  |
-| Negligible | Timetree     | [--n-branches-posterior panics with todo!()](N-timetree-n-branches-posterior-unimplemented.md)                                        |
-| Negligible | Timetree     | [Negative coalescent Tc accepted without validation](N-timetree-negative-coalescent-tc.md)                                            |
-| Negligible | Timetree     | [write_node_dates() is a todo!() stub](N-timetree-node-dates-output-unimplemented.md)                                                 |
-| Negligible | Timetree     | [--plot-rtt and --plot-tree typed as Option\<usize\>](N-timetree-plot-arg-type.md)                                                    |
-| Negligible | Timetree     | [--plot-rtt and --plot-tree panic with todo!()](N-timetree-plot-unimplemented.md)                                                     |
-| Negligible | Timetree     | [--keep-polytomies and --resolve-polytomies no conflicts_with declaration](N-timetree-polytomy-flags-no-conflict.md)                  |
-| Negligible | Timetree     | [Stochastic polytomy resolution not implemented](N-timetree-stochastic-polytomy-unimplemented.md)                                     |
-| Negligible | Timetree     | [Auspice JSON output incomplete](N-timetree-auspice-json-incomplete.md)                                                               |
-| Negligible | Timetree     | [Unnamed root after reroot](N-timetree-unnamed-root-after-reroot.md)                                                                  |
-| Negligible | Timetree     | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                               |
-| Negligible | Timetree     | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                                     |
-| Medium     | Timetree     | [Branch distribution grid uses uniform spacing](M-timetree-branch-grid-uniform-resolution.md)                                         |
-| Medium     | Timetree     | [Timetree inference in input mode collapses internal-node dates to Empty](M-timetree-inference-input-mode-date-collapse.md)           |
-| Medium     | Timetree     | [Backward and forward traversals use unwrap on fallible distribution math](M-timetree-inference-unwrap-in-traversals.md)              |
-| Medium     | Timetree     | [build_branch_distributions is a public todo!() stub](M-timetree-branch-distributions-todo-stub.md)                                   |
-| Medium     | Timetree     | [resolve_polytomies_with_options ignores merge_compressed parameter](M-timetree-polytomy-merge-compressed-ignored.md)                 |
-| Medium     | Timetree     | [sum_coalescent_cost silently clamps negative branch lengths](M-timetree-coalescent-branch-length-clamp.md)                           |
-| Medium     | Alphabet     | [AlphabetConfig validation misses unknown-inside-ambiguous check](M-alphabet-validate-unknown-in-ambiguous.md)                        |
-| Medium     | Ancestral    | [Sparse ancestral does not re-run marginal after GTR inference](M-ancestral-sparse-no-rerun-after-gtr-inference.md)                   |
-| Medium     | Ancestral    | [Stdin FASTA path reads one record and truncates multi-record alignments](M-ancestral-stdin-fasta-truncation.md)                      |
-| Medium     | CLI          | [RTT chart gather_points swaps normal and outlier series](M-cli-rtt-chart-partition-inversion.md)                                     |
-| Medium     | CLI          | [RTT chart aborts clock command on non-TTY output](M-cli-rtt-chart-non-tty-abort.md)                                                  |
-| Medium     | Clock        | [Clock command discards eleven CLI arguments without wiring](M-clock-dead-cli-arguments.md)                                           |
-| Medium     | Clock        | [Clock command collapses date intervals to their mean](M-clock-date-interval-collapsed-to-mean.md)                                    |
-| Medium     | Discrete     | [DiscreteNodeData::missing(0) produces inf-filled profile](M-discrete-missing-zero-states-inf.md)                                     |
-| Medium     | GTR          | [GTR::new() panics on invalid dimensions](M-gtr-new-panics-on-invalid-dimensions.md)                                                  |
-| Medium     | GTR          | [GTR site-rate property tests excluded from build](M-gtr-site-rates-tests-excluded.md)                                                |
-| Medium     | Mugration    | [Mugration fixed_pi capture happens before pseudo-count smoothing](M-mugration-fixed-pi-timing.md)                                    |
-| Medium     | Mugration    | [Mugration optimize_gtr_rate restores mu without restoring profiles](M-mugration-gtr-rate-restore-inconsistency.md)                   |
-| Medium     | Optimize     | [evaluate_site_contributions does not guard against negative branch lengths](M-optimize-negative-bl-in-evaluate.md)                   |
-| Negligible | Timetree     | [Branch grid extent uses base clock_rate, not effective rate](N-timetree-branch-grid-gamma-omitted.md)                                |
+| Severity   | Scope          | Issue                                                                                                                                 |
+| ---------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| High       | Ancestral      | [Ancestral joint method default panics](H-ancestral-joint-default-panics.md)                                                          |
+| High       | Clock          | [ClockSet dateless-leaf contribution biases regression](H-clock-clockset-dateless-leaf-bias.md)                                       |
+| High       | Clock          | [Clock filter panics on trees with fewer than four dated leaves](H-clock-filter-panic-small-trees.md)                                 |
+| High       | Clock          | [Clock covariation divides by zero when sequence length is absent](H-clock-covariation-divide-by-zero.md)                             |
+| High       | Homoplasy      | [Homoplasy command is unimplemented](H-homoplasy-command-unimplemented.md)                                                            |
+| High       | Timetree       | [Coalescent backward pass grid explosion](H-timetree-coalescent-grid-explosion.md)                                                    |
+| High       | Timetree       | [Skyline optimizer uses a different objective than the reported coalescent cost](H-timetree-skyline-objective-mismatch.md)            |
+| High       | Timetree       | [No tree inference from alignment](H-timetree-tree-inference-unimplemented.md)                                                        |
+| Medium     | Timetree       | [Golden master runner missing internal node times](M-timetree-gm-runner-missing-internal-times.md)                                    |
+| Medium     | Clock          | [Clock filter residual parity](M-clock-filter-residual-parity.md)                                                                     |
+| Negligible | Clock          | [Clock regression all-negative-rate divergence](N-clock-regression-all-negative-rate.md)                                              |
+| Negligible | Clock          | [Clock chisq near-zero determinant](N-clock-chisq-near-zero-determinant.md)                                                           |
+| Medium     | Ancestral      | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                      |
+| Medium     | Ancestral      | [Marginal reconstruction uses plain probability space](M-ancestral-marginal-probability-space.md)                                     |
+| Medium     | Ancestral      | [Sparse root invariance violation](M-ancestral-sparse-root-invariance.md)                                                             |
+| Medium     | Ancestral      | [Sparse variable-site alphabet mismatch](M-ancestral-sparse-alphabet-mismatch.md)                                                     |
+| Medium     | Core           | [Dummy GTR initialization pattern across commands](M-core-dummy-gtr-initialization.md)                                                |
+| Medium     | Clock          | [Clock covariation overdispersion hardcoded](M-clock-covariation-overdispersion.md)                                                   |
+| Medium     | Dates          | [Column auto-detection gaps in CSV readers](M-dates-column-auto-detection-gaps.md)                                                    |
+| Medium     | GTR            | [Per-site rate variation not implemented](M-gtr-per-site-rate-variation.md)                                                           |
+| Medium     | I/O            | [Sequence attachment has O(n squared) complexity](M-io-sequence-attachment-quadratic.md)                                              |
+| Medium     | I/O            | [Sequence-to-node name matching is unreliable](M-io-sequence-name-matching-unreliable.md)                                             |
+| Medium     | Mugration      | [Iterative GTR inference not implemented for mugration](M-mugration-iterative-gtr.md)                                                 |
+| Medium     | Optimize       | [Negative branch lengths not validated or reported across optimizer modes](M-optimize-negative-branch-length-validation.md)           |
+| Medium     | Optimize       | [Optimizer and marginal propagation use incompatible branch-length scales when GTR mu != 1](M-optimize-gtr-mu-coordinate-mismatch.md) |
+| Low        | Core           | [Duplicate `write_graph()` across commands](L-core-duplicate-write-graph.md)                                                          |
+| Low        | Topology       | [Move `merge_shared_mutation_branches()` to shared topology_cleanup module](L-topology-cleanup-move-merge-shared-mutations.md)        |
+| Low        | GTR            | [Site-specific GTR partition integration pending](L-gtr-site-specific-partition-integration.md)                                       |
+| Low        | GTR            | [Site-specific GTR end-to-end inference test pending](L-gtr-site-specific-e2e-inference-test.md)                                      |
+| Low        | Representation | [`infer_dense()` stub always returns false](L-representation-infer-dense-stub.md)                                                     |
+| Medium     | Optimize       | [Optimize per-branch lengths diverge from v0 fixture beyond 10% relative tolerance](M-optimize-gm-per-branch-divergence.md)           |
+| Medium     | Optimize       | [Optimize outer loop enters persistent likelihood 2-cycle (sparse)](M-optimize-sparse-em-2-cycle.md) (**fixed**)                      |
+| Medium     | GTR            | [Sparse GTR inference mixes MAP mutations with Fitch-era compositions](M-gtr-sparse-composition-stale-after-marginal.md)              |
+| Medium     | Timetree       | [--aln flag silently ignored](M-timetree-aln-flag-ignored.md)                                                                         |
+| Medium     | Timetree       | [Coalescent backward pass missing leaf and root contributions](M-timetree-coalescent-missing-leaf-and-root-contributions.md)          |
+| Medium     | Timetree       | [--coalescent-opt alone skips initial Tc pass](M-timetree-coalescent-opt-skips-initial.md)                                            |
+| Medium     | Timetree       | [Date column header matching breaks on hash](M-timetree-date-header-hash.md)                                                          |
+| Medium     | Timetree       | [Internal node dates missing in nexus for input branch length mode](M-timetree-internal-dates-missing-input-bl.md)                    |
+| Medium     | Timetree       | [--method-anc ignored in timetree](M-timetree-method-anc-ignored.md)                                                                  |
+| Medium     | Timetree       | [Positional likelihood metric differs from v0](M-timetree-positional-likelihood-metric.md)                                            |
+| Medium     | Timetree       | [Skyline coalescent uses Nelder-Mead instead of SLSQP](M-timetree-skyline-nelder-mead-optimizer.md)                                   |
+| Medium     | Timetree       | [Marginal dense golden master node key mismatch on ebola_20](M-timetree-dense-golden-master-node-mismatch.md)                         |
+| Medium     | Timetree       | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)                  |
+| Medium     | Timetree       | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                     |
+| Negligible | Ancestral      | [Sparse marginal passes still use remove/insert pattern](N-ancestral-sparse-remove-insert-pattern.md)                                 |
+| Negligible | Clock          | [assign_dates fails for small trees](N-clock-small-trees.md)                                                                          |
+| Negligible | Core           | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                       |
+| Negligible | Dates          | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                       |
+| Negligible | Distribution   | [Formula discretization errors silently swallowed](N-distribution-formula-silent-discretization.md)                                   |
+| Negligible | I/O            | [Large datasets require all sequences in memory simultaneously](N-io-large-dataset-memory-constraint.md)                              |
+| Negligible | I/O            | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                            |
+| Negligible | Optimize       | [initial_guess_mixed allocates Vec\<Sub\> per edge for count only](L-optimize-initial-guess-alloc.md)                                 |
+| Negligible | Optimize       | [Dense/sparse equivalence test bounds undocumented](N-optimize-equivalence-bounds-undocumented.md)                                    |
+| Negligible | Optimize       | [Optimize command accepts only a single alignment](N-optimize-multi-alignment-input.md)                                               |
+| Negligible | Optimize       | [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md)                                                                |
+| Negligible | Optimize       | [Multi-modal surface counterexample with $\ell'(0) < 0$ not constructed](N-optimize-multimodal-counterexample-unreproduced.md)        |
+| Negligible | Optimize       | [Grid search resolution (100 points) is unverified](N-optimize-grid-search-resolution-unverified.md)                                  |
+| Negligible | Optimize       | [Grid search upper bound caps at 0.5 subs/site](N-optimize-grid-search-upper-bound-capped.md)                                         |
+| Negligible | Optimize       | [`reconcile_zero_boundary` grid extent argument is unverified](N-optimize-reconcile-grid-extent-unverified.md)                        |
+| Negligible | Optimize       | [Optimize pre-step uses default Brent tolerance instead of v0's coarse tolerance](N-optimize-pre-step-coarse-tolerance.md)            |
+| Negligible | Optimize       | [Optimize writes gtr.json before rate normalization](N-optimize-gtr-json-before-normalization.md)                                     |
+| Negligible | Timetree       | [--dates not required, misleading error when omitted](N-timetree-dates-not-required.md)                                               |
+| Negligible | Timetree       | [Dead CLI flags in timetree](N-timetree-dead-cli-flags.md)                                                                            |
+| Negligible | Timetree       | [gtr.json missing for --branch-length-mode=input](N-timetree-gtr-json-missing-input-bl.md)                                            |
+| Negligible | Timetree       | [timetree.json missing coalescent and skyline parameters](N-timetree-json-missing-coalescent.md)                                      |
+| Negligible | Timetree       | [Missing output files compared to v0](N-timetree-missing-output-files.md)                                                             |
+| Negligible | Timetree       | [Missing skyline output files](N-timetree-missing-skyline-output.md)                                                                  |
+| Negligible | Timetree       | [--n-branches-posterior panics with todo!()](N-timetree-n-branches-posterior-unimplemented.md)                                        |
+| Negligible | Timetree       | [Negative coalescent Tc accepted without validation](N-timetree-negative-coalescent-tc.md)                                            |
+| Negligible | Timetree       | [write_node_dates() is a todo!() stub](N-timetree-node-dates-output-unimplemented.md)                                                 |
+| Negligible | Timetree       | [--plot-rtt and --plot-tree typed as Option\<usize\>](N-timetree-plot-arg-type.md)                                                    |
+| Negligible | Timetree       | [--plot-rtt and --plot-tree panic with todo!()](N-timetree-plot-unimplemented.md)                                                     |
+| Negligible | Timetree       | [--keep-polytomies and --resolve-polytomies no conflicts_with declaration](N-timetree-polytomy-flags-no-conflict.md)                  |
+| Negligible | Timetree       | [Stochastic polytomy resolution not implemented](N-timetree-stochastic-polytomy-unimplemented.md)                                     |
+| Negligible | Timetree       | [Auspice JSON output incomplete](N-timetree-auspice-json-incomplete.md)                                                               |
+| Negligible | Timetree       | [Unnamed root after reroot](N-timetree-unnamed-root-after-reroot.md)                                                                  |
+| Negligible | Timetree       | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                               |
+| Negligible | Timetree       | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                                     |
+| Medium     | Timetree       | [Branch distribution grid uses uniform spacing](M-timetree-branch-grid-uniform-resolution.md)                                         |
+| Medium     | Timetree       | [Timetree inference in input mode collapses internal-node dates to Empty](M-timetree-inference-input-mode-date-collapse.md)           |
+| Medium     | Timetree       | [Backward and forward traversals use unwrap on fallible distribution math](M-timetree-inference-unwrap-in-traversals.md)              |
+| Medium     | Timetree       | [build_branch_distributions is a public todo!() stub](M-timetree-branch-distributions-todo-stub.md)                                   |
+| Medium     | Timetree       | [resolve_polytomies_with_options ignores merge_compressed parameter](M-timetree-polytomy-merge-compressed-ignored.md)                 |
+| Medium     | Timetree       | [sum_coalescent_cost silently clamps negative branch lengths](M-timetree-coalescent-branch-length-clamp.md)                           |
+| Medium     | Alphabet       | [AlphabetConfig validation misses unknown-inside-ambiguous check](M-alphabet-validate-unknown-in-ambiguous.md)                        |
+| Medium     | Ancestral      | [Sparse ancestral does not re-run marginal after GTR inference](M-ancestral-sparse-no-rerun-after-gtr-inference.md)                   |
+| Medium     | Ancestral      | [Stdin FASTA path reads one record and truncates multi-record alignments](M-ancestral-stdin-fasta-truncation.md)                      |
+| Medium     | CLI            | [RTT chart gather_points swaps normal and outlier series](M-cli-rtt-chart-partition-inversion.md)                                     |
+| Medium     | CLI            | [RTT chart aborts clock command on non-TTY output](M-cli-rtt-chart-non-tty-abort.md)                                                  |
+| Medium     | Clock          | [Clock command discards eleven CLI arguments without wiring](M-clock-dead-cli-arguments.md)                                           |
+| Medium     | Clock          | [Clock command collapses date intervals to their mean](M-clock-date-interval-collapsed-to-mean.md)                                    |
+| Medium     | Discrete       | [DiscreteNodeData::missing(0) produces inf-filled profile](M-discrete-missing-zero-states-inf.md)                                     |
+| Medium     | GTR            | [GTR::new() panics on invalid dimensions](M-gtr-new-panics-on-invalid-dimensions.md)                                                  |
+| Medium     | GTR            | [GTR site-rate property tests excluded from build](M-gtr-site-rates-tests-excluded.md)                                                |
+| Medium     | Mugration      | [Mugration fixed_pi capture happens before pseudo-count smoothing](M-mugration-fixed-pi-timing.md)                                    |
+| Medium     | Mugration      | [Mugration optimize_gtr_rate restores mu without restoring profiles](M-mugration-gtr-rate-restore-inconsistency.md)                   |
+| Medium     | Optimize       | [evaluate_site_contributions does not guard against negative branch lengths](M-optimize-negative-bl-in-evaluate.md)                   |
+| Negligible | Timetree       | [Branch grid extent uses base clock_rate, not effective rate](N-timetree-branch-grid-gamma-omitted.md)                                |
 
 ## Cross-references
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_common.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_common.rs
@@ -61,7 +61,7 @@ mod tests {
   fn test_distance_zero_to_uniform() {
     let actual = distance(&array![0.0, 0.0, 0.0, 0.0], &array![0.25, 0.25, 0.25, 0.25]);
     let expected = 0.5;
-    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-5);
+    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-8);
   }
 
   #[test]
@@ -71,7 +71,7 @@ mod tests {
       &array![0.16031624, 0.24247873, 0.3087257, 0.28847933],
     );
     let expected = 0.11414514039292292;
-    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-5);
+    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-8);
   }
 
   #[test]
@@ -81,7 +81,7 @@ mod tests {
       &array![0.14968981, 0.24040983, 0.31181279, 0.29808757],
     );
     let expected = 0.014800329884495377;
-    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-5);
+    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-8);
   }
 
   #[test]
@@ -91,7 +91,7 @@ mod tests {
       &array![0.14878922, 0.24051699, 0.31239221, 0.29830159],
     );
     let expected = 1.59484629332816e-05;
-    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-5);
+    pretty_assert_ulps_eq!(actual, expected, epsilon = 1e-8);
   }
 
   #[test]

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
@@ -4,7 +4,8 @@
 //! produce structurally different mutation counts. The inferred GTR models (W, pi, mu) should
 //! agree qualitatively on real data.
 //!
-//! Measured differences (2025-03):
+//! Measured differences (2025-03, commit bba8c177, by running this test with assertions
+//! replaced by println! and collecting the table below):
 //!
 //! | dataset          | pi_cosine    | W_rel_frob | mu_rel_diff |
 //! |------------------|--------------|------------|-------------|

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs
@@ -71,6 +71,7 @@ mod tests {
 
     // BLAS drift between NumPy and ndarray scales with sequence length. mpox_clade_ii_20
     // (~200k positions) shows max diff ~2.3e-7. Tightest passing: 1e-6.
+    // Measured at commit bba8c177 by running all cases and collecting max abs diff.
     pretty_assert_ulps_eq!(&expected.W, &actual.W, epsilon = 1e-6);
     pretty_assert_ulps_eq!(&expected.pi, &actual.pi, epsilon = 1e-6);
     pretty_assert_ulps_eq!(expected.mu, actual.mu, epsilon = 1e-6);

--- a/packages/treetime/src/gtr/infer_gtr/common.rs
+++ b/packages/treetime/src/gtr/infer_gtr/common.rs
@@ -91,9 +91,14 @@ const TINY_NUMBER: f64 = 1e-12;
 ///  * $T_i$ is the time on the tree spent in character state $i$.
 ///
 /// To regularize the process, we add pseudo-counts and also need to account for the fact that the root of the tree is
-/// in a particular state. the modified equation is
+/// in a particular state. The modified equation is
 ///
 /// $$ n_{ij} + pc = pi_i W_{ij} (T_j+pc+root\_state) $$
+///
+/// with two regularization terms:
+///
+///  * $pc$ is a scalar pseudo-count that regularizes zero observations in transition data
+///  * $root\_state$ is a vector of character-state counts at the root, acting as a prior on equilibrium frequencies
 pub fn infer_gtr_impl(counts: &MutationCounts, options: &InferGtrOptions) -> Result<InferGtrResult, Report> {
   let MutationCounts { nij, Ti, root_state } = counts;
   let InferGtrOptions {

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs
@@ -104,8 +104,14 @@ mod tests {
       let target_name = target.read_arc().payload().read_arc().name.clone();
       let edge_data = &p.edges[&edge.key()];
       match target_name.as_deref() {
-        Some("A") => assert_eq!(edge_data.subs.len(), 2, "A: collapsed-edge sub + own sub"),
-        Some("B") => assert_eq!(edge_data.subs.len(), 1, "B: collapsed-edge sub only"),
+        Some("A") => {
+          // Composed: collapsed-edge A0T + child-edge G5C
+          assert_eq!(edge_data.subs, vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]);
+        }
+        Some("B") => {
+          // Only the collapsed-edge sub A0T propagated (B had no own subs)
+          assert_eq!(edge_data.subs, vec![sub(b'A', 0, b'T')]);
+        }
         other => unreachable!("unexpected target node: {other:?}"),
       }
     }
@@ -393,13 +399,21 @@ mod tests {
     collapse_edge(&mut graph, &sparse, &dense, ri_key)?;
     graph.build()?;
 
-    for (i, partition) in sparse.iter().enumerate() {
-      let p = partition.read_arc();
-      for edge in graph.get_edges() {
-        let edge = edge.read_arc();
-        let data = &p.edges[&edge.key()];
-        assert_eq!(data.subs.len(), 1, "partition {i}: each child should inherit 1 sub");
-      }
+    // Partition 0: collapsed-edge sub is A0T
+    let p0 = sparse[0].read_arc();
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let data = &p0.edges[&edge.key()];
+      assert_eq!(data.subs, vec![sub(b'A', 0, b'T')], "partition 0: each child inherits A0T");
+    }
+    drop(p0);
+
+    // Partition 1: collapsed-edge sub is G5C
+    let p1 = sparse[1].read_arc();
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let data = &p1.edges[&edge.key()];
+      assert_eq!(data.subs, vec![sub(b'G', 5, b'C')], "partition 1: each child inherits G5C");
     }
 
     Ok(())


### PR DESCRIPTION
Test strengthening and documentation from GTR inference and representation algorithm audits.

The `distance()` tests used `1e-5` tolerance on a deterministic L2 norm, admitting 63% relative error on the smallest fixture (`expected = 1.59e-5`). Tightened to `1e-8`, the tightest passing `1e-N`. The `collapse_edge` tests asserted only `subs.len()`, which would pass with wrong substitutions composed; now asserts exact `Sub` values (position, parent state, child state).

The GTR inference equation doc block introduced `pc` and `root_state` without definitions. Empirical test thresholds in two test files lacked provenance (which commit measured them, how).

### Work items

- [x] Tighten `distance()` tolerances from `1e-5` to `1e-8` in [test_common.rs](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/packages/treetime/src/gtr/infer_gtr/__tests__/test_common.rs)
- [x] Assert exact `Sub` values in collapse-edge tests in [test_collapse_edge.rs](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs)
- [x] Define `pc` and `root_state` in GTR equation where-clause in [common.rs](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/packages/treetime/src/gtr/infer_gtr/common.rs)
- [x] Add provenance pointers to empirical thresholds in [test_contract_dense_sparse_real.rs](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs) and [test_gm_infer_gtr_dense.rs](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs)
- [x] File issue: [L-representation-infer-dense-stub.md](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/docs/port-known-issues/L-representation-infer-dense-stub.md): `infer_dense()` stub always returns false
- [x] Update issue: [M-gtr-sparse-composition-stale-after-marginal.md](https://github.com/neherlab/treetime/blob/2293040ff1e8541948fd155c2ff82990cdf6dcf5/docs/port-known-issues/M-gtr-sparse-composition-stale-after-marginal.md): document test files that encode stale composition behavior