### PR TITLE
fix: add warnings for silent error suppression and document default

### DIFF
--- a/packages/treetime-io/src/json.rs
+++ b/packages/treetime-io/src/json.rs
@@ -74,5 +74,11 @@ pub fn json_or_yaml_write_file<T: Serialize>(filepath: impl AsRef<Path>, obj: &T
 /// know the exact type. Usage: add attribute `#[serde(skip_serializing_if = "is_json_value_null")]` to a struct field
 /// you want to skip.
 pub fn is_json_value_null<T: Serialize>(t: &T) -> bool {
-  serde_json::to_value(t).unwrap_or(serde_json::Value::Null).is_null()
+  match serde_json::to_value(t) {
+    Ok(v) => v.is_null(),
+    Err(e) => {
+      log::warn!("JSON serialization failed during null check, treating as null: {e}");
+      true
+    },
+  }
 }

--- a/packages/treetime/src/cli/rtt_chart.rs
+++ b/packages/treetime/src/cli/rtt_chart.rs
@@ -49,6 +49,7 @@ pub fn write_clock_regression_chart_png(
   _clock_model: &ClockModel,
   _filepath: impl AsRef<Path>,
 ) -> Result<(), Report> {
+  log::warn!("PNG chart output requested but binary was built without the 'png' feature");
   Ok(())
 }
 

--- a/packages/treetime/src/commands/ancestral/marginal.rs
+++ b/packages/treetime/src/commands/ancestral/marginal.rs
@@ -70,9 +70,10 @@ where
 
     let seq: Seq = if !partitions.is_empty() {
       let mut partition = partitions[0].write_arc();
-      partition
-        .reconstruct_node_sequence(&node, include_leaves)
-        .unwrap_or_else(|| seq![])
+      partition.reconstruct_node_sequence(&node, include_leaves).unwrap_or_else(|| {
+        log::warn!("Missing reconstruction for node {:?}, using empty sequence", node.key);
+        seq![]
+      })
     } else {
       seq![]
     };

--- a/packages/treetime/src/commands/mugration/args.rs
+++ b/packages/treetime/src/commands/mugration/args.rs
@@ -35,7 +35,7 @@ pub struct TreetimeMugrationArgs {
   #[clap(value_hint = ValueHint::AnyPath)]
   pub confidence: Option<PathBuf>,
 
-  /// Pseudo-counts. Higher numbers results in 'flatter' models.
+  /// Pseudo-counts. Higher numbers results in 'flatter' models. Default: 1.0.
   #[clap(long)]
   pub pc: Option<f64>,
 


### PR DESCRIPTION
Four locations silently swallow errors or hide defaults from users: JSON serialization failure returns null without warning, missing ancestral reconstruction silently uses an empty sequence, absent `png` feature produces no output without explanation, and mugration's `--pc` default value is undocumented.

### Work items

- [x] JSON `is_json_value_null`: log warning on serialization failure instead of silently returning null
- [x] Ancestral marginal: log warning when reconstruction is missing instead of silently using empty sequence
- [x] RTT chart PNG: log warning when `png` feature is absent instead of silent no-op
- [x] Mugration `--pc`: document default value 1.0 in CLI help text
