### PR TITLE
fix: dense Fitch gap resolution

### DIFF
--- a/docs/port-known-issues/M-ancestral-dense-effective-length-test-regression.md
+++ b/docs/port-known-issues/M-ancestral-dense-effective-length-test-regression.md
@@ -1,18 +1,45 @@
-# Dense effective length change breaks two tests
+# Dense/sparse optimization metric divergence with IUPAC ambiguity codes
 
-After adding `unknown`/`non_char` tracking to dense partitions, `edge_effective_length()` subtracts `non_char` (gaps + unknowns) instead of gaps only. This is the correct behavior (matches sparse), but two pre-existing tests have hardcoded expectations derived from the old gaps-only computation.
+## Failing test
 
-## Failing tests
+`test_optimize_contribution_dense_sparse_ambiguous_r_value_and_gradient_consistency` at `packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs:106`
 
-1. `test_marginal_dense_update_is_idempotent` at `packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs:312`: golden log-likelihood `-57.712498930787206` was computed with gaps-only effective length. The corrected effective length shifts it to approximately `-57.83`.
+Asserts `create_edge_contribution().evaluate(0.1)` produces identical `log_lh` and `derivative` for dense and sparse partitions at `1e-12` tolerance. Actual values: dense `-0.836`, sparse `-0.800`.
 
-2. `test_optimize_contribution_dense_sparse_ambiguous_r_value_and_gradient_consistency` at `packages/treetime/src/commands/optimize/__tests__/test_initial_guess_formula.rs:125`: dense and sparse log-likelihoods diverge at `1e-12` tolerance. The sparse path already subtracted `non_char`; dense previously subtracted gaps only. The correction brings them closer in principle but the test data contains IUPAC ambiguity codes (`R`) that interact differently with `non_char` tracking in dense vs sparse representations.
+The sibling test `test_initial_guess_dense_sparse_ambiguous_r_reference_state_consistency` at line 86 (which asserts branch lengths after `initial_guess_mixed`) also fails.
 
-## Root cause
+## Test data
 
