### PR TITLE
refactor: representation review cleanup and known-issue filing

### DIFF
--- a/docs/port-known-issues/L-marginal-forward-zero-divisor-floor.md
+++ b/docs/port-known-issues/L-marginal-forward-zero-divisor-floor.md
@@ -1,0 +1,21 @@
+# Marginal forward pass zero-divisor floor converts structural zeros
+
+The forward pass msg_to_child computation divides the node posterior by the child's msg_from_child. When msg_from_child contains exact zeros (a state is structurally impossible given the subtree evidence), the division would produce infinity. The code floors the divisor to `f64::MIN_POSITIVE` (~2.2e-308) to avoid this.
+
+The floor converts structurally impossible states (probability exactly zero) into states with tiny but nonzero support in the msg_to_child. This changes the information sent to the child: instead of "this state is impossible given the outgroup", the message becomes "this state has negligible but nonzero probability".
+
+## Affected code
+
+- Sparse: [packages/treetime/src/representation/partition/marginal_passes.rs#L295](../../packages/treetime/src/representation/partition/marginal_passes.rs#L295)
+- Dense: [packages/treetime/src/representation/partition/marginal_dense.rs#L324](../../packages/treetime/src/representation/partition/marginal_dense.rs#L324)
+- Discrete: [packages/treetime/src/representation/partition/discrete.rs#L206](../../packages/treetime/src/representation/partition/discrete.rs#L206)
+
+## Impact
+
+The practical impact is negligible because `f64::MIN_POSITIVE` is ~2.2e-308, making the resulting probability mass undetectable by downstream computations. The concern is principled: the operation changes the topology of the probability simplex (zero support becomes nonzero support).
+
+## Alternative approaches
+
+- Log-space division (subtraction) with explicit handling of -inf - -inf
+- Propagate structural zeros through the forward pass by skipping positions where msg_from_child is zero
+- v0 uses log-space arithmetic in the forward pass, avoiding the division entirely

--- a/docs/port-known-issues/M-ancestral-dense-sparse-divergence.md
+++ b/docs/port-known-issues/M-ancestral-dense-sparse-divergence.md
@@ -26,6 +26,15 @@ Candidates for root cause (from test file comments):
 The bimodal distribution (clean separation between populations 1 and 2)
 suggests a discrete trigger rather than continuous numerical drift.
 
+4. Sparse EPS demotion: `combine_messages()` demotes variable sites to fixed
+   when posterior peak exceeds `1 - EPS` (`EPS = 1e-4` at
+   `packages/treetime/src/representation/partition/marginal_helpers.rs#L15`).
+   This is an approximation not present in the dense path, which retains full
+   per-position probability vectors. The demotion replaces a position-specific
+   posterior with a shared per-character vector, introducing a small error
+   proportional to the distance between the position posterior and the shared
+   vector.
+
 ## Excluded cause
 
 Partial-IUPAC sparse reference-state fallback is covered separately by [`test_marginal_dense_sparse_ambiguous_r_reference_state_consistency`](../../packages/treetime/src/commands/ancestral/__tests__/test_marginal_consistency.rs#L317) and the `flu/h3n2/500` site-451 regression. The remaining issue in this file is not the fixed ambiguous-`R` exact-state bug.

--- a/docs/port-known-issues/M-marginal-forward-pass-missing-fix-branch-length.md
+++ b/docs/port-known-issues/M-marginal-forward-pass-missing-fix-branch-length.md
@@ -1,0 +1,25 @@
+# Marginal forward pass missing fix_branch_length
+
+The backward marginal pass applies `fix_branch_length()` to clamp zero-length branches to a minimum value, but the forward pass reads the raw branch length from the graph payload without clamping. This means backward and forward passes evaluate the same edge under different transition matrices when the raw branch length is below the minimum threshold.
+
+## Affected code
+
+Sparse marginal:
+
+- Backward: [packages/treetime/src/representation/partition/marginal_passes.rs#L135-L136](../../packages/treetime/src/representation/partition/marginal_passes.rs#L135-L136) applies `fix_branch_length()`
+- Forward: [packages/treetime/src/representation/partition/marginal_passes.rs#L202](../../packages/treetime/src/representation/partition/marginal_passes.rs#L202) uses raw `branch_length`
+
+Dense marginal:
+
+- Backward: [packages/treetime/src/representation/partition/marginal_dense.rs#L278-L279](../../packages/treetime/src/representation/partition/marginal_dense.rs#L278-L279) applies `fix_branch_length()`
+- Forward: [packages/treetime/src/representation/partition/marginal_dense.rs#L300](../../packages/treetime/src/representation/partition/marginal_dense.rs#L300) uses raw `branch_length`
+
+## Impact
+
+For edges with branch length exactly zero, the backward pass uses `fix_branch_length(length, 0.0)` which produces a small positive value, while the forward pass uses `0.0`. The forward-pass transition matrix `exp(Q * 0) = I` (identity), meaning the parent message passes through unchanged. The backward-pass transition matrix `exp(Q * epsilon)` is close to identity but not exact. The resulting posterior combines messages computed under two different models.
+
+The practical impact is small because `fix_branch_length` produces a very small minimum value (a fraction of one mutation per sequence length). The transition matrices differ by ~1e-6 or less.
+
+## Fix
+
+Apply `fix_branch_length()` consistently in both passes, or remove it from the backward pass. The choice depends on whether zero-length branches should be treated as literally zero (identity matrix) or as a small positive value (near-identity matrix).

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -152,6 +152,8 @@ exactly.
 | Medium     | Mugration      | [Mugration optimize_gtr_rate restores mu without restoring profiles](M-mugration-gtr-rate-restore-inconsistency.md)                   |
 | Medium     | Optimize       | [evaluate_site_contributions does not guard against negative branch lengths](M-optimize-negative-bl-in-evaluate.md)                   |
 | Negligible | Timetree       | [Branch grid extent uses base clock_rate, not effective rate](N-timetree-branch-grid-gamma-omitted.md)                                |
+| Medium     | Marginal       | [Marginal forward pass missing fix_branch_length](M-marginal-forward-pass-missing-fix-branch-length.md)                               |
+| Low        | Marginal       | [Marginal forward pass zero-divisor floor converts structural zeros](L-marginal-forward-zero-divisor-floor.md)                        |
 
 ## Cross-references
 

--- a/docs/port-test-inventory/representation.md
+++ b/docs/port-test-inventory/representation.md
@@ -112,7 +112,7 @@ Support files (helpers only, no tests): [`packages/treetime/src/representation/a
 | `test_get_reconstructed_trait`                         | Argmax state extraction                     |
 | `test_get_confidence`                                  | Confidence profile access                   |
 | `test_get_log_lh`                                      | Log-likelihood access                       |
-| `test_argmax_first_1d`                                 | Deterministic tie-breaking                  |
+| `test_discrete_argmax_first`                           | Deterministic tie-breaking (shared utility) |
 | `test_normalize_inplace_1d_zero_sum_returns_error`     | Zero-sum normalization returns error        |
 | `test_normalize_from_log_1d_all_neg_inf_returns_error` | All-neg-inf log normalization returns error |
 | `test_normalize_inplace_1d_valid_input`                | Valid normalization sums to 1               |
@@ -221,3 +221,14 @@ Production source files in `representation/` with no inline or dedicated tests:
 | `algo/infer_dense.rs`          | Dense inference algorithm        |
 
 These are exercised indirectly through command-level tests (ancestral, optimize, timetree) but have no direct unit tests.
+
+## Known Test Deficiencies
+
+Specific functions and code paths identified as needing direct test coverage:
+
+| Entity                              | File                                                          | Deficiency                                                                                                                      |
+| ----------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `combine_messages()`                | `partition/marginal_helpers.rs`                               | Core sparse marginal algorithm with no direct tests. Only indirect coverage via command integration tests.                      |
+| `reconcile_topology()`              | `partition/marginal_sparse.rs`, `partition/marginal_dense.rs` | Adds/removes partition entries after graph topology edits with no tests asserting correctness.                                  |
+| `propagate_raw_per_site()` tests    | `partition/marginal_helpers.rs`                               | Tests use circular oracle (same `expQt_with_rate()` as SUT). Need hand-computed expected values.                                |
+| `collapse_edge()` composition tests | `algo/topology_cleanup/__tests__/test_collapse_edge.rs`       | Assert substitution count, not exact content. Composition semantics verified separately in `test_partition_marginal_sparse.rs`. |

--- a/packages/treetime/src/representation/partition/discrete.rs
+++ b/packages/treetime/src/representation/partition/discrete.rs
@@ -11,6 +11,7 @@ use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey};
+use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::array::softmax_with_log_norm::softmax_with_log_norm;
 
 #[derive(Clone, Debug)]
@@ -48,7 +49,7 @@ impl PartitionDiscrete {
 
   pub fn get_reconstructed_trait(&self, node_key: GraphNodeKey) -> Option<String> {
     let node = self.nodes.get(&node_key)?;
-    let argmax = argmax_first_1d(&node.profile)?;
+    let argmax = argmax_first(&node.profile.view())?;
     Some(self.states.get_name(argmax).to_owned())
   }
 
@@ -219,21 +220,6 @@ impl HasLogLh for PartitionDiscrete {
   }
 }
 
-fn argmax_first_1d(arr: &Array1<f64>) -> Option<usize> {
-  if arr.is_empty() {
-    return None;
-  }
-  let mut max_idx = 0;
-  let mut max_val = arr[0];
-  for (i, &v) in arr.iter().enumerate().skip(1) {
-    if v > max_val {
-      max_val = v;
-      max_idx = i;
-    }
-  }
-  Some(max_idx)
-}
-
 fn normalize_inplace_1d(arr: &mut Array1<f64>) -> Result<f64, Report> {
   let sum = arr.sum();
   if sum.is_nan() || sum <= 0.0 {
@@ -338,10 +324,10 @@ mod tests {
   }
 
   #[test]
-  fn test_argmax_first_1d() {
-    assert_eq!(argmax_first_1d(&array![0.1, 0.5, 0.4]), Some(1));
-    assert_eq!(argmax_first_1d(&array![0.5, 0.5, 0.0]), Some(0)); // tie: first wins
-    assert_eq!(argmax_first_1d(&Array1::zeros(0)), None);
+  fn test_discrete_argmax_first() {
+    assert_eq!(argmax_first(&array![0.1, 0.5, 0.4].view()), Some(1));
+    assert_eq!(argmax_first(&array![0.5, 0.5, 0.0].view()), Some(0)); // tie: first wins
+    assert_eq!(argmax_first(&Array1::<f64>::zeros(0).view()), None);
   }
 
   #[test]

--- a/packages/treetime/src/representation/partition/marginal_passes.rs
+++ b/packages/treetime/src/representation/partition/marginal_passes.rs
@@ -72,7 +72,6 @@ where
       log_lh: 0.0,
     }
   } else {
-    // for internal nodes, combine the messages from the children
     let mut variable_pos = btreemap! {};
     let mut child_states = vec![];
     let mut child_messages: Vec<MarginalSparseSeqDistribution> = vec![];
@@ -90,7 +89,7 @@ where
       child_messages.push(edge_data.msg_from_child.clone());
     }
 
-    // collected child states of variable positions that are not yet determined
+    // Fill in child states for variable positions without edge substitutions.
     let alphabet = &partition.alphabet;
     for (ci, (child_key, _)) in node.child_keys.iter().enumerate() {
       let states = &mut child_states[ci];
@@ -127,10 +126,9 @@ where
   };
 
   if node.is_root {
-    // data from children * gtr.pi as calculated above is the root profile.
     partition.nodes.get_mut(&node.key).unwrap().profile = msg_to_parent;
   } else {
-    // what was calculated above is what is sent to the parent. we also calculate the propagated message to the parent (we need it in the forward pass).
+    // Store msg_to_parent and propagate it through P(t)^T for the forward pass.
     let edge_key = get_exactly_one(&node.parent_edge_keys).expect("Only nodes with exactly one parent are supported");
     let branch_length = node.parent_edges[0].branch_length().unwrap_or(0.0);
     let branch_length = fix_branch_length(length, branch_length);

--- a/packages/treetime/src/representation/payload/sparse.rs
+++ b/packages/treetime/src/representation/payload/sparse.rs
@@ -41,12 +41,6 @@ impl SparseNodePartition {
   }
 
   pub fn new(seq: &Seq, alphabet: &Alphabet) -> Result<Self, Report> {
-    // FIXME: the original code used `alphabet_gapN`:
-    //
-    // alphabet_gapN = ''.join(gtr.alphabet)+'-N'
-    //
-    // def seq_info_from_array(seq: np.array, profile: Dict[str,np.array], alphabet_gapN: str) -> SparseSeqInfo
-
     let variable = seq
       .iter()
       .enumerate()
@@ -94,8 +88,6 @@ pub struct SparseSeqInfo {
   pub sequence: Seq,
   pub fitch: FitchSeqDistribution,
 }
-
-///////////////////////////////////
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct SparseEdgePartition {


### PR DESCRIPTION
Code cleanup in the representation module and filing of three known issues surfaced by representation audit.

`PartitionDiscrete` had a local `argmax_first_1d()` reimplementing the shared `treetime_utils::argmax_first()`. `SparseNodePartition::new()` carried a FIXME comment referencing v0 porting residue that no longer applied. `marginal_passes.rs` had narrative "what" comments replaced with concise "why" comments, and `payload/sparse.rs` had a decorative separator line.

Three known issues filed: the marginal forward pass omits `fix_branch_length()` (backward pass applies it, creating asymmetric transition matrices on zero-length branches), the zero-divisor floor in the forward pass converts structural zeros to tiny nonzero values, and the sparse EPS demotion is documented as a contributing factor to the existing dense-sparse divergence issue.

### Work items

- [x] Replace local `argmax_first_1d()` with shared `treetime_utils::argmax_first()` in [discrete.rs](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/packages/treetime/src/representation/partition/discrete.rs)
- [x] Remove FIXME porting residue comment in [sparse.rs](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/packages/treetime/src/representation/payload/sparse.rs)
- [x] Remove decorative separator line in [sparse.rs](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/packages/treetime/src/representation/payload/sparse.rs)
- [x] Replace narrative comments with concise "why" comments in [marginal_passes.rs](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/packages/treetime/src/representation/partition/marginal_passes.rs)
- [x] File issue: [M-marginal-forward-pass-missing-fix-branch-length.md](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/docs/port-known-issues/M-marginal-forward-pass-missing-fix-branch-length.md): forward pass uses raw branch length while backward pass clamps via `fix_branch_length()`
- [x] File issue: [L-marginal-forward-zero-divisor-floor.md](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/docs/port-known-issues/L-marginal-forward-zero-divisor-floor.md): divisor floor converts structural zeros to tiny nonzero values
- [x] Update issue: [M-ancestral-dense-sparse-divergence.md](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/docs/port-known-issues/M-ancestral-dense-sparse-divergence.md): add sparse EPS demotion as contributing factor
- [x] Update test inventory: [representation.md](https://github.com/neherlab/treetime/blob/2a6846877a602e4a48c038a9ce490ce7f38df80e/docs/port-test-inventory/representation.md): add known test deficiencies table