### PR TITLE
docs(known-issues): file open issues to knowledge base

### DIFF
--- a/docs/port-known-issues/H-timetree-relaxed-clock-unit-mismatch.md
+++ b/docs/port-known-issues/H-timetree-relaxed-clock-unit-mismatch.md
@@ -1,0 +1,27 @@
+# Relaxed clock unit mismatch
+
+## Summary
+
+The relaxed clock penalty function mixes time units (years) with evolutionary distance units (substitutions/site), inflating the penalty by approximately 110,000x on flu-rate datasets and biasing gamma values toward 1.0.
+
+## Details
+
+`packages/treetime/src/commands/timetree/optimization/relaxed_clock.rs:50:`
+
+```rust
+let act_len = parent_edge.time_length().unwrap_or(opt_len)
+```
+
+`time_length()` returns years while `opt_len` is `branch_length()` in substitutions/site. The v0 reference implementation uses `clock_length` (substitutions/site) for both values, keeping the penalty dimensionally consistent.
+
+The dimensional mismatch makes the penalty term dominate the objective for datasets with typical molecular clock rates (~0.003 subs/site/year for influenza), suppressing rate variation across branches.
+
+## Impact
+
+- Relaxed clock gamma estimates biased toward 1.0 (strict clock behavior)
+- Rate variation across branches underestimated
+- Affects all timetree runs with `--relaxed-clock` enabled
+
+## Fix
+
+Replace `time_length()` with `clock_length()` (= `branch_length * clock_rate`) or use a consistent unit for both `act_len` and `opt_len`.

--- a/docs/port-known-issues/M-ancestral-sparse-missing-initialize-marginal.md
+++ b/docs/port-known-issues/M-ancestral-sparse-missing-initialize-marginal.md
@@ -1,0 +1,23 @@
+# Sparse variant skips initialize_marginal before update_marginal
+
+## Summary
+
+For `--model=infer`, the sparse path calls `update_marginal` without first calling `initialize_marginal`, diverging from the dense path which calls both.
+
+## Details
+
+`packages/treetime/src/commands/ancestral/run.rs:105-130:`
+
+The dense path (line 123+) calls `initialize_marginal` then `update_marginal`. The sparse path (line 105+) calls `update_marginal` only, skipping initialization. Both paths call `update_marginal` once.
+
+`initialize_marginal` performs the first backward+forward pass with the initial GTR model and populates baseline profiles. Without it, the sparse path starts `update_marginal` from an uninitialized state, relying on whatever Fitch-era data remains in the partition.
+
+## Impact
+
+- Sparse marginal reconstruction with `--model=infer` may produce different results than dense
+- First marginal iteration operates on different initial conditions between dense and sparse modes
+- Affects ancestral reconstruction accuracy when GTR model is inferred from data
+
+## Fix
+
+Add `initialize_marginal` call before `update_marginal` in the sparse path, matching the dense control flow.

--- a/docs/port-known-issues/M-clock-prefilter-ignores-user-variance.md
+++ b/docs/port-known-issues/M-clock-prefilter-ignores-user-variance.md
@@ -1,0 +1,24 @@
+# Clock pre-filter ignores user-provided variance parameters
+
+## Summary
+
+The clock command's outlier pre-filter step uses `ClockParams::default()` instead of user-provided `--sequence-length` and `--tip-slack` values, making the pre-filter insensitive to user-specified variance scaling.
+
+## Details
+
+`packages/treetime/src/commands/clock/run.rs:132:`
+
+The clock command runs a pre-filter step to remove outlier tips before the main regression. This step calls `fn estimate_clock_model_with_reroot_policy` with `ClockParams::default()` instead of the user-provided parameters.
+
+The main regression after filtering does use user parameters correctly. The pre-filter uses default variance scaling regardless of what the user specified via `--sequence-length` and `--tip-slack`.
+
+## Impact
+
+- Tips that should be retained (per user-specified tolerance) are incorrectly removed during pre-filtering
+- Tips that should be filtered (per user-specified tolerance) pass through pre-filtering
+- The effect is larger when user-specified parameters differ substantially from defaults
+- Users who explicitly set `--tip-slack` expect it to govern all filtering stages
+
+## Fix
+
+Pass user-provided `ClockParams` (or at minimum `sequence_length` and `tip_slack`) to the pre-filter call instead of `ClockParams::default()`.

--- a/docs/port-known-issues/M-coalescent-leaf-survival-sign-convention.md
+++ b/docs/port-known-issues/M-coalescent-leaf-survival-sign-convention.md
@@ -1,0 +1,38 @@
+# Coalescent leaf survival formula sign convention requires investigation
+
+## Summary
+
+The coalescent contribution functions use different sign conventions for leaf vs internal node survival integrals, and the return type name (`DistributionNegLog`) contradicts the actual value convention (log-probability). Requires verification against v0 and theory.
+
+## Details
+
+`packages/treetime/src/commands/timetree/coalescent/contributions.rs`
+
+The docstring states:
+
+- Leaves: exp(I(t)) (survival probability, positive exponent)
+- Internal nodes: exp(-I(t)) (negative exponent)
+
+Line 55 states: "The sign convention follows Python v0 which stores -I(t) in neg-log space."
+
+The return type is `DistributionNegLog`, which by naming convention implies the stored values are negated log-probabilities (positive values = low probability). The actual values follow log-probability convention (more negative = less likely), contradicting the type name.
+
+## Open questions
+
+1. Is the sign difference between leaf and internal contributions intentional or a bug?
+2. Does the `DistributionNegLog` type store neg-log values or log values? The name and usage disagree.
+3. Does v0 use the same sign convention, or was the sign inherited from a misreading of v0?
+4. What is the theoretical justification for different signs on leaf vs internal survival?
+
+## Required investigation
+
+- Trace the v0 Python implementation to verify sign conventions for leaf and internal coalescent contributions
+- Verify against Volz 2012 or Sagulenko 2018 coalescent formulation
+- Determine whether `DistributionNegLog` is misnamed or misused
+- If the sign is wrong: quantify impact on coalescent prior and time estimates
+
+## Impact
+
+- If sign is wrong, coalescent prior contribution is inverted for leaves or internals
+- Incorrect coalescent prior biases time estimates toward or away from the present
+- The type-name confusion makes the code harder to audit for correctness

--- a/docs/port-known-issues/M-coalescent-time-notation-conflict.md
+++ b/docs/port-known-issues/M-coalescent-time-notation-conflict.md
@@ -1,0 +1,30 @@
+# Coalescent subsystem time notation conflict
+
+## Summary
+
+Signed time (negative = past) coexists with time-before-present (TBP, positive = past) in the same coalescent subsystem, creating ambiguity about the direction of time in integration bounds and distribution evaluations.
+
+## Details
+
+`packages/treetime/src/commands/timetree/coalescent/`
+
+Two conventions are used simultaneously:
+
+1. Signed time (`coalescent.rs:34:`): past is negative t, present is 0, future is positive. Used for node dates and event ordering.
+
+2. Time before present / TBP (`integration.rs:42-43:`): I(0) = 0 at the present, the integral increases going into the past. Positive values represent time depth.
+
+The coalescent integral I(t) = integral from 0 to t of lambda(s) ds uses the TBP convention internally, but the integration bounds come from node times in the signed convention. The conversion between conventions is implicit (negation) and not documented at function boundaries.
+
+## Required investigation
+
+- Audit all functions in the coalescent module for which convention they expect as input and produce as output
+- Verify that the implicit sign flip at the signed-to-TBP boundary is correct in all callers
+- Determine if any callers pass signed times where TBP is expected (or vice versa)
+- Compare against v0 Python implementation to verify convention consistency
+
+## Impact
+
+- If a sign flip is missed at any boundary, the coalescent integral is evaluated backward (present-to-past vs past-to-present)
+- Wrong integration direction produces wrong coalescent costs, biasing time estimates
+- The implicit convention makes the code fragile: any new caller must know the undocumented sign convention

