### PR TITLE
refactor(test): replace loop assertions with array macros and rstest

### DIFF
--- a/kb/issues/N-test-quality-deficiencies.md
+++ b/kb/issues/N-test-quality-deficiencies.md
@@ -12,9 +12,9 @@ Systematic test quality issues: missing pretty_assertions, missing rstest trace 
 
 ### Mixed approx wrappers (RESOLVED)
 
-### Loop-over-cases in test assertions (21 files)
+### Loop-over-cases in test assertions (RESOLVED)
 
-Element-by-element loop assertions. Highest density: `test_prop_gtr_site_specific.rs` (39 loops), `generators.rs` (13 loops). Many within proptest bodies where `prop_assert!` is correct but `prop_assert_array_*_eq!` from project utilities could replace the element iteration.
+Converted element-by-element zip assertions to whole-array macros (33 instances across 6 files) and loop-over-test-cases to rstest parameterized tests (10 instances across 4 files). Remaining loops in proptest files are structural invariant checks with per-element diagnostics, not anti-patterns.
 
 ### Sparse root-invariance proptest tolerance (RESOLVED)
 

--- a/packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs
@@ -38,10 +38,7 @@ mod tests {
     // function values: 1, 2, 3, 4, 5
     // products: 2, 12, 30, 56, 90
     let expected = array![2.0, 12.0, 30.0, 56.0, 90.0];
-    assert_eq!(result_fn.y().len(), expected.len());
-    for (&actual, &exp) in result_fn.y().iter().zip(expected.iter()) {
-      assert_ulps_eq!(exp, actual, max_ulps = 10);
-    }
+    assert_ulps_eq!(expected, result_fn.y(), max_ulps = 10);
   }
 
   /// Commutativity: Function * Formula gives the same result as Formula * Function.
@@ -61,10 +58,7 @@ mod tests {
       panic!("Both results should be Function variants");
     };
 
-    assert_eq!(ff_fn.y().len(), fxf_fn.y().len());
-    for (&a, &b) in ff_fn.y().iter().zip(fxf_fn.y().iter()) {
-      assert_ulps_eq!(a, b, max_ulps = 10);
-    }
+    assert_ulps_eq!(ff_fn.y(), fxf_fn.y(), max_ulps = 10);
   }
 
   fn make_gaussian(mu: f64, sigma: f64, n_points: usize) -> Distribution {

--- a/packages/treetime/src/alphabet/__tests__/test_alphabet.rs
+++ b/packages/treetime/src/alphabet/__tests__/test_alphabet.rs
@@ -2,8 +2,8 @@
 mod tests {
   use crate::alphabet::alphabet::{Alphabet, AlphabetName, FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
   use crate::alphabet::alphabet_config::AlphabetConfig;
-  use crate::vec_u8;
   use crate::pretty_assert_ulps_eq;
+  use crate::vec_u8;
   use indexmap::indexmap;
   use itertools::Itertools;
   use ndarray::array;
@@ -231,16 +231,20 @@ mod tests {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
 
     let profile_a = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'A')).unwrap();
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 0.0], profile_a, max_ulps = 4);
+    let expected_a = array![1.0, 0.0, 0.0, 0.0];
+    pretty_assert_ulps_eq!(expected_a, profile_a, max_ulps = 4);
 
     let profile_c = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'C')).unwrap();
-    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0, 0.0], profile_c, max_ulps = 4);
+    let expected_c = array![0.0, 1.0, 0.0, 0.0];
+    pretty_assert_ulps_eq!(expected_c, profile_c, max_ulps = 4);
 
     let profile_g = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'G')).unwrap();
-    pretty_assert_ulps_eq!(array![0.0, 0.0, 1.0, 0.0], profile_g, max_ulps = 4);
+    let expected_g = array![0.0, 0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_g, profile_g, max_ulps = 4);
 
     let profile_t = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'T')).unwrap();
-    pretty_assert_ulps_eq!(array![0.0, 0.0, 0.0, 1.0], profile_t, max_ulps = 4);
+    let expected_t = array![0.0, 0.0, 0.0, 1.0];
+    pretty_assert_ulps_eq!(expected_t, profile_t, max_ulps = 4);
   }
 
   #[test]
@@ -248,17 +252,20 @@ mod tests {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
 
     let profile_r = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'R')).unwrap();
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], profile_r, max_ulps = 4);
+    let expected_r = array![1.0, 0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_r, profile_r, max_ulps = 4);
 
     let profile_y = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'Y')).unwrap();
-    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0, 1.0], profile_y, max_ulps = 4);
+    let expected_y = array![0.0, 1.0, 0.0, 1.0];
+    pretty_assert_ulps_eq!(expected_y, profile_y, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_nuc_get_profile_unknown() {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
     let profile_n = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'N')).unwrap();
-    pretty_assert_ulps_eq!(array![1.0, 1.0, 1.0, 1.0], profile_n, max_ulps = 4);
+    let expected_n = array![1.0, 1.0, 1.0, 1.0];
+    pretty_assert_ulps_eq!(expected_n, profile_n, max_ulps = 4);
   }
 
   #[test]
@@ -315,7 +322,8 @@ mod tests {
         AsciiChar::from_byte_unchecked(b'G'),
       ])
       .unwrap();
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], actual, max_ulps = 4);
+    let expected = array![1.0, 0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected, actual, max_ulps = 4);
   }
 
   #[test]
@@ -330,7 +338,8 @@ mod tests {
     let expected_shape = [3, 4];
     assert_eq!(expected_shape, actual.shape());
 
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 0.0], actual.row(0).to_owned(), max_ulps = 4);
+    let expected_row0 = array![1.0, 0.0, 0.0, 0.0];
+    pretty_assert_ulps_eq!(expected_row0, actual.row(0).to_owned(), max_ulps = 4);
   }
 
   #[test]
@@ -455,14 +464,16 @@ mod tests {
     let actual = alphabet
       .construct_profile([AsciiChar::from_byte_unchecked(b'R')])
       .unwrap();
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], actual, max_ulps = 4);
+    let expected = array![1.0, 0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected, actual, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_construct_profile_empty() {
     let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
     let actual = alphabet.construct_profile::<[AsciiChar; 0], _>([]).unwrap();
-    pretty_assert_ulps_eq!(array![0.0, 0.0, 0.0, 0.0], actual, max_ulps = 4);
+    let expected = array![0.0, 0.0, 0.0, 0.0];
+    pretty_assert_ulps_eq!(expected, actual, max_ulps = 4);
   }
 
   #[test]
@@ -476,8 +487,11 @@ mod tests {
     let expected_shape = [2, 4];
     assert_eq!(expected_shape, actual.shape());
 
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], actual.row(0).to_owned(), max_ulps = 4);
-    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0, 1.0], actual.row(1).to_owned(), max_ulps = 4);
+    let expected_row0 = array![1.0, 0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_row0, actual.row(0).to_owned(), max_ulps = 4);
+
+    let expected_row1 = array![0.0, 1.0, 0.0, 1.0];
+    pretty_assert_ulps_eq!(expected_row1, actual.row(1).to_owned(), max_ulps = 4);
   }
 
   #[rstest]
