### PR TITLE
test: replace element-by-element float loops with array assertions

### DIFF
--- a/kb/issues/N-test-quality-deficiencies.md
+++ b/kb/issues/N-test-quality-deficiencies.md
@@ -40,9 +40,9 @@ Tightened to 1e-6 and `#[ignore]`d pending fix of `M-ancestral-sparse-root-invar
 
 Both test functions compute expected values using `gtr.expQt_with_rate()`, the same function called internally by the SUT. Tautological verification.
 
-### Element-by-element float loops in alphabet tests
+### Element-by-element float loops in alphabet tests (RESOLVED)
 
-`packages/treetime/src/alphabet/__tests__/` - 19+ instances of `for (actual, expected) in ... { assert_ulps_eq!(...) }`. Should use `pretty_assert_ulps_eq!` or `pretty_assert_abs_diff_eq!` on whole arrays.
+Replaced 22 element-by-element loops with `pretty_assert_ulps_eq!` on whole arrays.
 
 ### GM runner tests use grossly loose tolerance (RESOLVED)
 

--- a/kb/tickets/test-replace-element-by-element-float-loops-with-array-assertions.md
+++ b/kb/tickets/test-replace-element-by-element-float-loops-with-array-assertions.md
@@ -1,9 +1,0 @@
-# Replace 19+ element-by-element float comparison loops with array assertions
-
-## Problem
-
-`packages/treetime/src/alphabet/__tests__/` -- 19+ instances of `for (actual, expected) in ... { assert_ulps_eq!(...) }`. Should use `pretty_assert_ulps_eq!` or `pretty_assert_abs_diff_eq!` on whole arrays.
-
-## Related issues
-
-- Source: [N-test-quality-deficiencies.md](../issues/N-test-quality-deficiencies.md) -- delete after full resolution

--- a/packages/treetime/src/alphabet/__tests__/test_alphabet.rs
+++ b/packages/treetime/src/alphabet/__tests__/test_alphabet.rs
@@ -231,28 +231,16 @@ mod tests {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
 
     let profile_a = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'A')).unwrap();
-    let expected_a = array![1.0, 0.0, 0.0, 0.0];
-    for (actual, expected) in profile_a.iter().zip(expected_a.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 0.0], profile_a, max_ulps = 4);
 
     let profile_c = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'C')).unwrap();
-    let expected_c = array![0.0, 1.0, 0.0, 0.0];
-    for (actual, expected) in profile_c.iter().zip(expected_c.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0, 0.0], profile_c, max_ulps = 4);
 
     let profile_g = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'G')).unwrap();
-    let expected_g = array![0.0, 0.0, 1.0, 0.0];
-    for (actual, expected) in profile_g.iter().zip(expected_g.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 0.0, 1.0, 0.0], profile_g, max_ulps = 4);
 
     let profile_t = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'T')).unwrap();
-    let expected_t = array![0.0, 0.0, 0.0, 1.0];
-    for (actual, expected) in profile_t.iter().zip(expected_t.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 0.0, 0.0, 1.0], profile_t, max_ulps = 4);
   }
 
   #[test]
@@ -260,26 +248,17 @@ mod tests {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
 
     let profile_r = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'R')).unwrap();
-    let expected_r = array![1.0, 0.0, 1.0, 0.0];
-    for (actual, expected) in profile_r.iter().zip(expected_r.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], profile_r, max_ulps = 4);
 
     let profile_y = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'Y')).unwrap();
-    let expected_y = array![0.0, 1.0, 0.0, 1.0];
-    for (actual, expected) in profile_y.iter().zip(expected_y.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0, 1.0], profile_y, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_nuc_get_profile_unknown() {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
     let profile_n = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'N')).unwrap();
-    let expected_n = array![1.0, 1.0, 1.0, 1.0];
-    for (actual, expected) in profile_n.iter().zip(expected_n.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 1.0, 1.0, 1.0], profile_n, max_ulps = 4);
   }
 
   #[test]
@@ -336,10 +315,7 @@ mod tests {
         AsciiChar::from_byte_unchecked(b'G'),
       ])
       .unwrap();
-    let expected = array![1.0, 0.0, 1.0, 0.0];
-    for (actual, expected) in actual.iter().zip(expected.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], actual, max_ulps = 4);
   }
 
   #[test]
@@ -354,10 +330,7 @@ mod tests {
     let expected_shape = [3, 4];
     assert_eq!(expected_shape, actual.shape());
 
-    let expected_row0 = array![1.0, 0.0, 0.0, 0.0];
-    for (actual, expected) in actual.row(0).iter().zip(expected_row0.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 0.0], actual.row(0).to_owned(), max_ulps = 4);
   }
 
   #[test]
@@ -372,9 +345,7 @@ mod tests {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
     let profile_gap = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'-')).unwrap();
     let profile_unknown = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'N')).unwrap();
-    for (gap, unk) in profile_gap.iter().zip(profile_unknown.iter()) {
-      pretty_assert_ulps_eq!(*unk, *gap, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(profile_unknown, profile_gap, max_ulps = 4);
   }
 
   #[test]
@@ -484,20 +455,14 @@ mod tests {
     let actual = alphabet
       .construct_profile([AsciiChar::from_byte_unchecked(b'R')])
       .unwrap();
-    let expected = array![1.0, 0.0, 1.0, 0.0];
-    for (actual, expected) in actual.iter().zip(expected.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], actual, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_construct_profile_empty() {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
     let actual = alphabet.construct_profile::<[AsciiChar; 0], _>([]).unwrap();
-    let expected = array![0.0, 0.0, 0.0, 0.0];
-    for (actual, expected) in actual.iter().zip(expected.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 0.0, 0.0, 0.0], actual, max_ulps = 4);
   }
 
   #[test]
@@ -511,15 +476,8 @@ mod tests {
     let expected_shape = [2, 4];
     assert_eq!(expected_shape, actual.shape());
 
-    let expected_row0 = array![1.0, 0.0, 1.0, 0.0];
-    for (actual, expected) in actual.row(0).iter().zip(expected_row0.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
-
-    let expected_row1 = array![0.0, 1.0, 0.0, 1.0];
-    for (actual, expected) in actual.row(1).iter().zip(expected_row1.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], actual.row(0).to_owned(), max_ulps = 4);
+    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0, 1.0], actual.row(1).to_owned(), max_ulps = 4);
   }
 
   #[rstest]
@@ -563,10 +521,7 @@ mod tests {
     assert_eq!(expected_gap, alphabet.gap());
 
     let profile_w = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'W')).unwrap();
-    let expected_w = array![1.0, 1.0, 0.0];
-    for (actual, expected) in profile_w.iter().zip(expected_w.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 1.0, 0.0], profile_w, max_ulps = 4);
   }
 
   #[test]

--- a/packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs
+++ b/packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs
@@ -185,22 +185,13 @@ mod tests {
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_a = &profile_map[&AsciiChar::from_byte_unchecked(b'A')];
-    let expected_a = array![1.0, 0.0, 0.0, 0.0];
-    for (actual, expected) in profile_a.iter().zip(expected_a.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 0.0], profile_a, max_ulps = 4);
 
     let profile_r = &profile_map[&AsciiChar::from_byte_unchecked(b'R')];
-    let expected_r = array![1.0, 0.0, 1.0, 0.0];
-    for (actual, expected) in profile_r.iter().zip(expected_r.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], profile_r, max_ulps = 4);
 
     let profile_n = &profile_map[&AsciiChar::from_byte_unchecked(b'N')];
-    let expected_n = array![1.0, 1.0, 1.0, 1.0];
-    for (actual, expected) in profile_n.iter().zip(expected_n.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 1.0, 1.0, 1.0], profile_n, max_ulps = 4);
   }
 
   #[test]
@@ -210,9 +201,7 @@ mod tests {
 
     let profile_gap = &profile_map[&AsciiChar::from_byte_unchecked(b'-')];
     let profile_n = &profile_map[&AsciiChar::from_byte_unchecked(b'N')];
-    for (gap, unk) in profile_gap.iter().zip(profile_n.iter()) {
-      pretty_assert_ulps_eq!(*unk, *gap, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(profile_n, profile_gap, max_ulps = 4);
   }
 
   #[test]
@@ -226,22 +215,13 @@ mod tests {
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_x = &profile_map[&AsciiChar::from_byte_unchecked(b'X')];
-    let expected_x = array![1.0, 0.0, 0.0];
-    for (actual, expected) in profile_x.iter().zip(expected_x.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0], profile_x, max_ulps = 4);
 
     let profile_y = &profile_map[&AsciiChar::from_byte_unchecked(b'Y')];
-    let expected_y = array![0.0, 1.0, 0.0];
-    for (actual, expected) in profile_y.iter().zip(expected_y.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0], profile_y, max_ulps = 4);
 
     let profile_z = &profile_map[&AsciiChar::from_byte_unchecked(b'Z')];
-    let expected_z = array![0.0, 0.0, 1.0];
-    for (actual, expected) in profile_z.iter().zip(expected_z.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 0.0, 1.0], profile_z, max_ulps = 4);
   }
 
   #[test]
@@ -331,16 +311,10 @@ mod tests {
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_s = &profile_map[&AsciiChar::from_byte_unchecked(b'S')];
-    let expected_s = array![0.0, 1.0, 1.0, 0.0];
-    for (actual, expected) in profile_s.iter().zip(expected_s.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![0.0, 1.0, 1.0, 0.0], profile_s, max_ulps = 4);
 
     let profile_w = &profile_map[&AsciiChar::from_byte_unchecked(b'W')];
-    let expected_w = array![1.0, 0.0, 0.0, 1.0];
-    for (actual, expected) in profile_w.iter().zip(expected_w.iter()) {
-      pretty_assert_ulps_eq!(*expected, *actual, max_ulps = 4);
-    }
+    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 1.0], profile_w, max_ulps = 4);
   }
 
   #[test]


### PR DESCRIPTION
- Depends on: #648

Replace elementwise float comparison loops with whole-array `pretty_assert_ulps_eq!` calls in `test_alphabet.rs` and `test_alphabet_config.rs`.

### Work items

- [x] Replace loops with array assertions
- [x] Mark issue resolved in `kb/issues/N-test-quality-deficiencies.md`, delete ticket