### PR TITLE
fix(test): add missing #[cfg(test)] guards, normalize test module visibility

### DIFF
--- a/packages/treetime-distribution/src/distribution_core/mod.rs
+++ b/packages/treetime-distribution/src/distribution_core/mod.rs
@@ -4,4 +4,5 @@ pub mod function;
 pub mod point;
 pub mod range;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime-distribution/src/distribution_ops/mod.rs
+++ b/packages/treetime-distribution/src/distribution_ops/mod.rs
@@ -7,4 +7,5 @@ pub mod scalar_multiply;
 pub mod subtract;
 pub mod time_bounds;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime-distribution/src/distribution_scaled/mod.rs
+++ b/packages/treetime-distribution/src/distribution_scaled/mod.rs
@@ -3,4 +3,5 @@ pub mod divide;
 pub mod multiply;
 pub mod scaled;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime-distribution/src/lib.rs
+++ b/packages/treetime-distribution/src/lib.rs
@@ -3,6 +3,7 @@ pub(crate) mod distribution_ops;
 pub(crate) mod distribution_scaled;
 pub(crate) mod policy;
 
+#[cfg(test)]
 mod __tests__;
 
 pub use distribution_core::distribution::{

--- a/packages/treetime-io/src/lib.rs
+++ b/packages/treetime-io/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod __tests__;
 pub mod auspice;
 pub mod auspice_types;

--- a/packages/treetime-primitives/src/lib.rs
+++ b/packages/treetime-primitives/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod __tests__;
 pub mod bitset128;
 pub mod seq;

--- a/packages/treetime/src/commands/clock/find_best_root/mod.rs
+++ b/packages/treetime/src/commands/clock/find_best_root/mod.rs
@@ -6,4 +6,5 @@ pub mod method_golden_section;
 pub mod method_grid_search;
 pub mod params;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime/src/commands/clock/mod.rs
+++ b/packages/treetime/src/commands/clock/mod.rs
@@ -13,4 +13,5 @@ pub mod reroot;
 pub mod rtt;
 pub mod run;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime/src/commands/prune/mod.rs
+++ b/packages/treetime/src/commands/prune/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod __tests__;
 pub mod args;
 pub mod run;

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/mod.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/mod.rs
@@ -2,6 +2,5 @@ mod test_gm_runner_marginal_dense;
 mod test_gm_runner_marginal_sparse;
 mod test_gm_runner_poisson;
 mod test_gm_runner_pre_optimize;
-#[cfg(test)]
 mod test_gm_runner_support;
 mod test_runner_coalescent;

--- a/packages/treetime/src/commands/timetree/inference/mod.rs
+++ b/packages/treetime/src/commands/timetree/inference/mod.rs
@@ -4,4 +4,5 @@ pub mod branch_length_likelihood;
 pub mod forward_pass;
 pub mod runner;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime/src/commands/timetree/optimization/mod.rs
+++ b/packages/treetime/src/commands/timetree/optimization/mod.rs
@@ -3,4 +3,5 @@ pub mod polytomy;
 pub mod relaxed_clock;
 pub mod reroot;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime/src/commands/timetree/output/mod.rs
+++ b/packages/treetime/src/commands/timetree/output/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod __tests__;
 
 pub mod auspice;

--- a/packages/treetime/src/gtr/__tests__/mod.rs
+++ b/packages/treetime/src/gtr/__tests__/mod.rs
@@ -1,7 +1,5 @@
 mod generators;
-#[cfg(test)]
 mod prop_support;
-#[cfg(test)]
 pub mod site_specific_support;
 mod test_gm_gtr;
 mod test_gm_gtr_site_specific;

--- a/packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/mod.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gtr_numerical_edge/mod.rs
@@ -1,5 +1,4 @@
 mod test_gtr_numerical_edge_branch_length;
 mod test_gtr_numerical_edge_extreme_parameters;
 mod test_gtr_numerical_edge_parameterized;
-#[cfg(test)]
 mod test_gtr_numerical_edge_support;

--- a/packages/treetime/src/gtr/infer_gtr/mod.rs
+++ b/packages/treetime/src/gtr/infer_gtr/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod __tests__;
 pub(crate) mod common;
 pub(crate) mod dense;

--- a/packages/treetime/src/gtr/mod.rs
+++ b/packages/treetime/src/gtr/mod.rs
@@ -5,4 +5,5 @@ pub mod infer_gtr;
 pub mod jc_distance;
 pub mod site_rate_variation;
 
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime/src/io/mod.rs
+++ b/packages/treetime/src/io/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(test)]
 mod __tests__;

--- a/packages/treetime/src/seq/mod.rs
+++ b/packages/treetime/src/seq/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod __tests__;
 
 pub mod composition;


### PR DESCRIPTION
Test code was compiled into production builds due to missing `#[cfg(test)]` guards on `mod __tests__` declarations. Redundant guards inside already-gated directories added noise.

### Work items

- [x] Add `#[cfg(test)]` to 16 unguarded `mod __tests__` declarations across treetime, treetime-io, treetime-primitives, treetime-distribution
- [x] Remove 4 redundant `#[cfg(test)]` inside already-gated `__tests__/` directories
