### PR TITLE
refactor: replace eyre::eyre! with make_report!, use imports for qualified paths

### DIFF
--- a/packages/treetime/src/commands/mugration/run.rs
+++ b/packages/treetime/src/commands/mugration/run.rs
@@ -5,11 +5,12 @@ use crate::commands::mugration::gtr_refinement::refine_gtr_iterative;
 use crate::commands::mugration::input::MugrationInput;
 use crate::commands::mugration::output::{MugrationGtrOutput, MugrationResult, MugrationTraitsOutput};
 use crate::gtr::gtr::{GTR, GTRParams};
-use crate::make_error;
+use crate::{make_error, make_report};
 use crate::representation::discrete_states::DiscreteStates;
 use crate::representation::partition::discrete::PartitionDiscrete;
 use crate::representation::payload::ancestral::GraphAncestral;
 use eyre::Report;
+use std::path::Path;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use log::{info, warn};
@@ -115,7 +116,7 @@ pub fn parse_mugration_input(args: &TreetimeMugrationArgs) -> Result<MugrationIn
   } = args;
 
   // Read tree
-  let tree_path = tree.as_ref().ok_or_else(|| eyre::eyre!("Tree file is required"))?;
+  let tree_path = tree.as_ref().ok_or_else(|| make_report!("Tree file is required"))?;
   let graph: GraphAncestral = nwk_read_file(tree_path)?;
 
   // Read trait values
