### PR TITLE
fix(alphabet): build char_to_index from config Vec order

### DIFF
--- a/packages/treetime/src/alphabet/__tests__/test_alphabet.rs
+++ b/packages/treetime/src/alphabet/__tests__/test_alphabet.rs
@@ -643,4 +643,46 @@ mod tests {
       assert_eq!(c, back);
     }
   }
+
+  #[rstest]
+  #[case::nuc(AlphabetName::Nuc)]
+  #[case::aa(AlphabetName::Aa)]
+  #[case::aa_no_stop(AlphabetName::AaNoStop)]
+  #[trace]
+  fn test_alphabet_profile_index_consistency(#[case] name: AlphabetName) {
+    let alphabet = Alphabet::new(name).unwrap();
+    for c in alphabet.canonical() {
+      let index = alphabet.index(c).unwrap();
+      let profile = alphabet.get_profile(c).unwrap();
+      assert_ulps_eq!(1.0, profile[index], max_ulps = 4);
+
+      for j in 0..alphabet.n_canonical() {
+        if j != index {
+          assert_ulps_eq!(0.0, profile[j], max_ulps = 4);
+        }
+      }
+
+      let roundtrip = alphabet.char(index);
+      assert_eq!(c, roundtrip, "char(index({c})) should roundtrip");
+    }
+  }
+
+  #[test]
+  fn test_alphabet_aa_star_index_matches_profile() {
+    let alphabet = Alphabet::new(AlphabetName::Aa).unwrap();
+    let star = AsciiChar::from_byte_unchecked(b'*');
+    let index = alphabet.index(star).unwrap();
+    let profile = alphabet.get_profile(star).unwrap();
+    assert_ulps_eq!(1.0, profile[index], max_ulps = 4);
+  }
+
+  #[test]
+  fn test_alphabet_char_index_roundtrip_aa() {
+    let alphabet = Alphabet::new(AlphabetName::Aa).unwrap();
+    for i in 0..alphabet.n_canonical() {
+      let c = alphabet.char(i);
+      let idx = alphabet.index(c).unwrap();
+      assert_eq!(i, idx);
+    }
+  }
 }

--- a/packages/treetime/src/alphabet/alphabet.rs
+++ b/packages/treetime/src/alphabet/alphabet.rs
@@ -149,7 +149,8 @@ impl Alphabet {
 
     let mut char_to_index = vec![None; 128];
     let mut index_to_char = Vec::with_capacity(canonical.len());
-    for (i, c) in canonical.iter().enumerate() {
+    for (i, &b) in config.canonical.iter().enumerate() {
+      let c = AsciiChar::try_new(b)?;
       char_to_index[usize::from(c)] = Some(i);
       index_to_char.push(c);
     }


### PR DESCRIPTION
Profile map assigns indices using the config canonical `Vec` order. `char_to_index` was built from `canonical.iter()` in ascending ASCII byte order, causing `index()` and `get_profile()` to disagree for the AA alphabet where `*` sorts differently in `StateSet` byte order vs the config `Vec` order.

Build `char_to_index` from `config.canonical.iter()` (Vec order) instead of `canonical.iter()` (sorted StateSet), keeping index assignment consistent with profile map construction.

### Work items

- [x] Build `char_to_index` from `config.canonical.iter()` (Vec order) instead of `canonical.iter()` (sorted StateSet)
- [x] Add 3 regression tests for AA alphabet ordering