-`edge_effective_length()` at `packages/treetime/src/representation/partition/marginal_dense.rs:116` changed from subtracting gap positions to subtracting `non_char` positions. For sequences without unknowns, `non_char == gaps` and the result is identical. For sequences with IUPAC ambiguity codes or `N` characters, `non_char` is a superset of gaps, reducing effective length. The backward-pass `non_char` computation (intersection of children's `non_char`) can also produce different ranges than the backward-pass `gaps` computation when children disagree on gap vs unknown status.
+```
+Tree: ((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;
 
-## Fix
+A: RCGTACGT    (R = IUPAC ambiguity: A or G)
+B: GCGTACGT
+C: GCGTACGT
+D: GCGTACGT
+```
 
-1. Update the golden log-likelihood in `test_marginal_dense_update_is_idempotent` to match the corrected value. Verify the new value against v0 oracle.
-2. Investigate the dense/sparse divergence in the ambiguous-R test. Determine whether the remaining divergence is within expected numerical tolerance or indicates a gap/unknown classification discrepancy for IUPAC codes.
+Position 0 is the only variable site. `R` in leaf A is the only ambiguity code. Both dense and sparse use the same `find_letter_ranges(seq, alphabet.unknown())` to detect unknowns, so `R` is not classified as unknown or gap in either path (it is neither `N` nor `-`).
+
+## How each path handles R at position 0
+
+**Sparse**: Fitch backward maps `R` to state set `{A, G}`. Intersection with B's `{G}` gives `{G}` (non-empty), so position 0 is a fixed site resolved to `G`. The sparse coefficient extraction operates on variable sites only, treating position 0 as fixed.
+
+**Dense**: The profile map assigns `R` a mixed profile (e.g. `{A: 0.5, C: 0, G: 0.5, T: 0}`). The dense coefficient extraction operates on full N-by-K posterior matrices including position 0's mixed profile. The marginal posterior at this position incorporates evidence from the subtree (B/C/D all have G), but the mixed prior from `R` still influences the log-likelihood computation.
+
+## Why the values diverge
+
+The divergence is not from `edge_effective_length()` or `edge_subs()` (which are the same here since `R` is not in `non_char` for either path). It is from `create_edge_contribution()`, which computes optimization coefficients differently:
+
+- Sparse (`packages/treetime/src/representation/partition/marginal_sparse.rs`): extracts coefficients from variable sites only. Position 0 is fixed (resolved to G by Fitch), so its contribution is a simple fixed-site term.
+- Dense (`packages/treetime/src/representation/partition/marginal_dense.rs`): extracts coefficients from the full posterior matrix. Position 0 has a mixed profile from the `R` ambiguity, contributing a different log-likelihood term than a pure `G`.
+
+The 4.5% divergence (`-0.836` vs `-0.800`) reflects the different treatment of ambiguity-code positions in the optimization objective: sparse resolves ambiguity at the Fitch stage (parsimony), dense carries it through as posterior uncertainty (marginal inference).
+
+## Fix options
+
+1. **Widen tolerance**: if the divergence is an acceptable consequence of dense vs sparse representation, replace `1e-12` with a tolerance that accommodates the difference. This acknowledges that dense and sparse optimization surfaces differ when ambiguity codes are present.
+
+2. **Classify ambiguity codes as non_char in dense**: add `find_letter_ranges` calls for each ambiguity code character and merge into `non_char`. This would make dense skip ambiguous positions in `edge_subs()` and `edge_effective_length()`, matching sparse Fitch's treatment of resolved-away ambiguity sites. But it would not fix the coefficient extraction divergence.
+
+3. **Unify coefficient extraction for ambiguous sites**: make dense treat Fitch-resolved-fixed sites the same way sparse does during coefficient extraction. This requires the dense path to distinguish "fixed by Fitch parsimony" from "fixed by sequence identity", which is not currently tracked.

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -70,7 +70,7 @@ exactly.
 | Negligible | Clock          | [Clock regression all-negative-rate divergence](N-clock-regression-all-negative-rate.md)                                                            |
 | Negligible | Clock          | [Clock chisq near-zero determinant](N-clock-chisq-near-zero-determinant.md)                                                                         |
 | Medium     | Ancestral      | [Refactor Fitch compression long functions](M-ancestral-fitch-compression-long-functions.md)                                                        |
-| Medium     | Ancestral      | [Dense effective length change breaks two tests](M-ancestral-dense-effective-length-test-regression.md)                                             |
+| Medium     | Ancestral      | [Dense/sparse optimization metric divergence with IUPAC ambiguity codes](M-ancestral-dense-effective-length-test-regression.md)                     |
 | Medium     | Ancestral      | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                                    |
 | Medium     | Ancestral      | [Marginal reconstruction uses plain probability space](M-ancestral-marginal-probability-space.md)                                                   |
 | Medium     | Ancestral      | [Sparse root invariance violation](M-ancestral-sparse-root-invariance.md)                                                                           |

--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch_indel.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch_indel.rs
@@ -52,14 +52,12 @@ mod tests {
     let mut child1_vi = BTreeMap::new();
     child1_vi.insert((2, 4), Deletion { deleted: 1, present: 1 });
     let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&empty0, &child1_vi];
-    let result = resolve_indels_backward(&child_gaps, &child_vis, 10).variable_indel;
+    let result = resolve_indels_backward(&child_gaps, &child_vis, 10);
 
-    assert_eq!(result.len(), 1);
-    let del = &result[&(2, 4)];
-    // Step 1 adds deleted=1, present=1 (child 0 gap vs consensus no-gap)
-    // Step 2 adds deleted += 1 for child 1's variable indel
-    assert_eq!(del.deleted, 2);
-    assert_eq!(del.present, 0);
+    // deleted=2 (child 0 gap + child 1 variable indel), present=0
+    // deleted == n_children: resolved as consensus gap, removed from variable_indel
+    assert!(result.variable_indel.is_empty());
+    assert_eq!(result.resolved_gaps, vec![(2, 4)]);
   }
 
   #[test]

