### PR TITLE
fix: restore test conventions from stack regressions

### DIFF
--- a/packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs
+++ b/packages/treetime/src/commands/timetree/optimization/__tests__/test_relaxed_clock.rs
@@ -7,33 +7,7 @@ mod tests {
   use rstest::rstest;
   use treetime_io::nwk::nwk_read_str;
 
-  /// Build a simple tree with time_length set on edges
-  fn build_simple_tree() -> Result<GraphTimetree, Report> {
-    let graph: GraphTimetree = nwk_read_str("(A:0.1,B:0.2)root:0.0;")?;
-
-    // Set time_length on edges (simulating clock inference)
-    for edge in graph.get_edges() {
-      let edge = edge.write_arc();
-      let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
-      // time_length = branch_length * 100 (arbitrary scaling for testing)
-      edge.payload().write_arc().time_length = Some(branch_length * 100.0);
-    }
-
-    Ok(graph)
-  }
-
-  /// Build a deeper tree with time_length set
-  fn build_deep_tree() -> Result<GraphTimetree, Report> {
-    let graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2)AB:0.15,(C:0.05,D:0.1)CD:0.08)root:0.0;")?;
-
-    for edge in graph.get_edges() {
-      let edge = edge.write_arc();
-      let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
-      edge.payload().write_arc().time_length = Some(branch_length * 100.0);
-    }
-
-    Ok(graph)
-  }
+  use helpers::{build_deep_tree, build_simple_tree, compute_variance};
 
   #[test]
   fn test_relaxed_clock_default_params_produce_reasonable_gamma() -> Result<(), Report> {
@@ -212,12 +186,6 @@ mod tests {
     Ok(())
   }
 
-  fn compute_variance(values: &[f64]) -> f64 {
-    let n = values.len() as f64;
-    let mean = values.iter().sum::<f64>() / n;
-    values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n
-  }
-
   /// Regression test for T3: one_mutation must sum sequence lengths across partitions.
   /// Different one_mutation values produce different gamma values.
   /// This validates that the calculation in refinement.rs matters.
@@ -352,6 +320,12 @@ mod tests {
     let graph: GraphTimetree = nwk_read_str("root:0.0;")?;
     let params = [slack, 1.0];
     apply_relaxed_clock(&graph, &params, one_mutation);
+
+    for edge in graph.get_edges() {
+      let gamma = edge.read_arc().payload().read_arc().gamma;
+      pretty_assert_ulps_eq!(gamma, 1.0, max_ulps = 4);
+    }
+
     Ok(())
   }
 
@@ -379,5 +353,36 @@ mod tests {
     pretty_assert_ulps_eq!(gamma, 1.0, max_ulps = 100);
 
     Ok(())
+  }
+
+  mod helpers {
+    use super::*;
+
+    pub fn build_simple_tree() -> Result<GraphTimetree, Report> {
+      let graph: GraphTimetree = nwk_read_str("(A:0.1,B:0.2)root:0.0;")?;
+      for edge in graph.get_edges() {
+        let edge = edge.write_arc();
+        let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
+        edge.payload().write_arc().time_length = Some(branch_length * 100.0);
+      }
+      Ok(graph)
+    }
+
+    pub fn build_deep_tree() -> Result<GraphTimetree, Report> {
+      let graph: GraphTimetree =
+        nwk_read_str("((A:0.1,B:0.2)AB:0.15,(C:0.05,D:0.1)CD:0.08)root:0.0;")?;
+      for edge in graph.get_edges() {
+        let edge = edge.write_arc();
+        let branch_length = edge.payload().read_arc().base.branch_length.unwrap_or(0.0);
+        edge.payload().write_arc().time_length = Some(branch_length * 100.0);
+      }
+      Ok(graph)
+    }
+
+    pub fn compute_variance(values: &[f64]) -> f64 {
+      let n = values.len() as f64;
+      let mean = values.iter().sum::<f64>() / n;
+      values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n
+    }
   }
 }

--- a/packages/treetime/src/seq/__tests__/test_find_char_ranges.rs
+++ b/packages/treetime/src/seq/__tests__/test_find_char_ranges.rs
@@ -12,6 +12,7 @@ mod tests {
   #[case::two_ranges("ATGXXXCATGXXXXA",  b'X', vec![(3, 6), (10, 14)])]
   #[case::at_end("GCAXXXX",          b'X', vec![(3, 7)])]
   #[case::at_start("XXXXGCA",          b'X', vec![(0, 4)])]
+  #[trace]
   fn test_find_letter_ranges(#[case] s: &str, #[case] letter: u8, #[case] expected: Vec<(usize, usize)>) {
     let actual = find_letter_ranges(&helpers::seq(s), helpers::c(letter));
     assert_eq!(expected, actual);
@@ -25,6 +26,7 @@ mod tests {
   #[case::two_ranges("ATGNNNCATGNNNNA", vec![(3, 6), (10, 14)])]
   #[case::at_end("GCANNNN",         vec![(3, 7)])]
   #[case::at_start("NNNNGCA",         vec![(0, 4)])]
+  #[trace]
   fn test_find_ambiguous_ranges(#[case] s: &str, #[case] expected: Vec<(usize, usize)>) {
     let actual = find_letter_ranges(&helpers::seq(s), helpers::c(b'N'));
     assert_eq!(expected, actual);
@@ -38,6 +40,7 @@ mod tests {
   #[case::two_ranges("ATG---CATG----A", vec![(3, 6), (10, 14)])]
   #[case::at_end("GCA----",         vec![(3, 7)])]
   #[case::at_start("----GCA",         vec![(0, 4)])]
+  #[trace]
   fn test_find_gap_ranges(#[case] s: &str, #[case] expected: Vec<(usize, usize)>) {
     let actual = find_letter_ranges(&helpers::seq(s), helpers::c(b'-'));
     assert_eq!(expected, actual);
@@ -56,6 +59,7 @@ mod tests {
   #[case::alternating_n_gaps("ANNNNT----GNNNNC", vec![(1, 5), (6, 10), (11, 15)])]
   #[case::n_middle_gaps_end("ATGNNNTTTT---",    vec![(3, 6), (10, 13)])]
   #[case::gaps_middle_n_end("ATG---TTTTNNN",    vec![(3, 6), (10, 13)])]
+  #[trace]
   fn test_find_undetermined_ranges(#[case] s: &str, #[case] expected: Vec<(usize, usize)>) {
     let actual = find_letter_ranges_by(&helpers::seq(s), |ch| ch == helpers::c(b'N') || ch == helpers::c(b'-'));
     assert_eq!(expected, actual);


### PR DESCRIPTION
- Depends on: #660

PRs #647-#651 were authored as a stack where later PRs changed approach without rebasing earlier ones. The final merged state has three convention regressions: missing `#[trace]` attributes on parameterized tests, a vacuous assertion (test name claims `gamma_equals_one` but no assertion verifies it), and helper functions placed before tests instead of in `mod helpers`.

This PR restores the intended conventions without modifying the original PRs.

### Work items

- [x] Add `#[trace]` to 4 rstest tests in `test_find_char_ranges.rs`
- [x] Add `gamma == 1.0` assertion to `test_relaxed_clock_childless_root_gamma_equals_one` (20 parameterized cases)
- [x] Move `build_simple_tree`, `build_deep_tree`, `compute_variance` to `mod helpers` after all tests