### PR TITLE
fix(test): move rayon build_global to crate-level init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "approx",
  "ctor",
  "ndarray",
+ "rayon",
  "serde",
  "statrs",
  "treetime-ops",
@@ -3669,6 +3670,7 @@ name = "treetime-distribution"
 version = "1.0.0"
 dependencies = [
  "approx",
+ "ctor",
  "eyre",
  "getset",
  "itertools 0.14.0",
@@ -3677,6 +3679,7 @@ dependencies = [
  "num",
  "ordered-float",
  "pretty_assertions",
+ "rayon",
  "rstest",
  "serde",
  "treetime-analytical",
@@ -3713,6 +3716,7 @@ dependencies = [
  "num",
  "num-traits",
  "pretty_assertions",
+ "rayon",
  "rstest",
  "serde",
  "treetime-utils",
@@ -3736,6 +3740,7 @@ dependencies = [
  "petgraph",
  "phyloxml",
  "pretty_assertions",
+ "rayon",
  "rstest",
  "serde",
  "serde_json",
@@ -3756,6 +3761,7 @@ dependencies = [
  "eyre",
  "ndarray",
  "ndarray-conv",
+ "rayon",
  "serde",
  "treetime-utils",
 ]
@@ -3765,9 +3771,11 @@ name = "treetime-primitives"
 version = "1.0.0"
 dependencies = [
  "auto_ops",
+ "ctor",
  "eyre",
  "itertools 0.14.0",
  "pretty_assertions",
+ "rayon",
  "rstest",
  "serde",
  "serde_json",
@@ -3808,6 +3816,7 @@ dependencies = [
  "pretty_dtoa",
  "rand",
  "rand_isaac",
+ "rayon",
  "regex",
  "rstest",
  "serde",

--- a/kb/issues/N-code-quality-conventions.md
+++ b/kb/issues/N-code-quality-conventions.md
@@ -86,12 +86,6 @@ Divides by `n` (count of overlapping keys). Disjoint node sets produce `n = 0`, 
 
 Passes `filepath` directly to `SVGBackend::new()` instead of using `fn create_file_or_stdout()` from `treetime-utils`.
 
-### rayon::ThreadPoolBuilder::build_global called per-test
-
-`packages/treetime/src/graph/__tests__/graph.rs:148,167:` and multiple ancestral test files.
-
-Calling `build_global` multiple times causes nondeterministic test failures because the global pool can only be initialized once.
-
 ### BrentOpt absolute epsilon on calendar time
 
 `packages/treetime/src/commands/timetree/optimization/polytomy.rs:265:`

--- a/kb/tickets/test-rayon-thread-pool-builder-called-per-test.md
+++ b/kb/tickets/test-rayon-thread-pool-builder-called-per-test.md
@@ -1,9 +1,0 @@
-# rayon::ThreadPoolBuilder::build_global called per-test
-
-Calling `build_global` multiple times causes nondeterministic test failures because the global pool can only be initialized once.
-
-v1: [`packages/treetime/src/graph/__tests__/graph.rs#L148`](../../packages/treetime/src/graph/__tests__/graph.rs#L148), [`graph.rs#L167`](../../packages/treetime/src/graph/__tests__/graph.rs#L167) and multiple ancestral test files.
-
-## Related issues
-
-- Source: `do../issues/N-code-quality-conventions.md` -- delete after full resolution

--- a/packages/treetime-analytical/Cargo.toml
+++ b/packages/treetime-analytical/Cargo.toml
@@ -24,6 +24,7 @@ statrs = { workspace = true }
 [dev-dependencies]
 approx = { workspace = true }
 ctor = { workspace = true }
+rayon = { workspace = true }
 treetime-utils = { workspace = true }
 
 [lints]

--- a/packages/treetime-analytical/src/lib.rs
+++ b/packages/treetime-analytical/src/lib.rs
@@ -21,5 +21,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime-cli/src/lib.rs
+++ b/packages/treetime-cli/src/lib.rs
@@ -9,5 +9,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime-distribution/Cargo.toml
+++ b/packages/treetime-distribution/Cargo.toml
@@ -33,8 +33,10 @@ ndarray-stats = { workspace = true }
 treetime-analytical = { workspace = true }
 
 # [external]
+ctor = { workspace = true }
 ordered-float = { workspace = true }
 pretty_assertions = { workspace = true }
+rayon = { workspace = true }
 rstest = { workspace = true }
 
 [lints]

--- a/packages/treetime-distribution/src/lib.rs
+++ b/packages/treetime-distribution/src/lib.rs
@@ -3,9 +3,6 @@ pub(crate) mod distribution_ops;
 pub(crate) mod distribution_scaled;
 pub(crate) mod policy;
 
-#[cfg(test)]
-mod __tests__;
-
 pub use distribution_core::distribution::{
   Distribution, DistributionNegLog, DistributionPlain, TIME_EPSILON, TIME_LIMIT,
 };
@@ -29,3 +26,21 @@ pub use distribution_scaled::divide::scaled_distribution_division;
 pub use distribution_scaled::multiply::{scaled_distribution_multiplication, scaled_distribution_multiply_many};
 pub use distribution_scaled::scaled::ScaledDistribution;
 pub use policy::{NegLog, Plain, PolicyMarker, SupportsConvolution, SupportsSubtraction, YAxisPolicy};
+
+#[cfg(test)]
+mod __tests__;
+
+#[cfg(test)]
+mod tests {
+  use ctor::ctor;
+  use treetime_utils::init::global::global_init;
+
+  #[ctor]
+  fn init() {
+    global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
+  }
+}

--- a/packages/treetime-grid/Cargo.toml
+++ b/packages/treetime-grid/Cargo.toml
@@ -29,6 +29,7 @@ ndarray-stats = { workspace = true }
 [dev-dependencies]
 ctor = { workspace = true }
 pretty_assertions = { workspace = true }
+rayon = { workspace = true }
 rstest = { workspace = true }
 
 [lints]

--- a/packages/treetime-grid/src/lib.rs
+++ b/packages/treetime-grid/src/lib.rs
@@ -25,5 +25,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime-io/Cargo.toml
+++ b/packages/treetime-io/Cargo.toml
@@ -41,6 +41,7 @@ traversal = { workspace = true }
 approx = { workspace = true }
 ctor = { workspace = true }
 pretty_assertions = { workspace = true }
+rayon = { workspace = true }
 rstest = { workspace = true }
 
 [lints]

--- a/packages/treetime-io/src/lib.rs
+++ b/packages/treetime-io/src/lib.rs
@@ -22,5 +22,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime-ops/Cargo.toml
+++ b/packages/treetime-ops/Cargo.toml
@@ -25,6 +25,7 @@ ndarray-conv = { workspace = true }
 [dev-dependencies]
 approx = { workspace = true }
 ctor = { workspace = true }
+rayon = { workspace = true }
 
 [lints]
 workspace = true

--- a/packages/treetime-ops/src/lib.rs
+++ b/packages/treetime-ops/src/lib.rs
@@ -42,5 +42,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime-primitives/Cargo.toml
+++ b/packages/treetime-primitives/Cargo.toml
@@ -21,7 +21,9 @@ itertools = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
+ctor = { workspace = true }
 pretty_assertions = { workspace = true }
+rayon = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
 

--- a/packages/treetime-primitives/src/lib.rs
+++ b/packages/treetime-primitives/src/lib.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-mod __tests__;
 pub mod bitset128;
 pub mod seq;
 pub mod seq_char;
@@ -33,4 +31,22 @@ macro_rules! stateset {
   ($($args:tt)*) => {
     $crate::bitset128!($($args)*)
   };
+}
+
+#[cfg(test)]
+mod __tests__;
+
+#[cfg(test)]
+mod tests {
+  use ctor::ctor;
+  use treetime_utils::init::global::global_init;
+
+  #[ctor]
+  fn init() {
+    global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
+  }
 }

--- a/packages/treetime-utils/Cargo.toml
+++ b/packages/treetime-utils/Cargo.toml
@@ -68,6 +68,7 @@ zstd = { workspace = true }
 ctor = { workspace = true }
 pretty_assertions = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 rstest = { workspace = true }
 
 [lints]

--- a/packages/treetime-utils/src/lib.rs
+++ b/packages/treetime-utils/src/lib.rs
@@ -27,5 +27,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime-validation/src/lib.rs
+++ b/packages/treetime-validation/src/lib.rs
@@ -9,5 +9,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_fitch.rs
@@ -178,7 +178,6 @@ mod tests {
   /// state is preferred when present in the child's state set.
   #[test]
   fn test_ancestral_reconstruction_fitch() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
 
     let aln = read_many_fasta_str(
       indoc! {r#"
@@ -244,7 +243,6 @@ mod tests {
   /// observed data) and that internal node sequences match the expected reconstruction.
   #[test]
   fn test_ancestral_reconstruction_fitch_with_leaves() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
 
     let aln = read_many_fasta_str(
       indoc! {r#"
@@ -313,7 +311,6 @@ mod tests {
 
   #[test]
   fn test_compress_sequences_retains_internal_exact_sequences() -> Result<(), Report> {
-    drop(rayon::ThreadPoolBuilder::new().num_threads(1).build_global());
 
     let aln = read_many_fasta_str(
       indoc! {r#"
@@ -367,7 +364,6 @@ mod tests {
   /// indel events.
   #[test]
   fn test_fitch_internals() -> Result<(), Report> {
-    drop(rayon::ThreadPoolBuilder::new().num_threads(1).build_global());
 
     let aln = read_many_fasta_str(
       indoc! {r#"
@@ -442,7 +438,6 @@ mod tests {
   ///   requiring both indel and substitution tracking within the insertion.
   #[test]
   fn test_fitch_complex_gaps() -> Result<(), Report> {
-    drop(rayon::ThreadPoolBuilder::new().num_threads(1).build_global());
 
     // Test cases: a) deletions overlap, b) root has a deletion, c) inserted sequence is variable
     // In DE, position 3 is inserted, but it varies in D and E
@@ -524,7 +519,6 @@ mod tests {
   /// binary tree version.
   #[test]
   fn test_fitch_polytomy() -> Result<(), Report> {
-    drop(rayon::ThreadPoolBuilder::new().num_threads(1).build_global());
 
     // Test polytomy (node with more than 2 children)
     let aln = read_many_fasta_str(
@@ -611,7 +605,6 @@ mod tests {
   /// - After forward: same variable positions are tracked, but root sequence is fully resolved.
   #[test]
   fn test_fitch_backward_state() -> Result<(), Report> {
-    drop(rayon::ThreadPoolBuilder::new().num_threads(1).build_global());
 
     let aln = read_many_fasta_str(
       indoc! {r#"

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_dense.rs
@@ -150,7 +150,6 @@ mod tests {
   /// posteriori) state argmax_s P(s|data) at each position.
   #[test]
   fn test_ancestral_reconstruction_marginal_dense() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
 
     let expected = read_many_fasta_str(
       indoc! {r#"
@@ -345,7 +344,6 @@ mod tests {
   /// exponentiated log-likelihoods are summed.
   #[test]
   fn test_total_likelihood_marginal_dense_all_triplets() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
 
     let alphabet = Alphabet::default();
     let mut total_lh = 0.0;

--- a/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_marginal_sparse.rs
@@ -149,7 +149,6 @@ mod tests {
   /// Also verifies the total log-likelihood matches the expected value.
   #[test]
   fn test_ancestral_reconstruction_marginal_sparse() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
 
     let aln = read_many_fasta_str(
       indoc! {r#"
@@ -421,7 +420,6 @@ mod tests {
   /// with extreme frequency imbalance.
   #[test]
   fn test_total_likelihood_marginal_sparse_all_triplets() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
 
     let alphabet = Alphabet::default();
     let mut total_lh = 0.0;

--- a/packages/treetime/src/graph/__tests__/graph.rs
+++ b/packages/treetime/src/graph/__tests__/graph.rs
@@ -145,8 +145,6 @@ pub mod tests {
 
   #[test]
   fn test_traversal_parallel_breadth_first_forward() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
-
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let actual = Arc::new(RwLock::new(vec![]));
@@ -164,8 +162,6 @@ pub mod tests {
 
   #[test]
   fn test_traversal_parallel_breadth_first_backward() -> Result<(), Report> {
-    rayon::ThreadPoolBuilder::new().num_threads(1).build_global()?;
-
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let actual = Arc::new(RwLock::new(vec![]));

--- a/packages/treetime/src/lib.rs
+++ b/packages/treetime/src/lib.rs
@@ -28,5 +28,9 @@ mod tests {
   #[ctor]
   fn init() {
     global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
   }
 }


### PR DESCRIPTION
- Depends on: #637

Each workspace crate compiles into its own test binary, and `rayon::ThreadPoolBuilder::build_global()` can only succeed once per process. Several test functions in the `treetime` crate called `build_global` individually, causing whichever test ran second to receive an `Err` from the already-initialized global pool. Depending on test execution order, this produced nondeterministic test failures.

This PR moves the single `build_global(num_threads=1)` call into the `#[ctor] fn init()` block in every workspace crate's `lib.rs`, alongside the existing `global_init()` call. All per-test `build_global` invocations are removed. Seven crates that did not previously depend on rayon gain it as a dev-dependency. Two crates (`treetime-distribution`, `treetime-primitives`) had tests but no `#[ctor]` init block at all and gain the full boilerplate.

The fix is applied uniformly across all 10 crates with test init blocks rather than only the 4 test files that contained the bug.

### Work items

- [x] Add `build_global(num_threads=1)` to `#[ctor] fn init()` in all 10 crate `lib.rs` files
- [x] Add missing `#[ctor]` init blocks to `treetime-distribution` and `treetime-primitives`
- [x] Remove per-test `build_global` calls from `graph.rs`, `test_fitch.rs`, `test_marginal_dense.rs`, `test_marginal_sparse.rs`
- [x] Add `rayon` dev-dependency to 7 crates (analytical, distribution, grid, io, ops, primitives, utils)
- [x] Add `ctor` dev-dependency to `treetime-distribution` and `treetime-primitives`
- [x] Delete resolved ticket `kb/tickets/test-rayon-thread-pool-builder-called-per-test.md`
- [x] Remove entry from `kb/issues/N-code-quality-conventions.md`