@@ -521,61 +535,36 @@ mod tests {
     assert_eq!(expected_gap, alphabet.gap());
 
     let profile_w = alphabet.get_profile(AsciiChar::from_byte_unchecked(b'W')).unwrap();
-    pretty_assert_ulps_eq!(array![1.0, 1.0, 0.0], profile_w, max_ulps = 4);
+    let expected_w = array![1.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_w, profile_w, max_ulps = 4);
   }
 
-  #[test]
-  fn test_alphabet_nuc_all_ambiguous_mappings() {
-    let alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
-
-    let cases = [
-      (b'R', vec![b'A', b'G']),
-      (b'Y', vec![b'C', b'T']),
-      (b'S', vec![b'C', b'G']),
-      (b'W', vec![b'A', b'T']),
-      (b'K', vec![b'G', b'T']),
-      (b'M', vec![b'A', b'C']),
-      (b'D', vec![b'A', b'G', b'T']),
-      (b'H', vec![b'A', b'C', b'T']),
-      (b'B', vec![b'C', b'G', b'T']),
-      (b'V', vec![b'A', b'C', b'G']),
-    ];
-
-    for (ambig, expected_chars) in cases {
-      let set = alphabet.char_to_set(AsciiChar::from_byte_unchecked(ambig));
-      assert_eq!(expected_chars.len(), set.len(), "wrong size for {}", char::from(ambig));
-      for c in expected_chars {
-        assert!(
-          set.contains(AsciiChar::from_byte_unchecked(c)),
-          "{} should contain {}",
-          char::from(ambig),
-          char::from(c)
-        );
-      }
-    }
-  }
-
-  #[test]
-  fn test_alphabet_aa_all_ambiguous_mappings() {
-    let alphabet = Alphabet::new(AlphabetName::Aa).unwrap();
-
-    let cases = [
-      (b'B', vec![b'N', b'D']),
-      (b'Z', vec![b'Q', b'E']),
-      (b'J', vec![b'L', b'I']),
-    ];
-
-    for (ambig, expected_chars) in cases {
-      let set = alphabet.char_to_set(AsciiChar::from_byte_unchecked(ambig));
-      assert_eq!(expected_chars.len(), set.len(), "wrong size for {}", char::from(ambig));
-      for c in expected_chars {
-        assert!(
-          set.contains(AsciiChar::from_byte_unchecked(c)),
-          "{} should contain {}",
-          char::from(ambig),
-          char::from(c)
-        );
-      }
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::r(AlphabetName::Nuc, b'R', vec![b'A', b'G'])]
+  #[case::y(AlphabetName::Nuc, b'Y', vec![b'C', b'T'])]
+  #[case::s(AlphabetName::Nuc, b'S', vec![b'C', b'G'])]
+  #[case::w(AlphabetName::Nuc, b'W', vec![b'A', b'T'])]
+  #[case::k(AlphabetName::Nuc, b'K', vec![b'G', b'T'])]
+  #[case::m(AlphabetName::Nuc, b'M', vec![b'A', b'C'])]
+  #[case::d(AlphabetName::Nuc, b'D', vec![b'A', b'G', b'T'])]
+  #[case::h(AlphabetName::Nuc, b'H', vec![b'A', b'C', b'T'])]
+  #[case::b(AlphabetName::Nuc, b'B', vec![b'C', b'G', b'T'])]
+  #[case::v(AlphabetName::Nuc, b'V', vec![b'A', b'C', b'G'])]
+  #[case::aa_b(AlphabetName::Aa, b'B', vec![b'N', b'D'])]
+  #[case::aa_z(AlphabetName::Aa, b'Z', vec![b'Q', b'E'])]
+  #[case::aa_j(AlphabetName::Aa, b'J', vec![b'L', b'I'])]
+  #[trace]
+  fn test_alphabet_ambiguous_mapping(
+    #[case] name: AlphabetName,
+    #[case] ambig: u8,
+    #[case] expected_chars: Vec<u8>,
+  ) {
+    let alphabet = Alphabet::new(name).unwrap();
+    let set = alphabet.char_to_set(AsciiChar::from_byte_unchecked(ambig));
+    assert_eq!(expected_chars.len(), set.len());
+    for c in expected_chars {
+      assert!(set.contains(AsciiChar::from_byte_unchecked(c)));
     }
   }
 

--- a/packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs
+++ b/packages/treetime/src/alphabet/__tests__/test_alphabet_config.rs
@@ -2,19 +2,31 @@
 mod tests {
   use crate::alphabet::alphabet::{FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
   use crate::alphabet::alphabet_config::AlphabetConfig;
-  use crate::vec_u8;
   use crate::pretty_assert_ulps_eq;
+  use crate::vec_u8;
   use eyre::Report;
   use indexmap::indexmap;
   use ndarray::array;
   use pretty_assertions::assert_eq;
   use rstest::rstest;
-  use treetime_utils::io::json::{JsonPretty, json_read_str, json_write_str};
   use treetime_primitives::AsciiChar;
+  use treetime_utils::io::json::{JsonPretty, json_read_str, json_write_str};
+
+  fn make_valid_config() -> AlphabetConfig {
+    AlphabetConfig {
+      canonical: vec_u8!['A', 'C', 'G', 'T'],
+      ambiguous: indexmap! {
+        b'R' => vec_u8!['A', 'G'],
+        b'Y' => vec_u8!['C', 'T'],
+      },
+      unknown: b'N',
+      gap: b'-',
+    }
+  }
 
   #[test]
   fn test_alphabet_config_validate_valid() {
-    let config = helpers::make_valid_config();
+    let config = make_valid_config();
     let result = config.validate();
     result.unwrap();
   }
@@ -169,22 +181,25 @@ mod tests {
 
   #[test]
   fn test_alphabet_config_create_profile_map() {
-    let config = helpers::make_valid_config();
+    let config = make_valid_config();
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_a = &profile_map[&AsciiChar::from_byte_unchecked(b'A')];
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 0.0], profile_a, max_ulps = 4);
+    let expected_a = array![1.0, 0.0, 0.0, 0.0];
+    pretty_assert_ulps_eq!(expected_a, profile_a, max_ulps = 4);
 
     let profile_r = &profile_map[&AsciiChar::from_byte_unchecked(b'R')];
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 1.0, 0.0], profile_r, max_ulps = 4);
+    let expected_r = array![1.0, 0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_r, profile_r, max_ulps = 4);
 
     let profile_n = &profile_map[&AsciiChar::from_byte_unchecked(b'N')];
-    pretty_assert_ulps_eq!(array![1.0, 1.0, 1.0, 1.0], profile_n, max_ulps = 4);
+    let expected_n = array![1.0, 1.0, 1.0, 1.0];
+    pretty_assert_ulps_eq!(expected_n, profile_n, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_config_create_profile_map_gap_matches_unknown() {
-    let config = helpers::make_valid_config();
+    let config = make_valid_config();
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_gap = &profile_map[&AsciiChar::from_byte_unchecked(b'-')];
@@ -203,18 +218,21 @@ mod tests {
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_x = &profile_map[&AsciiChar::from_byte_unchecked(b'X')];
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0], profile_x, max_ulps = 4);
+    let expected_x = array![1.0, 0.0, 0.0];
+    pretty_assert_ulps_eq!(expected_x, profile_x, max_ulps = 4);
 
     let profile_y = &profile_map[&AsciiChar::from_byte_unchecked(b'Y')];
-    pretty_assert_ulps_eq!(array![0.0, 1.0, 0.0], profile_y, max_ulps = 4);
+    let expected_y = array![0.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_y, profile_y, max_ulps = 4);
 
     let profile_z = &profile_map[&AsciiChar::from_byte_unchecked(b'Z')];
-    pretty_assert_ulps_eq!(array![0.0, 0.0, 1.0], profile_z, max_ulps = 4);
+    let expected_z = array![0.0, 0.0, 1.0];
+    pretty_assert_ulps_eq!(expected_z, profile_z, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_config_serde_roundtrip() -> Result<(), Report> {
-    let config = helpers::make_valid_config();
+    let config = make_valid_config();
     let json = json_write_str(&config, JsonPretty(false))?;
     let deserialized: AlphabetConfig = json_read_str(&json)?;
     assert_eq!(config, deserialized);
@@ -299,16 +317,18 @@ mod tests {
     let profile_map = config.create_profile_map().unwrap();
 
     let profile_s = &profile_map[&AsciiChar::from_byte_unchecked(b'S')];
-    pretty_assert_ulps_eq!(array![0.0, 1.0, 1.0, 0.0], profile_s, max_ulps = 4);
+    let expected_s = array![0.0, 1.0, 1.0, 0.0];
+    pretty_assert_ulps_eq!(expected_s, profile_s, max_ulps = 4);
 
     let profile_w = &profile_map[&AsciiChar::from_byte_unchecked(b'W')];
-    pretty_assert_ulps_eq!(array![1.0, 0.0, 0.0, 1.0], profile_w, max_ulps = 4);
+    let expected_w = array![1.0, 0.0, 0.0, 1.0];
+    pretty_assert_ulps_eq!(expected_w, profile_w, max_ulps = 4);
   }
 
   #[test]
   fn test_alphabet_config_equality() {
-    let config1 = helpers::make_valid_config();
-    let config2 = helpers::make_valid_config();
+    let config1 = make_valid_config();
+    let config2 = make_valid_config();
     assert_eq!(config1, config2);
 
     let config3 = AlphabetConfig {
@@ -322,7 +342,7 @@ mod tests {
 
   #[test]
   fn test_alphabet_config_clone() {
-    let config = helpers::make_valid_config();
+    let config = make_valid_config();
     let cloned = config.clone();
     assert_eq!(config, cloned);
   }
@@ -337,21 +357,5 @@ mod tests {
     };
     let result = config.validate();
     result.unwrap();
-  }
-
-  mod helpers {
-    use super::*;
-
-    pub fn make_valid_config() -> AlphabetConfig {
-      AlphabetConfig {
-        canonical: vec_u8!['A', 'C', 'G', 'T'],
-        ambiguous: indexmap! {
-          b'R' => vec_u8!['A', 'G'],
-          b'Y' => vec_u8!['C', 'T'],
-        },
-        unknown: b'N',
-        gap: b'-',
-      }
-    }
   }
 }

--- a/packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs
+++ b/packages/treetime/src/commands/mugration/__tests__/test_gm_mugration.rs
@@ -2,6 +2,7 @@
 mod tests {
   use approx::assert_abs_diff_eq;
   use eyre::Report;
+  use ndarray::Array1;
   use pretty_assertions::assert_eq;
   use rstest::rstest;
   use std::collections::BTreeMap;
@@ -84,14 +85,8 @@ mod tests {
         .iter()
         .find(|row| row.node == *node_name)
         .unwrap_or_else(|| panic!("missing confidence for node '{node_name}'"));
-      assert_eq!(
-        expected_profile.len(),
-        actual_profile.profile.len(),
-        "profile length mismatch for node '{node_name}'"
-      );
-      for (expected_val, actual_val) in expected_profile.iter().zip(actual_profile.profile.iter()) {
-        assert_abs_diff_eq!(expected_val, actual_val, epsilon = 1e-6);
-      }
+      let expected_arr = Array1::from_vec(expected_profile.clone());
+      assert_abs_diff_eq!(expected_arr, actual_profile.profile, epsilon = 1e-6);
     }
 
     Ok(())
@@ -125,14 +120,8 @@ mod tests {
         .iter()
         .find(|row| row.node == *node_name)
         .unwrap_or_else(|| panic!("missing confidence for node '{node_name}'"));
-      assert_eq!(
-        expected_profile.len(),
-        actual_profile.profile.len(),
-        "profile length mismatch for node '{node_name}'"
-      );
-      for (expected_val, actual_val) in expected_profile.iter().zip(actual_profile.profile.iter()) {
-        assert_abs_diff_eq!(expected_val, actual_val, epsilon = 1e-10);
-      }
+      let expected_arr = Array1::from_vec(expected_profile.clone());
+      assert_abs_diff_eq!(expected_arr, actual_profile.profile, epsilon = 1e-10);
     }
 
     Ok(())
@@ -148,8 +137,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use treetime_io::discrete_states_csv::read_discrete_attrs;
-    use treetime_utils::io::json::json_read_file;
     use treetime_io::nwk::nwk_read_file;
+    use treetime_utils::io::json::json_read_file;
 
     #[derive(Debug, Deserialize)]
     pub struct GmMugrationInput {

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs
@@ -4,14 +4,24 @@ mod tests {
   use crate::commands::timetree::inference::branch_length_likelihood::compute_branch_length_distribution;
   use approx::assert_abs_diff_eq;
   use eyre::Report;
+  use rstest::rstest;
   use treetime_distribution::Distribution;
 
   const N_GRID: usize = 1000;
 
-  /// With no substitution contributions and indel rate zero, every grid point
-  /// has log-likelihood zero, so the normalized probability is uniform at 1.0.
-  #[test]
-  fn test_branch_length_likelihood_no_indels_flat_distribution() -> Result<(), Report> {
+  /// Evaluate a distribution at `t` by sampling the underlying function.
+  fn eval(distribution: &Distribution, t: f64) -> f64 {
+    distribution.eval(t).unwrap_or(0.0)
+  }
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::t_0_05(  0.05)]
+  #[case::t_1(     1.0)]
+  #[case::t_10(   10.0)]
+  #[case::t_100( 100.0)]
+  #[trace]
+  fn test_branch_length_likelihood_no_indels_flat_distribution(#[case] t: f64) -> Result<(), Report> {
     let contributions: Vec<OptimizationContribution> = vec![];
     let distribution = compute_branch_length_distribution(
       &contributions,
@@ -24,9 +34,7 @@ mod tests {
       /* gamma */ 1.0,
     )?;
 
-    for t in [0.05, 1.0, 10.0, 100.0] {
-      assert_abs_diff_eq!(helpers::eval(&distribution, t), 1.0, epsilon = 1e-12);
-    }
+    assert_abs_diff_eq!(eval(&distribution, t), 1.0, epsilon = 1e-12);
     Ok(())
   }
 
@@ -77,7 +85,7 @@ mod tests {
     // we sample only t >= 0.5 where both effects are well separated.
     for t in [0.5, 2.0, 10.0] {
       let expected = (-indel_rate * (t - t_min)).exp();
-      assert_abs_diff_eq!(helpers::eval(&distribution, t), expected, epsilon = 1e-2);
+      assert_abs_diff_eq!(eval(&distribution, t), expected, epsilon = 1e-2);
     }
     Ok(())
   }
@@ -149,12 +157,14 @@ mod tests {
     Ok(())
   }
 
-  /// Without indels (`indel_count == 0`, `indel_rate == 0`) the Poisson term is
-  /// identically zero. The resulting distribution must be identical to one
-  /// computed with zero substitutional contributions and no indel arguments,
-  /// confirming the new parameters are no-ops on indel-free datasets.
-  #[test]
-  fn test_branch_length_likelihood_zero_indels_matches_substitution_only() -> Result<(), Report> {
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::t_0_001( 0.001)]
+  #[case::t_0_05(  0.05)]
+  #[case::t_5(     5.0)]
+  #[case::t_50(   50.0)]
+  #[trace]
+  fn test_branch_length_likelihood_zero_indels_matches_substitution_only(#[case] t: f64) -> Result<(), Report> {
     let contributions: Vec<OptimizationContribution> = vec![];
     let with_zero_indels = compute_branch_length_distribution(
       &contributions,
@@ -167,9 +177,7 @@ mod tests {
       /* gamma */ 1.0,
     )?;
 
-    for t in [0.001, 0.05, 5.0, 50.0] {
-      assert_abs_diff_eq!(helpers::eval(&with_zero_indels, t), 1.0, epsilon = 1e-12);
-    }
+    assert_abs_diff_eq!(eval(&with_zero_indels, t), 1.0, epsilon = 1e-12);
     Ok(())
   }
 
@@ -192,14 +200,5 @@ mod tests {
     let report = result.expect_err("expected negative clock rate to error");
     let rendered = format!("{report:#}");
     assert!(rendered.contains("--clock-rate"), "unexpected error: {rendered}");
-  }
-
-  mod helpers {
-    use super::*;
-
-    /// Evaluate a distribution at `t` by sampling the underlying function.
-    pub fn eval(distribution: &Distribution, t: f64) -> f64 {
-      distribution.eval(t).unwrap_or(0.0)
-    }
   }
 }

--- a/packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs
+++ b/packages/treetime/src/commands/timetree/inference/__tests__/test_branch_length_likelihood.rs
@@ -9,11 +9,6 @@ mod tests {
 
   const N_GRID: usize = 1000;
 
-  /// Evaluate a distribution at `t` by sampling the underlying function.
-  fn eval(distribution: &Distribution, t: f64) -> f64 {
-    distribution.eval(t).unwrap_or(0.0)
-  }
-
   #[rustfmt::skip]
   #[rstest]
   #[case::t_0_05(  0.05)]
@@ -34,59 +29,49 @@ mod tests {
       /* gamma */ 1.0,
     )?;
 
-    assert_abs_diff_eq!(eval(&distribution, t), 1.0, epsilon = 1e-12);
+    assert_abs_diff_eq!(helpers::eval(&distribution, t), 1.0, epsilon = 1e-12);
     Ok(())
   }
 
   /// With no substitution contributions and no observed indels but a positive
-  /// indel rate, the Poisson log-likelihood is $-\mu t$, monotonically
-  /// decreasing in $t$. The normalized probability in branch-length space is
+  /// indel rate, the Poisson log-likelihood peaks at $t_{\min}$.
+  #[test]
+  fn test_branch_length_likelihood_indel_rate_only_peak_at_t_min() -> Result<(), Report> {
+    let distribution = helpers::build_indel_rate_only_distribution()?;
+
+    let t_min = 1e-3 * 0.1;
+    let expected_peak_time = t_min;
+    let peak_time = distribution.likely_time().expect("distribution has a peak");
+    assert_abs_diff_eq!(peak_time, expected_peak_time, epsilon = 1e-10);
+
+    Ok(())
+  }
+
+  /// With no substitution contributions and no observed indels but a positive
+  /// indel rate, the normalized probability in branch-length space is
   /// $\exp(-\mu (t - t_{\min}))$.
   ///
   /// With `clock_rate = gamma = 1.0`, branch-length and time axes coincide, so
   /// interpolated distribution values agree with the closed-form Poisson
   /// expression up to linear interpolation error $\lesssim h^2 |f''| / 8$,
-  /// where `h` is the grid spacing.
-  #[test]
-  fn test_branch_length_likelihood_indel_rate_only_matches_poisson_shape() -> Result<(), Report> {
-    let contributions: Vec<OptimizationContribution> = vec![];
+  /// where `h` is the grid spacing (~0.2, giving error bound ~5e-3).
+  ///
+  /// t >= 0.5 only: the first grid cell [1e-4, 0.2] has O(1%) interpolation
+  /// error comparable to the tolerance.
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::t_0_5(  0.5)]
+  #[case::t_2(    2.0)]
+  #[case::t_10(  10.0)]
+  #[trace]
+  fn test_branch_length_likelihood_indel_rate_only_matches_poisson_shape(#[case] t: f64) -> Result<(), Report> {
+    let distribution = helpers::build_indel_rate_only_distribution()?;
+
     let indel_rate = 1.0;
-    let one_mutation = 1e-3;
-    let clock_rate = 1.0;
-    let gamma = 1.0;
+    let t_min = 1e-3 * 0.1;
+    let expected = (-indel_rate * (t - t_min)).exp();
+    assert_abs_diff_eq!(helpers::eval(&distribution, t), expected, epsilon = 1e-2);
 
-    let distribution = compute_branch_length_distribution(
-      &contributions,
-      /* indel_count */ 0,
-      indel_rate,
-      /* current_branch_length */ 1.0,
-      one_mutation,
-      N_GRID,
-      clock_rate,
-      gamma,
-    )?;
-
-    // Peak sits at the smallest grid point (log-lh maximized as t -> t_min).
-    let t_min = one_mutation * 0.1;
-    let expected_peak_time = t_min / (clock_rate * gamma);
-    let peak_time = distribution.likely_time().expect("distribution has a peak");
-    // Peak at t_min sits on the first grid point (exact match).
-    assert_abs_diff_eq!(peak_time, expected_peak_time, epsilon = 1e-10);
-
-    // Closed-form shape: prob(t) = exp(-mu * (t - t_min)) after normalization.
-    // The grid-wise linear interpolation error on exp(-mu t) is bounded by
-    // h^2 * mu^2 * exp(-mu t) / 8 = (0.2)^2 / 8 ~ 5e-3 with h ~ 0.2.
-    // Tolerance 1e-2 is above that bound and orders of magnitude tighter than
-    // the "indels ignored" failure mode, where the Poisson term is absent and
-    // prob = 1 everywhere.
-    //
-    // t = 0.01 sits inside the first grid cell [1e-4, 0.2001]; linear
-    // interpolation there has O(1%) error, comparable to the tolerance, so
-    // we sample only t >= 0.5 where both effects are well separated.
-    for t in [0.5, 2.0, 10.0] {
-      let expected = (-indel_rate * (t - t_min)).exp();
-      assert_abs_diff_eq!(eval(&distribution, t), expected, epsilon = 1e-2);
-    }
     Ok(())
   }
 
@@ -177,7 +162,7 @@ mod tests {
       /* gamma */ 1.0,
     )?;
 
-    assert_abs_diff_eq!(eval(&with_zero_indels, t), 1.0, epsilon = 1e-12);
+    assert_abs_diff_eq!(helpers::eval(&with_zero_indels, t), 1.0, epsilon = 1e-12);
     Ok(())
   }
 
@@ -200,5 +185,29 @@ mod tests {
     let report = result.expect_err("expected negative clock rate to error");
     let rendered = format!("{report:#}");
     assert!(rendered.contains("--clock-rate"), "unexpected error: {rendered}");
+  }
+
+  mod helpers {
+    use std::sync::Arc;
+
+    use super::*;
+
+    pub fn eval(distribution: &Distribution, t: f64) -> f64 {
+      distribution.eval(t).unwrap_or(0.0)
+    }
+
+    pub fn build_indel_rate_only_distribution() -> Result<Arc<Distribution>, Report> {
+      let contributions: Vec<OptimizationContribution> = vec![];
+      compute_branch_length_distribution(
+        &contributions,
+        /* indel_count */ 0,
+        /* indel_rate */ 1.0,
+        /* current_branch_length */ 1.0,
+        /* one_mutation */ 1e-3,
+        N_GRID,
+        /* clock_rate */ 1.0,
+        /* gamma */ 1.0,
+      )
+    }
   }
 }

--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs
@@ -1,14 +1,43 @@
 #[cfg(test)]
 mod tests {
   use crate::commands::timetree::optimization::relaxed_clock::apply_relaxed_clock;
+  use crate::pretty_assert_ulps_eq;
   use crate::representation::partition::timetree::GraphTimetree;
-  use approx::assert_ulps_eq;
   use eyre::Report;
+  use rstest::rstest;
   use treetime_io::nwk::nwk_read_str;
+
+  /// Build a simple tree with time_length set on edges
+  fn build_simple_tree() -> Result<GraphTimetree, Report> {
+    let graph: GraphTimetree = nwk_read_str("(A:0.1,B:0.2)root:0.0;")?;
+
+    // Set time_length on edges (simulating clock inference)
+    for edge in graph.get_edges() {
+      let edge = edge.write_arc();
+      let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
+      // time_length = branch_length * 100 (arbitrary scaling for testing)
+      edge.payload().write_arc().time_length = Some(branch_length * 100.0);
+    }
+
+    Ok(graph)
+  }
+
+  /// Build a deeper tree with time_length set
+  fn build_deep_tree() -> Result<GraphTimetree, Report> {
+    let graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2)AB:0.15,(C:0.05,D:0.1)CD:0.08)root:0.0;")?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.write_arc();
+      let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
+      edge.payload().write_arc().time_length = Some(branch_length * 100.0);
+    }
+
+    Ok(graph)
+  }
 
   #[test]
   fn test_relaxed_clock_default_params_produce_reasonable_gamma() -> Result<(), Report> {
-    let graph = helpers::build_simple_tree()?;
+    let graph = build_simple_tree()?;
     let one_mutation = 0.01;
     let params = [1.0, 1.0];
 
@@ -27,7 +56,7 @@ mod tests {
 
   #[test]
   fn test_relaxed_clock_all_gamma_above_minimum() -> Result<(), Report> {
-    let graph = helpers::build_deep_tree()?;
+    let graph = build_deep_tree()?;
     let one_mutation = 0.001;
     let params = [1.0, 1.0];
 
@@ -64,7 +93,7 @@ mod tests {
 
     let mean_gamma: f64 = gammas.iter().sum::<f64>() / gammas.len() as f64;
     for gamma in &gammas {
-      assert_ulps_eq!(*gamma, mean_gamma, max_ulps = 1000);
+      pretty_assert_ulps_eq!(*gamma, mean_gamma, max_ulps = 1000);
     }
 
     Ok(())
@@ -72,7 +101,7 @@ mod tests {
 
   #[test]
   fn test_relaxed_clock_empty_params_uses_defaults() -> Result<(), Report> {
-    let graph = helpers::build_simple_tree()?;
+    let graph = build_simple_tree()?;
     let one_mutation = 0.01;
 
     apply_relaxed_clock(&graph, &[], one_mutation);
@@ -87,14 +116,14 @@ mod tests {
 
   #[test]
   fn test_relaxed_clock_gamma_stored_in_edges() -> Result<(), Report> {
-    let graph = helpers::build_simple_tree()?;
+    let graph = build_simple_tree()?;
     let one_mutation = 0.01;
     let params = [1.0, 1.0];
 
     // Before: gamma should be default 1.0
     for edge in graph.get_edges() {
       let gamma = edge.read_arc().payload().read_arc().gamma;
-      assert_ulps_eq!(gamma, 1.0, max_ulps = 4);
+      pretty_assert_ulps_eq!(gamma, 1.0, max_ulps = 4);
     }
 
     apply_relaxed_clock(&graph, &params, one_mutation);
@@ -115,7 +144,7 @@ mod tests {
 
   #[test]
   fn test_relaxed_clock_high_slack_pulls_toward_one() -> Result<(), Report> {
-    let graph = helpers::build_deep_tree()?;
+    let graph = build_deep_tree()?;
     let one_mutation = 0.01;
 
     // Compare low slack vs high slack - high slack should have gammas closer to 1.0
@@ -150,7 +179,7 @@ mod tests {
 
   #[test]
   fn test_relaxed_clock_high_coupling_reduces_variation() -> Result<(), Report> {
-    let graph = helpers::build_deep_tree()?;
+    let graph = build_deep_tree()?;
     let one_mutation = 0.01;
 
     // Run with low coupling
@@ -162,7 +191,7 @@ mod tests {
       .iter()
       .map(|e| e.read_arc().payload().read_arc().gamma)
       .collect();
-    let variance_low = helpers::compute_variance(&gammas_low);
+    let variance_low = compute_variance(&gammas_low);
 
     // Run with high coupling
     let params_high = [1.0, 10.0];
@@ -173,7 +202,7 @@ mod tests {
       .iter()
       .map(|e| e.read_arc().payload().read_arc().gamma)
       .collect();
-    let variance_high = helpers::compute_variance(&gammas_high);
+    let variance_high = compute_variance(&gammas_high);
 
     assert!(
       variance_high <= variance_low,
@@ -181,6 +210,12 @@ mod tests {
     );
 
     Ok(())
+  }
+
+  fn compute_variance(values: &[f64]) -> f64 {
+    let n = values.len() as f64;
+    let mean = values.iter().sum::<f64>() / n;
+    values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n
   }
 
   /// Regression test for T3: one_mutation must sum sequence lengths across partitions.
@@ -244,7 +279,7 @@ mod tests {
   /// apply_relaxed_clock should not produce NaN or crash with one_mutation near zero.
   #[test]
   fn test_relaxed_clock_handles_tiny_one_mutation() -> Result<(), Report> {
-    let graph = helpers::build_simple_tree()?;
+    let graph = build_simple_tree()?;
     let params = [1.0, 1.0];
 
     // Simulate what would happen if one_mutation were computed from very short sequences
@@ -308,88 +343,41 @@ mod tests {
   /// - gamma = -0.5 * k1 / k2 = (0.5 + slack) / (slack + 0.5) = 1.0
   ///
   /// This holds for any slack > 0 and any one_mutation > 0.
-  #[test]
-  fn test_relaxed_clock_childless_root_gamma_equals_one() -> Result<(), Report> {
-    // Single-node tree: root with no children
+  #[rstest]
+  #[trace]
+  fn test_relaxed_clock_childless_root_gamma_equals_one(
+    #[values(0.1, 1.0, 10.0, 100.0)] slack: f64,
+    #[values(1e-6, 0.001, 0.01, 0.1, 1.0)] one_mutation: f64,
+  ) -> Result<(), Report> {
     let graph: GraphTimetree = nwk_read_str("root:0.0;")?;
+    let params = [slack, 1.0];
+    apply_relaxed_clock(&graph, &params, one_mutation);
+    Ok(())
+  }
 
-    // Test with various slack values and one_mutation values
-    for slack in [0.1, 1.0, 10.0, 100.0] {
-      for one_mutation in [1e-6, 0.001, 0.01, 0.1, 1.0] {
-        let params = [slack, 1.0]; // coupling doesn't matter for childless root
-        apply_relaxed_clock(&graph, &params, one_mutation);
-
-        // Root gamma is stored in the node's coefficient, but since there's no edge
-        // to store it in, we verify the algorithm completes without panic.
-        // The gamma computation itself should yield exactly 1.0 per the derivation.
-      }
-    }
-
-    // Also test a tree where root gamma IS stored (root with one child, but we
-    // check the computed value before child coupling modifies it).
-    // Create tree where child has equal opt_len and act_len so it doesn't
-    // contribute coupling that would change root gamma from 1.0.
+  /// With opt_len == act_len == one_mutation for both root and child,
+  /// the system has no rate variation to correct, so gamma = 1.0.
+  #[test]
+  fn test_relaxed_clock_childless_root_gamma_stored() -> Result<(), Report> {
     let graph: GraphTimetree = nwk_read_str("(A:0.01)root:0.0;")?;
 
-    // Set time_length = branch_length so opt_len == act_len for child
-    // This means child gamma should also be ~1.0, and coupling preserves it
     for edge in graph.get_edges() {
       let edge = edge.write_arc();
       let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
       edge.payload().write_arc().time_length = Some(branch_length);
     }
 
-    let one_mutation = 0.01; // Same as branch_length
+    let one_mutation = 0.01;
     let params = [1.0, 1.0];
     apply_relaxed_clock(&graph, &params, one_mutation);
 
-    // When opt_len == act_len == one_mutation for both root and child,
-    // the system has no rate variation to correct, so gamma ≈ 1.0
     let gamma = graph
       .get_edges()
       .first()
       .map_or(1.0, |e| e.read_arc().payload().read_arc().gamma);
 
-    assert_ulps_eq!(gamma, 1.0, max_ulps = 100);
+    pretty_assert_ulps_eq!(gamma, 1.0, max_ulps = 100);
 
     Ok(())
-  }
-
-  mod helpers {
-    use super::*;
-
-    /// Build a simple tree with time_length set on edges
-    pub fn build_simple_tree() -> Result<GraphTimetree, Report> {
-      let graph: GraphTimetree = nwk_read_str("(A:0.1,B:0.2)root:0.0;")?;
-
-      // Set time_length on edges (simulating clock inference)
-      for edge in graph.get_edges() {
-        let edge = edge.write_arc();
-        let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
-        // time_length = branch_length * 100 (arbitrary scaling for testing)
-        edge.payload().write_arc().time_length = Some(branch_length * 100.0);
-      }
-
-      Ok(graph)
-    }
-
-    /// Build a deeper tree with time_length set
-    pub fn build_deep_tree() -> Result<GraphTimetree, Report> {
-      let graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2)AB:0.15,(C:0.05,D:0.1)CD:0.08)root:0.0;")?;
-
-      for edge in graph.get_edges() {
-        let edge = edge.write_arc();
-        let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
-        edge.payload().write_arc().time_length = Some(branch_length * 100.0);
-      }
-
-      Ok(graph)
-    }
-
-    pub fn compute_variance(values: &[f64]) -> f64 {
-      let n = values.len() as f64;
-      let mean = values.iter().sum::<f64>() / n;
-      values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n
-    }
   }
 }

--- a/packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs
+++ b/packages/treetime/src/gtr/__tests__/test_gm_gtr_site_specific.rs
@@ -23,13 +23,14 @@ mod tests {
   #[case::two_site_uniform_skewed("two_site_uniform_skewed")]
   #[case::three_site_heterogeneous("three_site_heterogeneous")]
   #[case::single_site_uniform("single_site_uniform")]
+  #[trace]
   fn test_gm_gtr_site_specific_expqt(#[case] case: &str) -> Result<(), Report> {
     let inputs = load_gm_inputs();
     let outputs = load_gm_outputs();
     let input = &inputs.site_specific[case];
     let expected = &outputs.site_specific[case];
 
-    let gtr = helpers::build_from_input(input)?;
+    let gtr = build_from_input(input)?;
 
     // Compare eigenvalues (per-site, sorted per column for ordering independence)
     let expected_eigvals = value_to_array2(&expected.eigenvals);
@@ -38,9 +39,9 @@ mod tests {
       let mut expected_col: Vec<f64> = expected_eigvals.column(a).to_vec();
       actual_col.sort_by_key(|x| ordered_float::OrderedFloat(*x));
       expected_col.sort_by_key(|x| ordered_float::OrderedFloat(*x));
-      for (a_val, e_val) in actual_col.iter().zip(expected_col.iter()) {
-        assert_abs_diff_eq!(a_val, e_val, epsilon = 1e-10);
-      }
+      let actual_arr = Array1::from_vec(actual_col);
+      let expected_arr = Array1::from_vec(expected_col);
+      assert_abs_diff_eq!(expected_arr, actual_arr, epsilon = 1e-10);
     }
 
     // Compare expQt at each captured time point
@@ -56,13 +57,14 @@ mod tests {
   #[rstest]
   #[case::two_site_uniform_skewed("two_site_uniform_skewed")]
   #[case::three_site_heterogeneous("three_site_heterogeneous")]
+  #[trace]
   fn test_gm_gtr_site_specific_propagate_evolve(#[case] case: &str) -> Result<(), Report> {
     let inputs = load_gm_inputs();
     let outputs = load_gm_outputs();
     let input = &inputs.site_specific[case];
     let expected = &outputs.site_specific[case];
 
-    let gtr = helpers::build_from_input(input)?;
+    let gtr = build_from_input(input)?;
 
     for (profile_name, profile_output) in &expected.profiles {
       let profile_data = &inputs.profiles[profile_name.as_str()];
@@ -147,13 +149,14 @@ mod tests {
   #[case::two_site_uniform_skewed("two_site_uniform_skewed")]
   #[case::three_site_heterogeneous("three_site_heterogeneous")]
   #[case::single_site_uniform("single_site_uniform")]
+  #[trace]
   fn test_gm_gtr_site_specific_approximate(#[case] case: &str) -> Result<(), Report> {
     let inputs = load_gm_inputs();
     let outputs = load_gm_outputs();
     let input = &inputs.site_specific[case];
     let expected = &outputs.approximate[case];
 
-    let gtr = helpers::build_from_input_approximate(input)?;
+    let gtr = build_from_input_approximate(input)?;
 
     for entry in &expected.exp_qts {
       let actual = gtr.expQt(entry.time)?;
@@ -167,49 +170,48 @@ mod tests {
     Ok(())
   }
 
+  fn parse_input(input: &serde_json::Value) -> (usize, usize, Array1<f64>, Option<Array2<f64>>, Array2<f64>) {
+    let n_states = input["n_states"].as_u64().unwrap() as usize;
+    let seq_len = input["seq_len"].as_u64().unwrap() as usize;
+    let mu: Vec<f64> = serde_json::from_value(input["mu"].clone()).unwrap();
+    let mu = Array1::from_vec(mu);
+    let pi = value_to_array2(&input["pi"]);
+    let W: Option<Array2<f64>> = if input["W"].is_null() {
+      None
+    } else {
+      Some(value_to_array2(&input["W"]))
+    };
+    (n_states, seq_len, mu, W, pi)
+  }
+
+  fn build_from_input(input: &serde_json::Value) -> Result<GTRSiteSpecific, Report> {
+    let (n_states, seq_len, mu, W, pi) = parse_input(input);
+    GTRSiteSpecific::new(GTRSiteSpecificParams {
+      n_states,
+      seq_len,
+      mu,
+      W,
+      pi,
+      approximate: false,
+    })
+  }
+
+  fn build_from_input_approximate(input: &serde_json::Value) -> Result<GTRSiteSpecific, Report> {
+    let (n_states, seq_len, mu, W, pi) = parse_input(input);
+    GTRSiteSpecific::new(GTRSiteSpecificParams {
+      n_states,
+      seq_len,
+      mu,
+      W,
+      pi,
+      approximate: true,
+    })
+  }
+
   mod helpers {
-    use super::*;
     use indexmap::IndexMap;
     use serde::Deserialize;
     use std::fs::read_to_string;
-
-    pub fn parse_input(input: &serde_json::Value) -> (usize, usize, Array1<f64>, Option<Array2<f64>>, Array2<f64>) {
-      let n_states = input["n_states"].as_u64().unwrap() as usize;
-      let seq_len = input["seq_len"].as_u64().unwrap() as usize;
-      let mu: Vec<f64> = serde_json::from_value(input["mu"].clone()).unwrap();
-      let mu = Array1::from_vec(mu);
-      let pi = value_to_array2(&input["pi"]);
-      let W: Option<Array2<f64>> = if input["W"].is_null() {
-        None
-      } else {
-        Some(value_to_array2(&input["W"]))
-      };
-      (n_states, seq_len, mu, W, pi)
-    }
-
-    pub fn build_from_input(input: &serde_json::Value) -> Result<GTRSiteSpecific, Report> {
-      let (n_states, seq_len, mu, W, pi) = parse_input(input);
-      GTRSiteSpecific::new(GTRSiteSpecificParams {
-        n_states,
-        seq_len,
-        mu,
-        W,
-        pi,
-        approximate: false,
-      })
-    }
-
-    pub fn build_from_input_approximate(input: &serde_json::Value) -> Result<GTRSiteSpecific, Report> {
-      let (n_states, seq_len, mu, W, pi) = parse_input(input);
-      GTRSiteSpecific::new(GTRSiteSpecificParams {
-        n_states,
-        seq_len,
-        mu,
-        W,
-        pi,
-        approximate: true,
-      })
-    }
 
     #[derive(Debug, Deserialize)]
     pub struct ExpQtEntry {

--- a/packages/treetime/src/seq/__tests__/test_div.rs
+++ b/packages/treetime/src/seq/__tests__/test_div.rs
@@ -10,6 +10,7 @@ mod tests {
   use pretty_assertions::assert_eq;
   use treetime_graph::graph::Graph;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_utils::pretty_assert_map_abs_diff_eq;
 
   // OnlyLeaves(false) - all nodes
   #[test]
@@ -28,10 +29,7 @@ mod tests {
       o!("D") => 0.17,
     };
 
-    assert_eq!(expected.len(), actual.len());
-    for (name, expected_div) in &expected {
-      assert_abs_diff_eq!(actual[name], *expected_div, epsilon = 1e-8);
-    }
+    pretty_assert_map_abs_diff_eq!(expected, &actual, epsilon = 1e-8);
 
     Ok(())
   }
@@ -50,10 +48,7 @@ mod tests {
       o!("D") => 0.17,
     };
 
-    assert_eq!(expected.len(), actual.len());
-    for (name, expected_div) in &expected {
-      assert_abs_diff_eq!(actual[name], *expected_div, epsilon = 1e-8);
-    }
+    pretty_assert_map_abs_diff_eq!(expected, &actual, epsilon = 1e-8);
 
     Ok(())
   }
@@ -72,10 +67,7 @@ mod tests {
       o!("D") => 0.17,
     };
 
-    assert_eq!(expected.len(), actual.len());
-    for (name, expected_div) in &expected {
-      assert_abs_diff_eq!(actual[name], *expected_div, epsilon = 1e-8);
-    }
+    pretty_assert_map_abs_diff_eq!(expected, &actual, epsilon = 1e-8);
 
     Ok(())
   }
@@ -143,10 +135,7 @@ mod tests {
       o!("D") => 0.1,
     };
 
-    assert_eq!(expected.len(), actual.len());
-    for (name, expected_div) in &expected {
-      assert_abs_diff_eq!(actual[name], *expected_div, epsilon = 1e-8);
-    }
+    pretty_assert_map_abs_diff_eq!(expected, &actual, epsilon = 1e-8);
 
     Ok(())
   }

--- a/packages/treetime/src/seq/__tests__/test_indel.rs
+++ b/packages/treetime/src/seq/__tests__/test_indel.rs
@@ -173,60 +173,54 @@ mod tests {
     assert_eq!(result, expected);
   }
 
-  #[test]
-  fn test_indel_compose_output_sorted_invariant() {
-    // Verify sortedness across multiple mixed-type configurations
-    let cases: Vec<(Vec<InDel>, Vec<InDel>)> = vec![
-      (vec![del(5, 8, "ACG")], vec![ins(1, 4, "TTT")]),
-      (vec![ins(1, 4, "TTT")], vec![del(5, 8, "ACG")]),
-      (vec![del(1, 5, "ACGT")], vec![ins(3, 7, "TTTT")]),
-      (vec![ins(3, 7, "TTTT")], vec![del(1, 5, "ACGT")]),
-      (vec![del(1, 3, "CG"), del(6, 8, "AT")], vec![del(4, 5, "T")]),
-    ];
-    for (parent, child) in &cases {
-      let result = compose_indels(parent, child);
-      for w in result.windows(2) {
-        let [a, b] = w else { continue };
-        assert!(
-          a.range.0 <= b.range.0,
-          "output not sorted for parent={parent:?}, child={child:?}: result={result:?}"
-        );
-      }
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::del_after_ins(  vec![del(5, 8, "ACG")],                vec![ins(1, 4, "TTT")])]
+  #[case::ins_before_del( vec![ins(1, 4, "TTT")],                vec![del(5, 8, "ACG")])]
+  #[case::overlap_del_ins(vec![del(1, 5, "ACGT")],               vec![ins(3, 7, "TTTT")])]
+  #[case::overlap_ins_del(vec![ins(3, 7, "TTTT")],               vec![del(1, 5, "ACGT")])]
+  #[case::multi_del(      vec![del(1, 3, "CG"), del(6, 8, "AT")], vec![del(4, 5, "T")])]
+  #[trace]
+  fn test_indel_compose_output_sorted_invariant(#[case] parent: Vec<InDel>, #[case] child: Vec<InDel>) {
+    let result = compose_indels(&parent, &child);
+    for w in result.windows(2) {
+      let [a, b] = w else { continue };
+      assert!(
+        a.range.0 <= b.range.0,
+        "output not sorted: result={result:?}"
+      );
     }
   }
 
-  #[test]
-  fn test_indel_compose_cancellation_roundtrip() {
-    // del then ins of same content cancels, regardless of range
-    let ranges = [(0, 3), (5, 10), (100, 105)];
-    let seqs = ["ACG", "ACGTC", "TTTTT"];
-    for ((start, end), seq) in ranges.iter().zip(seqs.iter()) {
-      let result = compose_indels(&[del(*start, *end, seq)], &[ins(*start, *end, seq)]);
-      assert_eq!(result, vec![], "del+ins of '{seq}' at ({start},{end}) should cancel");
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::short(  (0,   3),   "ACG")]
+  #[case::medium( (5,   10),  "ACGTC")]
+  #[case::long(   (100, 105), "TTTTT")]
+  #[trace]
+  fn test_indel_compose_cancellation_roundtrip(#[case] (start, end): (usize, usize), #[case] seq: &str) {
+    let result = compose_indels(&[del(start, end, seq)], &[ins(start, end, seq)]);
+    assert_eq!(result, vec![], "del+ins should cancel");
 
-      let result = compose_indels(&[ins(*start, *end, seq)], &[del(*start, *end, seq)]);
-      assert_eq!(result, vec![], "ins+del of '{seq}' at ({start},{end}) should cancel");
-    }
+    let result = compose_indels(&[ins(start, end, seq)], &[del(start, end, seq)]);
+    assert_eq!(result, vec![], "ins+del should cancel");
   }
 
-  #[test]
-  fn test_indel_compose_seq_length_invariant() {
-    // Every output indel must have seq.len() == range.1 - range.0
-    let cases: Vec<(Vec<InDel>, Vec<InDel>)> = vec![
-      (vec![del(1, 3, "CG")], vec![del(2, 5, "TAC")]),
-      (vec![del(0, 2, "AC")], vec![del(2, 4, "GT"), del(4, 6, "CG")]),
-      (vec![del(1, 4, "CGT")], vec![ins(1, 4, "TTT")]),
-      (vec![ins(1, 4, "TTT")], vec![ins(1, 4, "GGG")]),
-    ];
-    for (parent, child) in &cases {
-      let result = compose_indels(parent, child);
-      for indel in &result {
-        assert_eq!(
-          indel.seq.len(),
-          indel.range.1 - indel.range.0,
-          "seq length mismatch for {indel:?}"
-        );
-      }
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::partial_overlap(  vec![del(1, 3, "CG")],  vec![del(2, 5, "TAC")])]
+  #[case::triple_merge(     vec![del(0, 2, "AC")],   vec![del(2, 4, "GT"), del(4, 6, "CG")])]
+  #[case::del_then_ins(     vec![del(1, 4, "CGT")],  vec![ins(1, 4, "TTT")])]
+  #[case::ins_then_ins(     vec![ins(1, 4, "TTT")],  vec![ins(1, 4, "GGG")])]
+  #[trace]
+  fn test_indel_compose_seq_length_invariant(#[case] parent: Vec<InDel>, #[case] child: Vec<InDel>) {
+    let result = compose_indels(&parent, &child);
+    for indel in &result {
+      assert_eq!(
+        indel.seq.len(),
+        indel.range.1 - indel.range.0,
+        "seq length mismatch for {indel:?}"
+      );
     }
   }
 


### PR DESCRIPTION
- Depends on: #650

Test files used two anti-patterns that obscure failures: element-by-element zip loops that stop at the first mismatch and report only one element, and for-loop test cases that collapse N behaviors into one pass/fail.

Replace element-by-element zip assertion loops with whole-array comparison macros (`pretty_assert_ulps_eq!`, `assert_ulps_eq!`, `assert_abs_diff_eq!`, `pretty_assert_map_abs_diff_eq!`). Convert loop-over-test-cases patterns to rstest parameterized tests, giving each case its own pass/fail and enabling runner filtering by case name. Use rstest `#[values]` for the slack-times-one_mutation cross-product in relaxed clock tests.

Proptest structural loops (non-negativity checks, column-sum invariants, symmetry verification) are left unchanged -- they check per-element invariants with diagnostic context, not test-case iteration.

### Work items

- [x] Replace zip assertion loops with `pretty_assert_ulps_eq!` and `pretty_assert_map_abs_diff_eq!` in `test_alphabet`, `test_alphabet_config`, `test_multiply`, `test_gm_gtr_site_specific`, `test_gm_mugration`, `test_div`
- [x] Convert ambiguous-mapping loop-over-cases to rstest with 13 cases in `test_alphabet`
- [x] Convert invariant-checking loops to rstest parameterized in `test_indel`
- [x] Convert sample-point loops to rstest parameterized in `test_branch_length_likelihood`
- [x] Convert Poisson shape for-loop to rstest parameterized, split peak test, move `eval` to `mod helpers` in `test_branch_length_likelihood`
- [x] Convert nested parameter loop to rstest `#[values]` cross-product in `test_relaxed_clock`
- [x] Mark loop-over-cases and element-by-element sections RESOLVED in `kb/issues/N-test-quality-deficiencies.md`