--- a/docs/port-known-issues/M-inference-forward-backward-asymmetry.md
+++ b/docs/port-known-issues/M-inference-forward-backward-asymmetry.md
@@ -1,0 +1,40 @@
+# Inference forward/backward pass asymmetries
+
+## Summary
+
+Four asymmetries between the backward and forward marginal passes: normalization strategy differs, graph mutation through interior mutability during read traversal, branch-length floor applied inside GTR inference, and clock model rebuilt unnecessarily.
+
+## Instances
+
+### Silent normalization asymmetry backward/forward pass
+
+In the dense forward pass (`marginal_dense.rs:363:`), `msg_to_child` for each edge is computed as `node_data.profile.dis / safe_child` where `safe_child` is `msg_from_child.dis` clamped to `MIN_POSITIVE` (`marginal_dense.rs:424-428:`). The result is normalized via `normalize_inplace`.
+
+The intermediate node profile at line 363 is built by multiplying `msg_to_parent.dis * msg_child` in probability space without per-step normalization across parent edges, unlike the backward pass which normalizes via `normalize_from_log` after combining child messages in log space.
+
+This means the forward pass accumulates probability-space products (risk of underflow for deep trees) while the backward pass accumulates log-space sums (numerically stable).
+
+### gather_clock_regression_results mutates graph via interior mutability
+
+`packages/treetime/src/commands/clock/rtt.rs:42:`
+
+Mutates node `div` (divergence) through a read-path graph traversal. The function signature suggests a read-only operation (gathering results) but has write side effects. This makes the function non-idempotent and its ordering relative to other graph operations significant.
+
+### fix_branch_length clamp inside GTR inference
+
+`packages/treetime/src/gtr/infer_gtr/dense.rs:192:`
+
+Applies the marginal-pass branch-length floor during mutation counting for GTR inference. This means GTR parameter estimation sees clamped branch lengths rather than raw values, biasing the rate matrix toward shorter-branch statistics.
+
+### run_refinement_iteration always rebuilds clock model
+
+`packages/treetime/src/commands/timetree/refinement.rs:97:`
+
+Rebuilds the clock model even when nothing moved (`n_diff==0 && n_resolved==0`). The clock model estimation involves regression over all dated tips, which is wasted computation when no dates changed. More importantly, floating-point non-determinism in the regression can introduce small perturbations that prevent clean convergence.
+
+## Impact
+
+- Forward pass underflow risk for deep trees with many siblings
+- Hidden write side effects in nominally read-only functions
+- GTR inference biased by branch-length clamping
+- Unnecessary clock model rebuilds can prevent convergence detection

--- a/docs/port-known-issues/M-marginal-forward-pass-neg-infinity-nan.md
+++ b/docs/port-known-issues/M-marginal-forward-pass-neg-infinity-nan.md
@@ -1,0 +1,37 @@
+# Marginal forward pass NEG_INFINITY produces NaN
+
+## Summary
+
+The marginal forward pass computes NaN from infinity arithmetic and poisons likelihood accumulators when nodes have degenerate (zero-probability) profiles.
+
+## Details
+
+Two related defects in the forward pass:
+
+### NaN from log_lh subtraction
+
+`packages/treetime/src/representation/partition/marginal_passes.rs:355:` and `marginal_dense.rs:327:`
+
+The forward pass computes:
+
+```rust
+log_lh: seq_info.profile.log_lh - child_edge_data.msg_from_child.log_lh
+```
+
+When both values are `f64::NEG_INFINITY` (degenerate node), the subtraction produces NaN (`-inf - (-inf) = NaN`). No guard prevents this arithmetic.
+
+### NEG_INFINITY poisons delta_ll accumulator
+
+`packages/treetime/src/representation/partition/marginal_passes.rs:406:`
+
+The sparse forward pass adds `NEG_INFINITY` directly into the `delta_ll` accumulator. A single degenerate site contribution poisons the `log_lh` for the entire child message, making the total log-likelihood meaningless for downstream convergence checks.
+
+## Impact
+
+- NaN propagates silently through the tree during forward pass
+- Convergence metrics become unreliable
+- Affects trees with degenerate nodes (zero-probability states at any position)
+
+## Fix
+
+Guard the subtraction: when both operands are `NEG_INFINITY`, treat the result as 0.0 (the normalization constants cancel). For the accumulator, skip `NEG_INFINITY` contributions or use a sentinel that does not poison finite sums.

--- a/docs/port-known-issues/M-marginal-normalize-neg-infinity-masks-total.md
+++ b/docs/port-known-issues/M-marginal-normalize-neg-infinity-masks-total.md
@@ -1,0 +1,33 @@
+# normalize_inplace NEG_INFINITY masks all contributions
+
+## Summary
+
+`normalize_inplace` returns `f64::NEG_INFINITY` for degenerate rows and substitutes uniform distributions. A single degenerate row makes the total log-likelihood negative infinity, masking contributions from all well-determined rows.
+
+## Details
+
+`packages/treetime/src/representation/partition/marginal_dense.rs:390:`
+
+The function iterates rows, normalizing each to sum to 1.0. For rows where the sum is zero or non-finite, it fills the row with a uniform distribution (1/n_cols) and adds `NEG_INFINITY` to the running `log_lh` total.
+
+Since `log_lh` accumulates via addition, a single degenerate row produces:
+
+```
+log_lh = ... + finite_contributions + NEG_INFINITY = NEG_INFINITY
+```
+
+Convergence checks downstream see `NEG_INFINITY` even when the rest of the tree is well-determined. The degenerate row's contribution dominates and makes it impossible to detect likelihood improvements.
+
+## Impact
+
+- Convergence criteria based on likelihood changes become unreliable
+- A single degenerate position (e.g., all-gap column) masks the entire tree's likelihood signal
+- Optimizer cannot distinguish "improving" from "stuck" when total is negative infinity
+
+## Fix
+
+Options:
+
+1. Return a finite penalty for degenerate rows (e.g., `ln(1/n_cols) * n_positions`) instead of `NEG_INFINITY`
+2. Track degenerate row count separately and exclude from convergence arithmetic
+3. Use a masked accumulator that skips degenerate contributions

--- a/docs/port-known-issues/M-timetree-confidence-citation-accuracy.md
+++ b/docs/port-known-issues/M-timetree-confidence-citation-accuracy.md
@@ -1,0 +1,27 @@
+# Rate susceptibility citation references wrong paper section
+
+## Summary
+
+Four code locations cite "Sagulenko, Puller & Neher 2018, Section 2.5" for rate susceptibility analysis, but Section 2.5 covers the coalescent model, not rate susceptibility. The correct section appears to be Section 2.4. Requires paper verification.
+
+## Details
+
+The following locations reference Section 2.5:
+
+- `representation/payload/timetree.rs:29:`
+- `commands/timetree/output/confidence.rs:38:`
+- `commands/timetree/output/confidence.rs:161:`
+- `commands/timetree/output/confidence.rs:165:`
+
+Two independent code reviews flagged this discrepancy. The rate susceptibility analysis (perturbing the clock rate and measuring date shifts) is described in Section 2.4 of Sagulenko et al. 2018, while Section 2.5 describes the coalescent tree prior.
+
+## Required investigation
+
+- Verify which section of Sagulenko, Puller & Neher (TreeTime: Maximum-likelihood phylodynamic analysis, Virus Evolution, 2018) describes the rate susceptibility / confidence interval method
+- Update all four citations to reference the correct section
+- Verify that the implementation matches the cited method
+
+## Impact
+
+- Incorrect citations make it harder to verify implementation correctness against the paper
+- If the implementation was written following Section 2.5 instead of 2.4, the confidence interval method itself could be wrong

--- a/docs/port-known-issues/M-timetree-confidence-interval-deficiencies.md
+++ b/docs/port-known-issues/M-timetree-confidence-interval-deficiencies.md
@@ -1,0 +1,31 @@
+# Timetree confidence interval computation deficiencies
+
+## Summary
+
+Three defects in the confidence interval computation: the rate susceptibility function mutates graph state without postcondition assertion, date uncertainty is forced symmetric, and the CI clamp hides inconsistencies.
+
+## Details
+
+### compute_rate_susceptibility mutates graph 3 times without postcondition
+
+`packages/treetime/src/commands/timetree/output/confidence.rs:56-124:`
+
+The function runs marginal inference three times (upper rate, lower rate, restored original rate), relying on the third run to restore the graph to its pre-call state. No postcondition assertion verifies that restoration succeeded. If the third pass fails or produces different rounding, subsequent operations read corrupted state.
+
+### date_uncertainty_due_to_rate uses abs() making CI symmetric
+
+`packages/treetime/src/commands/timetree/output/confidence.rs:155-156:`
+
+Both upper and lower confidence bounds are computed as the absolute difference between the rate-perturbed date and the nominal date. This forces the confidence interval to be symmetric around the point estimate, regardless of whether the rate-date relationship is asymmetric (which it is for short branches where the Poisson likelihood is skewed).
+
+### CI clamp forces point estimate inside interval
+
+`packages/treetime/src/commands/timetree/output/confidence.rs:219-220:`
+
+After computing confidence bounds, the code clamps the point estimate to lie within `[lower, upper]`. This hides cases where the CI computation and the reported date are inconsistent (e.g., due to the symmetric approximation above or numerical issues in rate susceptibility). The inconsistency should be reported, not masked.
+
+## Impact
+
+- Confidence intervals are symmetric when they should be asymmetric for short branches
+- Graph state corruption if third rate-susceptibility pass diverges from original
+- Inconsistent point estimates hidden instead of flagged