--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch_indel.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch_indel.rs
@@ -12,7 +12,7 @@ mod tests {
     let empty0 = BTreeMap::new();
     let empty1 = BTreeMap::new();
     let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&empty0, &empty1];
-    let result = resolve_indels_backward(&child_gaps, &child_vis, 10);
+    let result = resolve_indels_backward(&child_gaps, &child_vis, 10).variable_indel;
     assert!(result.is_empty(), "No disagreement when all children have same gaps");
   }
 
@@ -22,7 +22,7 @@ mod tests {
     let empty0 = BTreeMap::new();
     let empty1 = BTreeMap::new();
     let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&empty0, &empty1];
-    let result = resolve_indels_backward(&child_gaps, &child_vis, 10);
+    let result = resolve_indels_backward(&child_gaps, &child_vis, 10).variable_indel;
     assert_eq!(result.len(), 1);
     let del = &result[&(2, 4)];
     assert_eq!(del.deleted, 1);
@@ -39,7 +39,7 @@ mod tests {
 
     // consensus gaps = intersection = [(2,4)], so non_gap doesn't include this range.
     // No disagreement ranges produced.
-    let result = resolve_indels_backward(&child_gaps, &child_vis, 10);
+    let result = resolve_indels_backward(&child_gaps, &child_vis, 10).variable_indel;
     assert!(result.is_empty(), "All children agree on gap, no variable indels");
   }
 
@@ -52,7 +52,7 @@ mod tests {
     let mut child1_vi = BTreeMap::new();
     child1_vi.insert((2, 4), Deletion { deleted: 1, present: 1 });
     let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&empty0, &child1_vi];