@@ -279,7 +280,7 @@ fn write_annotated_tree(
   graph: &GraphAncestral,
   partition: &PartitionDiscrete,
   traits: &MugrationTraitsOutput,
-  outdir: &std::path::Path,
+  outdir: &Path,
 ) -> Result<(), Report> {
   let provider = PartitionCommentProvider::new(partition, &traits.attribute);
   let providers = CommentProviders::new().with(&provider);
@@ -292,11 +293,11 @@ fn write_annotated_tree(
   Ok(())
 }
 
-fn write_gtr_json_file(gtr: &MugrationGtrOutput, outdir: &std::path::Path) -> Result<(), Report> {
+fn write_gtr_json_file(gtr: &MugrationGtrOutput, outdir: &Path) -> Result<(), Report> {
   json_write_file(outdir.join("gtr.json"), gtr, JsonPretty(true))
 }
 
-fn write_confidence_csv(result: &MugrationResult, output_path: &std::path::Path) -> Result<(), Report> {
+fn write_confidence_csv(result: &MugrationResult, output_path: &Path) -> Result<(), Report> {
   fs::write(output_path, result.confidence.render_csv())?;
   Ok(())
 }

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -26,7 +26,7 @@ use crate::commands::timetree::output::confidence::{
 use crate::commands::timetree::partition_ops::PartitionTimetreeAll;
 use crate::commands::timetree::refinement::run_refinement_iteration;
 use crate::commands::timetree::utils::initialize_clock_totals_from_time_distributions;
-use crate::make_error;
+use crate::{make_error, make_report};
 use crate::representation::partition::timetree::GraphTimetree;
 use crate::representation::payload::ancestral::annotate_branch_mutations;
 use crate::representation::payload::timetree::EdgeTimetree;
@@ -443,7 +443,7 @@ fn build_covariation_clock_params(
   } else {
     args
       .sequence_length
-      .ok_or_else(|| eyre::eyre!("--sequence-length required for --covariation without alignment"))? as f64
+      .ok_or_else(|| make_report!("--sequence-length required for --covariation without alignment"))? as f64
   };
 
   // v0 default: OVER_DISPERSION = 10 (config.py:8), overridable via --tip-slack

--- a/packages/treetime/src/gtr/gtr_site_specific.rs
+++ b/packages/treetime/src/gtr/gtr_site_specific.rs
@@ -1,5 +1,5 @@
 use crate::gtr::gtr::eig_single_site;
-use crate::make_error;
+use crate::{make_error, make_report};
 use eyre::Report;
 use ndarray::prelude::*;
 use ndarray::{Array3, Array4};
@@ -224,7 +224,7 @@ impl GTRSiteSpecific {
     let pi = {
       let mut pi = Array2::zeros((n_states, seq_len));
       if pi_dirichlet_alpha > 0.0 {
-        let gamma = Gamma::new(pi_dirichlet_alpha, 1.0).map_err(|e| eyre::eyre!("{e}"))?;
+        let gamma = Gamma::new(pi_dirichlet_alpha, 1.0).map_err(|e| make_report!("{e}"))?;
         for a in 0..seq_len {
           for i in 0..n_states {
             pi[[i, a]] = rng.sample(gamma);
@@ -241,7 +241,7 @@ impl GTRSiteSpecific {
     let W = {
       let mut W = Array2::zeros((n_states, n_states));
       if W_dirichlet_alpha > 0.0 {
-        let gamma = Gamma::new(W_dirichlet_alpha, 1.0).map_err(|e| eyre::eyre!("{e}"))?;
+        let gamma = Gamma::new(W_dirichlet_alpha, 1.0).map_err(|e| make_report!("{e}"))?;
         for i in 0..n_states {
           for j in 0..i {
             let val: f64 = rng.sample(gamma);
@@ -260,7 +260,7 @@ impl GTRSiteSpecific {
     let mu = {
       let mut mu = Array1::zeros(seq_len);
       if mu_gamma_alpha > 0.0 {
-        let gamma = Gamma::new(mu_gamma_alpha, 1.0).map_err(|e| eyre::eyre!("{e}"))?;
+        let gamma = Gamma::new(mu_gamma_alpha, 1.0).map_err(|e| make_report!("{e}"))?;
         for a in 0..seq_len {
           mu[a] = rng.sample(gamma);
         }

--- a/packages/treetime/src/gtr/site_rate_variation.rs
+++ b/packages/treetime/src/gtr/site_rate_variation.rs
@@ -1,7 +1,7 @@
 use eyre::Report;
 use ndarray::Array1;
 use statrs::distribution::{ContinuousCDF, Gamma};
-use treetime_utils::make_error;
+use treetime_utils::{make_error, make_report};
 
 /// Compute K discrete rate categories approximating a Gamma(alpha, alpha) distribution.
 ///
@@ -54,13 +54,13 @@ pub fn discrete_gamma_rates(alpha: f64, n_categories: usize) -> Result<Array1<f6
 
   // Gamma(alpha, alpha) has mean = alpha/alpha = 1.0
   let gamma =
-    Gamma::new(alpha, alpha).map_err(|e| eyre::eyre!("Failed to create Gamma({alpha}, {alpha}) distribution: {e}"))?;
+    Gamma::new(alpha, alpha).map_err(|e| make_report!("Failed to create Gamma({alpha}, {alpha}) distribution: {e}"))?;
 
   // Gamma(alpha+1, alpha) for computing conditional means within quantile intervals.
   // Derivation: integral of x * f_{a,b}(x) dx = (a/b) * F_{a+1,b}(x)
   // For a=alpha, b=alpha: integral = 1 * F_{alpha+1,alpha}(x)
   let gamma_next = Gamma::new(alpha + 1.0, alpha)
-    .map_err(|e| eyre::eyre!("Failed to create Gamma({}, {alpha}) distribution: {e}", alpha + 1.0))?;
+    .map_err(|e| make_report!("Failed to create Gamma({}, {alpha}) distribution: {e}", alpha + 1.0))?;
 
   let k = n_categories as f64;
   let mut rates = Array1::zeros(n_categories);

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -1,7 +1,8 @@
 use crate::alphabet::alphabet::Alphabet;
 use crate::commands::ancestral::fitch_indel::{resolve_indels_backward, resolve_indels_forward};
+use crate::commands::optimize::optimize_unified::OptimizationContribution;
 use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
-use crate::commands::timetree::partition_ops::PartitionRerootOps;
+use crate::commands::timetree::partition_ops::{PartitionRerootOps, PartitionTimetreeOps};
 use crate::gtr::gtr::GTR;
 use crate::hacks::fix_branch_length::fix_branch_length;
 use crate::make_report;
@@ -158,8 +159,8 @@ impl PartitionOptimizeOps for PartitionMarginalDense {
   fn create_edge_contribution(
     &self,
     edge_key: GraphEdgeKey,
-  ) -> Result<crate::commands::optimize::optimize_unified::OptimizationContribution, Report> {
-    Ok(crate::commands::optimize::optimize_unified::OptimizationContribution::from_dense(edge_key, self))
+  ) -> Result<OptimizationContribution, Report> {
+    Ok(OptimizationContribution::from_dense(edge_key, self))
   }
 
   fn edge_indel_count(&self, edge_key: GraphEdgeKey) -> usize {
@@ -167,7 +168,7 @@ impl PartitionOptimizeOps for PartitionMarginalDense {
   }
 }
 
-impl<N, E> crate::commands::timetree::partition_ops::PartitionTimetreeOps<N, E> for PartitionMarginalDense
+impl<N, E> PartitionTimetreeOps<N, E> for PartitionMarginalDense
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,

--- a/packages/treetime/src/representation/partition/marginal_sparse.rs
+++ b/packages/treetime/src/representation/partition/marginal_sparse.rs
@@ -1,6 +1,7 @@
 use crate::alphabet::alphabet::Alphabet;
+use crate::commands::optimize::optimize_unified::OptimizationContribution;
 use crate::commands::optimize::partition_ops::PartitionOptimizeOps;
-use crate::commands::timetree::partition_ops::PartitionRerootOps;
+use crate::commands::timetree::partition_ops::{PartitionRerootOps, PartitionTimetreeOps};
 use crate::gtr::gtr::GTR;
 use crate::representation::algo::topology_cleanup::reroot::RerootChanges;
 use crate::representation::partition::marginal_passes;
@@ -260,8 +261,8 @@ impl PartitionOptimizeOps for PartitionMarginalSparse {
   fn create_edge_contribution(
     &self,
     edge_key: GraphEdgeKey,
-  ) -> Result<crate::commands::optimize::optimize_unified::OptimizationContribution, Report> {
-    crate::commands::optimize::optimize_unified::OptimizationContribution::from_sparse(edge_key, self)
+  ) -> Result<OptimizationContribution, Report> {
+    OptimizationContribution::from_sparse(edge_key, self)
   }
 
   fn edge_indel_count(&self, edge_key: GraphEdgeKey) -> usize {
@@ -269,7 +270,7 @@ impl PartitionOptimizeOps for PartitionMarginalSparse {
   }
 }
 
-impl<N, E> crate::commands::timetree::partition_ops::PartitionTimetreeOps<N, E> for PartitionMarginalSparse
+impl<N, E> PartitionTimetreeOps<N, E> for PartitionMarginalSparse
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,


### PR DESCRIPTION
Direct `eyre::eyre!()` calls bypass the project's `make_report!()` macro, and fully qualified type paths obscure the code.

Replace 7 `eyre::eyre!()` calls with `make_report!()` in site_rate_variation, gtr_site_specific, mugration, timetree. Replace fully qualified `OptimizationContribution` and `PartitionTimetreeOps` with imports in marginal_dense and marginal_sparse. Replace `&std::path::Path` with imported `&Path` in mugration run.

### Work items

- [x] Replace 7 `eyre::eyre!()` calls with `make_report!()` in site_rate_variation, gtr_site_specific, mugration, timetree
- [x] Replace fully qualified `OptimizationContribution` and `PartitionTimetreeOps` with imports in marginal_dense and marginal_sparse
- [x] Replace `&std::path::Path` with imported `&Path` in mugration run