--- a/docs/port-known-issues/M-timetree-convergence-metric-deficiencies.md
+++ b/docs/port-known-issues/M-timetree-convergence-metric-deficiencies.md
@@ -1,0 +1,31 @@
+# Timetree convergence metric deficiencies
+
+## Summary
+
+Three defects in the timetree convergence tracking system: the convergence check ignores likelihood stagnation, topology changes cause undercounting of sequence diffs, and the total likelihood composition changes between iterations.
+
+## Details
+
+### has_converged ignores likelihood stagnation
+
+`packages/treetime/src/commands/timetree/convergence/metrics.rs:140-142:`
+
+`fn has_converged()` returns true when `n_diff==0 && n_resolved==0` (no node date changes, no newly resolved dates). It does not check whether `lh_total` has plateaued. The `ConvergenceMetrics` struct carries `lh_seq`, `lh_pos`, `lh_coal`, and `lh_total` fields, but none are used in the convergence decision. A tree where dates are stable but likelihood is still improving (or worsening) is declared converged.
+
+### count_sequence_changes underreports on topology changes
+
+`packages/treetime/src/commands/timetree/convergence/sequence_changes.rs:25-44:`
+
+Compares per-partition sequence maps between iterations by zipping keys present in both `previous` and `current`. Nodes that exist only in `previous` (removed by topology change) or only in `current` (newly created) are counted as `prev_only` / `curr_only` but not as sequence diffs. The total diff count excludes all changes at nodes that were replaced during polytomy resolution or pruning.
+
+### total_lh_reduce meaning changes with Some/None patterns
+
+`packages/treetime/src/commands/timetree/convergence/metrics.rs:67:`
+
+`lh_total` is computed as `[lh_seq, lh_pos, lh_coal].into_iter().flatten().reduce(|acc, v| acc + v)`. When the coalescent prior is enabled in one iteration but not another (first iteration runs without coalescent, second adds it), the number of `Some` components changes. Comparing `lh_total` across iterations compares sums of different terms, making likelihood deltas meaningless as convergence indicators.
+
+## Impact
+
+- Premature convergence declaration when dates stabilize but likelihood has not plateaued
+- After polytomy resolution, convergence check undercounts actual sequence changes
+- Likelihood-based convergence criteria are unreliable when coalescent is enabled mid-run

--- a/docs/port-known-issues/M-timetree-polytomy-stale-fields-after-topology-change.md
+++ b/docs/port-known-issues/M-timetree-polytomy-stale-fields-after-topology-change.md
@@ -1,0 +1,28 @@
+# Polytomy resolution leaves stale fields after topology change
+
+## Summary
+
+`prepare_tree_after_topology_change` clears only `msg_to_parent` and `branch_length_distribution` after polytomy resolution, leaving `gamma`, `clock_to_parent`, `clock_to_child`, and `clock_from_child` stale on newly created edges.
+
+## Details
+
+`packages/treetime/src/commands/timetree/optimization/polytomy.rs:456-478:`
+
+After resolving a polytomy (splitting a multifurcation into binary nodes), the function resets the message-passing fields but leaves relaxed-clock and time-tree specific fields at their values from the previous iteration:
+
+- `gamma`: relaxed clock rate multiplier (should be 1.0 for new edges)
+- `clock_to_parent`: clock-scaled branch length toward parent
+- `clock_to_child`: clock-scaled branch length toward child
+- `clock_from_child`: clock message from child
+
+These stale values from the pre-resolution topology persist into the next refinement iteration, biasing the optimizer with rate information from edges that no longer exist in the same configuration.
+
+## Impact
+
+- Relaxed clock estimates on newly resolved edges start from stale gamma values
+- Time inference on resolved polytomies uses outdated clock messages
+- Effects compound across refinement iterations
+
+## Fix
+
+Reset `gamma` to 1.0 and clear `clock_to_parent`, `clock_to_child`, `clock_from_child` alongside the existing field resets in `prepare_tree_after_topology_change`.

--- a/docs/port-known-issues/N-architectural-debt-documented.md
+++ b/docs/port-known-issues/N-architectural-debt-documented.md
@@ -1,0 +1,31 @@
+# Architectural debt (documented, low priority)
+
+## Summary
+
+Three documented architectural choices that are suboptimal but stable: mixed stochastic conventions in GTR, looser-than-typical Newton tolerance, and a hardcoded damping floor.
+
+## Instances
+
+### Mixed row/column stochastic convention in GTR
+
+`packages/treetime/src/gtr/gtr.rs:47-54:`
+
+The `Q` matrix and `expQt` use different stochastic conventions in different contexts. Documented in code comments. The convention difference is intentional for performance (avoiding transpositions) but increases cognitive load for contributors working on GTR-related code.
+
+### NEWTON_REL_TOL=0.001 looser than typical
+
+`packages/treetime/src/commands/optimize/method_newton.rs:10:`
+
+Relative tolerance of 0.001 for Newton's method convergence. Documented and tested. Looser than the typical 1e-6 to 1e-8 for Newton's method. The choice is deliberate: branch length optimization does not require machine-precision convergence, and the looser tolerance reduces iteration count.
+
+### apply_damping hardcodes 1% floor
+
+`packages/treetime/src/commands/optimize/run.rs:501:`
+
+`DAMPING_FLOOR=0.01`. Prevents damping from suppressing updates entirely. Documented as a named constant. The value matches v0 behavior and is not configurable.
+
+## Impact
+
+- Low: all three are documented, tested, and stable
+- Mixed stochastic convention increases onboarding cost for GTR contributors
+- Newton tolerance and damping floor values are not configurable but satisfy current use cases