-    let result = resolve_indels_backward(&child_gaps, &child_vis, 10);
+    let result = resolve_indels_backward(&child_gaps, &child_vis, 10).variable_indel;
 
     assert_eq!(result.len(), 1);
     let del = &result[&(2, 4)];

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs
@@ -150,9 +150,9 @@ mod tests {
     let expected = read_many_fasta_str(
       indoc! {r#"
       >root
-      TCGGCGCTGTATTGAC
+      TCGGCGCTGTATTG--
       >AB
-      ACATCGCTGTA-TGAC
+      ACATCGCTGTA-TG--
       >CD
       TCGGCGGTGTATTG--
     "#},
@@ -309,7 +309,7 @@ mod tests {
     let log_lh_second = update_marginal(&graph, &partitions)?;
 
     // Regression check: same tree/alignment/model as normalization test
-    pretty_assert_ulps_eq!(-57.712498930787206, log_lh_first, epsilon = 1e-6);
+    pretty_assert_ulps_eq!(-57.83384186579029, log_lh_first, epsilon = 1e-6);
 
     // Idempotency: second pass must produce identical log-likelihood
     assert_ulps_eq!(log_lh_first, log_lh_second, epsilon = 1e-10);

--- a/packages/treetime/src/commands/ancestral/fitch.rs
+++ b/packages/treetime/src/commands/ancestral/fitch.rs
@@ -208,16 +208,9 @@ where
     let child_gaps_vec: Vec<Vec<(usize, usize)>> = children.iter().map(|(c, _)| c.gaps.clone()).collect_vec();
     let child_variable_indels: Vec<&_> = children.iter().map(|(c, _)| &c.fitch.variable_indel).collect_vec();
 
-    seq_dis.variable_indel = resolve_indels_backward(&child_gaps_vec, &child_variable_indels, partition.length());
-
-    seq_dis.variable_indel.retain(|r, indel| {
-      if indel.deleted == n_children {
-        gaps.push(*r);
-        false
-      } else {
-        true
-      }
-    });
+    let indels_bw = resolve_indels_backward(&child_gaps_vec, &child_variable_indels, partition.length());
+    seq_dis.variable_indel = indels_bw.variable_indel;
+    gaps.extend(indels_bw.resolved_gaps);
 
     let new_node_data = SparseNodePartition {
       seq: SparseSeqInfo {

--- a/packages/treetime/src/commands/ancestral/fitch_indel.rs
+++ b/packages/treetime/src/commands/ancestral/fitch_indel.rs
@@ -57,7 +57,10 @@ pub fn resolve_indels_backward(
     }
   });
 
-  IndelsBackward { variable_indel, resolved_gaps }
+  IndelsBackward {
+    variable_indel,
+    resolved_gaps,
+  }
 }
 
 /// Resolve variable indels during the forward pass using parent context.

--- a/packages/treetime/src/commands/ancestral/fitch_indel.rs
+++ b/packages/treetime/src/commands/ancestral/fitch_indel.rs
@@ -6,32 +6,27 @@ use treetime_utils::interval::range_complement::range_complement;
 use treetime_utils::interval::range_difference::range_difference;
 use treetime_utils::interval::range_intersection::range_intersection;
 
+pub struct IndelsBackward {
+  pub variable_indel: BTreeMap<(usize, usize), Deletion>,
+  pub resolved_gaps: Vec<(usize, usize)>,
+}
+
 /// Resolve indels during the backward pass: identify positions where children
 /// disagree on gap presence.
 ///
-/// Operates on gap range lists and integer counters. Independent of sparse/dense
-/// types - usable by both partition kinds.
-///
-/// Three steps, matching the sparse Fitch backward logic:
-/// 1. For each child, intersect child gaps with complement of consensus gaps
-///    (intersection of all children's gaps) to find disagreement ranges.
-/// 2. Propagate variable indels from children.
-/// 3. Caller is responsible for collapsing ranges where all children agree on gap.
-///
-/// Returns the variable_indel map. The caller must filter out entries where
-/// `deleted == n_children` and push those ranges back to the consensus gaps.
+/// Returns variable indels (unresolved disagreements) and resolved gaps (ranges
+/// where all children agree on gap).
 pub fn resolve_indels_backward(
   child_gaps: &[Vec<(usize, usize)>],
   child_variable_indels: &[&BTreeMap<(usize, usize), Deletion>],
   length: usize,
-) -> BTreeMap<(usize, usize), Deletion> {
+) -> IndelsBackward {
   let n_children = child_gaps.len();
   let consensus_gaps = range_intersection(child_gaps);
   let non_gap = range_complement(&[(0, length)], &[consensus_gaps]);
 
   let mut variable_indel = BTreeMap::new();
 
-  // Step 1: find gap ranges in children that are not in consensus (disagreement)
   for child_gap in child_gaps {
     for r in range_intersection(&[non_gap.clone(), child_gap.clone()]) {
       let indel = variable_indel.entry(r).or_insert_with(|| Deletion {
@@ -43,7 +38,6 @@ pub fn resolve_indels_backward(
     }
   }
 
-  // Step 2: propagate variable indels from children
   for child_vi in child_variable_indels {
     for r in child_vi.keys() {
       if let Some(indel) = variable_indel.get_mut(r) {
@@ -53,7 +47,17 @@ pub fn resolve_indels_backward(
     }
   }
 
-  variable_indel
+  let mut resolved_gaps = Vec::new();
+  variable_indel.retain(|r, indel| {
+    if indel.deleted == n_children {
+      resolved_gaps.push(*r);
+      false
+    } else {
+      true
+    }
+  });
+
+  IndelsBackward { variable_indel, resolved_gaps }
 }
 
 /// Resolve variable indels during the forward pass using parent context.

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -224,7 +224,7 @@ where
         .iter()
         .map(|(child_key, _)| self.nodes[child_key].seq.gaps.clone())
         .collect_vec();
-      let gaps = range_intersection(&child_gaps);
+      let mut gaps = range_intersection(&child_gaps);
 
       let unknown = range_intersection_iter(
         node
@@ -247,22 +247,12 @@ where
         .map(|(child_key, _)| &self.nodes[child_key].seq.variable_indel)
         .collect_vec();
 
-      let variable_indel = resolve_indels_backward(&child_gaps, &child_variable_indels, length);
-      let mut final_gaps = gaps;
-      let variable_indel = variable_indel
-        .into_iter()
-        .filter(|(r, indel)| {
-          if indel.deleted == node.child_keys.len() {
-            final_gaps.push(*r);
-            false
-          } else {
-            true
-          }
-        })
-        .collect();
+      let indels_bw = resolve_indels_backward(&child_gaps, &child_variable_indels, length);
+      gaps.extend(indels_bw.resolved_gaps);
+      let variable_indel = indels_bw.variable_indel;
 
       let seq = DenseSeqInfo {
-        gaps: final_gaps,
+        gaps,
         unknown,
         non_char,
         variable_indel,

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -248,12 +248,21 @@ where
         .collect_vec();
 
       let variable_indel = resolve_indels_backward(&child_gaps, &child_variable_indels, length);
+      let mut final_gaps = gaps;
+      let variable_indel = variable_indel
+        .into_iter()
+        .filter(|(r, indel)| {
+          if indel.deleted == node.child_keys.len() {
+            final_gaps.push(*r);
+            false
+          } else {
+            true
+          }
+        })
+        .collect();
 
-      // Dense keeps gaps as pure backward-pass intersection. Unlike sparse Fitch,
-      // we do NOT push resolved variable_indels into gaps because dense sequence
-      // reconstruction relies on marginal profiles, not Fitch gap assignments.
       let seq = DenseSeqInfo {
-        gaps,
+        gaps: final_gaps,
         unknown,
         non_char,
         variable_indel,
@@ -319,10 +328,12 @@ where
 
   fn process_node_forward(&mut self, graph: &Graph<N, E, ()>, node: &GraphNodeForward<N, E, ()>) -> Result<(), Report> {
     if node.is_root {
-      // Resolve variable indels at root by majority rule into a scratch list
-      // so that the node's canonical gaps (backward-pass intersection) are not
-      // altered. Dense uses marginal profiles for sequence reconstruction.
       let node_data = self.nodes.get_mut(&node.key).unwrap();
+      for (r, indel) in &node_data.seq.variable_indel {
+        if indel.deleted > indel.present {
+          node_data.seq.gaps.push(*r);
+        }
+      }
       node_data.seq.variable_indel.clear();
       let seq = assign_sequence(node_data, &self.alphabet);
       node_data.seq.sequence = seq;
@@ -356,10 +367,6 @@ where
       node_data.seq.sequence = assign_sequence(node_data, &self.alphabet);
 
       // Resolve indels using parent context. Use a scratch copy of gaps so that
-      // resolve_indels_forward can track gap mutations for indel detection without
-      // altering the node's canonical gap list. Dense sequence reconstruction uses
-      // marginal profiles (assign_sequence), not Fitch gap assignments, so the
-      // node's seq.gaps must stay as the backward-pass intersection.
       let (parent_key, edge_key) =
         get_exactly_one(&node.parent_keys).expect("Non-root dense node must have exactly one parent");
       let parent_gaps = self.nodes[parent_key].seq.gaps.clone();
@@ -367,16 +374,25 @@ where
 
       let node_data = self.nodes.get_mut(&node.key).unwrap();
       let variable_indel = std::mem::take(&mut node_data.seq.variable_indel);
-      let mut scratch_gaps = node_data.seq.gaps.clone();
+      let node_gaps = &mut node_data.seq.gaps;
       let node_sequence = &node_data.seq.sequence;
 
       let indels = resolve_indels_forward(
         &variable_indel,
-        &mut scratch_gaps,
+        node_gaps,
         &parent_gaps,
         &parent_sequence,
         node_sequence,
       );
+
+      let node_data = self.nodes.get_mut(&node.key).unwrap();
+      node_data.seq.non_char = range_union(&[node_data.seq.gaps.clone(), node_data.seq.unknown.clone()]);
+      for gap in &node_data.seq.gaps {
+        node_data.seq.sequence[gap.0..gap.1].fill(self.alphabet.gap());
+      }
+      for unk in &node_data.seq.unknown {
+        node_data.seq.sequence[unk.0..unk.1].fill(self.alphabet.unknown());
+      }
 
       let edge_data = self.edges.get_mut(edge_key).unwrap();
       edge_data.indels = indels;


### PR DESCRIPTION
The dense forward pass did not store Fitch-resolved variable indels in `seq.gaps`, so parent-child gap comparisons used under-resolved gap sets. Dense indel counts were inflated relative to sparse (4.5x at iteration 1 on ebola/20) and the indel rate diverged (17857 vs 5548). Gap positions receive uniform profiles under the substitution model, so Fitch parsimony resolution is the correct semantic assignment for both dense and sparse.

This PR makes the dense backward and forward passes push resolved variable indels into `seq.gaps` consistently with sparse Fitch, and extracts the duplicated retain-and-push logic from both callers into `resolve_indels_backward` as a pure return value (`IndelsBackward` struct).

### Verification

```bash
treetime optimize --tree=data/ebola/20/tree.nwk --aln=data/ebola/20/aln.fasta.xz --outdir=tmp/out --dense=true -vv
treetime optimize --tree=data/ebola/20/tree.nwk --aln=data/ebola/20/aln.fasta.xz --outdir=tmp/out -vv
```

Iteration 1 (initial):

|              | Dense, before | Dense, after | Sparse |
| ------------ | ------------- | ------------ | ------ |
| Total        | -27812        | -27538       | -27553 |
| Substitution | -27459        | -27459       | -27474 |
| Indel        | -352.6        | -79.1        | -79.1  |
| Indel rate   | 17857         | 5682         | 5548   |

Converged:

|              | Dense, before (iter 7) | Dense, after (iter 6) | Sparse (iter 7) |
| ------------ | ---------------------- | --------------------- | --------------- |
| Total        | -27593                 | -27512                | -27521          |
| Substitution | -27501                 | -27466                | -27473          |
| Indel        | -91.8                  | -46.4                 | -47.9           |

### Work items

- [x] Dense backward and forward passes push resolved variable indels into `seq.gaps`, matching sparse Fitch
- [x] Extract `IndelsBackward` return struct from `resolve_indels_backward`, removing duplicated retain logic from sparse `fitch.rs` and dense `marginal_dense.rs` callers
- [x] Update `test_ancestral_reconstruction_marginal_dense` expectations: positions 14-15 in AB and root are gaps (Fitch majority resolution)
- [x] Update `test_marginal_dense_update_is_idempotent` golden log-likelihood
- [x] Update `test_fitch_indel_backward_propagates_child_variable_indels` for `IndelsBackward` return type
- [x] Update issue: [M-ancestral-dense-effective-length-test-regression.md](https://github.com/neherlab/treetime/blob/8988368f876e489068527d133a558510f910a81a/docs/port-known-issues/M-ancestral-dense-effective-length-test-regression.md): narrow to remaining IUPAC divergence (2 of 3 tests now pass)

### Possible improvements

- [ ] Investigate dense/sparse IUPAC ambiguity code handling divergence. Tracked in [M-ancestral-dense-effective-length-test-regression.md](https://github.com/neherlab/treetime/blob/8988368f876e489068527d133a558510f910a81a/docs/port-known-issues/M-ancestral-dense-effective-length-test-regression.md)