--- a/docs/port-known-issues/N-coalescent-skyline-robustness.md
+++ b/docs/port-known-issues/N-coalescent-skyline-robustness.md
@@ -1,0 +1,56 @@
+# Coalescent skyline robustness deficiencies
+
+## Summary
+
+Seven defects in the coalescent skyline subsystem affecting numerical robustness: silent skipping of timeless nodes, unclamped optimizer output, ignored convergence flags, non-scaling simplex perturbation, flat extrapolation outside grid, first-order integration approximation, and sign-convention inconsistency.
+
+## Instances
+
+### collect_tree_events silently skips nodes without likely_time
+
+`packages/treetime/src/commands/timetree/coalescent/events.rs:28-41:`
+
+Lineage count k(t) is wrong for nodes with `time_distribution` but `None` for `likely_time`. These nodes are silently excluded from the event timeline, under-counting active lineages.
+
+### Skyline unclamped return from optimizer
+
+`packages/treetime/src/commands/timetree/coalescent/skyline.rs:154:`
+
+`log_tc_values` returns raw optimizer output while the cost function internally clamps to [-200, 100]. The optimizer can return values outside the clamp range that were never evaluated by the actual cost function.
+
+### optimize_tc ignores argmin convergence flag
+
+`packages/treetime/src/commands/timetree/coalescent/optimize_tc.rs:75:`
+
+Reports `success=true` when Brent's method returns `None` (no convergence). Callers cannot distinguish converged from unconverged results.
+
+### Simplex perturbation fixed at +0.5
+
+`packages/treetime/src/commands/timetree/coalescent/skyline.rs:310:`
+
+`fn create_initial_simplex` perturbs each dimension of the initial Nelder-Mead vertex by a fixed +0.5 in log-Tc space (~1.65x multiplicative factor). The perturbation does not scale with the number of grid points or their spacing, and is asymmetric (positive direction only).
+
+### Tc distribution flat extrapolation outside grid
+
+`packages/treetime/src/commands/timetree/coalescent/skyline.rs:233-238:`
+
+Calls to `tc_dist.eval(t)` at times outside the lineage-count event range return the boundary value silently, implying constant Tc beyond observed data without any indication to callers.
+
+### Midpoint integration for non-constant Tc
+
+`packages/treetime/src/commands/timetree/coalescent/integration.rs:63-68:`
+
+First-order midpoint approximation for the coalescent integral. Error up to 2.5% for rapidly varying Tc between grid points. Higher-order quadrature (Simpson's or Gauss-Legendre) would reduce this.
+
+### Leaf contribution sign-convention inconsistency
+
+`packages/treetime/src/commands/timetree/coalescent/contributions.rs:89-105:`
+
+Return type is `DistributionNegLog` but values follow log-probability convention (positive = more likely). The type name implies negated log-probability (positive = less likely). Related to the time notation conflict documented in `M-coalescent-time-notation-conflict.md`.
+
+## Impact
+
+- Lineage counts underestimated when nodes lack `likely_time`
+- Optimizer results unreliable when convergence not checked
+- Skyline Tc estimates biased by non-scaling simplex and flat extrapolation
+- Integration error accumulates for rapidly changing population sizes

--- a/docs/port-known-issues/N-code-quality-conventions.md
+++ b/docs/port-known-issues/N-code-quality-conventions.md
@@ -1,0 +1,162 @@
+# Code quality and convention violations
+
+## Summary
+
+Convention violations across the codebase: fully qualified paths, inconsistent derives, manual loops replaceable by ndarray operations, module ordering violations, naming conventions, and miscellaneous quality issues.
+
+## Instances
+
+### Fully qualified paths instead of imports (2 locations)
+
+1. `treetime-utils/src/io/compression.rs:131,190:` `std::io::Result<usize>` in trait impl signatures
+2. `treetime-utils/src/lib.rs:20:` `tikv_jemallocator::Jemalloc` in global static
+
+### Inconsistent derives: SmartDefault vs std Default
+
+`packages/treetime/src/commands/timetree/args.rs:20,29,39,49:`
+
+Three enums use `#[derive(Default)]` + `#[default]` (std), while `struct TreetimeTimetreeArgs` uses `SmartDefault`. Should use one approach consistently.
+
+### ndarray over manual loops (7 instances)
+
+1. `gtr/infer_gtr/dense.rs:100-129:` triple-nested loop replaceable by `sum_axis()`
+2. `gtr/infer_gtr/dense.rs:59-79:` manual outer product
+3. `gtr/get_gtr.rs:398-409:` manual W computation
+4. `gtr/infer_gtr/site_specific.rs:209-223:` manual einsum
+5. `treetime-grid/src/interp_nonuniform.rs:38-53:` zeros + loop instead of `from_shape_fn`
+6. `treetime-grid/src/grid_fn.rs:397-401:` manual swap loop instead of `reverse_inplace()`
+7. `treetime-validation/src/testing/metrics/aggregate/domain_agreement/error_stats.rs:43-44:` ndarray to Vec conversion
+
+### Module ordering violations (4 instances)
+
+1. `commands/optimize/run.rs:52:` private fn before pub fn
+2. `commands/optimize/optimize_unified.rs:729:` pub fn after private fn
+3. `commands/prune/run.rs:34:` private fn before pub fn
+4. `treetime-ops/src/multiplication.rs:10:` private fn before pub fn
+
+### Float-formatted BTreeMap keys
+
+`packages/treetime-validation/src/testing/metrics/pointwise/structural.rs:122-126:`
+
+`format!("{val:.12}")` used as `BTreeMap` key for numeric lookup. String-formatted floats as map keys are fragile (formatting changes break lookups).
+
+### Section separator comment
+
+`packages/treetime/src/commands/timetree/run.rs:305:` `// --- Postprocessing ---` banner comment. Should split file instead.
+
+### Same-type tuple return
+
+`packages/treetime-analytical/src/gaussian.rs:30:`
+
+`fn gaussian_product_params()` returns `(f64, f64, f64)`. A named struct would prevent argument-order bugs.
+
+### Unchecked integer casts (3 instances)
+
+- `treetime-cli/src/convert/usher.rs:17:` `i32 as usize` (negative wraps to large positive)
+- `treetime-cli/src/convert/usher.rs:34:` `i32 as usize`
+- `treetime-cli/src/convert/usher.rs:56:` `usize as i32` (truncation on large values)
+
+### Alphabet serde skip fields not rebuilt
+
+`packages/treetime/src/alphabet/alphabet.rs:48-56:`
+
+Four `#[serde(skip)]` fields with no post-deserialization rebuild. If `struct Alphabet` is deserialized, lookup tables are empty/default.
+
+### Missing empty-canonical rejection
+
+`packages/treetime/src/alphabet/alphabet_config.rs:72:`
+
+`fn validate()` does not reject an empty canonical character set. An empty alphabet produces division-by-zero in profile construction.
+
+### NodeTimetree.nwk_comments() truncates date to 2 decimals
+
+`packages/treetime/src/representation/payload/timetree.rs:135:`
+
+Two decimal places gives ~3.6 days resolution, insufficient for fast-evolving pathogens sampled days apart.
+
+### calculate_diff_stats divides by zero on disjoint sets
+
+`packages/treetime/examples/timetree_validation.rs:411-412:`
+
+Divides by `n` (count of overlapping keys). Disjoint node sets produce `n = 0`, yielding NaN.
+
+### write_clock_regression_chart_svg bypasses file-helper conventions
+
+`packages/treetime/src/cli/rtt_chart.rs:27:`
+
+Passes `filepath` directly to `SVGBackend::new()` instead of using `fn create_file_or_stdout()` from `treetime-utils`.
+
+### rayon::ThreadPoolBuilder::build_global called per-test
+
+`packages/treetime/src/graph/__tests__/graph.rs:148,167:` and multiple ancestral test files.
+
+Calling `build_global` multiple times causes nondeterministic test failures because the global pool can only be initialized once.
+
+### BrentOpt absolute epsilon on calendar time
+
+`packages/treetime/src/commands/timetree/optimization/polytomy.rs:265:`
+
+`BrentOpt::new(parent_time + 1e-10, child_min_time - 1e-10)` uses absolute epsilon. For calendar times (e.g., 2020.5), 1e-10 is below f64 precision at that magnitude.
+
+### Normalize helpers duplicated in discrete.rs
+
+`packages/treetime/src/representation/partition/discrete.rs:223,232:`
+
+`fn normalize_inplace_1d` and `fn normalize_from_log_1d` are Array1 analogs of the Array2 versions in `marginal_dense.rs:493,514:`. The 1D versions add error handling that the 2D versions lack. Should be unified.
+
+### edge_effective_length saturating_sub clamps to 0
+
+`packages/treetime/src/representation/partition/marginal_sparse.rs:255:` and `marginal_dense.rs:153:`
+
+Returns 0 when non-char positions exceed sequence length. Used as denominator in `edge_subs().len() / edge_effective_length()`, producing division by zero.
+
+### Brent cost function recomputes exp(eigvals\*t) per call
+
+`packages/treetime/src/commands/optimize/method_brent.rs`
+
+When multiple `OptimizationContribution` entries share the same GTR eigvals at the same branch length, the `exp_ev` vector is redundantly computed per contribution.
+
+### #[allow(trivial_casts)] + magic damping 0.75
+
+`packages/treetime/src/commands/timetree/run.rs:477-481:`
+
+`let damping = 0.75;` is a hardcoded magic number (v0 default from `treeanc.py:1298`). No named constant or configuration.
+
+### #[allow(clippy::useless_let_if_seq)]
+
+`packages/treetime/src/commands/timetree/refinement.rs:20:`
+
+Suppresses clippy lint. Could be rewritten as a single `let ... = if ...` expression.
+
+### Distribution::Empty fallback prevents polytomy merges
+
+`packages/treetime/src/commands/timetree/optimization/polytomy.rs:216:`
+
+Silently prevents merges when branch-length distributions are Empty. Should log or error.
+
+### TODO/FIXME comments (6 locations)
+
+1. `treetime-io/src/nwk.rs:73:` TODO: parse nwk comments
+2. `treetime-io/src/concat.rs:38-42:` 2 TODOs about delimiter behavior
+3. `treetime-cli/src/convert/auspice.rs:73,80:` 2 FIXMEs about assumed-zero values
+4. `commands/clock/run.rs:64:` TODO: empirical overdispersion value
+5. `treetime-grid/src/grid_fn.rs:180:` TODO: remove inefficient method
+
+### edge_effective_length clones gap vectors
+
+`packages/treetime/src/representation/partition/marginal_dense.rs:122:` and `marginal_sparse.rs:380:`
+
+`fn range_union` clones both gap vectors on every call. Allocation pressure on heavily gapped alignments.
+
+### PartitionFitchConfig::new() infallible Result
+
+`packages/treetime/src/representation/partition/fitch_config.rs:27:`
+
+Constructor wraps result in `Ok()` without validation. `Result` return type is misleading when the function cannot fail.
+
+## Impact
+
+- Integer cast bugs produce wrong indices on negative or large values
+- Division by zero in edge_effective_length and diff_stats
+- Magic numbers without named constants reduce maintainability
+- Duplicate normalization code creates maintenance divergence risk

--- a/docs/port-known-issues/N-dead-code-orphaned-apis.md
+++ b/docs/port-known-issues/N-dead-code-orphaned-apis.md
@@ -1,0 +1,43 @@
+# Dead code and orphaned APIs
+
+## Summary
+
+Five instances of dead code: unreferenced structs, pub functions with zero callers, re-exports with no consumers, and a marker trait with no contract.
+
+## Instances
+
+### MugrationParams and MugrationInput::params() unreferenced
+
+`packages/treetime/src/commands/mugration/input.rs:42-72:`
+
+`struct MugrationParams` and its accessor `fn params()` are defined but never referenced anywhere in the workspace.
+
+### collect_edge_contributions pub but zero callers
+
+`packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs:13:`
+
+Public function with no callers in the workspace.
+
+### lib.rs pub use re-exports with no workspace consumer
+
+`packages/treetime/src/lib.rs:15-17:`
+
+Re-exports `treetime_graph`, `treetime_io`, `treetime_primitives` but no workspace crate imports them through this path.
+
+### DenseSeqDis::new() hard-codes log_lh: 0.0
+
+`packages/treetime/src/representation/payload/dense.rs:53-55:`
+
+`struct DenseSeqDis` holds a 2D probability array and a `log_lh: f64` field tracking the log-likelihood normalization constant. The constructor sets `log_lh: 0.0` with no parameter to override. Callers that need a non-zero initial `log_lh` must mutate the field after construction, violating the "initialize fully upfront" principle.
+
+### PartitionMarginal empty marker trait
+
+`packages/treetime/src/representation/partition/traits.rs:98:`
+
+`trait PartitionMarginal` has no methods and no associated types. Used as a supertrait bound on `trait PartitionMarginalOps<N, E>`. The marker adds no contract beyond requiring `Send + Sync`, which could be expressed as direct bounds.
+
+## Impact
+
+- Dead code increases binary size and cognitive load
+- Marker trait without contract creates false abstraction boundary
+- Constructor requiring post-construction mutation is error-prone

--- a/docs/port-known-issues/N-error-suppression-unwrap-or-defaults.md
+++ b/docs/port-known-issues/N-error-suppression-unwrap-or-defaults.md
@@ -1,0 +1,57 @@
+# Error suppression via unwrap_or_default and silent fallbacks
+
+## Summary
+
+Multiple locations suppress errors by substituting default values for semantically important data, or by silently proceeding after failures that should be reported.
+
+## Instances
+
+### unwrap_or_default() on semantically important data (8 instances)
+
+- `commands/clock/clock_filter.rs:41:` branch length defaults to 0.0
+- `commands/clock/reroot.rs:178:` branch length defaults to 0.0
+- `commands/clock/rtt.rs:36:` branch length defaults to 0.0
+- `seq/div.rs:26:` parent divergence defaults to 0.0
+- `seq/div.rs:28:` branch length defaults to 0.0
+- `commands/mugration/discrete_marginal.rs:113:` node name defaults to empty string
+- `commands/prune/run.rs:477-478:` indels default to empty
+- `commands/timetree/optimization/relaxed_clock.rs:87:` coefficients default to zero
+
+A default of 0.0 for branch length can produce division-by-zero downstream or silently exclude the branch from optimization. An empty node name makes the node invisible to output serialization.
+
+### debug_assert_eq! stripped in release (compose_substitutions)
+
+`packages/treetime/src/seq/mutation.rs:100:`
+
+`debug_assert_eq!(ps.qry(), cs.reff(), ...)` is stripped in release builds. A broken substitution chain (where the query state of the parent substitution does not match the reference state of the child substitution) silently produces incorrect mutation annotations.
+
+### branch_length().unwrap_or(one_mutation) silent fallback
+
+`packages/treetime/src/commands/timetree/inference/runner.rs:106:`
+
+Edges with no branch length get `one_mutation` (= 1.0 / total_sites) as a fallback when building Poisson branch-length distributions. A missing branch length could indicate a tree-loading error or an uninitialized edge, but the fallback silently assigns a plausible value.
+
+### infer_gtr_impl silently proceeds after non-convergence
+
+`packages/treetime/src/gtr/infer_gtr/common.rs:157-158:`
+
+Returns `Ok(...)` with a `warn!` log when GTR inference does not converge. No convergence flag in the result struct. Callers cannot distinguish a converged model from a non-converged one without parsing log output.
+
+### Composition::adjust_count saturating_add_signed silently clamps
+
+`packages/treetime/src/seq/composition.rs:76-79:`
+
+Uses `saturating_add_signed` which silently clamps to 0 on underflow. A negative composition count indicates a data integrity problem that should be reported, not masked.
+
+### extract_node_times silently drops unnamed/timeless nodes
+
+`packages/treetime/src/commands/timetree/utils.rs:63:`
+
+Iterates all graph nodes and collects (name, time) pairs via `filter_map`. Nodes without a name or without a time are silently excluded from the convergence tracking map, making them invisible to the convergence diff count.
+
+## Impact
+
+- Silent data corruption in release builds from unchecked substitution chains
+- Branch length 0.0 defaults cause division-by-zero or exclusion from optimization
+- Non-converged GTR models used without caller awareness
+- Convergence tracking undercounts changes at unnamed or timeless nodes

--- a/docs/port-known-issues/N-gtr-site-specific-interpolation-tolerance.md
+++ b/docs/port-known-issues/N-gtr-site-specific-interpolation-tolerance.md
@@ -1,0 +1,34 @@
+# GTR site-specific interpolation tolerance requires investigation
+
+## Summary
+
+Property tests for GTR site-specific rate variation use 1e-2 tolerance with a `TODO(investigate)` tag. The tolerance is 100x looser than the project standard and requires verification of whether it reflects genuine interpolation error or test gaming.
+
+## Details
+
+`packages/treetime/src/gtr/__tests__/test_prop_gtr_site_specific.rs:283:`
+
+The test compares GTR transition probabilities computed via eigendecomposition against values interpolated from a precomputed 61-point grid. The justification comment (lines 244-270) explains:
+
+- Linear interpolation on a 61-point grid has inherent accuracy limits
+- Observed max error is approximately 1.8e-3
+- The 1e-2 tolerance provides margin above observed error
+
+## Open questions
+
+1. Was the 1e-2 tolerance measured as the interpolation error bound, or was it widened iteratively until the test passed?
+2. Is the 61-point grid density sufficient for the rate variation range being tested?
+3. Would a denser grid (e.g., 200 points) reduce interpolation error below 1e-6?
+4. Does the error scale with rate magnitude or branch length?
+
+## Required investigation
+
+- Measure actual max interpolation error across the full parameter space (not just observed in random samples)
+- Determine whether the error bound is a property of the grid density or of the interpolation method
+- If grid-density-limited: compute the grid size needed for 1e-6 accuracy and assess performance tradeoff
+- If method-limited: evaluate cubic spline or other higher-order interpolation
+
+## Impact
+
+- The test validates that site-specific GTR is approximately correct but does not enforce tight numerical agreement
+- If the tolerance masks a real bug, site-specific rate variation results could be wrong by up to 1%

--- a/docs/port-known-issues/N-numerical-stability-magic-constants.md
+++ b/docs/port-known-issues/N-numerical-stability-magic-constants.md
@@ -1,0 +1,49 @@
+# Numerical stability magic constants
+
+## Summary
+
+Six locations use hardcoded numeric thresholds without named constants, documentation, or validation of degenerate inputs.
+
+## Instances
+
+### create_poisson_branch_distributions hardcoded threshold
+
+`packages/treetime/src/commands/timetree/utils.rs:100:`
+
+Hardcoded `1e-10` threshold with no `n_points==1` or `mu<=0` validation. Mishandles `branch_length==0` (produces degenerate grid).
+
+### 1e-10 magic denominator in relaxed_clock.rs
+
+`packages/treetime/src/commands/timetree/optimization/relaxed_clock.rs:70,91,106:`
+
+Three locations use `1e-10` as a denominator floor. No named constant. Related to the unit mismatch in `H-timetree-relaxed-clock-unit-mismatch.md`.
+
+### Discrete MIN_POSITIVE clamp biases near-zero divisor
+
+`packages/treetime/src/representation/partition/discrete.rs:207:`
+
+Silently biases near-zero values to `f64::MIN_POSITIVE` without propagating information about the degenerate log-likelihood to callers.
+
+### SUPERTINY_NUMBER distorts column-stochastic normalization
+
+`packages/treetime/src/gtr/infer_gtr/dense.rs:199:`
+
+`SUPERTINY_NUMBER` (1e-24) added to `expQt` result distorts column-stochastic normalization. The additive constant prevents exact zeros but shifts column sums away from 1.0.
+
+### Non-positive Tc yields NaN in contributions
+
+`packages/treetime/src/commands/timetree/coalescent/contributions.rs:117-178:`
+
+`fn compute_internal_contribution_single()` has no guard on non-positive Tc. When Tc(t) <= 0, lambda(t) goes negative or infinite, and ln() yields NaN or negative infinity. Callers do not validate Tc positivity before invoking.
+
+### debug_assert!(gamma > 0.0) not a production guard
+
+`packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs:61:`
+
+The assertion is stripped in release builds. When gamma <= 0 reaches this code path in production, the computation produces inf/NaN silently.
+
+## Impact
+
+- Silent NaN/inf propagation in production builds for edge-case inputs
+- Column-stochastic property violated by additive perturbation
+- Degenerate inputs (zero branch length, non-positive Tc, zero gamma) not rejected at boundaries

--- a/docs/port-known-issues/N-production-unwrap-expect-audit.md
+++ b/docs/port-known-issues/N-production-unwrap-expect-audit.md
@@ -1,0 +1,53 @@
+# Production unwrap/expect/assert audit
+
+## Summary
+
+One CLI-reachable panic via `assert!` and approximately 75 production `unwrap()`/`expect()`/`assert!()` calls that panic instead of returning errors.
+
+## CLI-reachable panic
+
+### InDel::new uses assert! instead of Result
+
+`packages/treetime/src/seq/indel.rs:23-24:`
+
+`assert!(range.0 <= range.1)` and `assert_eq!(seq.len(), range.1 - range.0)` panic on invalid input instead of returning `Result`. Reachable from any command that processes alignments with indels when input data contains malformed gap annotations.
+
+## Production unwrap/expect/assert instances (~75+)
+
+| File                                            | Instances | Pattern                                                       |
+| :---------------------------------------------- | :-------- | :------------------------------------------------------------ |
+| `representation/partition/marginal_passes.rs`   | 10        | `.unwrap()` / `.expect()` on node/edge lookup                 |
+| `representation/partition/marginal_dense.rs`    | 8         | `.unwrap()` / `.expect()` on node/edge lookup                 |
+| `commands/clock/reroot.rs`                      | 6         | `.expect("Edge not found")`                                   |
+| `commands/timetree/optimization/polytomy.rs`    | 5         | `.expect("Node must exist")`                                  |
+| `representation/partition/traits.rs`            | 4         | `.expect()` on `node()`, `edge()`, `node_mut()`, `edge_mut()` |
+| `treetime-grid/src/grid.rs`                     | 5         | `T::from(...).unwrap()` numeric conversions                   |
+| `treetime-grid/src/grid_fn.rs`                  | 3         | `.unwrap()` on numeric conversions                            |
+| `commands/clock/clock_regression.rs`            | 3         | `.expect()` / `.unwrap()`                                     |
+| `commands/clock/date_constraints.rs`            | 2         | `.unwrap()` on name/dates                                     |
+| `gtr/gtr.rs`                                    | 3         | `assert!()` / `assert_eq!()` in constructors                  |
+| `gtr/get_gtr.rs`                                | 1         | `.expect()` on JSON serialization                             |
+| `treetime-utils/src/datetime/datetime.rs`       | 3         | `.unwrap()` / `.expect()`                                     |
+| `treetime-utils/src/datetime/date_range.rs`     | 4         | `.unwrap()` in `from_ymd()`                                   |
+| `seq/mutation.rs`                               | 2         | `.unwrap()` on byte access                                    |
+| `seq/div.rs`                                    | 2         | `.unwrap()` on graph lookups                                  |
+| `seq/indel.rs`                                  | 1         | `assert!()` on range validity                                 |
+| `commands/ancestral/fitch.rs`                   | 3         | `.unwrap()` on node operations                                |
+| `commands/timetree/coalescent/contributions.rs` | 1         | `.unwrap()` on Result in parallel traversal                   |
+| `commands/timetree/inference/backward_pass.rs`  | 1         | `.unwrap()` on Result                                         |
+| `commands/timetree/inference/forward_pass.rs`   | 1         | `.unwrap()` on Result                                         |
+| `treetime-cli/src/cli/verbosity.rs`             | 1         | `.unwrap()` on parse                                          |
+| `cli/rtt_chart.rs`                              | 1         | `assert!(!results.is_empty())`                                |
+
+The inference traversal unwraps are tracked separately in `M-timetree-inference-unwrap-in-traversals.md`.
+
+## Impact
+
+- Any malformed input reaching InDel::new causes an unrecoverable panic
+- Graph lookup unwraps panic if tree structure is inconsistent (e.g., after failed topology operations)
+- Numeric conversion unwraps panic on out-of-range values
+- Production users see panic backtraces instead of actionable error messages
+
+## Fix
+
+Replace `assert!` in `InDel::new` with `Result` return. For the ~75 production unwraps, prioritize by reachability: graph traversal unwraps and numeric conversion unwraps are highest priority since they are reachable from normal input paths.

--- a/docs/port-known-issues/N-test-coverage-gaps.md
+++ b/docs/port-known-issues/N-test-coverage-gaps.md
@@ -1,0 +1,109 @@
+# Test coverage gaps across production functions
+
+## Summary
+
+Systematic test coverage gaps across major subsystems: timetree inference, clock command, coalescent, ancestral, optimize, mugration, prune, representation, GTR, and foundation modules. Four golden-master tests are gated with `#[ignore]`.
+
+## Ignored golden-master tests
+
+- `timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs:40:` `#[ignore = "golden master datasets not yet passing"]`
+- `timetree/inference/__tests__/test_gm_runner/test_runner_coalescent.rs:37:` `#[ignore = "golden master datasets not yet passing"]`
+- `ancestral/__tests__/test_marginal_dense_sparse_prop.rs:75:` `#[ignore]` with `max_relative=1e-5`. Related: `M-ancestral-dense-sparse-divergence.md`
+- `optimize/__tests__/test_gm_optimize.rs:70:` `#[ignore]`. Related: `M-optimize-gm-per-branch-divergence.md`
+
+## Zero-test production functions
+
+### Timetree inference
+
+- `fn propagate_distributions_forward`: zero dedicated unit tests (forward pass tested only through GM)
+- `fn create_poisson_branch_distributions`: no unit tests for edge cases
+- `fn load_input_data` / `fn initialize_partitions`: no direct tests
+- `fn run_refinement_iteration`: no tests
+- `fn build_branch_distributions()`: untestable (`todo!()` body)
+- `fn run_timetree_estimation()`: no branch coverage for input mode, confidence, skyline, rerooting, failure paths
+
+### Clock command
+
+- `fn run_clock()`: no end-to-end CLI test
+- `fn clock_regression_forward`: no direct unit test
+- `fn clock_filter_inplace()`: only tested with one idealized 8-leaf tree, no low-cardinality tests (0, 1, 2 dated leaves)
+- `fn load_date_constraints()`: validation failure paths untested
+- `fn write_clock_model()`, CSV writers, RTT chart writers: untested at serialized-output level
+
+### Timetree optimization and output
+
+- `fn apply_outlier_bad_branches` / `fn report_bad_branches`: zero tests
+- `fn collect_outliers()` and `fn report_bad_branches()`: unverified
+- `fn compute_rate_susceptibility()`: no integration coverage for upper/lower/restored rate passes
+- `fn write_confidence_intervals()`: untested for TSV serialization
+- `fn write_node_dates()`, `fn plot_root_to_tip()`, `fn plot_time_tree()`: unimplemented and untested
+
+### Coalescent
+
+- `fn collect_tree_events()` error paths untested (multiple roots, missing time distributions, non-finite present time)
+- `fn collect_coalescent_edges()` and `fn sum_coalescent_cost()`: no edge-case coverage
+- `fn compute_node_contributions()` and `fn compute_internal_contribution_single()`: no tests for `tc_dist.eval()` failure
+- `fn compute_total_neg_log_lh()` and `fn optimize_skyline()`: no analytical or golden-master tests
+
+### Ancestral command
+
+- CLI entrypoint and `MethodAncestral` parsing: no end-to-end coverage
+- Stdin FASTA path: no multi-record test
+- `fn get_common_length()` error branches: untested
+- `fn write_graph()` output files: untested for existence and parse-back
+
+### Optimize command
+
+- `fn apply_initial_guess_mode()`: no test for finite negative branch lengths in `Never` mode
+- `fn run_optimize()`: no integration test proving negative branch lengths rejected
+- `fn OptimizationContribution::from_sparse()` and `fn get_coefficients()`: not exercised through real sparse fixtures
+
+### Mugration and prune
+
+- `fn run_homoplasy()`: completely unverified (body is `unimplemented!()`)
+- Mugration file-I/O wrappers: no integration coverage
+- `fn optimize_gtr_rate()` and `fn refine_gtr_iterative()`: no tests for no-bracket path, backward-pass failure, rollback
+- `fn run_prune`: no end-to-end test
+
+### Representation module
+
+- `fn combine_messages()`: zero direct unit tests (coverage indirect through integration only)
+- `fn reconcile_topology()`: no tests (dense and sparse implementations)
+- `fn fix_branch_length()`: no direct tests for clamp threshold, very short branches, `seq_length == 0`
+- Sparse classification and reconstruction paths: no direct gap, unknown, ambiguity, parity, reroot-invariance tests
+- `fn gather_points`: no test
+
+### GTR
+
+- `fn GTR::new()` invalid-input handling: no tests assert error returns vs panic
+- Nucleotide constructors: no tests rejecting non-nucleotide alphabets
+- `fn write_gtr_json()`: tests only check filename and existence, not JSON payload content
+- `fn jtt92`: no direct regression coverage for 20-state empirical model
+
+### Foundation
+
+- `fn AlphabetConfig::validate()`: no direct test for `unknown` inside ambiguous value set
+- `cli::rtt_chart` functions: no tests
+- `timetree_validation.rs` functions: no tests for overlapping, disjoint, empty-overlap maps
+- `seq::indel::InDel`: no dedicated constructor-boundary, inversion, formatting coverage
+
+### Other
+
+- No tests for `fn Sub::from_str`, `fn parse_pos`, validators at `seq/mutation.rs`
+- No tests for `enum AlphabetName::AaNoStop` at `alphabet.rs`
+- `fn count_sequence_changes`, `fn compute_rate_susceptibility`, `fn write_confidence_intervals`: zero direct tests
+- `fn evaluate_site_contributions`: no direct unit test
+- `trait BranchTopology` blanket impl: untested
+- `fn propagate_raw`: not directly tested
+
+## Missing property tests
+
+### No property tests for ClockSet algebraic identities
+
+`packages/treetime/src/commands/clock/clock_set.rs:53-172:`
+
+`+`, `-`, `+=`, `-=`, `fn propagate_averages` lack property test coverage for algebraic identities (associativity, commutativity, identity element).
+
+### No property tests for Fitch parsimony invariants
+
+Score invariant under rerooting, state-set subset relation between parent and child Fitch sets.

--- a/docs/port-known-issues/N-test-quality-deficiencies.md
+++ b/docs/port-known-issues/N-test-quality-deficiencies.md
@@ -1,0 +1,148 @@
+# Test quality deficiencies
+
+## Summary
+
+Systematic test quality issues: missing pretty_assertions, missing rstest trace attributes, mixed assertion macro styles, loop-over-cases anti-pattern, helper placement violations, circular tests, weak assertions, loose tolerances, and other anti-patterns.
+
+## Instances
+
+### Missing pretty_assertions (8 files, 46+ raw assert_eq!)
+
+1. `commands/ancestral/__tests__/test_fitch.rs` (14)
+2. `commands/clock/__tests__/test_date_constraints.rs` (14)
+3. `commands/clock/__tests__/test_clock_filter.rs` (2)
+4. `commands/clock/__tests__/test_clock_dengue100.rs` (1)
+5. `commands/ancestral/__tests__/test_marginal_consistency.rs` (3)
+6. `seq/__tests__/test_find_char_ranges.rs` (4)
+7. `seq/__tests__/test_div.rs` (7)
+8. `commands/mugration/__tests__/test_comment_output.rs` (1)
+
+### Missing #[trace] on rstest (5 files, 17 blocks)
+
+1. `gtr/__tests__/test_gm_gtr.rs` (7)
+2. `gtr/__tests__/test_gm_gtr_site_specific.rs` (3)
+3. `gtr/__tests__/test_gtr_numerical_edge/test_gtr_numerical_edge_parameterized.rs` (2)
+4. `representation/__tests__/test_partition_marginal_sparse.rs` (1)
+5. `seq/__tests__/test_find_char_ranges.rs` (4)
+
+### Mixed approx wrappers (4 files)
+
+Files using both `approx::assert_ulps_eq!` and `pretty_assert_ulps_eq!`:
+
+1. `commands/ancestral/__tests__/test_marginal_dense.rs`
+2. `commands/ancestral/__tests__/test_marginal_sparse.rs`
+3. `commands/ancestral/__tests__/test_marginal_consistency.rs`
+4. `commands/clock/__tests__/test_clock_regression.rs`
+
+### Loop-over-cases in test assertions (21 files)
+
+Element-by-element loop assertions. Highest density: `test_prop_gtr_site_specific.rs` (39 loops), `generators.rs` (13 loops). Many within proptest bodies where `prop_assert!` is correct but `prop_assert_array_*_eq!` from project utilities could replace the element iteration.
+
+### Helpers placement violations (9 files)
+
+Helper functions before tests and/or not wrapped in `mod helpers`:
+
+1. `seq/__tests__/test_mutation.rs`
+2. `seq/__tests__/test_find_char_ranges.rs`
+3. `alphabet/__tests__/test_alphabet_config.rs`
+4. `commands/timetree/coalescent/__tests__/test_skyline.rs`
+5. `commands/timetree/optimization/__tests__/test_relaxed_clock.rs`
+6. `commands/timetree/optimization/__tests__/test_polytomy.rs`
+7. `commands/timetree/convergence/__tests__/test_metrics.rs`
+8. `commands/timetree/inference/__tests__/test_branch_length_likelihood.rs`
+9. `gtr/__tests__/test_gm_gtr_site_specific.rs:170-207:`
+
+### Sparse root-invariance proptest tolerance 1e-1
+
+`packages/treetime/src/commands/ancestral/__tests__/test_marginal_root_invariance_prop.rs:57:`
+
+Hides >2-orders-of-magnitude pulley-principle violation. Dense uses 1e-6. The 5-order gap indicates real algorithmic divergence. Related: `M-ancestral-sparse-root-invariance.md`.
+
+### propagate_raw_per_site tests are circular
+
+`packages/treetime/src/representation/partition/marginal_helpers.rs:209,245:`
+
+Both test functions compute expected values using `gtr.expQt_with_rate()`, the same function called internally by the SUT. Tautological verification.
+
+### Weak sorted-output assertion
+
+`packages/treetime/src/seq/__tests__/test_mutation.rs:89:`
+
+Uses `windows(2)` loop to check ordering instead of asserting exact expected vector.
+
+### Element-by-element float loops in alphabet tests
+
+`packages/treetime/src/alphabet/__tests__/` - 19+ instances of `for (actual, expected) in ... { assert_ulps_eq!(...) }`. Should use `pretty_assert_ulps_eq!` or `pretty_assert_abs_diff_eq!` on whole arrays.
+
+### Collapse edge tests assert count, not content
+
+`packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_collapse_edge.rs:100,396:`
+
+Success defined as `subs.len()` matching expectation, not exact `Vec<Sub>` content.
+
+### Nexus serialization test uses substring check
+
+`packages/treetime/src/representation/payload/timetree.rs:413:`
+
+Uses `contains()` instead of structured comparison.
+
+### GM runner tests use grossly loose tolerance
+
+`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs:80:`
+
+`epsilon = 1e0` (1.0 year tolerance). Comment: "Tolerance increased from 0.9 to 1.0".
+
+### Skyline tests are runs-to-completion only
+
+`packages/treetime/src/commands/timetree/coalescent/__tests__/test_skyline.rs`
+
+Assert finite/positive only, no numerical verification against known values.
+
+### Polytomy topology tests use point distributions
+
+`packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs:46:`
+
+Branch-length distributions are point masses making the cost function trivial: any merge time not exactly at the point yields `ln(1e-10)` from the `unwrap_or` fallback.
+
+### test_gm_runner_marginal_sparse compares against dense expected
+
+`packages/treetime/src/commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs:45:`
+
+Cross-mode validation (no independent sparse oracle exists).
+
+### .read() instead of .read_arc() (8 instances)
+
+`packages/treetime/src/commands/ancestral/__tests__/test_python_parity.rs:192,240,283,327,390,391,463,473:`
+
+Test code calls `.read()` on `parking_lot::RwLock` values wrapped in `Arc`. Per project convention, `.read_arc()` should be used to return an `ArcRwLockReadGuard` that keeps the `Arc` alive.
+
+### Loose tolerance 1e-6 in div tests
+
+`packages/treetime/src/seq/__tests__/test_div.rs`
+
+6 assertions use `epsilon = 1e-6`, 1 uses `epsilon = 1e-9`. Whether 1e-6 is the tightest passing tolerance has not been measured.
+
+### Missing test coverage for specific entities
+
+- No tests for `fn Sub::from_str`, `fn parse_pos`, validators at `seq/mutation.rs`
+- No tests for `enum AlphabetName::AaNoStop` at `alphabet.rs`
+
+## Tolerance violations
+
+### Grossly loose (hard failure per project rules)
+
+- `commands/timetree/coalescent/__tests__/test_integration.rs:157:` `epsilon = 10.0`
+- `commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs:80:` `epsilon = 1e0` (= 1.0)
+
+### Non-standard format
+
+- `commands/timetree/inference/__tests__/test_gm_runner/test_gm_runner_poisson.rs:46:` `epsilon = 3e-1`
+- `commands/mugration/__tests__/test_gm_mugration.rs:92:` `epsilon = 2e-2`
+
+### Variable tolerances
+
+- `commands/timetree/inference/__tests__/test_branch_length_likelihood.rs:80,129,162:` `GRID_SPACING_BL`, `expected_epsilon` (computed)
+- `commands/timetree/output/__tests__/test_confidence_extract.rs:232:` `epsilon = dx` (computed)
+- `commands/timetree/coalescent/__tests__/test_gm_coalescent.rs:102:` `worst_err < PASS_THRESHOLD` (named constant)
+- `commands/ancestral/__tests__/test_marginal_dense.rs:364:` `let epsilon = 1e-6;` (variable)
+- `gtr/__tests__/test_prop_gtr_site_specific.rs:283:` `1e-2` with `TODO(investigate)` tag. Justification: linear interpolation on 61-point grid has inherent accuracy limits; observed max error ~1.8e-3.

--- a/docs/port-known-issues/N-timetree-indel-rate-recomputed-per-iteration.md
+++ b/docs/port-known-issues/N-timetree-indel-rate-recomputed-per-iteration.md
@@ -1,0 +1,23 @@
+# Timetree indel rate recomputed per refinement iteration
+
+## Summary
+
+The timetree inference runner recomputes `estimate_indel_rate()` on every call to `run_timetree`, causing the indel rate to oscillate across refinement iterations as branch lengths change.
+
+## Details
+
+`packages/treetime/src/commands/timetree/inference/runner.rs:95:`
+
+Each refinement iteration calls `run_timetree` which calls `estimate_indel_rate(graph, partitions)`. Since branch lengths change between iterations (that is the purpose of refinement), the indel rate estimate changes too, creating a feedback loop: branch length changes shift the indel rate, which shifts the Poisson indel likelihood contribution, which shifts branch length targets.
+
+The optimize command hoisted indel rate estimation before its loop (PR #619), but the timetree runner still recomputes per iteration.
+
+## Impact
+
+- Indel rate oscillates across timetree refinement iterations
+- Convergence behavior is less predictable due to the feedback loop
+- Branch length estimates in indel-rich regions are less stable
+
+## Fix
+
+Hoist `estimate_indel_rate()` before the timetree refinement loop, matching the optimize command pattern. Compute once and hold fixed across iterations.

--- a/docs/port-known-issues/_index.md
+++ b/docs/port-known-issues/_index.md
@@ -147,6 +147,29 @@ exactly.
 | Negligible | Timetree       | [Branch grid extent uses base clock_rate, not effective rate](N-timetree-branch-grid-gamma-omitted.md)                                              |
 | Low        | Marginal       | [Marginal forward pass zero-divisor floor converts structural zeros](L-marginal-forward-zero-divisor-floor.md)                                      |
 | Negligible | Timetree       | [Convergence metric silently excludes failed coalescent likelihood](N-timetree-convergence-metric-excludes-coalescent.md)                           |
+| High       | Timetree       | [Relaxed clock unit mismatch](H-timetree-relaxed-clock-unit-mismatch.md)                                                                            |
+| Medium     | Ancestral      | [Sparse variant skips initialize_marginal before update_marginal](M-ancestral-sparse-missing-initialize-marginal.md)                                |
+| Medium     | Marginal       | [Marginal forward pass NEG_INFINITY produces NaN](M-marginal-forward-pass-neg-infinity-nan.md)                                                      |
+| Medium     | Marginal       | [normalize_inplace NEG_INFINITY masks all contributions](M-marginal-normalize-neg-infinity-masks-total.md)                                          |
+| Medium     | Timetree       | [Polytomy resolution leaves stale fields after topology change](M-timetree-polytomy-stale-fields-after-topology-change.md)                          |
+| Medium     | Timetree       | [Timetree convergence metric deficiencies](M-timetree-convergence-metric-deficiencies.md)                                                           |
+| Medium     | Timetree       | [Timetree confidence interval computation deficiencies](M-timetree-confidence-interval-deficiencies.md)                                             |
+| Medium     | Timetree       | [Rate susceptibility citation references wrong paper section](M-timetree-confidence-citation-accuracy.md)                                           |
+| Medium     | Coalescent     | [Coalescent leaf survival formula sign convention requires investigation](M-coalescent-leaf-survival-sign-convention.md)                            |
+| Medium     | Coalescent     | [Coalescent subsystem time notation conflict](M-coalescent-time-notation-conflict.md)                                                               |
+| Medium     | Inference      | [Inference forward/backward pass asymmetries](M-inference-forward-backward-asymmetry.md)                                                            |
+| Medium     | Clock          | [Clock pre-filter ignores user-provided variance parameters](M-clock-prefilter-ignores-user-variance.md)                                            |
+| Negligible | Timetree       | [Timetree indel rate recomputed per refinement iteration](N-timetree-indel-rate-recomputed-per-iteration.md)                                        |
+| Negligible | Numerical      | [Numerical stability magic constants](N-numerical-stability-magic-constants.md)                                                                     |
+| Negligible | Coalescent     | [Coalescent skyline robustness deficiencies](N-coalescent-skyline-robustness.md)                                                                    |
+| Negligible | Core           | [Error suppression via unwrap_or_default and silent fallbacks](N-error-suppression-unwrap-or-defaults.md)                                           |
+| Negligible | Core           | [Dead code and orphaned APIs](N-dead-code-orphaned-apis.md)                                                                                         |
+| Negligible | Core           | [Code quality and convention violations](N-code-quality-conventions.md)                                                                             |
+| Negligible | Core           | [Architectural debt (documented, low priority)](N-architectural-debt-documented.md)                                                                 |
+| Negligible | Core           | [Production unwrap/expect/assert audit](N-production-unwrap-expect-audit.md)                                                                        |
+| Negligible | Test           | [Test coverage gaps across production functions](N-test-coverage-gaps.md)                                                                           |
+| Negligible | Test           | [Test quality deficiencies](N-test-quality-deficiencies.md)                                                                                         |
+| Negligible | GTR            | [GTR site-specific interpolation tolerance requires investigation](N-gtr-site-specific-interpolation-tolerance.md)                                  |
 
 ## Cross-references
 

--- a/docs/port-test-inventory/_index.md
+++ b/docs/port-test-inventory/_index.md
@@ -186,6 +186,15 @@ Datasets disabled via commented-out `#[case]` annotations:
 
 ---
 
+## Known Test Deficiencies
+
+Tracked in `docs/port-known-issues/`:
+
+- [Test coverage gaps](../port-known-issues/N-test-coverage-gaps.md): zero-test production functions across all major subsystems, 4 ignored golden-master tests, missing property tests for ClockSet and Fitch invariants
+- [Test quality deficiencies](../port-known-issues/N-test-quality-deficiencies.md): missing pretty_assertions (46+ instances), loop-over-cases anti-pattern (21 files), circular tests, weak assertions, grossly loose tolerances (epsilon = 10.0, 1e0), helper placement violations
+
+---
+
 ## References
 
 - Test framework: [rstest](https://docs.rs/rstest) for parameterized tests


### PR DESCRIPTION
Findings from code audits across the codebase were not tracked in the persistent knowledge base. File them into `docs/port-known-issues/` as self-contained entries with proper severity classification, organized by theme where multiple related findings share a root cause.

### Work items

- [x] File 23 known-issue entries covering bugs, numerical stability, inference defects, dead code, test gaps, and escalations needing investigation
- [x] Update `_index.md` summary table and cross-reference from test inventory
