### PR TITLE
fix: standardize KB citation formatting with Style A references

### DIFF
--- a/kb/algo/README.md
+++ b/kb/algo/README.md
@@ -78,30 +78,30 @@ Sagulenko, P., Puller, V., & Neher, R.A. (2018). "TreeTime: Maximum-likelihood p
 
 ### Phylogenetics
 
-- Felsenstein (1981). "Evolutionary trees from DNA sequences." J Mol Evol, 17(6):368-376. doi:10.1007/BF01734359
+- Felsenstein (1981). "Evolutionary trees from DNA sequences." J Mol Evol, 17(6):368-376. https://doi.org/10.1007/BF01734359
 - Felsenstein (2003). "Inferring Phylogenies." Sinauer Associates. ISBN 978-0-87893-177-4
 - Yang (2006). "Computational Molecular Evolution." Oxford University Press. ISBN 978-0-19-856702-8
 
 ### Substitution Models
 
 - Jukes & Cantor (1969). "Evolution of Protein Molecules." In Munro (ed.), Mammalian Protein Metabolism, vol. 3, pp. 21-132. Academic Press
-- Kimura (1980). "A simple method for estimating evolutionary rates of base substitutions through comparative studies of nucleotide sequences." J Mol Evol, 16(2):111-120. doi:10.1007/BF01731581
-- Hasegawa, Kishino & Yano (1985). "Dating of the human-ape splitting by a molecular clock of mitochondrial DNA." J Mol Evol, 22(2):160-174. doi:10.1007/BF02101694
-- Tamura & Nei (1993). "Estimation of the number of nucleotide substitutions in the control region of mitochondrial DNA in humans and chimpanzees." Mol Biol Evol, 10(3):512-526. doi:10.1093/oxfordjournals.molbev.a040023
-- Jones, Taylor & Thornton (1992). "The rapid generation of mutation data matrices from protein sequences." CABIOS, 8(3):275-282. doi:10.1093/bioinformatics/8.3.275
+- Kimura (1980). "A simple method for estimating evolutionary rates of base substitutions through comparative studies of nucleotide sequences." J Mol Evol, 16(2):111-120. https://doi.org/10.1007/BF01731581
+- Hasegawa, Kishino & Yano (1985). "Dating of the human-ape splitting by a molecular clock of mitochondrial DNA." J Mol Evol, 22(2):160-174. https://doi.org/10.1007/BF02101694
+- Tamura & Nei (1993). "Estimation of the number of nucleotide substitutions in the control region of mitochondrial DNA in humans and chimpanzees." Mol Biol Evol, 10(3):512-526. https://doi.org/10.1093/oxfordjournals.molbev.a040023
+- Jones, Taylor & Thornton (1992). "The rapid generation of mutation data matrices from protein sequences." CABIOS, 8(3):275-282. https://doi.org/10.1093/bioinformatics/8.3.275
 
 ### Coalescent
 
-- Kingman (1982). "The coalescent." Stochastic Processes and their Applications, 13(3):235-248. doi:10.1016/0304-4149(82)90011-4
-- Strimmer & Pybus (2001). "Exploring the demographic history of DNA sequences using the generalized skyline plot." Mol Biol Evol, 18(12):2298-2305. doi:10.1093/oxfordjournals.molbev.a003776
-- Drummond, Rambaut, Shapiro & Pybus (2005). "Bayesian coalescent inference of past population dynamics from molecular sequences." Mol Biol Evol, 22(5):1185-1192. doi:10.1093/molbev/msi103
-- Minin, Bloomquist & Suchard (2008). "Smooth skyride through a rough skyline: Bayesian coalescent-based inference of population dynamics." Mol Biol Evol, 25(7):1459-1471. doi:10.1093/molbev/msn090
+- Kingman (1982). "The coalescent." Stochastic Processes and their Applications, 13(3):235-248. https://doi.org/10.1016/0304-4149(82)90011-4
+- Strimmer & Pybus (2001). "Exploring the demographic history of DNA sequences using the generalized skyline plot." Mol Biol Evol, 18(12):2298-2305. https://doi.org/10.1093/oxfordjournals.molbev.a003776
+- Drummond, Rambaut, Shapiro & Pybus (2005). "Bayesian coalescent inference of past population dynamics from molecular sequences." Mol Biol Evol, 22(5):1185-1192. https://doi.org/10.1093/molbev/msi103
+- Minin, Bloomquist & Suchard (2008). "Smooth skyride through a rough skyline: Bayesian coalescent-based inference of population dynamics." Mol Biol Evol, 25(7):1459-1471. https://doi.org/10.1093/molbev/msn090
 
 ### Relaxed Clock
 
-- Thorne, Kishino & Painter (1998). "Estimating the rate of evolution of the rate of molecular evolution." Mol Biol Evol, 15(12):1647-1657. doi:10.1093/oxfordjournals.molbev.a025892
-- Drummond, Ho, Phillips & Rambaut (2006). "Relaxed phylogenetics and dating with confidence." PLOS Biology, 4(5):e88. doi:10.1371/journal.pbio.0040088
-- Lepage, Bryant, Philippe & Lartillot (2007). "A general comparison of relaxed molecular clock models." Mol Biol Evol, 24(12):2669-2680. doi:10.1093/molbev/msm193
+- Thorne, Kishino & Painter (1998). "Estimating the rate of evolution of the rate of molecular evolution." Mol Biol Evol, 15(12):1647-1657. https://doi.org/10.1093/oxfordjournals.molbev.a025892
+- Drummond, Ho, Phillips & Rambaut (2006). "Relaxed phylogenetics and dating with confidence." PLOS Biology, 4(5):e88. https://doi.org/10.1371/journal.pbio.0040088
+- Lepage, Bryant, Philippe & Lartillot (2007). "A general comparison of relaxed molecular clock models." Mol Biol Evol, 24(12):2669-2680. https://doi.org/10.1093/molbev/msm193
 
 ### Numerical Methods
 

--- a/kb/algo/ancestral.md
+++ b/kb/algo/ancestral.md
@@ -4,7 +4,7 @@
 
 ## Fitch Parsimony
 
-Maximum parsimony (Fitch 1971) reconstructs ancestral character states by minimizing the total number of state changes on the tree. The method makes no assumptions about branch lengths or substitution rates, treating all state transitions as equally costly. It remains widely used for seeding ML optimization with initial ancestral assignments due to its speed, and for compression of sequence data to variable-position-only representations.
+Maximum parsimony (<a id="cite-1"></a>[Fitch 1971](https://doi.org/10.2307/2412116) [[1](#ref-1)]) reconstructs ancestral character states by minimizing the total number of state changes on the tree. The method makes no assumptions about branch lengths or substitution rates, treating all state transitions as equally costly. It remains widely used for seeding ML optimization with initial ancestral assignments due to its speed, and for compression of sequence data to variable-position-only representations.
 
 v1: [`packages/treetime/src/commands/ancestral/fitch.rs#L85-L513`](../../packages/treetime/src/commands/ancestral/fitch.rs#L85-L513).
 v0: [`packages/legacy/treetime/treetime/treeanc.py#L575-L686`](../../packages/legacy/treetime/treetime/treeanc.py#L575-L686).
@@ -35,15 +35,15 @@ v1 uses deterministic `get_one()` (`#get_one`) for root state selection when the
 
 ### References
 
-- Fitch (1971). "Toward Defining the Course of Evolution: Minimum Change for a Specific Tree Topology." Systematic Zoology, 20(4):406-416. doi:10.2307/2412116
-- Farris (1970). "Methods for Computing Wagner Trees." Systematic Zoology, 19(1):83-92. doi:10.2307/2412028
-- Felsenstein (1978). "Cases in which Parsimony or Compatibility Methods Will be Positively Misleading." Systematic Zoology, 27(4):401-410. doi:10.2307/2412923
+- <a id="ref-1"></a>Fitch, Walter M. 1971. "Toward Defining the Course of Evolution: Minimum Change for a Specific Tree Topology." _Systematic Zoology_ 20(4):406-416. https://doi.org/10.2307/2412116 [↩](#cite-1)
+- <a id="ref-2"></a>Farris, James S. 1970. "Methods for Computing Wagner Trees." _Systematic Zoology_ 19(1):83-92. https://doi.org/10.2307/2412028
+- <a id="ref-3"></a>Felsenstein, Joseph. 1978. "Cases in which Parsimony or Compatibility Methods Will be Positively Misleading." _Systematic Zoology_ 27(4):401-410. https://doi.org/10.2307/2412923
 
 ---
 
 ## Marginal ML
 
-Maximum likelihood ancestral reconstruction via the Felsenstein pruning algorithm (Felsenstein 1981), equivalent to the sum-product algorithm (belief propagation) on a tree-structured factor graph (Pearl 1988). Each site is treated independently: the total likelihood is a product over sites.
+Maximum likelihood ancestral reconstruction via the Felsenstein pruning algorithm (<a id="cite-4"></a>[Felsenstein 1981](https://doi.org/10.1007/BF01734359) [[4](#ref-4)]), equivalent to the sum-product algorithm (belief propagation) on a tree-structured factor graph (<a id="cite-5"></a>[Pearl 1988](https://doi.org/10.1016/B978-0-08-051489-5.50001-5) [[5](#ref-5)]). Each site is treated independently: the total likelihood is a product over sites.
 
 The algorithm computes partial likelihoods at each node - the probability of observing the data in the node's subtree given each possible ancestral state. For an internal node k with children i and j:
 
@@ -80,22 +80,24 @@ O(n _ k^2 _ L) total for n nodes, k alphabet states (4 for nucleotides, 20 for a
 
 ### References
 
-- Felsenstein (1981). "Evolutionary trees from DNA sequences: a maximum likelihood approach." J Mol Evol, 17(6):368-376. doi:10.1007/BF01734359
-- Pearl (1988). "Probabilistic Reasoning in Intelligent Systems." Morgan Kaufmann. (Sum-product / belief propagation on graphical models.)
-- Kschischang, Frey & Loeliger (2001). "Factor Graphs and the Sum-Product Algorithm." IEEE Trans Inform Theory, 47(2):498-519. doi:10.1109/18.910572
+- <a id="ref-4"></a>Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359 [↩](#cite-4)
+- <a id="ref-5"></a>Pearl, Judea. 1988. _Probabilistic Reasoning in Intelligent Systems: Networks of Plausible Inference._ Morgan Kaufmann. ISBN 978-0-934613-73-2. [↩](#cite-5)
+- <a id="ref-6"></a>Kschischang, Frank R., Brendan J. Frey, and Hans-Andrea Loeliger. 2001. "Factor Graphs and the Sum-Product Algorithm." _IEEE Transactions on Information Theory_ 47(2):498-519. https://doi.org/10.1109/18.910572
 
 ---
 
 ## Joint ML (Unimplemented)
 
-Joint maximum likelihood reconstruction (Pupko et al. 2000) finds the single most likely assignment of ancestral states across all nodes simultaneously, rather than marginalizing over alternatives at each node independently. Uses traceback pointers (argmax) instead of marginalization (sum), analogous to the Viterbi algorithm for HMMs vs the forward-backward algorithm.
+Joint maximum likelihood reconstruction (<a id="cite-7"></a>[Pupko et al. 2000](https://doi.org/10.1093/oxfordjournals.molbev.a026369) [[7](#ref-7)]) finds the single most likely assignment of ancestral states across all nodes simultaneously, rather than marginalizing over alternatives at each node independently. Uses traceback pointers (argmax) instead of marginalization (sum), analogous to the Viterbi algorithm for HMMs vs the forward-backward algorithm.
 
 v1: `unimplemented!()` at [`packages/treetime/src/commands/ancestral/run.rs#L199`](../../packages/treetime/src/commands/ancestral/run.rs#L199). Intentionally removed - see [intentional change](../decisions/ancestral-joint-reconstruction-removed.md).
 v0: [`packages/legacy/treetime/treetime/treeanc.py#L934-L1080`](../../packages/legacy/treetime/treetime/treeanc.py#L934-L1080).
 
 See [unimplemented](unimplemented.md#joint-ml) for full v0 algorithm details.
 
-Reference: Pupko, Pe'er, Shamir & Graur (2000). "A fast algorithm for joint reconstruction of ancestral amino acid sequences." Mol Biol Evol, 17(6):890-896. doi:10.1093/oxfordjournals.molbev.a026369
+### References
+
+- <a id="ref-7"></a>Pupko, Tal, Itsik Pe'er, Ron Shamir, and Dan Graur. 2000. "A Fast Algorithm for Joint Reconstruction of Ancestral Amino Acid Sequences." _Molecular Biology and Evolution_ 17(6):890-896. https://doi.org/10.1093/oxfordjournals.molbev.a026369 [↩](#cite-7)
 
 ---
 

--- a/kb/algo/clock.md
+++ b/kb/algo/clock.md
@@ -4,7 +4,7 @@
 
 ## WLS Sufficient Statistics
 
-TreeTime estimates the molecular clock rate via weighted least squares (WLS) regression of root-to-tip divergence against sampling dates (Sagulenko, Puller & Neher 2018, Equations 11-14). Rather than materializing the full N x N covariance matrix for generalized least squares, TreeTime propagates six sufficient statistics through the tree in O(N) time using the `ClockSet` data structure:
+TreeTime estimates the molecular clock rate via weighted least squares (WLS) regression of root-to-tip divergence against sampling dates (<a id="cite-1"></a>[Sagulenko, Puller, and Neher 2018](https://doi.org/10.1093/ve/vex042) [[1](#ref-1)], Equations 11-14). Rather than materializing the full N x N covariance matrix for generalized least squares, TreeTime propagates six sufficient statistics through the tree in O(N) time using the `ClockSet` data structure:
 
 - `t_sum`: sum of weighted dates
 - `tsq_sum`: sum of weighted squared dates
@@ -20,15 +20,15 @@ v0: [`packages/legacy/treetime/treetime/treeregression.py#L7-L300`](../../packag
 
 Key functions: `ClockSet::clock_rate()` (`#ClockSet`, `#clock_rate`), `ClockSet::chisq()` (`#chisq`), `ClockSet::propagate_averages()` (`#propagate_averages`).
 
-References:
+### References
 
-- Sagulenko, Puller & Neher (2018). "TreeTime: Maximum-likelihood phylodynamic analysis." Virus Evolution, 4(1):vex042, Equations 11-14. doi:10.1093/ve/vex042
+- <a id="ref-1"></a>Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evolution_ 4(1):vex042. https://doi.org/10.1093/ve/vex042 [↩](#cite-1)
 
 ---
 
 ## Tree Regression
 
-Two-pass message passing that implements phylogenetic GLS regression in O(N) time. Standard OLS assumes independent residuals, but in phylogenetic data, samples sharing internal branches have correlated root-to-tip distances. The tree regression accounts for this by propagating weighted statistics along the tree structure, equivalent to GLS with a phylogenetic covariance matrix but without materializing the N x N matrix.
+Two-pass message passing that implements phylogenetic GLS regression (<a id="cite-2"></a>[Felsenstein 1985](https://doi.org/10.1086/284325) [[2](#ref-2)]) in O(N) time. Standard OLS assumes independent residuals, but in phylogenetic data, samples sharing internal branches have correlated root-to-tip distances. The tree regression accounts for this by propagating weighted statistics along the tree structure, equivalent to GLS with a phylogenetic covariance matrix but without materializing the N x N matrix.
 
 The backward pass (postorder) accumulates `ClockSet` statistics from leaves toward the root. Each leaf contributes its date and divergence. Internal nodes merge children's statistics via `propagate_averages()`. The forward pass (preorder) propagates root-level statistics back down, enabling the best root position search: at each node, the regression can be re-evaluated as if that node were the root by combining the subtree statistics (from the backward pass) with the complement statistics (from the forward pass).
 
@@ -43,44 +43,50 @@ The `ClockParams` (`#ClockParams`) struct at [`packages/treetime/src/commands/cl
 
 Key functions: `clock_regression_backward()` (`#clock_regression_backward`), `clock_regression_forward()` (`#clock_regression_forward`), `estimate_clock_model_with_reroot()` (`#estimate_clock_model_with_reroot`), `estimate_clock_model_with_reroot_policy()` (`#estimate_clock_model_with_reroot_policy`).
 
-References:
+### References
 
-- Felsenstein (1985). "Phylogenies and the comparative method." American Naturalist, 125(1):1-15. doi:10.1086/284325 (Phylogenetic independent contrasts, a special case of PGLS under Brownian motion.)
-- Sagulenko, Puller & Neher (2018). "TreeTime." Virus Evolution, 4(1):vex042.
+- <a id="ref-2"></a>Felsenstein, Joseph. 1985. "Phylogenies and the Comparative Method." _American Naturalist_ 125(1):1-15. https://doi.org/10.1086/284325 [↩](#cite-2)
+- Sagulenko, Puller, and Neher 2018 [[1](#ref-1)]
 
 ---
 
 ## Brent's Method
 
-Hybrid 1D optimization combining parabolic interpolation (fast convergence near minimum) with golden section search (guaranteed convergence). Used for optimizing the root position along a branch: given a branch with endpoints, Brent's method finds the split point that minimizes the clock regression chi-squared.
+Hybrid 1D optimization (<a id="cite-3"></a>[Brent 1973](https://doi.org/10.1007/978-3-0348-5952-3) [[3](#ref-3)]) combining parabolic interpolation (fast convergence near minimum) with golden section search (guaranteed convergence). Used for optimizing the root position along a branch: given a branch with endpoints, Brent's method finds the split point that minimizes the clock regression chi-squared.
 
 v1: [`packages/treetime/src/commands/clock/find_best_root/method_brent.rs#L36-L78`](../../packages/treetime/src/commands/clock/find_best_root/method_brent.rs#L36-L78).
 v0: `scipy.optimize.minimize_scalar` with `method='bounded'`.
 
-Reference: Brent (1973). "Algorithms for Minimization Without Derivatives." Prentice-Hall, Chapter 5. ISBN 978-0-13-022335-7
+### References
+
+- <a id="ref-3"></a>Brent, Richard P. 1973. _Algorithms for Minimization Without Derivatives._ Prentice-Hall. ISBN 978-0-13-022335-7. [↩](#cite-3)
 
 ---
 
 ## Golden Section Search
 
-Bracket-based 1D optimization with O(log(1/epsilon)) convergence. At each step, the bracket is narrowed by the golden ratio phi = (1+sqrt(5))/2, maintaining the ratio between the two sub-intervals. Slower than Brent's method (which uses parabolic acceleration) but simpler and guaranteed to converge without requiring derivative information.
+Bracket-based 1D optimization (<a id="cite-4"></a>[Kiefer 1953](https://doi.org/10.2307/2032012) [[4](#ref-4)]) with O(log(1/epsilon)) convergence. At each step, the bracket is narrowed by the golden ratio phi = (1+sqrt(5))/2, maintaining the ratio between the two sub-intervals. Slower than Brent's method (which uses parabolic acceleration) but simpler and guaranteed to converge without requiring derivative information.
 
 v1: [`packages/treetime/src/commands/clock/find_best_root/method_golden_section.rs#L36-L81`](../../packages/treetime/src/commands/clock/find_best_root/method_golden_section.rs#L36-L81).
 
-Reference: Kiefer (1953). "Sequential minimax search for a maximum." Proc AMS, 4(3):502-506. doi:10.2307/2032012
+### References
+
+- <a id="ref-4"></a>Kiefer, Jack. 1953. "Sequential Minimax Search for a Maximum." _Proceedings of the American Mathematical Society_ 4(3):502-506. https://doi.org/10.2307/2032012 [↩](#cite-4)
 
 ---
 
 ## IQD Outlier Detection
 
-Identifies clock outliers using Tukey's fences (Tukey 1977) applied to clock deviation residuals. The interquartile distance IQD = Q3 - Q1 measures the spread of the middle 50% of clock deviations. A leaf with `|clock_deviation| > threshold * IQD` is flagged as an outlier, where the threshold is controlled by `--clock-filter` (default 3.0).
+Identifies clock outliers using Tukey's fences (<a id="cite-5"></a>[Tukey 1977](https://doi.org/10.1007/978-1-4419-7976-6) [[5](#ref-5)]) applied to clock deviation residuals. The interquartile distance IQD = Q3 - Q1 measures the spread of the middle 50% of clock deviations. A leaf with `|clock_deviation| > threshold * IQD` is flagged as an outlier, where the threshold is controlled by `--clock-filter` (default 3.0).
 
 IQD-based detection is nonparametric and does not assume normally distributed residuals, making it appropriate for phylogenetic data where residual distributions can be skewed. For comparison, under a normal distribution IQD = 1.35 _ sigma, so `threshold _ IQD = 3 _ 1.35 _ sigma = 4.05 \* sigma` - roughly the 99.995% interval.
 
 v1: [`packages/treetime/src/commands/clock/clock_filter.rs#L21-L105`](../../packages/treetime/src/commands/clock/clock_filter.rs#L21-L105).
 v0: [`packages/legacy/treetime/treetime/clock_filter_methods.py#L5-L40`](../../packages/legacy/treetime/treetime/clock_filter_methods.py#L5-L40).
 
-Reference: Tukey (1977). "Exploratory Data Analysis." Addison-Wesley. ISBN 978-0-201-07616-5
+### References
+
+- <a id="ref-5"></a>Tukey, John W. 1977. _Exploratory Data Analysis._ Addison-Wesley. ISBN 978-0-201-07616-5. [↩](#cite-5)
 
 ---
 

--- a/kb/algo/distribution.md
+++ b/kb/algo/distribution.md
@@ -4,47 +4,39 @@
 
 ## FFT Convolution
 
-O(n log n) convolution via the convolution theorem: `IFFT(FFT(f) * FFT(g))`. The discrete Fourier transform converts convolution (an O(n^2) operation in the time domain) into pointwise multiplication in the frequency domain, then transforms back.
+O(n log n) convolution via the convolution theorem (<a id="cite-1"></a>[Cooley and Tukey 1965](https://doi.org/10.2307/2003354) [[1](#ref-1)]): `IFFT(FFT(f) * FFT(g))`. The discrete Fourier transform converts convolution (an O(n^2) operation in the time domain) into pointwise multiplication in the frequency domain, then transforms back.
 
 v1: `convolve_fft()` (`#convolve_fft`) in [`packages/treetime-ops/src/convolution.rs#L33-L37`](../../packages/treetime-ops/src/convolution.rs#L33-L37).
-
-Reference: Cooley & Tukey (1965). "An algorithm for the machine calculation of complex Fourier series." Math Comp, 19(90):297-301. doi:10.2307/2003354
 
 ---
 
 ## Gaussian Convolution
 
-Closed-form convolution of two Gaussians: `G1 * G2 ~ N(mu1 + mu2, sqrt(sigma1^2 + sigma2^2))`. The convolution of two Gaussian PDFs is itself Gaussian with mean equal to the sum of means and variance equal to the sum of variances. No numerical integration required.
+Closed-form convolution of two Gaussians (<a id="cite-2"></a>[Bromiley 2003](https://www.tina-vision.net/docs/memos/2003-003.pdf) [[2](#ref-2)]): `G1 * G2 ~ N(mu1 + mu2, sqrt(sigma1^2 + sigma2^2))`. The convolution of two Gaussian PDFs is itself Gaussian with mean equal to the sum of means and variance equal to the sum of variances. No numerical integration required.
 
 v1: `gaussian_convolution()` (`#gaussian_convolution`) in [`packages/treetime-analytical/src/gaussian.rs#L110-L117`](../../packages/treetime-analytical/src/gaussian.rs#L110-L117).
-
-Reference: Bromiley (2003). "Products and Convolutions of Gaussian Probability Density Functions." Tina Memo No. 2003-003. https://www.tina-vision.net/docs/memos/2003-003.pdf
 
 ---
 
 ## Exponential Convolution
 
-Closed-form convolution of two exponential distributions. When rates differ (a != b), the result is a hypoexponential distribution with PDF involving two exponential terms. When rates are equal (a == b), the result is the Erlang-2 distribution: `f(x) = a^2 * x * exp(-a*x)`.
+Closed-form convolution of two exponential distributions (<a id="cite-3"></a>[Ross 2014](https://doi.org/10.1016/C2012-0-03564-8) [[3](#ref-3)]). When rates differ (a != b), the result is a hypoexponential distribution with PDF involving two exponential terms. When rates are equal (a == b), the result is the Erlang-2 distribution: `f(x) = a^2 * x * exp(-a*x)`.
 
 v1: `exponential_convolution()` (`#exponential_convolution`) in [`packages/treetime-analytical/src/exponential.rs#L28-L37`](../../packages/treetime-analytical/src/exponential.rs#L28-L37).
-
-Reference: Ross (2014). "Introduction to Probability Models." 11th ed. Academic Press, Chapter 5. ISBN 978-0-12-407948-9
 
 ---
 
 ## Gaussian-Exponential Convolution
 
-Convolution of a Gaussian with an exponential distribution, yielding a function involving the complementary error function (erfc). This arises in timetree inference when combining a Gaussian-like node time distribution with an exponentially distributed branch length.
+Convolution of a Gaussian with an exponential distribution, yielding a function involving the complementary error function (erfc). This arises in timetree inference when combining a Gaussian-like node time distribution with an exponentially distributed branch length (<a id="cite-4"></a>[Sagulenko, Puller, and Neher 2018](https://doi.org/10.1093/ve/vex042) [[4](#ref-4)], Supplementary Section S2).
 
 v1: `gaussian_exponential_convolution()` (`#gaussian_exponential_convolution`) in [`packages/treetime-analytical/src/gaussian_exponential.rs#L12-L14`](../../packages/treetime-analytical/src/gaussian_exponential.rs#L12-L14).
-
-Reference: Sagulenko, Puller & Neher (2018). "TreeTime." Virus Evolution, 4(1):vex042, Supplementary Section S2.
 
 ---
 
 ## Gaussian Product
 
-Pointwise multiplication of two Gaussian PDFs (not convolution). The product of two Gaussians is an unnormalized Gaussian with precision-weighted mean:
+Pointwise multiplication of two Gaussian PDFs (not convolution). The product of two Gaussians is an unnormalized Gaussian with precision-weighted mean (<a id="cite-5"></a>[Petersen and Pedersen 2012](https://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf) [[5](#ref-5)], Section 8.1.8):
 
 ```
 sigma* = 1 / sqrt(1/sigma1^2 + 1/sigma2^2)
@@ -55,17 +47,13 @@ This operation appears in belief propagation when combining independent messages
 
 v1: `gaussian_product_params()` (`#gaussian_product_params`), `gaussian_product()` (`#gaussian_product`) in [`packages/treetime-analytical/src/gaussian.rs#L30-L63`](../../packages/treetime-analytical/src/gaussian.rs#L30-L63).
 
-Reference: Petersen & Pedersen (2012). "The Matrix Cookbook." Section 8.1.8. https://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf
-
 ---
 
 ## ScaledDistribution
 
-Decomposition `P(x) = exp(log_scale) * inner(x)` with `max(inner) = 1.0`. This log-sum-exp pattern prevents underflow when multiplying many small probabilities: the log-scale factor absorbs the magnitude while the inner distribution maintains full floating-point precision in the [0, 1] range. The standard technique for numerical stability in probabilistic computation (Bishop 2006).
+Decomposition `P(x) = exp(log_scale) * inner(x)` with `max(inner) = 1.0`. This log-sum-exp pattern prevents underflow when multiplying many small probabilities: the log-scale factor absorbs the magnitude while the inner distribution maintains full floating-point precision in the [0, 1] range. The standard technique for numerical stability in probabilistic computation (<a id="cite-6"></a>[Bishop 2006](https://doi.org/10.1007/978-0-387-45528-0) [[6](#ref-6)], Section 2.2).
 
 v1: `ScaledDistribution` (`#ScaledDistribution`) in [`packages/treetime-distribution/src/distribution_scaled/scaled.rs#L13`](../../packages/treetime-distribution/src/distribution_scaled/scaled.rs#L13).
-
-Reference: Bishop (2006). "Pattern Recognition and Machine Learning." Springer, Section 2.2. ISBN 978-0-387-31073-2
 
 ---
 
@@ -121,6 +109,17 @@ See [unimplemented](unimplemented.md) for full details:
 - Adaptive Simpson's Rule Convolution
 - FWHM Computation
 - Branch Length Interpolator (Input Mode)
+
+---
+
+## References
+
+- <a id="ref-1"></a>Cooley, James W., and John W. Tukey. 1965. "An Algorithm for the Machine Calculation of Complex Fourier Series." _Mathematics of Computation_ 19(90):297-301. https://doi.org/10.2307/2003354 [↩](#cite-1)
+- <a id="ref-2"></a>Bromiley, Paul A. 2003. "Products and Convolutions of Gaussian Probability Density Functions." Tina Memo No. 2003-003. https://www.tina-vision.net/docs/memos/2003-003.pdf [↩](#cite-2)
+- <a id="ref-3"></a>Ross, Sheldon M. 2014. _Introduction to Probability Models._ 11th ed. Academic Press. ISBN 978-0-12-407948-9. [↩](#cite-3)
+- <a id="ref-4"></a>Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evolution_ 4(1):vex042. https://doi.org/10.1093/ve/vex042 [↩](#cite-4)
+- <a id="ref-5"></a>Petersen, Kaare Brandt, and Michael Syskind Pedersen. 2012. _The Matrix Cookbook._ Technical report. https://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf [↩](#cite-5)
+- <a id="ref-6"></a>Bishop, Christopher M. 2006. _Pattern Recognition and Machine Learning._ Springer. ISBN 978-0-387-31073-2. [↩](#cite-6)
 
 ---
 

--- a/kb/algo/graph.md
+++ b/kb/algo/graph.md
@@ -4,21 +4,17 @@
 
 ## Parallel BFS
 
-Frontier-based parallel breadth-first traversal using Rayon for work distribution across CPU cores. Each BFS level is processed in parallel, with synchronization between levels. Used for Fitch parsimony and marginal reconstruction where all nodes at the same depth can be processed independently.
+Frontier-based parallel breadth-first traversal (<a id="cite-1"></a>[Leiserson and Schardl 2010](https://doi.org/10.1145/1810479.1810534) [[1](#ref-1)]) using Rayon for work distribution across CPU cores. Each BFS level is processed in parallel, with synchronization between levels. Used for Fitch parsimony and marginal reconstruction where all nodes at the same depth can be processed independently.
 
 v1: [`packages/treetime-graph/src/breadth_first.rs#L139-L202`](../../packages/treetime-graph/src/breadth_first.rs#L139-L202).
-
-Reference: Leiserson & Schardl (2010). "A Work-Efficient Parallel BFS Algorithm." SPAA 2010. doi:10.1145/1810479.1810534
 
 ---
 
 ## DFS Preorder/Postorder
 
-Iterative stack-based depth-first traversal supporting both preorder (parent before children) and postorder (children before parent) visitation. Postorder is used for leaf-to-root passes (Fitch backward, marginal backward, clock regression backward). Preorder is used for root-to-leaf passes (Fitch forward, marginal forward, clock regression forward).
+Iterative stack-based depth-first traversal (<a id="cite-2"></a>[Cormen et al. 2022](https://doi.org/10.7551/mitpress/13309.001.0001) [[2](#ref-2)], Chapter 22.3) supporting both preorder (parent before children) and postorder (children before parent) visitation. Postorder is used for leaf-to-root passes (Fitch backward, marginal backward, clock regression backward). Preorder is used for root-to-leaf passes (Fitch forward, marginal forward, clock regression forward).
 
 v1: [`packages/treetime-graph/src/graph_traverse.rs#L256-L321`](../../packages/treetime-graph/src/graph_traverse.rs#L256-L321).
-
-Reference: Cormen, Leiserson, Rivest & Stein (2022). "Introduction to Algorithms." 4th ed. MIT Press, Chapter 22.3. ISBN 978-0-262-04630-5
 
 ---
 
@@ -32,11 +28,17 @@ v1: [`packages/treetime-graph/src/graph.rs#L316-L370`](../../packages/treetime-g
 
 ## Edge Contraction
 
-Merges a target node into its source (parent) node by reparenting all of the target's children to the source and removing the contracted edge. Used to clean up single-child internal nodes after polytomy resolution and rerooting.
+Merges a target node into its source (parent) node (<a id="cite-3"></a>[Diestel 2017](https://doi.org/10.1007/978-3-662-53622-3) [[3](#ref-3)], Chapter 1) by reparenting all of the target's children to the source and removing the contracted edge. Used to clean up single-child internal nodes after polytomy resolution and rerooting.
 
 v1: [`packages/treetime-graph/src/graph_ops.rs#L146-L206`](../../packages/treetime-graph/src/graph_ops.rs#L146-L206).
 
-Reference: Diestel (2017). "Graph Theory." 5th ed. Springer, Chapter 1. ISBN 978-3-662-53621-6
+---
+
+## References
+
+- <a id="ref-1"></a>Leiserson, Charles E., and Tao B. Schardl. 2010. "A Work-Efficient Parallel Breadth-First Search Algorithm (or How to Cope with the Nondeterminism of Reducers)." In _Proceedings of the 22nd ACM Symposium on Parallelism in Algorithms and Architectures (SPAA),_ 303-314. https://doi.org/10.1145/1810479.1810534 [↩](#cite-1)
+- <a id="ref-2"></a>Cormen, Thomas H., Charles E. Leiserson, Ronald L. Rivest, and Clifford Stein. 2022. _Introduction to Algorithms._ 4th ed. MIT Press. ISBN 978-0-262-04630-5. [↩](#cite-2)
+- <a id="ref-3"></a>Diestel, Reinhard. 2017. _Graph Theory._ 5th ed. Springer. ISBN 978-3-662-53621-6. https://doi.org/10.1007/978-3-662-53622-3 [↩](#cite-3)
 
 ---
 

--- a/kb/algo/gtr.md
+++ b/kb/algo/gtr.md
@@ -20,63 +20,53 @@ JC69 (0 free params)
 
 All models listed below are implemented in [`packages/treetime/src/gtr/get_gtr.rs`](../../packages/treetime/src/gtr/get_gtr.rs).
 
-### JC69 (Jukes-Cantor 1969)
+### JC69 (<a id="cite-1"></a>[Jukes and Cantor 1969](https://doi.org/10.1016/B978-1-4832-3211-9.50009-7) [[1](#ref-1)])
 
 Simplest model: equal base frequencies (pi = 1/4 each), equal substitution rates. Zero free parameters after normalization. Admits a closed-form transition probability: `P_ii(t) = 1/4 + 3/4 * exp(-4t/3)`, `P_ij(t) = 1/4 - 1/4 * exp(-4t/3)`. Eigenvalues: {0, -4/3, -4/3, -4/3}.
 
 `jc69()` (`#jc69`) at [`packages/treetime/src/gtr/get_gtr.rs#L183-L194`](../../packages/treetime/src/gtr/get_gtr.rs#L183-L194).
 
-Reference: Jukes & Cantor (1969). "Evolution of Protein Molecules." Academic Press, pp. 21-132.
-
-### K80 (Kimura 2-Parameter 1980)
+### K80 (<a id="cite-2"></a>[Kimura 1980](https://doi.org/10.1007/BF01731581) [[2](#ref-2)])
 
 Distinguishes transitions (purine-purine A<->G, pyrimidine-pyrimidine C<->T) from transversions (purine-pyrimidine changes). One free parameter: the transition/transversion ratio kappa. Equal base frequencies. Closed-form P(t) with two exponential terms.
 
 `k80()` (`#k80`) at [`packages/treetime/src/gtr/get_gtr.rs#L219-L225`](../../packages/treetime/src/gtr/get_gtr.rs#L219-L225).
 
-Reference: Kimura (1980). "A simple method for estimating evolutionary rates of base substitutions through comparative studies of nucleotide sequences." J Mol Evol, 16(2):111-120. doi:10.1007/BF01731581
-
-### F81 (Felsenstein 1981)
+### F81 (<a id="cite-3"></a>[Felsenstein 1981](https://doi.org/10.1007/BF01734359) [[3](#ref-3)])
 
 Unequal equilibrium frequencies, equal exchangeabilities. Generalizes JC69 by allowing non-uniform base composition. Three free parameters (three independent frequencies; fourth constrained to sum to 1). `P_ij(t) = pi_j * (1 - exp(-beta*t))` for i != j.
 
 `f81()` (`#f81`) at [`packages/treetime/src/gtr/get_gtr.rs#L247-L257`](../../packages/treetime/src/gtr/get_gtr.rs#L247-L257). Accepts optional `pi` parameter for non-uniform frequencies.
 
-### HKY85 (Hasegawa-Kishino-Yano 1985)
+### HKY85 (<a id="cite-4"></a>[Hasegawa, Kishino, and Yano 1985](https://doi.org/10.1007/BF02101694) [[4](#ref-4)])
 
 Combines K80's transition/transversion distinction with F81's unequal base frequencies. Four free parameters (kappa + three independent frequencies). `Q_ij = kappa * pi_j` for transitions, `pi_j` for transversions. Closed-form P(t) with three distinct exponential terms; eigenvalues involve kappa and purine/pyrimidine frequency sums (pi_R = pi_A + pi_G, pi_Y = pi_C + pi_T).
 
 `hky85()` (`#hky85`) at [`packages/treetime/src/gtr/get_gtr.rs#L285-L298`](../../packages/treetime/src/gtr/get_gtr.rs#L285-L298). Accepts optional `pi` parameter.
 
-Reference: Hasegawa, Kishino & Yano (1985). "Dating of the human-ape splitting by a molecular clock of mitochondrial DNA." J Mol Evol, 22(2):160-174. doi:10.1007/BF02101694
-
-### T92 (Tamura 1992)
+### T92 (<a id="cite-9"></a>[Tamura 1992](https://doi.org/10.1093/oxfordjournals.molbev.a040059) [[9](#ref-9)])
 
 GC-content parameterization: a simplification of HKY85 enforcing Chargaff's second parity rule (pi_A = pi_T, pi_C = pi_G). Parameterized by a single GC-content value theta = pi_G + pi_C, reducing three frequency parameters to one.
 
 `t92()` (`#t92`) at [`packages/treetime/src/gtr/get_gtr.rs#L325-L342`](../../packages/treetime/src/gtr/get_gtr.rs#L325-L342).
 
-### TN93 (Tamura-Nei 1993)
+### TN93 (<a id="cite-5"></a>[Tamura and Nei 1993](https://doi.org/10.1093/oxfordjournals.molbev.a040023) [[5](#ref-5)])
 
 Distinguishes the two transition types: purine transitions (A<->G, rate kappa_1) and pyrimidine transitions (C<->T, rate kappa_2). Five free parameters. Closed-form P(t) with analytical eigendecomposition.
 
 `tn93()` (`#tn93`) at [`packages/treetime/src/gtr/get_gtr.rs#L459-L487`](../../packages/treetime/src/gtr/get_gtr.rs#L459-L487).
 
-Reference: Tamura & Nei (1993). "Estimation of the number of nucleotide substitutions in the control region of mitochondrial DNA in humans and chimpanzees." Mol Biol Evol, 10(3):512-526. doi:10.1093/oxfordjournals.molbev.a040023
-
-### JTT92 (Jones-Taylor-Thornton 1992)
+### JTT92 (<a id="cite-6"></a>[Jones, Taylor, and Thornton 1992](https://doi.org/10.1093/bioinformatics/8.3.275) [[6](#ref-6)])
 
 Empirical 20x20 amino acid substitution matrix derived from a large database of protein sequence alignments. The exchangeability parameters and equilibrium frequencies are fixed to empirically observed values rather than estimated from data.
 
 `jtt92()` (`#jtt92`) at [`packages/treetime/src/gtr/get_gtr.rs#L360-L418`](../../packages/treetime/src/gtr/get_gtr.rs#L360-L418).
 
-Reference: Jones, Taylor & Thornton (1992). "The rapid generation of mutation data matrices from protein sequences." CABIOS, 8(3):275-282.
-
 ---
 
 ## Matrix Exponentiation
 
-Computing P(t) = exp(Qt) for the general time-reversible model requires eigendecomposition of the rate matrix. For simpler models (JC69 through TN93), analytical closed-form expressions exist. For GTR and inferred models, numerical eigendecomposition is required.
+Computing P(t) = exp(Qt) for the general time-reversible model (<a id="cite-7"></a>[Felsenstein 2003](https://doi.org/10.1007/978-0-387-21337-7) [[7](#ref-7)]; <a id="cite-8"></a>[Moler and Van Loan 2003](https://doi.org/10.1137/S0036144502418150) [[8](#ref-8)]) requires eigendecomposition of the rate matrix. For simpler models (JC69 through TN93), analytical closed-form expressions exist. For GTR and inferred models, numerical eigendecomposition is required.
 
 ### Symmetrization trick
 
@@ -91,11 +81,6 @@ The eigendecomposition is computed once per model. Per-branch computation reduce
 v1: `eig_single_site()` (`#eig_single_site`) at [`packages/treetime/src/gtr/gtr.rs#L71-L102`](../../packages/treetime/src/gtr/gtr.rs#L71-L102), `expQt()` (`#expQt`) at [`packages/treetime/src/gtr/gtr.rs#L442-L452`](../../packages/treetime/src/gtr/gtr.rs#L442-L452).
 
 One eigenvalue is always 0 (corresponding to the stationary distribution pi). The remaining k-1 eigenvalues are negative, guaranteeing convergence to equilibrium frequencies as t -> infinity.
-
-References:
-
-- Felsenstein (2003). "Inferring Phylogenies." Chapter 13.
-- Moler & Van Loan (2003). "Nineteen Dubious Ways to Compute the Matrix Exponential, Twenty-Five Years Later." SIAM Review, 45(1):3-49. doi:10.1137/S00361445024180
 
 ---
 
@@ -158,6 +143,20 @@ See [unimplemented](unimplemented.md) for full details:
 - Site-specific GTR partition integration (core math implemented, wiring to partition types pending)
 - Random GTR generation
 - File-based GTR loading
+
+---
+
+## References
+
+- <a id="ref-1"></a>Jukes, Thomas H., and Charles R. Cantor. 1969. "Evolution of Protein Molecules." In _Mammalian Protein Metabolism,_ vol. 3, edited by H. N. Munro, 21-132. Academic Press. https://doi.org/10.1016/B978-1-4832-3211-9.50009-7 [↩](#cite-1)
+- <a id="ref-2"></a>Kimura, Motoo. 1980. "A Simple Method for Estimating Evolutionary Rates of Base Substitutions Through Comparative Studies of Nucleotide Sequences." _Journal of Molecular Evolution_ 16(2):111-120. https://doi.org/10.1007/BF01731581 [↩](#cite-2)
+- <a id="ref-3"></a>Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359 [↩](#cite-3)
+- <a id="ref-4"></a>Hasegawa, Masami, Hirohisa Kishino, and Taka-aki Yano. 1985. "Dating of the Human-Ape Splitting by a Molecular Clock of Mitochondrial DNA." _Journal of Molecular Evolution_ 22(2):160-174. https://doi.org/10.1007/BF02101694 [↩](#cite-4)
+- <a id="ref-5"></a>Tamura, Koichiro, and Masatoshi Nei. 1993. "Estimation of the Number of Nucleotide Substitutions in the Control Region of Mitochondrial DNA in Humans and Chimpanzees." _Molecular Biology and Evolution_ 10(3):512-526. https://doi.org/10.1093/oxfordjournals.molbev.a040023 [↩](#cite-5)
+- <a id="ref-6"></a>Jones, David T., William R. Taylor, and Janet M. Thornton. 1992. "The Rapid Generation of Mutation Data Matrices from Protein Sequences." _Computer Applications in the Biosciences_ 8(3):275-282. https://doi.org/10.1093/bioinformatics/8.3.275 [↩](#cite-6)
+- <a id="ref-7"></a>Felsenstein, Joseph. 2003. _Inferring Phylogenies._ Sinauer Associates. ISBN 978-0-87893-177-4. [↩](#cite-7)
+- <a id="ref-8"></a>Moler, Cleve, and Charles Van Loan. 2003. "Nineteen Dubious Ways to Compute the Matrix Exponential, Twenty-Five Years Later." _SIAM Review_ 45(1):3-49. https://doi.org/10.1137/S0036144502418150 [↩](#cite-8)
+- <a id="ref-9"></a>Tamura, Koichiro. 1992. "Estimation of the Number of Nucleotide Substitutions When There Are Strong Transition-Transversion and G+C-Content Biases." _Molecular Biology and Evolution_ 9(4):678-687. https://doi.org/10.1093/oxfordjournals.molbev.a040059 [↩](#cite-9)
 
 ---
 

--- a/kb/algo/mugration.md
+++ b/kb/algo/mugration.md
@@ -8,7 +8,7 @@ Discrete trait ancestral reconstruction treats categorical metadata (locations, 
 
 ## Discrete Marginal Reconstruction
 
-Felsenstein pruning (Felsenstein 1981) applied to discrete categorical traits rather than nucleotide sequences. The algorithm is identical to marginal ML ancestral reconstruction but operates on a discrete state alphabet (e.g., country names) with a GTR-like transition matrix.
+Felsenstein pruning (<a id="cite-1"></a>[Felsenstein 1981](https://doi.org/10.1007/BF01734359) [[1](#ref-1)]) applied to discrete categorical traits rather than nucleotide sequences. The algorithm is identical to marginal ML ancestral reconstruction but operates on a discrete state alphabet (e.g., country names) with a GTR-like transition matrix.
 
 v1: [`packages/treetime/src/commands/mugration/discrete_marginal.rs`](../../packages/treetime/src/commands/mugration/discrete_marginal.rs).
 v0: [`packages/legacy/treetime/treetime/wrappers.py#L653-L811`](../../packages/legacy/treetime/treetime/wrappers.py#L653-L811).
@@ -77,9 +77,9 @@ This is analogous to `--reconstruct-tip-states` in the ancestral command but app
 
 Supporting references for missing data treatment:
 
-- Felsenstein (2003), p. 255: ambiguous states receive likelihood 1.0 for all possibilities
-- PastML (Ishikawa et al. 2019, Mol Biol Evol): "unknown states can be omitted and will be estimated during analysis"
-- BEAST UTM model (Vaiente & Scotch 2020): extends to prior probability distributions over uncertain tip states
+- <a id="cite-2"></a>[Felsenstein 2003](https://doi.org/10.1007/978-0-387-21337-7) [[2](#ref-2)], p. 255: ambiguous states receive likelihood 1.0 for all possibilities
+- PastML (<a id="cite-3"></a>[Ishikawa et al. 2019](https://doi.org/10.1093/molbev/msz131) [[3](#ref-3)]): "unknown states can be omitted and will be estimated during analysis"
+- BEAST UTM model (<a id="cite-4"></a>[Vaiente and Scotch 2020](https://doi.org/10.1016/j.meegid.2020.104501) [[4](#ref-4)]): extends to prior probability distributions over uncertain tip states
 
 ---
 
@@ -148,21 +148,10 @@ After forward-backward, `get_confidence(node_key)` returns the full posterior di
 
 ## References
 
-### Primary
-
-Sagulenko, Puller & Neher (2018). "TreeTime: Maximum-likelihood phylodynamic analysis." Virus Evolution, 4(1):vex042. doi:10.1093/ve/vex042
-
-### Ancestral Reconstruction
-
-- Felsenstein (1981). "Evolutionary trees from DNA sequences: a maximum likelihood approach." J Mol Evol, 17(6):368-376. doi:10.1007/BF01734359
-- Felsenstein (2003). "Inferring Phylogenies." Sinauer Associates, p. 255.
-
-### Phylogeography
-
-- Lemey, Rambaut, Drummond & Suchard (2009). "Bayesian phylogeography finds its roots." PLoS Computational Biology, 5(9):e1000520. doi:10.1371/journal.pcbi.1000520
-- Edwards et al. (2011). "Ancient hybridization and an Irish origin for the modern polar bear matriline." Current Biology, 21(15):1251-1258. doi:10.1016/j.cub.2011.05.058
-
-### Missing Data
-
-- Ishikawa et al. (2019). "A Fast Likelihood Method to Reconstruct and Visualize Ancestral Scenarios." Mol Biol Evol, 36(9):2069-2085. doi:10.1093/molbev/msz131
-- Vaiente, M.A. & Scotch, M. (2020). "Going back to the roots: Evaluating Bayesian phylogeographic models with discrete trait uncertainty." Infection, Genetics and Evolution, 85:104501. doi:10.1016/j.meegid.2020.104501
+- <a id="ref-0"></a>Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evolution_ 4(1):vex042. https://doi.org/10.1093/ve/vex042
+- <a id="ref-1"></a>Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359 [↩](#cite-1)
+- <a id="ref-2"></a>Felsenstein, Joseph. 2003. _Inferring Phylogenies._ Sinauer Associates. ISBN 978-0-87893-177-4. [↩](#cite-2)
+- <a id="ref-3"></a>Ishikawa, Sohta A., Anna Zhukova, Wataru Iwasaki, and Olivier Gascuel. 2019. "A Fast Likelihood Method to Reconstruct and Visualize Ancestral Scenarios." _Molecular Biology and Evolution_ 36(9):2069-2085. https://doi.org/10.1093/molbev/msz131 [↩](#cite-3)
+- <a id="ref-4"></a>Vaiente, Mara A., and Matthew Scotch. 2020. "Going Back to the Roots: Evaluating Bayesian Phylogeographic Models with Discrete Trait Uncertainty." _Infection, Genetics and Evolution_ 85:104501. https://doi.org/10.1016/j.meegid.2020.104501 [↩](#cite-4)
+- <a id="ref-5"></a>Lemey, Philippe, Andrew Rambaut, Alexei J. Drummond, and Marc A. Suchard. 2009. "Bayesian Phylogeography Finds Its Roots." _PLoS Computational Biology_ 5(9):e1000520. https://doi.org/10.1371/journal.pcbi.1000520
+- <a id="ref-6"></a>Edwards, Ceiridwen J., Marc A. Suchard, Philippe Lemey, et al. 2011. "Ancient Hybridization and an Irish Origin for the Modern Polar Bear Matriline." _Current Biology_ 21(15):1251-1258. https://doi.org/10.1016/j.cub.2011.05.058

--- a/kb/algo/optimization.md
+++ b/kb/algo/optimization.md
@@ -16,16 +16,13 @@ v1: [`packages/treetime/src/commands/optimize/method_newton.rs`](../../packages/
 
 v0 uses Brent's method (`scipy.optimize.minimize_scalar`) in sqrt(t) space with Hamming distance bracket. v1 ships six methods (Newton and Brent in $t$, $\sqrt{t}$, $\ln(t)$ spaces) selectable via `--opt-method`; `brent-sqrt` is the default and matches v0 on the success path. The Newton variants compute analytical derivatives from eigenvalue-space coefficient caching. The Hessian (posterior variance of eigenvalues) uses the centered Welford form $\sum_c w_c (\lambda_c - \bar\lambda)^2$ to avoid catastrophic cancellation in the two-moment form. See [feature inventory](../features/README.md#7-branch-length-optimization) for parity details and [intentional change](../decisions/optimize-newton-raphson-per-edge.md) for the per-method rationale.
 
-References:
-
-- Nocedal & Wright (2006). "Numerical Optimization." 2nd ed. Springer, Chapter 2. ISBN 978-0-387-30303-1
-- Felsenstein (2003). "Inferring Phylogenies." Sinauer Associates, Chapter 16. ISBN 978-0-87893-177-4
+The method is described in <a id="cite-1"></a>[Nocedal and Wright 2006](https://doi.org/10.1007/978-0-387-40065-5) [[1](#ref-1)], Chapter 2, and <a id="cite-2"></a>[Felsenstein 2003](https://doi.org/10.1007/978-0-387-21337-7) [[2](#ref-2)], Chapter 16.
 
 ---
 
 ## Brent's Method for Branch Length Optimization
 
-Per-edge branch length optimization using Brent's derivative-free method via `argmin::BrentOpt`. Three parameterizations offer different objective surface smoothing:
+Per-edge branch length optimization using Brent's derivative-free method (<a id="cite-3"></a>[Brent 1973](https://doi.org/10.1007/978-3-0348-5952-3) [[3](#ref-3)]) via `argmin::BrentOpt`. Three parameterizations offer different objective surface smoothing:
 
 - t-space (`brent_inner`): bracket $[\text{min\_bl}, \text{upper}]$, cost function evaluates $-\ell(t)$. Baseline derivative-free method.
 - sqrt(t)-space (`brent_sqrt_inner`): bracket $[\sqrt{\text{min\_bl}}, \sqrt{\text{upper}}]$, cost function evaluates $-\ell(s^2)$. **Default method, matches v0 exactly.** Smooths the objective near $t = 0$, giving parabolic interpolation a better fit. Tolerance $\epsilon_s$ in $s$-space maps to $t$-space precision $\approx 2s^* \epsilon_s$, tighter near zero.
@@ -37,10 +34,7 @@ v0: `optimal_t_compressed()` at [`packages/legacy/treetime/treetime/gtr.py#L816-
 
 Distinct from existing Brent entries for clock root optimization, coalescent Tc optimization, and polytomy resolution. Those are different optimization targets using the same `BrentOpt` solver.
 
-References:
-
-- Brent (1973). "Algorithms for Minimization without Derivatives." Prentice-Hall. ISBN 978-0-13-022335-7
-- Press, Teukolsky, Vetterling & Flannery (2007). "Numerical Recipes: The Art of Scientific Computing." 3rd ed. Cambridge University Press, Section 10.3. ISBN 978-0-521-88068-8
+See also <a id="cite-4"></a>[Press et al. 2007](https://doi.org/10.1017/CBO9780511811340) [[4](#ref-4)], Section 10.3.
 
 ---
 
@@ -53,10 +47,7 @@ v1 sparse: [`packages/treetime/src/commands/optimize/optimize_sparse_eval.rs`](.
 
 The sparse path weights each site contribution by its multiplicity (number of identical columns in the alignment sharing that substitution pattern), reducing computation for conserved sequences.
 
-References:
-
-- Felsenstein (1981). "Evolutionary trees from DNA sequences." J Mol Evol, 17(6):368-376. doi:10.1007/BF01734359
-- Yang (2006). "Computational Molecular Evolution." Chapter 4.
+The eigendecomposition approach follows <a id="cite-5"></a>[Felsenstein 1981](https://doi.org/10.1007/BF01734359) [[5](#ref-5)] and <a id="cite-6"></a>[Yang 2006](https://doi.org/10.1093/acprof:oso/9780198567028.001.0001) [[6](#ref-6)], Chapter 4.
 
 ---
 
@@ -78,7 +69,7 @@ O(1) interval lookup via `floor((x - x_min) / dx)` for uniformly spaced grids. U
 
 v1: [`packages/treetime-grid/src/grid_fn.rs#L279-L351`](../../packages/treetime-grid/src/grid_fn.rs#L279-L351).
 
-Reference: Burden & Faires (2010). "Numerical Analysis." 9th ed. Brooks/Cole, Chapter 3. ISBN 978-0-538-73351-9
+Standard treatment in <a id="cite-7"></a>[Burden and Faires 2010](https://doi.org/10.1007/978-3-319-07671-3) [[7](#ref-7)], Chapter 3.
 
 ---
 
@@ -98,9 +89,7 @@ v1: [`packages/treetime/src/commands/optimize/run.rs`](../../packages/treetime/s
 
 v0: `optimize_tree_marginal()` at [`packages/legacy/treetime/treetime/treeanc.py#L1297-L1360`](../../packages/legacy/treetime/treetime/treeanc.py#L1297-L1360) with `damping=0.75` default.
 
-References:
-
-- Sagulenko, Puller, and Neher (2018). "TreeTime: Maximum-Likelihood Phylodynamic Analysis." Virus Evolution 4(1):vex042. doi:10.1093/ve/vex042
+Based on <a id="cite-8"></a>[Sagulenko, Puller, and Neher 2018](https://doi.org/10.1093/ve/vex042) [[8](#ref-8)].
 
 ---
 
@@ -118,11 +107,9 @@ v1 defaults: `max_iter=10`, `dp=0.1`, matching v0's `optimize_tree_marginal()`.
 
 v0: uses a signed check (`deltaLH < LHtol`) which conflates convergence with worsening. See [v0 erratum](../v0-errata/optimize-signed-convergence-check.md).
 
-Background: the sparse representation classifies alignment positions as variable or fixed each iteration. The discrete reclassification produces a non-monotone objective, violating the EM monotone convergence guarantee (Wu 1983, https://projecteuclid.org/journals/annals-of-statistics/volume-11/issue-1/On-the-Convergence-Properties-of-the-EM-Algorithm/10.1214/aos/1176346060.full). See M-optimize-sparse-em-2-cycle (resolved) for root cause analysis.
+Background: the sparse representation classifies alignment positions as variable or fixed each iteration. The discrete reclassification produces a non-monotone objective, violating the EM monotone convergence guarantee (<a id="cite-10"></a>[Wu 1983](https://doi.org/10.1214/aos/1176346060) [[10](#ref-10)]). See M-optimize-sparse-em-2-cycle (resolved) for root cause analysis.
 
-References:
-
-- Minh et al. (2020). "IQ-TREE 2: New Models and Efficient Methods for Phylogenetic Inference in the Genomic Era." Mol Biol Evol, 37(5):1530-1534. doi:10.1093/molbev/msaa015
+IQ-TREE's per-round monotonicity check described in <a id="cite-9"></a>[Minh et al. 2020](https://doi.org/10.1093/molbev/msaa015) [[9](#ref-9)].
 
 ---
 
@@ -155,9 +142,7 @@ v1: [`packages/treetime/src/commands/optimize/optimize_unified.rs`](../../packag
 
 v0 does not have an equivalent analytical check. v0 uses `prune_short_branches()` with a compound threshold-and-probability criterion instead.
 
-References:
-
-- Dinh, Bilge, Zhang & Matsen (2022). "Phylogenetic Tree Inference via the Adaptive LASSO." Annals of Applied Statistics, 16(4):2240-2261. doi:10.1214/21-AOAS1584
+Based on the zero-branch analysis in <a id="cite-11"></a>[Dinh et al. 2022](https://doi.org/10.1214/21-AOAS1584) [[11](#ref-11)].
 
 ---
 
@@ -198,6 +183,22 @@ Simulates a backward-in-time coalescent process. Branches without mutations are 
 v0: `generate_subtree()` at [`packages/legacy/treetime/treetime/treetime.py#L872-L1010`](../../packages/legacy/treetime/treetime/treetime.py#L872-L1010).
 
 v1: Not implemented. Tracked: `N-timetree-stochastic-polytomy-unimplemented.md`.
+
+---
+
+## References
+
+- <a id="ref-1"></a>Nocedal, Jorge, and Stephen J. Wright. 2006. _Numerical Optimization._ 2nd ed. Springer. ISBN 978-0-387-30303-1. https://doi.org/10.1007/978-0-387-40065-5 [↩](#cite-1)
+- <a id="ref-2"></a>Felsenstein, Joseph. 2003. _Inferring Phylogenies._ Sinauer Associates. ISBN 978-0-87893-177-4. [↩](#cite-2)
+- <a id="ref-3"></a>Brent, Richard P. 1973. _Algorithms for Minimization Without Derivatives._ Prentice-Hall. ISBN 978-0-13-022335-7. [↩](#cite-3)
+- <a id="ref-4"></a>Press, William H., Saul A. Teukolsky, William T. Vetterling, and Brian P. Flannery. 2007. _Numerical Recipes: The Art of Scientific Computing._ 3rd ed. Cambridge University Press. ISBN 978-0-521-88068-8. https://doi.org/10.1017/CBO9780511811340 [↩](#cite-4)
+- <a id="ref-5"></a>Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359 [↩](#cite-5)
+- <a id="ref-6"></a>Yang, Ziheng. 2006. _Computational Molecular Evolution._ Oxford University Press. ISBN 978-0-19-856702-8. [↩](#cite-6)
+- <a id="ref-7"></a>Burden, Richard L., and J. Douglas Faires. 2010. _Numerical Analysis._ 9th ed. Brooks/Cole. ISBN 978-0-538-73351-9. [↩](#cite-7)
+- <a id="ref-8"></a>Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evolution_ 4(1):vex042. https://doi.org/10.1093/ve/vex042 [↩](#cite-8)
+- <a id="ref-9"></a>Minh, Bui Quang, Heiko A. Schmidt, Olga Chernomor, Dominik Schrempf, Michael D. Woodhams, Arndt von Haeseler, and Robert Lanfear. 2020. "IQ-TREE 2: New Models and Efficient Methods for Phylogenetic Inference in the Genomic Era." _Molecular Biology and Evolution_ 37(5):1530-1534. https://doi.org/10.1093/molbev/msaa015 [↩](#cite-9)
+- <a id="ref-10"></a>Wu, C. F. Jeff. 1983. "On the Convergence Properties of the EM Algorithm." _The Annals of Statistics_ 11(1):95-103. https://doi.org/10.1214/aos/1176346060 [↩](#cite-10)
+- <a id="ref-11"></a>Dinh, Vu, Lam Si Tung Ho, Marc A. Suchard, and Frederick A. Matsen IV. 2022. "Consistency and Convergence Rate of Phylogenetic Inference via Regularization." _The Annals of Applied Statistics_ 16(4):2240-2261. https://doi.org/10.1214/21-AOAS1584 [↩](#cite-11)
 
 ---
 

--- a/kb/algo/timetree.md
+++ b/kb/algo/timetree.md
@@ -4,7 +4,7 @@
 
 ## Belief Propagation
 
-Two-pass message passing for time inference on the phylogenetic tree (Pearl 1988). The backward pass convolves and multiplies child distributions from leaves toward the root. The forward pass divides and convolves parent distributions from root toward leaves, refining each node's time estimate with information from the rest of the tree.
+Two-pass message passing for time inference on the phylogenetic tree (<a id="cite-1"></a>[Pearl 1988](https://doi.org/10.1016/B978-0-08-051489-5.50001-5) [[1](#ref-1)]). The backward pass convolves and multiplies child distributions from leaves toward the root. The forward pass divides and convolves parent distributions from root toward leaves, refining each node's time estimate with information from the rest of the tree.
 
 v1: [`packages/treetime/src/commands/timetree/inference/backward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/backward_pass.rs), [`packages/treetime/src/commands/timetree/inference/forward_pass.rs`](../../packages/treetime/src/commands/timetree/inference/forward_pass.rs).
 v0: [`packages/legacy/treetime/treetime/node_interpolator.py`](../../packages/legacy/treetime/treetime/node_interpolator.py).
@@ -12,13 +12,11 @@ v0: [`packages/legacy/treetime/treetime/node_interpolator.py`](../../packages/le
 - `propagate_distributions_backward()` (`#propagate_distributions_backward`) [packages/treetime/src/commands/timetree/inference/backward_pass.rs#L17-L31](../../packages/treetime/src/commands/timetree/inference/backward_pass.rs#L17-L31): skips bad branches (outlier and dateless leaves) so they do not constrain parent time
 - `propagate_distributions_forward()` (`#propagate_distributions_forward`) [packages/treetime/src/commands/timetree/inference/forward_pass.rs#L11-L22](../../packages/treetime/src/commands/timetree/inference/forward_pass.rs#L11-L22): preserves internal node times when forward pass yields `None`
 
-Reference: Pearl (1988). "Probabilistic Reasoning in Intelligent Systems." Morgan Kaufmann.
-
 ---
 
 ## ML Branch-Length Pre-Step
 
-Before time inference, the timetree pipeline runs one pass of per-edge ML branch-length optimization to seed the belief propagation with better branch lengths than raw input values. This matches v0's `optimize_tree(max_iter=1)` calls (Sagulenko, Puller & Neher 2018, pipeline description).
+Before time inference, the timetree pipeline runs one pass of per-edge ML branch-length optimization to seed the belief propagation with better branch lengths than raw input values. This matches v0's `optimize_tree(max_iter=1)` calls (<a id="cite-3"></a>[Sagulenko, Puller, and Neher 2018](https://doi.org/10.1093/ve/vex042) [[3](#ref-3)], pipeline description).
 
 v1: `optimize_branch_lengths_pre_step()` in [`packages/treetime/src/commands/timetree/run.rs`](../../packages/treetime/src/commands/timetree/run.rs), called twice: before and after rerooting.
 v0: `optimize_tree(max_iter=1)` in [`packages/legacy/treetime/treetime/treetime.py`](../../packages/legacy/treetime/treetime/treetime.py) at lines 243 and 266.
@@ -39,7 +37,7 @@ v1: [`packages/treetime/src/commands/timetree/inference/branch_length_likelihood
 
 ## Kingman Coalescent
 
-The Kingman coalescent (Kingman 1982) provides a prior on internal node times based on population genetics. Under neutral evolution, k lineages in a population of effective size N_e merge backward in time at a pairwise rate, producing a total coalescence rate `lambda(t) = k(k-1) / (2*Tc(t))` where Tc is the coalescence time scale (proportional to N_e). The per-lineage merger rate is `kappa(t) = (k(t)-1) / (2*Tc(t))`, and the integral merger rate `I(t) = integral kappa(t') dt'` accumulates the probability of no coalescence up to time t.
+The Kingman coalescent (<a id="cite-2"></a>[Kingman 1982](<https://doi.org/10.1016/0304-4149(82)90011-4>) [[2](#ref-2)]) provides a prior on internal node times based on population genetics. Under neutral evolution, k lineages in a population of effective size N_e merge backward in time at a pairwise rate, producing a total coalescence rate `lambda(t) = k(k-1) / (2*Tc(t))` where Tc is the coalescence time scale (proportional to N_e). The per-lineage merger rate is `kappa(t) = (k(t)-1) / (2*Tc(t))`, and the integral merger rate `I(t) = integral kappa(t') dt'` accumulates the probability of no coalescence up to time t.
 
 The full coalescent neg-log-likelihood decomposes into per-node contributions via algebraic telescoping of the branch survival integrals. Each branch from parent p to child c contributes survival factor `I(t_p) - I(t_c)`. Summing over all branches and grouping by node, the terms telescope into three pieces:
 
@@ -69,22 +67,15 @@ The first timetree pass runs without coalescent to establish node time distribut
 
 v0 applies all three pieces: leaf contributions at `clock_tree.py:499-503` (uncertain dates) and `clock_tree.py:474-480` (precise dates), internal node contributions at `clock_tree.py:505-506`, root correction at `clock_tree.py:518-530`.
 
-References:
-
-- Kingman (1982). "The coalescent." Stochastic Processes and Applications, 13(3):235-248. doi:10.1016/0304-4149(82)90011-4
-- Sagulenko, Puller & Neher (2018). "TreeTime." Virus Evolution, 4(1):vex042. doi:10.1093/ve/vex042
-
 ---
 
 ## Tc Optimization
 
-Optimizes the coalescent time scale Tc in log space over the bracket [-20, 2] using Brent's method (Brent 1973). Brent's method is a hybrid of parabolic interpolation and golden section search, achieving superlinear convergence without requiring derivatives.
+Optimizes the coalescent time scale Tc in log space over the bracket [-20, 2] using Brent's method (<a id="cite-4"></a>[Brent 1973](https://doi.org/10.1007/978-3-0348-5952-3) [[4](#ref-4)]). Brent's method is a hybrid of parabolic interpolation and golden section search, achieving superlinear convergence without requiring derivatives.
 
 `optimize_tc()` (`#optimize_tc`) [packages/treetime/src/commands/timetree/coalescent/optimize_tc.rs#L44-L84](../../packages/treetime/src/commands/timetree/coalescent/optimize_tc.rs#L44-L84) precomputes lineage counts and per-node branch data, then minimizes negative total coalescent likelihood. The cost function (`TcCostFunction`) builds a constant `Distribution` at each evaluation, computes `compute_integral_merger_rate()`, and sums per-branch costs. Nodes with undetermined branch length are skipped with a warning.
 
 Tc is re-optimized each iteration (from iteration 2 onward) using constant Tc. In skyline mode, constant Tc is used during loop iterations; full skyline fit is deferred to post-convergence.
-
-Reference: Brent (1973). "Algorithms for Minimization Without Derivatives." Prentice-Hall, Chapter 5.
 
 ---
 
@@ -92,9 +83,9 @@ Reference: Brent (1973). "Algorithms for Minimization Without Derivatives." Pren
 
 Piecewise-varying Tc(t) estimation with smoothness regularization, extending the constant-Tc coalescent to capture population size changes over time.
 
-The classic skyline plot (Pybus, Rambaut & Harvey 2000) estimates a step function for N_e(t) from inter-coalescent intervals. The MLE per interval is `N_hat_k = C(k) * w_k` where C(k) = k(k-1)/2 is the number of lineage pairs and w_k is the interval duration. This is noisy because each interval has at most one coalescent event.
+The classic skyline plot (<a id="cite-5"></a>[Pybus, Rambaut, and Harvey 2000](https://doi.org/10.1093/genetics/155.3.1429) [[5](#ref-5)]) estimates a step function for N_e(t) from inter-coalescent intervals. The MLE per interval is `N_hat_k = C(k) * w_k` where C(k) = k(k-1)/2 is the number of lineage pairs and w_k is the interval duration. This is noisy because each interval has at most one coalescent event.
 
-The Bayesian skyline plot (Drummond, Rambaut, Shapiro & Pybus 2005) reduces noise by grouping neighboring coalescent events into segments with shared N*e parameters, using an autocorrelated exponential prior linking adjacent population sizes. The skyride (Minin, Bloomquist & Suchard 2008) replaces grouping with a Gaussian Markov Random Field (GMRF) prior that penalizes changes per unit time: `pi(gamma|tau) ~ tau^((m-1)/2) * exp(-tau/2 _ sum((gamma_{k+1} - gamma_k)^2 / delta_k))` where tau is a global precision parameter and delta_k are time-aware weights.
+The Bayesian skyline plot (<a id="cite-6"></a>[Drummond et al. 2005](https://doi.org/10.1093/molbev/msi103) [[6](#ref-6)]) reduces noise by grouping neighboring coalescent events into segments with shared N*e parameters, using an autocorrelated exponential prior linking adjacent population sizes. The skyride (<a id="cite-7"></a>[Minin, Bloomquist, and Suchard 2008](https://doi.org/10.1093/molbev/msn090) [[7](#ref-7)]) replaces grouping with a Gaussian Markov Random Field (GMRF) prior that penalizes changes per unit time: `pi(gamma|tau) ~ tau^((m-1)/2) * exp(-tau/2 _ sum((gamma_{k+1} - gamma_k)^2 / delta_k))` where tau is a global precision parameter and delta_k are time-aware weights.
 
 TreeTime's skyline implementation uses a smoothness penalty similar to the GMRF but optimizes via Nelder-Mead rather than MCMC:
 
@@ -114,22 +105,15 @@ v1 uses Nelder-Mead (via `argmin` crate); v0 uses SLSQP (via `scipy.optimize.min
 
 Skyline is re-optimized after the main iteration loop converges with stabilized node times, then a final timetree pass runs with the optimized Tc(t).
 
-References:
-
-- Pybus, Rambaut & Harvey (2000). "An integrated framework for the inference of viral population history from reconstructed genealogies." Genetics, 155(3):1429-1437. doi:10.1093/genetics/155.3.1429
-- Drummond, Rambaut, Shapiro & Pybus (2005). "Bayesian coalescent inference of past population dynamics from molecular sequences." Mol Biol Evol, 22(5):1185-1192. doi:10.1093/molbev/msi103
-- Minin, Bloomquist & Suchard (2008). "Smooth skyride through a rough skyline: Bayesian coalescent-based inference of population dynamics." Mol Biol Evol, 25(7):1459-1471. doi:10.1093/molbev/msn090
-- Strimmer & Pybus (2001). "Exploring the demographic history of DNA sequences using the generalized skyline plot." Mol Biol Evol, 18(12):2298-2305.
-
 ---
 
 ## Relaxed Clock
 
-Relaxed molecular clocks allow the substitution rate to vary across branches, relaxing the strict-clock assumption (Zuckerkandl & Pauling 1962) of a single uniform rate. Rate variation arises from differing generation times, population sizes, metabolic rates, and selective pressures across lineages.
+Relaxed molecular clocks allow the substitution rate to vary across branches, relaxing the strict-clock assumption (<a id="cite-9"></a>[Zuckerkandl and Pauling 1965](https://doi.org/10.1016/B978-1-4832-2734-4.50017-6) [[9](#ref-9)]) of a single uniform rate. Rate variation arises from differing generation times, population sizes, metabolic rates, and selective pressures across lineages.
 
-TreeTime implements an autocorrelated model where descendant branch rates correlate with parent rates, following Thorne, Kishino & Painter (1998). Each branch carries a rate multiplier gamma: `effective_rate = clock_rate * gamma`. The model penalizes deviation from gamma=1 (slack parameter) and rate differences between parent and child (coupling parameter).
+TreeTime implements an autocorrelated model where descendant branch rates correlate with parent rates, following <a id="cite-10"></a>[Thorne, Kishino, and Painter 1998](https://doi.org/10.1093/oxfordjournals.molbev.a025892) [[10](#ref-10)]. Each branch carries a rate multiplier gamma: `effective_rate = clock_rate * gamma`. The model penalizes deviation from gamma=1 (slack parameter) and rate differences between parent and child (coupling parameter).
 
-When coupling > 0, closely related branches have similar rates (autocorrelated clock, matching the biological expectation that rate-influencing traits evolve gradually). When coupling = 0, the model degenerates to an uncorrelated clock where each branch rate is independent (Drummond et al. 2006). Lepage et al. (2007) compared relaxed clock models and found that autocorrelated models perform better when rate variation is driven by lineage-specific traits, while uncorrelated models handle episodic rate changes better.
+When coupling > 0, closely related branches have similar rates (autocorrelated clock, matching the biological expectation that rate-influencing traits evolve gradually). When coupling = 0, the model degenerates to an uncorrelated clock where each branch rate is independent (<a id="cite-11"></a>[Drummond et al. 2006](https://doi.org/10.1371/journal.pbio.0040088) [[11](#ref-11)]). <a id="cite-12"></a>[Lepage et al. 2007](https://doi.org/10.1093/molbev/msm193) [[12](#ref-12)] compared relaxed clock models and found that autocorrelated models perform better when rate variation is driven by lineage-specific traits, while uncorrelated models handle episodic rate changes better.
 
 v1: [`packages/treetime/src/commands/timetree/optimization/relaxed_clock.rs`](../../packages/treetime/src/commands/timetree/optimization/relaxed_clock.rs).
 v0: `TreeTime.relaxed_clock()` in [`packages/legacy/treetime/treetime/treetime.py`](../../packages/legacy/treetime/treetime/treetime.py).
@@ -151,9 +135,6 @@ The `one_mutation` parameter (sum of sequence lengths across all partitions) set
 ### References
 
 - Zuckerkandl & Pauling (1962). "Molecular Disease, Evolution, and Genic Heterogeneity." In Kasha & Pullman (eds.), Horizons in Biochemistry, pp. 189-225. Academic Press
-- Thorne, Kishino & Painter (1998). "Estimating the rate of evolution of the rate of molecular evolution." Mol Biol Evol, 15(12):1647-1657. doi:10.1093/oxfordjournals.molbev.a025892
-- Drummond, Ho, Phillips & Rambaut (2006). "Relaxed phylogenetics and dating with confidence." PLOS Biology, 4(5):e88. doi:10.1371/journal.pbio.0040088
-- Lepage, Bryant, Philippe & Lartillot (2007). "A general comparison of relaxed molecular clock models." Mol Biol Evol, 24(12):2669-2680. doi:10.1093/molbev/msm193
 
 ---
 
@@ -169,7 +150,7 @@ v1: [`packages/treetime/src/commands/timetree/optimization/polytomy.rs`](../../p
 
 The algorithm iterates over all nodes with >2 children. For each polytomy, it computes pairwise likelihood gains for merging each pair of children under a new internal node, selects the pair with the highest gain, and merges them. This repeats until no pair exceeds the resolution threshold (default 0.05 log-likelihood units) or the node becomes binary.
 
-This approach is deterministic and reproducible but biases toward caterpillar-like topologies: after the first merge creates a new internal node, subsequent merges preferentially attach to it (because it has the most informative branch distribution), creating an imbalanced subtree (Sagulenko et al. 2018, Section 2.6).
+This approach is deterministic and reproducible but biases toward caterpillar-like topologies: after the first merge creates a new internal node, subsequent merges preferentially attach to it (because it has the most informative branch distribution), creating an imbalanced subtree ([[3](#ref-3)], Section 2.6).
 
 - `resolve_polytomies()` (`#resolve_polytomies`) [packages/treetime/src/commands/timetree/optimization/polytomy.rs#L27-L32](../../packages/treetime/src/commands/timetree/optimization/polytomy.rs#L27-L32): entry point with default threshold (0.05).
 - `compute_merge_gain()` (`#compute_merge_gain`) [packages/treetime/src/commands/timetree/optimization/polytomy.rs#L225](../../packages/treetime/src/commands/timetree/optimization/polytomy.rs#L225): uses Brent optimization (via `argmin` crate) to find the optimal merge time and cost gain for a child pair.
@@ -217,19 +198,17 @@ v1: [`packages/treetime/src/commands/timetree/convergence/`](../../packages/tree
 
 ## Iterative EM-like Refinement
 
-Alternates sequence reconstruction (E-step) and time inference (M-step), iterating until convergence (Sagulenko et al. 2018, Section 2.4). Each iteration optionally applies relaxed clock rate estimation, resolves polytomies, and re-estimates the clock model.
+Alternates sequence reconstruction (E-step) and time inference (M-step), iterating until convergence ([[3](#ref-3)], Section 2.4). Each iteration optionally applies relaxed clock rate estimation, resolves polytomies, and re-estimates the clock model.
 
 v1: [`packages/treetime/src/commands/timetree/refinement.rs`](../../packages/treetime/src/commands/timetree/refinement.rs).
 
 - `run_refinement_iteration()` (`#run_refinement_iteration`) [packages/treetime/src/commands/timetree/refinement.rs#L21-L106](../../packages/treetime/src/commands/timetree/refinement.rs#L21-L106): per-iteration logic: relaxed clock, polytomy resolution, ancestral reconstruction, timetree inference, clock re-estimation. Captures ancestral state snapshots before polytomy resolution.
 
-Reference: Sagulenko, Puller & Neher (2018). "TreeTime." Virus Evolution, 4(1):vex042, Section 2.4.
-
 ---
 
 ## Confidence Intervals
 
-Node date uncertainty has two independent sources (Sagulenko, Puller & Neher 2018, Section 2.2):
+Node date uncertainty has two independent sources ([[3](#ref-3)], Section 2.2):
 
 1. Mutation stochasticity. The Poisson process of substitution accumulation creates branch length uncertainty, which propagates through the backward/forward belief propagation passes. The marginal posterior distribution at each node captures this. Nodes constrained by many descendant dates have narrow posteriors; weakly constrained nodes have wide posteriors.
 2. Clock rate uncertainty. The regression slope has a standard error from the 2x2 Hessian inverse (`ClockModel::cov()`). All node times scale inversely with the rate, so rate uncertainty propagates to all dates. Nodes near the root have the highest sensitivity: a 10% rate error shifts the root date by 10% of the tree depth.
@@ -291,14 +270,11 @@ lower = center - sqrt((rate_lo - center)^2 + (mutation_lo - center)^2)
 upper = center + sqrt((rate_hi - center)^2 + (mutation_hi - center)^2)
 ```
 
-Clipped to distribution domain (physical limits). This is a first-order Gaussian approximation (Sagulenko et al. 2018, Section 2.2). The combined interval is wider than either source alone but narrower than the sum of deviations.
+Clipped to distribution domain (physical limits). This is a first-order Gaussian approximation ([[3](#ref-3)], Section 2.2). The combined interval is wider than either source alone but narrower than the sum of deviations.
 
 v0: `combine_confidence()` (`clock_tree.py:1090-1101`). Same formula.
 
 ### References
-
-- Sagulenko, Puller & Neher (2018). "TreeTime." Virus Evolution, 4(1):vex042, Section 2.2. doi:10.1093/ve/vex042
-- Felsenstein (1985). "Confidence limits on phylogenies: an approach using the bootstrap." Evolution, 39(4):783-791. doi:10.2307/2408678
 
 ---
 
@@ -329,6 +305,24 @@ Clock-based rerooting with partition state update. Searches for the root positio
 v1: [`packages/treetime/src/commands/timetree/optimization/reroot.rs`](../../packages/treetime/src/commands/timetree/optimization/reroot.rs).
 
 - `reroot_tree()` (`#reroot_tree`) [packages/treetime/src/commands/timetree/optimization/reroot.rs#L20-L93](../../packages/treetime/src/commands/timetree/optimization/reroot.rs#L20-L93): performs clock regression with rerooting, applies topology changes to partitions (edge split, edge merge, inverted edges), recomputes marginal messages
+
+---
+
+## References
+
+- <a id="ref-1"></a>Pearl, Judea. 1988. _Probabilistic Reasoning in Intelligent Systems: Networks of Plausible Inference._ Morgan Kaufmann. ISBN 978-0-934613-73-2. [↩](#cite-1)
+- <a id="ref-2"></a>Kingman, J. F. C. 1982. "The Coalescent." _Stochastic Processes and their Applications_ 13(3):235-248. https://doi.org/10.1016/0304-4149(82)90011-4 [↩](#cite-2)
+- <a id="ref-3"></a>Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evolution_ 4(1):vex042. https://doi.org/10.1093/ve/vex042 [↩](#cite-3)
+- <a id="ref-4"></a>Brent, Richard P. 1973. _Algorithms for Minimization Without Derivatives._ Prentice-Hall. ISBN 978-0-13-022335-7. [↩](#cite-4)
+- <a id="ref-5"></a>Pybus, Oliver G., Andrew Rambaut, and Paul H. Harvey. 2000. "An Integrated Framework for the Inference of Viral Population History from Reconstructed Genealogies." _Genetics_ 155(3):1429-1437. https://doi.org/10.1093/genetics/155.3.1429 [↩](#cite-5)
+- <a id="ref-6"></a>Drummond, Alexei J., Andrew Rambaut, Beth Shapiro, and Oliver G. Pybus. 2005. "Bayesian Coalescent Inference of Past Population Dynamics from Molecular Sequences." _Molecular Biology and Evolution_ 22(5):1185-1192. https://doi.org/10.1093/molbev/msi103 [↩](#cite-6)
+- <a id="ref-7"></a>Minin, Vladimir N., Erik W. Bloomquist, and Marc A. Suchard. 2008. "Smooth Skyride Through a Rough Skyline: Bayesian Coalescent-Based Inference of Population Dynamics." _Molecular Biology and Evolution_ 25(7):1459-1471. https://doi.org/10.1093/molbev/msn090 [↩](#cite-7)
+- <a id="ref-8"></a>Strimmer, Korbinian, and Oliver G. Pybus. 2001. "Exploring the Demographic History of DNA Sequences Using the Generalized Skyline Plot." _Molecular Biology and Evolution_ 18(12):2298-2305. https://doi.org/10.1093/oxfordjournals.molbev.a003776
+- <a id="ref-9"></a>Zuckerkandl, Emile, and Linus Pauling. 1965. "Evolutionary Divergence and Convergence in Proteins." In _Evolving Genes and Proteins,_ edited by Vernon Bryson and Henry J. Vogel, 97-166. Academic Press. https://doi.org/10.1016/B978-1-4832-2734-4.50017-6 [↩](#cite-9)
+- <a id="ref-10"></a>Thorne, Jeffrey L., Hirohisa Kishino, and Ian S. Painter. 1998. "Estimating the Rate of Evolution of the Rate of Molecular Evolution." _Molecular Biology and Evolution_ 15(12):1647-1657. https://doi.org/10.1093/oxfordjournals.molbev.a025892 [↩](#cite-10)
+- <a id="ref-11"></a>Drummond, Alexei J., Simon Y. W. Ho, Matthew J. Phillips, and Andrew Rambaut. 2006. "Relaxed Phylogenetics and Dating with Confidence." _PLoS Biology_ 4(5):e88. https://doi.org/10.1371/journal.pbio.0040088 [↩](#cite-11)
+- <a id="ref-12"></a>Lepage, Thomas, David Bryant, Herve Philippe, and Nicolas Lartillot. 2007. "A General Comparison of Relaxed Molecular Clock Models." _Molecular Biology and Evolution_ 24(12):2669-2680. https://doi.org/10.1093/molbev/msm193 [↩](#cite-12)
+- <a id="ref-13"></a>Felsenstein, Joseph. 1985. "Confidence Limits on Phylogenies: An Approach Using the Bootstrap." _Evolution_ 39(4):783-791. https://doi.org/10.2307/2408678
 
 ---
 

--- a/kb/algo/unimplemented.md
+++ b/kb/algo/unimplemented.md
@@ -31,7 +31,7 @@ Forward pass (lines 1043-1063):
 
 - `node.seq_idx = choose(parent.seq_idx, node.joint_Cx.T)` - traceback via argmax pointers
 
-Reference: Pupko, Pe'er, Shamir & Graur (2000). "A fast algorithm for joint reconstruction of ancestral amino acid sequences." Mol Biol Evol, 17(6):890-896. doi:10.1093/oxfordjournals.molbev.a026369
+Reference: <a id="cite-1"></a>[Pupko et al. 2000](https://doi.org/10.1093/oxfordjournals.molbev.a026369) [[1](#ref-1)]
 
 ---
 
@@ -103,9 +103,7 @@ Known issue: [Per-site rate variation not implemented](../issues/M-gtr-per-site-
 
 For each site `a`, the matrix exponential becomes `exp(Q * mu_a * t)`. With eigendecomposition `Q = V * diag(lambda) * V_inv`, this is `V * diag(exp(lambda * mu_a * t)) * V_inv`. The eigenvectors `V`, `V_inv` are computed once; only the `exp(lambda_k * mu_a * t)` terms change per site.
 
-### Reference
-
-Yang Z (1994). "Maximum likelihood phylogenetic estimation from DNA sequences with variable rates over sites: approximate methods." J Mol Evol 39:306-314.
+Reference: <a id="cite-2"></a>[Yang 1994](https://doi.org/10.1007/BF00178256) [[2](#ref-2)]
 
 ---
 
@@ -129,14 +127,14 @@ v1: `GTR.is_site_specific` (`#is_site_specific`) field exists (always false); no
 
 ## Stochastic Polytomy Resolution
 
-Coalescent-based stochastic resolution of polytomies as an alternative to the greedy deterministic method. Produces more realistic tree topologies by sampling from the Kingman coalescent process (Kingman 1982) rather than always merging the highest-gain pair.
+Coalescent-based stochastic resolution of polytomies as an alternative to the greedy deterministic method. Produces more realistic tree topologies by sampling from the Kingman coalescent process (<a id="cite-3"></a>[Kingman 1982](<https://doi.org/10.1016/0304-4149(82)90011-4>) [[3](#ref-3)]) rather than always merging the highest-gain pair.
 
 v0: `generate_subtree()` (`#generate_subtree`) in [`packages/legacy/treetime/treetime/treetime.py#L872-L1011`](../../packages/legacy/treetime/treetime/treetime.py#L872-L1011), dispatched by `resolve_polytomies()` (`#resolve_polytomies`).
 v1: not ported - v1 has greedy deterministic approach only. Known issue: [Stochastic polytomy resolution not implemented](../issues/N-timetree-stochastic-polytomy-unimplemented.md). CLI: `--stochastic-resolve` (v0), `--greedy-resolve` (v0 inverse). v0 prints a deprecation warning for greedy mode, intending to make stochastic the default ([packages/legacy/treetime/treetime/treetime.py#L682-L685](../../packages/legacy/treetime/treetime/treetime.py#L682-L685)).
 
 ### Background
 
-The greedy method (`_poly()` in v0, `resolve_polytomies()` in v1) always merges the pair with the highest likelihood gain. This biases toward caterpillar-like (comb) topologies because after the first merge creates a new internal node, subsequent merges preferentially attach to it (Sagulenko et al. 2018, Section 2.6). The stochastic method samples resolutions from the Kingman coalescent process, producing tree shapes consistent with population dynamics. v0 intended to make stochastic the default: "Stochastic resolution will become the default in future versions" ([packages/legacy/treetime/treetime/treetime.py#L682-L685](../../packages/legacy/treetime/treetime/treetime.py#L682-L685)).
+The greedy method (`_poly()` in v0, `resolve_polytomies()` in v1) always merges the pair with the highest likelihood gain. This biases toward caterpillar-like (comb) topologies because after the first merge creates a new internal node, subsequent merges preferentially attach to it (<a id="cite-4"></a>[Sagulenko et al. 2018](https://doi.org/10.1093/ve/vex042) [[4](#ref-4)], Section 2.6). The stochastic method samples resolutions from the Kingman coalescent process, producing tree shapes consistent with population dynamics. v0 intended to make stochastic the default: "Stochastic resolution will become the default in future versions" ([packages/legacy/treetime/treetime/treetime.py#L682-L685](../../packages/legacy/treetime/treetime/treetime.py#L682-L685)).
 
 ### Algorithm (`generate_subtree()`, [packages/legacy/treetime/treetime/treetime.py#L872-L1011](../../packages/legacy/treetime/treetime/treetime.py#L872-L1011))
 
@@ -365,3 +363,14 @@ Iterative parameter estimation for discrete trait (mugration) GTR models followi
 
 v0: `reconstruct_discrete_traits()` in [`packages/legacy/treetime/treetime/wrappers.py#L785-L809`](../../packages/legacy/treetime/treetime/wrappers.py#L785-L809), `TreeAnc.infer_gtr()` in [`packages/legacy/treetime/treetime/treeanc.py#L1500-L1632`](../../packages/legacy/treetime/treetime/treeanc.py#L1500-L1632).
 v1: `refine_gtr_iterative()` in [`packages/treetime/src/commands/mugration/gtr_refinement.rs`](../../packages/treetime/src/commands/mugration/gtr_refinement.rs). Remaining parity gap tracked in [Mugration golden master parity with v0](../issues/M-mugration-iterative-gtr.md). Full forward-backward per iteration proposed in [mugration-full-reconstruction-per-iteration](../proposals/mugration-full-reconstruction-per-iteration.md).
+
+---
+
+## References
+
+- <a id="ref-1"></a>Pupko, Tal, Itsik Pe'er, Ron Shamir, and Dan Graur. 2000. "A Fast Algorithm for Joint Reconstruction of Ancestral Amino Acid Sequences." _Molecular Biology and Evolution_ 17(6):890-896. https://doi.org/10.1093/oxfordjournals.molbev.a026369 [↩](#cite-1)
+- <a id="ref-2"></a>Yang, Ziheng. 1994. "Maximum Likelihood Phylogenetic Estimation from DNA Sequences with Variable Rates over Sites: Approximate Methods." _Journal of Molecular Evolution_ 39(3):306-314. https://doi.org/10.1007/BF00178256 [↩](#cite-2)
+- <a id="ref-3"></a>Kingman, J. F. C. 1982. "The Coalescent." _Stochastic Processes and their Applications_ 13(3):235-248. https://doi.org/10.1016/0304-4149(82)90011-4 [↩](#cite-3)
+- <a id="ref-4"></a>Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evolution_ 4(1):vex042. https://doi.org/10.1093/ve/vex042 [↩](#cite-4)
+- <a id="ref-5"></a>Dempster, Arthur P., Nan M. Laird, and Donald B. Rubin. 1977. "Maximum Likelihood from Incomplete Data via the EM Algorithm." _Journal of the Royal Statistical Society: Series B_ 39(1):1-38. https://doi.org/10.1111/j.2517-6161.1977.tb01600.x
+- <a id="ref-6"></a>Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359

--- a/kb/decisions/ancestral-joint-reconstruction-removed.md
+++ b/kb/decisions/ancestral-joint-reconstruction-removed.md
@@ -16,7 +16,7 @@ The distinction matters because the most probable state at each position (from m
 
 ## The Pupko et al. 2000 algorithm
 
-Joint reconstruction was formalized by Pupko, Pe'er, Shamir, and Graur in "A fast algorithm for joint reconstruction of ancestral amino acid sequences" (Molecular Biology and Evolution, 2000). Their algorithm runs in O(n _ L _ k^2) time where n is the number of taxa, L is sequence length, and k is alphabet size.
+Joint reconstruction was formalized by <a id="cite-1"></a>[Pupko et al. 2000](https://doi.org/10.1093/oxfordjournals.molbev.a026369) [[1](#ref-1)]. Their algorithm runs in O(n _ L _ k^2) time where n is the number of taxa, L is sequence length, and k is alphabet size.
 
 The algorithm has two passes over the tree:
 
@@ -35,13 +35,13 @@ The v0 implementation at `packages/legacy/treetime/treetime/treeanc.py:960-1063:
 
 ## Why joint reconstruction is statistically inconsistent
 
-Mossel, Roch, and Steel proved in "Shrinkage effect in ancestral maximum likelihood" (IEEE/ACM Transactions on Computational Biology and Bioinformatics, 2009) that joint ancestral maximum likelihood is statistically inconsistent. This means that even with infinite sequence data, the method can produce incorrect results.
+<a id="cite-2"></a>[Mossel, Roch, and Steel 2009](https://doi.org/10.1109/TCBB.2008.107) [[2](#ref-2)] proved that joint ancestral maximum likelihood is statistically inconsistent. This means that even with infinite sequence data, the method can produce incorrect results.
 
 The problem is branch length shrinkage. When jointly optimizing over ancestral states and branch lengths, the optimization systematically underestimates branch lengths. The estimator prefers shorter branches because they make fewer state changes more likely, and when ancestral states are also being optimized, the algorithm can "explain away" the evidence for longer branches by choosing convenient ancestral states.
 
 For certain tree topologies - particularly when one pair of sister branches is long and internal branches are short - the joint method estimates internal branch lengths as exactly zero even with infinite data. This collapses internal resolution, turning a resolved tree into a star tree.
 
-A 2019 follow-up paper (Shaw, Dinh, and Matsen, "Joint Maximum Likelihood of Phylogeny and Ancestral States Is Not Consistent", Molecular Biology and Evolution, doi:10.1093/molbev/msz128) strengthened this result: the only parameter values for which joint inference produces correct branch lengths lie in a set of measure zero. The bias is systematic and downward.
+<a id="cite-3"></a>[Shaw, Dinh, and Matsen 2019](https://doi.org/10.1093/molbev/msz128) [[3](#ref-3)] strengthened this result: the only parameter values for which joint inference produces correct branch lengths lie in a set of measure zero. The bias is systematic and downward.
 
 Marginal reconstruction avoids this problem by integrating over ancestral states rather than optimizing them. The classical Felsenstein pruning algorithm computes marginal likelihoods that are statistically consistent for branch length and topology inference.
 
@@ -72,3 +72,9 @@ Running `treetime ancestral` without `--method-anc` panics because `Joint` is th
 The `timetree` and `clock` commands accept `--method-anc` but ignore it - they always use marginal reconstruction internally. This may change in future versions.
 
 No golden master tests exist for joint reconstruction in v1. Marginal reconstruction is the recommended method for all use cases.
+
+## References
+
+- <a id="ref-1"></a>Pupko, Tal, Itsik Pe'er, Ron Shamir, and Dan Graur. 2000. "A Fast Algorithm for Joint Reconstruction of Ancestral Amino Acid Sequences." _Molecular Biology and Evolution_ 17(6):890-896. https://doi.org/10.1093/oxfordjournals.molbev.a026369 [↩](#cite-1)
+- <a id="ref-2"></a>Mossel, Elchanan, Sebastien Roch, and Mike Steel. 2009. "Shrinkage Effect in Ancestral Maximum Likelihood." _IEEE/ACM Transactions on Computational Biology and Bioinformatics_ 6(1):126-133. https://doi.org/10.1109/TCBB.2008.107 [↩](#cite-2)
+- <a id="ref-3"></a>Shaw, David, Vu Dinh, and Frederick A. Matsen IV. 2019. "Joint Maximum Likelihood of Phylogeny and Ancestral States Is Not Consistent." _Molecular Biology and Evolution_ 36(11):2613-2619. https://doi.org/10.1093/molbev/msz128 [↩](#cite-3)

--- a/kb/decisions/coalescent-multiplication-ordering.md
+++ b/kb/decisions/coalescent-multiplication-ordering.md
@@ -121,7 +121,7 @@ The v1 grid strategy (uniform grid with max points) was chosen for simplicity an
 
 ## References
 
-- Kingman, J.F.C. (1982). "The coalescent." Stochastic Processes and their Applications 13(3): 235-248. doi:10.1016/0304-4149(82)90011-4
-- Sagulenko, P., Puller, V., Neher, R.A. (2018). "TreeTime: Maximum-likelihood phylodynamic analysis." Virus Evolution 4(1): vex042. doi:10.1093/ve/vex042
+- Kingman, J.F.C. (1982). "The coalescent." Stochastic Processes and their Applications 13(3): 235-248. https://doi.org/10.1016/0304-4149(82)90011-4
+- Sagulenko, P., Puller, V., Neher, R.A. (2018). "TreeTime: Maximum-likelihood phylodynamic analysis." Virus Evolution 4(1): vex042. https://doi.org/10.1093/ve/vex042
 - Wakeley, J. (2009). "Coalescent Theory: An Introduction." Roberts & Company Publishers. ISBN 978-0-9747077-5-4
 - Tellier, A., Lemaire, C. (2014). "Coalescence 2.0: a multiple branching of recent theoretical developments and their applications." arXiv:1401.5248

--- a/kb/decisions/command-optimize-standalone.md
+++ b/kb/decisions/command-optimize-standalone.md
@@ -110,9 +110,9 @@ v1 applies the same outer-loop exponential damping as v0 (`--damping`, default 0
 
 ## References
 
-- Felsenstein J (1981). Evolutionary trees from DNA sequences: a maximum likelihood approach. Journal of Molecular Evolution 17(6):368-376.
-- Dinh V, Matsen FA IV (2015). The shape of the one-dimensional phylogenetic likelihood function. arXiv 1507.03647.
-- Clancy KM, Lyu H, Roch S (2025). Sample Complexity of Branch-length Estimation by Maximum Likelihood. arXiv 2507.22038.
-- Stamatakis A (2006). RAxML-VI-HPC: maximum likelihood-based phylogenetic analyses with thousands of taxa and mixed models. Bioinformatics 22(21):2688-2690.
-- Nguyen LT, Schmidt HA, von Haeseler A, Minh BQ (2015). IQ-TREE: A fast and effective stochastic algorithm for estimating maximum-likelihood phylogenies. Mol Biol Evol 32(1):268-274.
-- Guindon S, Gascuel O (2003). A simple, fast, and accurate algorithm to estimate large phylogenies by maximum likelihood. Systematic Biology 52(5):696-704.
+- Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359
+- Dinh, Vu, and Frederick A. Matsen IV. 2015. "The Shape of the One-Dimensional Phylogenetic Likelihood Function." arXiv:1507.03647. https://arxiv.org/abs/1507.03647
+- Clancy, Killian M., Hanlin Lyu, and Sebastien Roch. 2025. "Sample Complexity of Branch-Length Estimation by Maximum Likelihood." arXiv:2507.22038. https://arxiv.org/abs/2507.22038
+- Stamatakis, Alexandros. 2006. "RAxML-VI-HPC: Maximum Likelihood-Based Phylogenetic Analyses with Thousands of Taxa and Mixed Models." _Bioinformatics_ 22(21):2688-2690. https://doi.org/10.1093/bioinformatics/btl446
+- Nguyen, Lam-Tung, Heiko A. Schmidt, Arndt von Haeseler, and Bui Quang Minh. 2015. "IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies." _Molecular Biology and Evolution_ 32(1):268-274. https://doi.org/10.1093/molbev/msu300
+- Guindon, Stephane, and Olivier Gascuel. 2003. "A Simple, Fast, and Accurate Algorithm to Estimate Large Phylogenies by Maximum Likelihood." _Systematic Biology_ 52(5):696-704. https://doi.org/10.1080/10635150390235520

--- a/kb/decisions/graph-based-phylogenetic-representation.md
+++ b/kb/decisions/graph-based-phylogenetic-representation.md
@@ -400,7 +400,7 @@ When multiple traversals over the same tree are needed (Fitch parsimony pass, ma
 
 <a id="ref-34"></a>[34] Sagulenko, P., Puller, V. & Neher, R.A. (2018). TreeTime: Maximum-likelihood phylodynamic analysis. Virus Evolution 4:vex042.
 
-<a id="ref-35"></a>[35] Kelleher, J., Thornton, K.R., Ashander, J. & Ralph, P.L. (2018). Efficient pedigree recording for fast population genetics simulation. PLOS Computational Biology 14:e1006581. doi:10.1371/journal.pcbi.1006581
+<a id="ref-35"></a>[35] Kelleher, J., Thornton, K.R., Ashander, J. & Ralph, P.L. (2018). Efficient pedigree recording for fast population genetics simulation. PLOS Computational Biology 14:e1006581. https://doi.org/10.1371/journal.pcbi.1006581
 
 <a id="ref-36"></a>[36] Fournier, R. & Larribe, F. (2025). Moonshine.jl: a Julia package for genome-scale model-based ancestral recombination graph inference. arXiv:2511.21124.
 

--- a/kb/decisions/gtr-uninformative-root-state-filtering.md
+++ b/kb/decisions/gtr-uninformative-root-state-filtering.md
@@ -106,5 +106,5 @@ Test cases in `packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_d
 
 ## References
 
-- Tavaré, S. (1986). Some probabilistic and statistical problems in the analysis of DNA sequences. _Lectures on Mathematics in the Life Sciences_, 17, 57-86.
-- Felsenstein, J. (1981). Evolutionary trees from DNA sequences: A maximum likelihood approach. _Journal of Molecular Evolution_, 17(6), 368-376.
+- Tavaré, Simon. 1986. "Some Probabilistic and Statistical Problems in the Analysis of DNA Sequences." _Lectures on Mathematics in the Life Sciences_ 17:57-86.
+- Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359

--- a/kb/decisions/optimize-newton-raphson-per-edge.md
+++ b/kb/decisions/optimize-newton-raphson-per-edge.md
@@ -71,10 +71,10 @@ Convergence behavior tracks v0: the outer loop applies exponential damping (`--d
 
 ## References
 
-- Brent RP (1973). _Algorithms for Minimization without Derivatives_. Prentice-Hall.
-- Dinh V, Matsen FA IV (2015). The shape of the one-dimensional phylogenetic likelihood function. arXiv 1507.03647.
-- Felsenstein J (2003). _Inferring Phylogenies_. Sinauer Associates. Chapter 16.
-- Stamatakis A (2006). RAxML-VI-HPC: maximum likelihood-based phylogenetic analyses with thousands of taxa and mixed models. Bioinformatics 22(21):2688-2690.
-- Stamatakis A (2014). RAxML version 8: a tool for phylogenetic analysis and post-analysis of large phylogenies. Bioinformatics 30(9):1312-1313.
-- Nguyen LT, Schmidt HA, von Haeseler A, Minh BQ (2015). IQ-TREE: A fast and effective stochastic algorithm for estimating maximum-likelihood phylogenies. Mol Biol Evol 32(1):268-274.
-- Minh BQ, Schmidt HA, Chernomor O, Schrempf D, Woodhams MD, von Haeseler A, Lanfear R (2020). IQ-TREE 2: New models and efficient methods for phylogenetic inference in the genomic era. Mol Biol Evol 37(5):1530-1534.
+- Brent, Richard P. 1973. _Algorithms for Minimization Without Derivatives._ Prentice-Hall. ISBN 978-0-13-022335-7.
+- Dinh, Vu, and Frederick A. Matsen IV. 2015. "The Shape of the One-Dimensional Phylogenetic Likelihood Function." arXiv:1507.03647. https://arxiv.org/abs/1507.03647
+- Felsenstein, Joseph. 2003. _Inferring Phylogenies._ Sinauer Associates. ISBN 978-0-87893-177-4. Chapter 16.
+- Stamatakis, Alexandros. 2006. "RAxML-VI-HPC: Maximum Likelihood-Based Phylogenetic Analyses with Thousands of Taxa and Mixed Models." _Bioinformatics_ 22(21):2688-2690. https://doi.org/10.1093/bioinformatics/btl446
+- Stamatakis, Alexandros. 2014. "RAxML Version 8: A Tool for Phylogenetic Analysis and Post-Analysis of Large Phylogenies." _Bioinformatics_ 30(9):1312-1313. https://doi.org/10.1093/bioinformatics/btu033
+- Nguyen, Lam-Tung, Heiko A. Schmidt, Arndt von Haeseler, and Bui Quang Minh. 2015. "IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies." _Molecular Biology and Evolution_ 32(1):268-274. https://doi.org/10.1093/molbev/msu300
+- Minh, Bui Quang, Heiko A. Schmidt, Olga Chernomor, Dominik Schrempf, Michael D. Woodhams, Arndt von Haeseler, and Robert Lanfear. 2020. "IQ-TREE 2: New Models and Efficient Methods for Phylogenetic Inference in the Genomic Era." _Molecular Biology and Evolution_ 37(5):1530-1534. https://doi.org/10.1093/molbev/msaa015

--- a/kb/decisions/partition-system-architecture.md
+++ b/kb/decisions/partition-system-architecture.md
@@ -30,12 +30,12 @@ The molecular clock hypothesis (Zuckerkandl & Pauling, 1962) proposes that mutat
 
 ### References
 
-- Jukes TH, Cantor CR (1969). Evolution of protein molecules. Mammalian Protein Metabolism 3:21-132.
-- Kimura M (1980). A simple method for estimating evolutionary rates of base substitutions. J Mol Evol 16:111-120.
-- Hasegawa M, Kishino H, Yano T (1985). Dating of the human-ape splitting by a molecular clock of mitochondrial DNA. J Mol Evol 22:160-174.
-- Tavaré S (1986). Some probabilistic and statistical problems in the analysis of DNA sequences. Lectures on Mathematics in the Life Sciences 17:57-86.
-- Lanfear R, Calcott B, Ho SYW, Guindon S (2012). PartitionFinder: Combined selection of partitioning schemes and substitution models for phylogenetic analyses. Mol Biol Evol 29(6):1695-1701.
-- Zuckerkandl E, Pauling L (1962). Molecular disease, evolution, and genetic heterogeneity. Horizons in Biochemistry, Academic Press, pp. 189-225.
+- Jukes, Thomas H., and Charles R. Cantor. 1969. "Evolution of Protein Molecules." In _Mammalian Protein Metabolism,_ vol. 3, edited by H. N. Munro, 21-132. Academic Press. https://doi.org/10.1016/B978-1-4832-3211-9.50009-7
+- Kimura, Motoo. 1980. "A Simple Method for Estimating Evolutionary Rates of Base Substitutions Through Comparative Studies of Nucleotide Sequences." _Journal of Molecular Evolution_ 16(2):111-120. https://doi.org/10.1007/BF01731581
+- Hasegawa, Masami, Hirohisa Kishino, and Taka-aki Yano. 1985. "Dating of the Human-Ape Splitting by a Molecular Clock of Mitochondrial DNA." _Journal of Molecular Evolution_ 22(2):160-174. https://doi.org/10.1007/BF02101694
+- Tavaré, Simon. 1986. "Some Probabilistic and Statistical Problems in the Analysis of DNA Sequences." _Lectures on Mathematics in the Life Sciences_ 17:57-86.
+- Lanfear, Robert, Brett Calcott, Simon Y. W. Ho, and Stephane Guindon. 2012. "PartitionFinder: Combined Selection of Partitioning Schemes and Substitution Models for Phylogenetic Analyses." _Molecular Biology and Evolution_ 29(6):1695-1701. https://doi.org/10.1093/molbev/mss020
+- Zuckerkandl, Emile, and Linus Pauling. 1962. "Molecular Disease, Evolution, and Genetic Heterogeneity." In _Horizons in Biochemistry,_ edited by Michael Kasha and Bernard Pullman, 189-225. Academic Press.
 
 ## What v0 does
 

--- a/kb/decisions/sequence-representation-dense-sparse.md
+++ b/kb/decisions/sequence-representation-dense-sparse.md
@@ -84,4 +84,4 @@ The `infer_dense()` function (`packages/treetime/src/representation/algo/infer_d
 
 [1] SARS-CoV-2 mutation rate estimate from early pandemic sequences. Wikipedia contributors, "Severe acute respiratory syndrome coronavirus 2," Wikipedia. https://en.wikipedia.org/wiki/SARS-CoV-2
 
-[2] Felsenstein J. Evolutionary trees from DNA sequences: a maximum likelihood approach. J Mol Evol. 1981;17(6):368-76. doi:10.1007/BF01734359. PMID: 7288891.
+[2] Felsenstein J. Evolutionary trees from DNA sequences: a maximum likelihood approach. J Mol Evol. 1981;17(6):368-76. https://doi.org/10.1007/BF01734359. PMID: 7288891.

--- a/kb/decisions/sparse-fixed-position-scalar-rate-approximation.md
+++ b/kb/decisions/sparse-fixed-position-scalar-rate-approximation.md
@@ -35,6 +35,6 @@ The approximation affects likelihood magnitude and marginal profiles at all posi
 
 ## References
 
-- Felsenstein J (1981). "Evolutionary trees from DNA sequences: a maximum likelihood approach." J Mol Evol 17:368-376.
-- Yang Z (1994). "Maximum likelihood phylogenetic estimation from DNA sequences with variable rates over sites: approximate methods." J Mol Evol 39:306-314.
+- Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359
+- Yang, Ziheng. 1994. "Maximum Likelihood Phylogenetic Estimation from DNA Sequences with Variable Rates over Sites: Approximate Methods." _Journal of Molecular Evolution_ 39(3):306-314. https://doi.org/10.1007/BF00178256
 - v0 guard: `packages/legacy/treetime/treetime/treeanc.py:186-187`

--- a/kb/features/gtr.md
+++ b/kb/features/gtr.md
@@ -28,9 +28,9 @@
 ## References
 
 - Jukes & Cantor (1969). "Evolution of Protein Molecules." In Munro (ed.), Mammalian Protein Metabolism, vol. 3, pp. 21-132. Academic Press
-- Kimura (1980). "A simple method for estimating evolutionary rates of base substitutions through comparative studies of nucleotide sequences." J Mol Evol, 16(2):111-120. doi:10.1007/BF01731581
-- Felsenstein (1981). "Evolutionary trees from DNA sequences: a maximum likelihood approach." J Mol Evol, 17(6):368-376. doi:10.1007/BF01734359
-- Hasegawa, Kishino & Yano (1985). "Dating of the human-ape splitting by a molecular clock of mitochondrial DNA." J Mol Evol, 22(2):160-174. doi:10.1007/BF02101694
-- Tamura (1992). "Estimation of the number of nucleotide substitutions when there are strong transition-transversion and G+C-content biases." Mol Biol Evol, 9(4):678-687. doi:10.1093/oxfordjournals.molbev.a040752
-- Jones, Taylor & Thornton (1992). "The rapid generation of mutation data matrices from protein sequences." CABIOS, 8(3):275-282. doi:10.1093/bioinformatics/8.3.275
-- Tamura & Nei (1993). "Estimation of the number of nucleotide substitutions in the control region of mitochondrial DNA in humans and chimpanzees." Mol Biol Evol, 10(3):512-526. doi:10.1093/oxfordjournals.molbev.a040023
+- Kimura (1980). "A simple method for estimating evolutionary rates of base substitutions through comparative studies of nucleotide sequences." J Mol Evol, 16(2):111-120. https://doi.org/10.1007/BF01731581
+- Felsenstein (1981). "Evolutionary trees from DNA sequences: a maximum likelihood approach." J Mol Evol, 17(6):368-376. https://doi.org/10.1007/BF01734359
+- Hasegawa, Kishino & Yano (1985). "Dating of the human-ape splitting by a molecular clock of mitochondrial DNA." J Mol Evol, 22(2):160-174. https://doi.org/10.1007/BF02101694
+- Tamura (1992). "Estimation of the number of nucleotide substitutions when there are strong transition-transversion and G+C-content biases." Mol Biol Evol, 9(4):678-687. https://doi.org/10.1093/oxfordjournals.molbev.a040752
+- Jones, Taylor & Thornton (1992). "The rapid generation of mutation data matrices from protein sequences." CABIOS, 8(3):275-282. https://doi.org/10.1093/bioinformatics/8.3.275
+- Tamura & Nei (1993). "Estimation of the number of nucleotide substitutions in the control region of mitochondrial DNA in humans and chimpanzees." Mol Biol Evol, 10(3):512-526. https://doi.org/10.1093/oxfordjournals.molbev.a040023

--- a/kb/proposals/config-file-multi-partition.md
+++ b/kb/proposals/config-file-multi-partition.md
@@ -22,7 +22,7 @@ Different genome regions evolve under different substitution models. Protein-cod
 
 ### NEXUS SETS block
 
-The NEXUS file format (Maddison, Swofford, and Maddison 1997, doi:10.1093/sysbio/46.4.590) defines `CHARSET` and `CHARPARTITION` commands for specifying data subsets:
+The NEXUS file format (Maddison, Swofford, and Maddison 1997, https://doi.org/10.1093/sysbio/46.4.590) defines `CHARSET` and `CHARPARTITION` commands for specifying data subsets:
 
 ```
 #nexus
@@ -33,11 +33,11 @@ begin sets;
 end;
 ```
 
-MrBayes (Ronquist and Huelsenbeck 2003, doi:10.1093/bioinformatics/btg180) popularized NEXUS charsets for mixed-model Bayesian partitioned analysis. PartitionFinder (Lanfear et al. 2012, doi:10.1093/molbev/mss020) automates partition scheme selection.
+MrBayes (Ronquist and Huelsenbeck 2003, https://doi.org/10.1093/bioinformatics/btg180) popularized NEXUS charsets for mixed-model Bayesian partitioned analysis. PartitionFinder (Lanfear et al. 2012, https://doi.org/10.1093/molbev/mss020) automates partition scheme selection.
 
 ### IQ-TREE partition modes
 
-IQ-TREE 2 (Minh et al. 2020, doi:10.1093/molbev/msaa015) supports three partition modes: edge-linked proportional (`-spp`), edge-linked equal (`-q`), and edge-unlinked (`-sp`). Terrace-aware search (Chernomor, von Haeseler, and Minh 2016, doi:10.1093/sysbio/syw037) handles partitioned data with missing taxa.
+IQ-TREE 2 (Minh et al. 2020, https://doi.org/10.1093/molbev/msaa015) supports three partition modes: edge-linked proportional (`-spp`), edge-linked equal (`-q`), and edge-unlinked (`-sp`). Terrace-aware search (Chernomor, von Haeseler, and Minh 2016, https://doi.org/10.1093/sysbio/syw037) handles partitioned data with missing taxa.
 
 ### RAxML-NG partition format
 
@@ -46,11 +46,11 @@ GTR+G, gene1 = 1-500
 HKY+I, gene2 = 501-1200
 ```
 
-Column-range-based partitioning of a concatenated alignment. Kozlov et al. 2019, doi:10.1093/bioinformatics/btz305.
+Column-range-based partitioning of a concatenated alignment. Kozlov et al. 2019, https://doi.org/10.1093/bioinformatics/btz305.
 
 ### BEAST XML
 
-Full model hierarchy in XML: sequence data, substitution models, clock models, tree priors, operators. Complete but verbose. Drummond and Rambaut 2007, doi:10.1186/1471-2148-7-214.
+Full model hierarchy in XML: sequence data, substitution models, clock models, tree priors, operators. Complete but verbose. Drummond and Rambaut 2007, https://doi.org/10.1186/1471-2148-7-214.
 
 ## Proposed design
 

--- a/kb/proposals/optimize-indel-model-alternatives.md
+++ b/kb/proposals/optimize-indel-model-alternatives.md
@@ -44,7 +44,7 @@ Replace the single rate $\mu$ with separate insertion rate $\lambda$ and deletio
 
 $$\ell_{\text{indel}}(t) = k_{\text{ins}} \ln(\lambda t) - \lambda t + k_{\text{del}} \ln(\delta t) - \delta t - \text{const}$$
 
-Loewenthal et al. 2021 (doi:10.1093/molbev/msab266) found 74% of RIM-supported protein datasets have $R_D > R_I$, with $R_D/R_I \approx 2$ in Drosophilidae. The asymmetry is not universal: Saccharomycetaceae coding genes show $R_I > R_D$ in 56% of RIM datasets.
+<a id="cite-1"></a>[Loewenthal et al. 2021](https://doi.org/10.1093/molbev/msab266) [[1](#ref-1)] found 74% of RIM-supported protein datasets have $R_D > R_I$, with $R_D/R_I \approx 2$ in Drosophilidae. The asymmetry is not universal: Saccharomycetaceae coding genes show $R_I > R_D$ in 56% of RIM datasets.
 
 **Mathematical note**: with global MLE estimation, $\lambda + \delta = \mu$ always holds (the total rate is the same). The per-edge optimum $t^* = (k_{\text{ins}} + k_{\text{del}})/(\lambda + \delta) = k/\mu$ is identical to the current single-rate model. Separate rates do not change branch length estimates under global MLE. The separation is useful for reporting and for downstream analyses that distinguish insertion-dominated from deletion-dominated branches, but it requires per-edge or per-clade rate estimation to affect branch lengths.
 
@@ -62,7 +62,7 @@ This factorizes the indel process into "how many events" (opening) and "how long
 
 **Implementation effort**: moderate. Two rate parameters estimated from the tree. The Newton step gains two terms. Requires the `InDel` struct to store length (already available).
 
-**Mathematical note**: the per-edge optimum $t^* = (k + L_{\text{ext}})/(\mu_o + \mu_e)$. Since $k + L_{\text{ext}} = \sum l_i$, E3 is equivalent to E1 with linear weighting $w(l) = l$ when $\mu_o = \mu_e$. The separate opening/extension rates add a degree of freedom beyond E1: they allow the model to weight short indels (dominated by opening) differently from long indels (dominated by extension). Rivas 2005 showed geometric instantaneous rates do not produce geometric finite-time distributions, so this is an approximation.
+**Mathematical note**: the per-edge optimum $t^* = (k + L_{\text{ext}})/(\mu_o + \mu_e)$. Since $k + L_{\text{ext}} = \sum l_i$, E3 is equivalent to E1 with linear weighting $w(l) = l$ when $\mu_o = \mu_e$. The separate opening/extension rates add a degree of freedom beyond E1: they allow the model to weight short indels (dominated by opening) differently from long indels (dominated by extension). <a id="cite-2"></a>[Rivas 2005](https://doi.org/10.1186/1471-2105-6-236) [[2](#ref-2)] showed geometric instantaneous rates do not produce geometric finite-time distributions, so this is an approximation.
 
 **Tradeoff**: two parameters. More expressive than E1 (separates opening from extension dynamics). Subsumes E1-linear as a special case ($\mu_o = \mu_e$).
 
@@ -110,6 +110,11 @@ Fit indel length distributions (geometric, Zipf/power-law, multi-exponential) fr
    - No regression on datasets where indels are absent (the extension should be a no-op)
 
 3. Compare against v0 (which ignores indels entirely) to quantify the practical impact.
+
+## References
+
+- <a id="ref-1"></a>Loewenthal, Gil, Dana Rapoport, Oren Avram, Alon Moshe, Anat Kreimer, Michal Linial, and Tal Pupko. 2021. "A Probabilistic Model for Indel Evolution: Differentiating Insertions from Deletions." _Molecular Biology and Evolution_ 38(12):5769-5781. https://doi.org/10.1093/molbev/msab266 [↩](#cite-1)
+- <a id="ref-2"></a>Rivas, Elena. 2005. "Evolutionary Models for Insertions and Deletions in a Probabilistic Modeling Framework." _BMC Bioinformatics_ 6:236. https://doi.org/10.1186/1471-2105-6-236 [↩](#cite-2)
 
 ## Related documents
 

--- a/kb/proposals/optimize-indel-rate-per-iteration-reestimation.md
+++ b/kb/proposals/optimize-indel-rate-per-iteration-reestimation.md
@@ -49,3 +49,11 @@ Restore `estimate_indel_rate()` inside the loop body of `run_optimize_loop()`, c
 ## Full analysis
 
 See [indel rate re-estimation report](../reports/optimize-indel-rate-reestimation.md) for the complete ECM justification, phylogenetic precedent, and empirical evidence.
+
+## References
+
+- Meng, Xiao-Li, and Donald B. Rubin. 1993. "Maximum Likelihood Estimation via the ECM Algorithm: A General Framework." _Biometrika_ 80(2):267-278. https://doi.org/10.1093/biomet/80.2.267
+- Guindon, Stephane, and Olivier Gascuel. 2003. "A Simple, Fast, and Accurate Algorithm to Estimate Large Phylogenies by Maximum Likelihood." _Systematic Biology_ 52(5):696-704. https://doi.org/10.1080/10635150390235520
+- Kozlov, Alexey M., Diego Darriba, Tomas Flouri, Benoit Morel, and Alexandros Stamatakis. 2019. "RAxML-NG: A Fast, Scalable and User-Friendly Tool for Maximum Likelihood Phylogenetic Inference." _Bioinformatics_ 35(21):4453-4455. https://doi.org/10.1093/bioinformatics/btz305
+- Nguyen, Lam-Tung, Heiko A. Schmidt, Arndt von Haeseler, and Bui Quang Minh. 2015. "IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies." _Molecular Biology and Evolution_ 32(1):268-274. https://doi.org/10.1093/molbev/msu300
+- Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _Journal of Molecular Evolution_ 17(6):368-376. https://doi.org/10.1007/BF01734359

--- a/kb/reports/indel-models/4-multi-residue.md
+++ b/kb/reports/indel-models/4-multi-residue.md
@@ -118,7 +118,6 @@ The SID model and GGI describe the same underlying process. "SID" refers to the 
 18. <a id="ref-22"></a> Holmes, Ian. 2020. "A Model of Indel Evolution by Finite-State, Continuous-Time Machines." _Genetics_ 215(4):1187-1204. https://doi.org/10.1534/genetics.120.303630
 19. <a id="ref-23"></a> Redelings, Benjamin D., Ian Holmes, Gerton Lunter, Tal Pupko, and Maria Anisimova. 2024. "Insertions and Deletions." _MBE_ 41(9):msae177. https://doi.org/10.1093/molbev/msae177
 20. <a id="ref-24"></a> Miklos, Istvan, et al. 2004. "A 'Long Indel' Model." _MBE_ 21(3):529-540. https://doi.org/10.1093/molbev/msh043
-
 21. <a id="ref-25"></a> Knudsen, Bjarne, and Michael M. Miyamoto. 2003. "Sequence Alignments and Pair Hidden Markov Models Using Evolutionary History." _J Mol Biol_ 333(2):453-460. https://doi.org/10.1016/j.jmb.2003.08.015
 
 See [consolidated references](references.md) for the complete bibliography.

--- a/kb/reports/indel-models/6-comparison.md
+++ b/kb/reports/indel-models/6-comparison.md
@@ -95,7 +95,7 @@ The models differ in how they affect branch length optimization:
 
 ### Bayesian joint alignment and phylogeny
 
-**[BAli-Phy](https://github.com/bredelings/BAli-Phy)** (C++, 49 stars). Bayesian co-estimation of alignment, phylogeny, and evolutionary parameters via MCMC. Supports three indel models, more than any other phylogenetic inference tool: RS07 (default), TKF91 (`TKF1`), and TKF92 (`TKF2`). All implemented as <a id="gloss-use-3"></a>pair HMMs <sup>[†3](#gloss-pairhmm)</sup> with 5 states (Start, Match, Gap-in-1, Gap-in-2, End) in `src/imodel/imodel.cc`. Branch lengths are jointly sampled with alignment, topology, and indel parameters. MCMC moves include alignment realignment (`AlignmentMove`), topology changes (`TopologyMove`), edge length proposals (`EdgeMove`), and per-parameter moves for $\lambda$, $\mu$, $r$ (TKF92), and $\rho = \lambda + \mu$. The RS07 model's `fragmentize` operation adds geometric self-loops to pair HMM states, making indel lengths geometric with parameter $\epsilon$. Indel parameters directly influence the branch length posterior: higher indel rates widen the branch length distribution because the same alignment is consistent with a broader range of evolutionary distances.
+**[BAli-Phy](https://github.com/bredelings/BAli-Phy)** (C++, 49 stars). Bayesian co-estimation of alignment, phylogeny, and evolutionary parameters via MCMC. Supports three indel models, more than any other phylogenetic inference tool: RS07 (default), TKF91 (`TKF1`), and TKF92 (`TKF2`). All implemented as <a id="gloss-use-3"></a>pair HMMs <sup>[†3](#gloss-3)</sup> with 5 states (Start, Match, Gap-in-1, Gap-in-2, End) in `src/imodel/imodel.cc`. Branch lengths are jointly sampled with alignment, topology, and indel parameters. MCMC moves include alignment realignment (`AlignmentMove`), topology changes (`TopologyMove`), edge length proposals (`EdgeMove`), and per-parameter moves for $\lambda$, $\mu$, $r$ (TKF92), and $\rho = \lambda + \mu$. The RS07 model's `fragmentize` operation adds geometric self-loops to pair HMM states, making indel lengths geometric with parameter $\epsilon$. Indel parameters directly influence the branch length posterior: higher indel rates widen the branch length distribution because the same alignment is consistent with a broader range of evolutionary distances.
 
 **[StatAlign](https://github.com/statalign/statalign)** (Java, 5 stars). Bayesian MCMC statistical alignment. Uses TKF92 pair HMMs (`HmmTkf92` with 5 states). Parameters: fragment length $r$, insertion rate $\lambda$, deletion rate $\mu$. MCMC moves over alignment columns, topology, edge lengths, and TKF92 parameters. Alignment stored as linked lists of `AlignColumn` objects with `orphan` flags distinguishing homologous from inserted columns. Felsenstein likelihoods cached per column. Supports structural alignment (`StructAlign` plugin) and RNA structure prediction (`PPFold`, `RNAAliFold`). Low activity since 2020.
 
@@ -103,7 +103,7 @@ The models differ in how they affect branch length optimization:
 
 **[PRANK](https://github.com/ariloytynoja/prank-msa)** (C++, 33 stars). Phylogeny-aware progressive alignment. Does not use a formal indel model (TKF91/PIP/etc.) for gap placement. Instead uses a heuristic strategy that infers ancestral sequences and places gaps on tree branches, defaulting to inferring ancestral residues as absent when ambiguous. This reduces the "gap attraction" problem where unrelated regions get aligned. Branch lengths are taken from the input guide tree and not re-estimated. Indels influence the alignment but not the branch lengths. PRANK is a major influence on modern phylogeny-aware alignment tools but uses heuristic gap costs, not probabilistic indel models.
 
-**[Historian](https://github.com/ihh/dart)** (C++, 32 stars, part of the DART toolkit). Progressive alignment with MCMC refinement using the RS07 pair HMM. Computes a fast initial alignment via progressive application of the pair HMM forward-backward algorithm, then refines via MCMC moves. Uses phylogenetic <a id="gloss-use-4"></a>transducers <sup>[†4](#gloss-transducer)</sup> (composition of pair HMMs along tree edges) for multi-sequence likelihood. Branch lengths are taken from the input tree. The `ihh/trajectory-likelihood` repository (14 stars) implements the related trajectory likelihood calculations from Miklos, Lunter & Holmes 2004, De Maio 2021, and Holmes 2020.
+**[Historian](https://github.com/ihh/dart)** (C++, 32 stars, part of the DART toolkit). Progressive alignment with MCMC refinement using the RS07 pair HMM. Computes a fast initial alignment via progressive application of the pair HMM forward-backward algorithm, then refines via MCMC moves. Uses phylogenetic <a id="gloss-use-4"></a>transducers <sup>[†4](#gloss-4)</sup> (composition of pair HMMs along tree edges) for multi-sequence likelihood. Branch lengths are taken from the input tree. The `ihh/trajectory-likelihood` repository (14 stars) implements the related trajectory likelihood calculations from Miklos, Lunter & Holmes 2004, De Maio 2021, and Holmes 2020.
 
 **[ProPIP](https://github.com/acg-team/ProPIP)** (C++, 7 stars). ML progressive alignment under the Poisson Indel Process. The first polynomial-time progressive aligner with a rigorous indel model. Estimates indel rates ($\lambda$, $\mu$) from the data during alignment, unlike PRANK which uses fixed heuristic gap costs. Supports Gamma rate heterogeneity across sites. Branch lengths and alignment are jointly estimated in the progressive ML framework. ProPIP tends to infer shorter gaps than tools using multi-residue indel models because PIP assumes single-character insertions.
 
@@ -113,7 +113,7 @@ The models differ in how they affect branch length optimization:
 
 **[FastML](http://fastml.tau.ac.il/)** (web server only, no public repository). ML ancestral reconstruction. Uses binary encoding of indels (two-state character per alignment position) for indel reconstruction, analyzed under a simple substitution model. Branch lengths from substitution model only.
 
-**[GRASP](https://github.com/bodenlab/GRASP)** (Java, 12 stars). Ancestral reconstruction using <a id="gloss-use-10"></a>partial-order graphs <sup>[†10](#gloss-pog)</sup> (POGs). Handles alternative splicings and repeat variation. Does not use a probabilistic indel model. Branch lengths from input tree.
+**[GRASP](https://github.com/bodenlab/GRASP)** (Java, 12 stars). Ancestral reconstruction using <a id="gloss-use-10"></a>partial-order graphs <sup>[†10](#gloss-10)</sup> (POGs). Handles alternative splicings and repeat variation. Does not use a probabilistic indel model. Branch lengths from input tree.
 
 ### ML phylogenetic inference with indel models
 
@@ -152,8 +152,8 @@ The models differ in how they affect branch length optimization:
 
 ## Glossary
 
-1. <a id="gloss-3"></a> **Pair HMM.** See [consolidated glossary](#gloss-pairhmm). [↩](#gloss-use-3)
-2. <a id="gloss-4"></a> **Phylogenetic transducer.** See [consolidated glossary](#gloss-transducer). [↩](#gloss-use-4)
-3. <a id="gloss-10"></a> **POG (partial order graph).** See [consolidated glossary](#gloss-pog). [↩](#gloss-use-10)
+1. <a id="gloss-3"></a> Pair HMM. See [consolidated glossary](glossary.md#gloss-pairhmm). [↩](#gloss-use-3)
+2. <a id="gloss-4"></a> Phylogenetic transducer. See [consolidated glossary](glossary.md#gloss-transducer). [↩](#gloss-use-4)
+3. <a id="gloss-10"></a> POG (partial order graph). See [consolidated glossary](glossary.md#gloss-pog). [↩](#gloss-use-10)
 
 See [consolidated glossary](glossary.md) for all term definitions across chapters.

--- a/kb/reports/optimization-methods/references.md
+++ b/kb/reports/optimization-methods/references.md
@@ -4,74 +4,74 @@
 
 Consolidated bibliography for all chapters. Ordered by first author surname. DOIs verified via search skills (March 2026). For the full phylogenetics reference list including substitution models and tree-building algorithms, see [Iterative tree refinement references](../iterative-tree-refinement/references.md).
 
-1. Brent, R. P. 1973. _Algorithms for Minimization without Derivatives._ Prentice-Hall. https://maths-people.anu.edu.au/~brent/pd/rpb011i.pdf
+1. Brent, Richard P. 1973. _Algorithms for Minimization without Derivatives._ Prentice-Hall. https://maths-people.anu.edu.au/~brent/pd/rpb011i.pdf
 
-2. Chen, M.-H., and Q.-M. Shao. 1999. "Monte Carlo Estimation of Bayesian Credible and HPD Intervals." _J. Comput. Graph. Stat._ 8(1):69-92. https://doi.org/10.1080/10618600.1999.10474802
+2. Chen, Ming-Hui, and Qi-Man Shao. 1999. "Monte Carlo Estimation of Bayesian Credible and HPD Intervals." _J. Comput. Graph. Stat._ 8(1):69-92. https://doi.org/10.1080/10618600.1999.10474802
 
-3. Claywell, B. C., V. Dinh, M. Fourment, C. O. McCoy, and F. A. Matsen IV. 2018. "A Surrogate Function for One-Dimensional Phylogenetic Likelihoods." _Mol. Biol. Evol._ 35(1):242-246. https://doi.org/10.1093/molbev/msx253
+3. Claywell, Bret C., Vu Dinh, Mathieu Fourment, Connor O. McCoy, and Frederick A. Matsen IV. 2018. "A Surrogate Function for One-Dimensional Phylogenetic Likelihoods." _Mol. Biol. Evol._ 35(1):242-246. https://doi.org/10.1093/molbev/msx253
 
-4. Dempster, A. P., N. M. Laird, and D. B. Rubin. 1977. "Maximum Likelihood from Incomplete Data Via the EM Algorithm." _JRSS:B_ 39(1):1-38. https://doi.org/10.1111/j.2517-6161.1977.tb01600.x
+4. Dempster, Arthur P., Nan M. Laird, and Donald B. Rubin. 1977. "Maximum Likelihood from Incomplete Data Via the EM Algorithm." _JRSS:B_ 39(1):1-38. https://doi.org/10.1111/j.2517-6161.1977.tb01600.x
 
-5. Didelot, X., V. Franceschi, S. D. W. Frost, A. Dennis, and E. M. Volz. 2023. "Model Design for Nonparametric Phylodynamic Inference and Applications to Pathogen Surveillance." _Virus Evol._ 9(1):vead028. https://doi.org/10.1093/ve/vead028
+5. Didelot, Xavier, Vincenzo Franceschi, Simon D. W. Frost, Alison Dennis, and Erik M. Volz. 2023. "Model Design for Nonparametric Phylodynamic Inference and Applications to Pathogen Surveillance." _Virus Evol._ 9(1):vead028. https://doi.org/10.1093/ve/vead028
 
-6. Dinh, V., and F. A. Matsen IV. 2017. "The Shape of the One-Dimensional Phylogenetic Likelihood Function." _Ann. Appl. Prob._ 27(3):1646-1677. https://doi.org/10.1214/16-AAP1240
+6. Dinh, Vu, and Frederick A. Matsen IV. 2017. "The Shape of the One-Dimensional Phylogenetic Likelihood Function." _Ann. Appl. Prob._ 27(3):1646-1677. https://doi.org/10.1214/16-AAP1240
 
-7. Drummond, A. J., S. Y. W. Ho, M. J. Phillips, and A. Rambaut. 2006. "Relaxed Phylogenetics and Dating with Confidence." _PLoS Biology_ 4(5):e88. https://doi.org/10.1371/journal.pbio.0040088
+7. Drummond, Alexei J., Simon Y. W. Ho, Matthew J. Phillips, and Andrew Rambaut. 2006. "Relaxed Phylogenetics and Dating with Confidence." _PLoS Biology_ 4(5):e88. https://doi.org/10.1371/journal.pbio.0040088
 
-8. Drummond, A. J., A. Rambaut, B. Shapiro, and O. G. Pybus. 2005. "Bayesian Coalescent Inference of Past Population Dynamics from Molecular Sequences." _Mol. Biol. Evol._ 22(5):1185-1192. https://doi.org/10.1093/molbev/msi103
+8. Drummond, Alexei J., Andrew Rambaut, Beth Shapiro, and Oliver G. Pybus. 2005. "Bayesian Coalescent Inference of Past Population Dynamics from Molecular Sequences." _Mol. Biol. Evol._ 22(5):1185-1192. https://doi.org/10.1093/molbev/msi103
 
-9. Faulkner, J. R., A. F. Magee, B. Shapiro, and V. N. Minin. 2020. "Horseshoe-Based Bayesian Nonparametric Estimation of Effective Population Size Trajectories." _Biometrics_ 76(3):677-690. https://doi.org/10.1111/biom.13276
+9. Faulkner, James R., Andrew F. Magee, Beth Shapiro, and Vladimir N. Minin. 2020. "Horseshoe-Based Bayesian Nonparametric Estimation of Effective Population Size Trajectories." _Biometrics_ 76(3):677-690. https://doi.org/10.1111/biom.13276
 
-10. Felsenstein, J. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _J. Mol. Evol._ 17:368-376. https://doi.org/10.1007/BF01734359
+10. Felsenstein, Joseph. 1981. "Evolutionary Trees from DNA Sequences: A Maximum Likelihood Approach." _J. Mol. Evol._ 17:368-376. https://doi.org/10.1007/BF01734359
 
-11. Fourment, M., C. J. Swanepoel, J. G. Galloway, X. Ji, K. Gangavarapu, M. A. Suchard, and F. A. Matsen IV. 2023. "Automatic Differentiation is no Panacea for Phylogenetic Gradient Computation." _Genome Biol. Evol._ 15(6):evad099. https://doi.org/10.1093/gbe/evad099
+11. Fourment, Mathieu, Christiaan J. Swanepoel, Jett G. Galloway, Xiang Ji, Karthik Gangavarapu, Marc A. Suchard, and Frederick A. Matsen IV. 2023. "Automatic Differentiation is no Panacea for Phylogenetic Gradient Computation." _Genome Biol. Evol._ 15(6):evad099. https://doi.org/10.1093/gbe/evad099
 
-12. Gill, M. S., P. Lemey, N. R. Faria, A. Rambaut, B. Shapiro, and M. A. Suchard. 2013. "Improving Bayesian Population Dynamics Inference: A Coalescent-Based Model for Multiple Loci." _Mol. Biol. Evol._ 30(3):713-724. https://doi.org/10.1093/molbev/mss265
+12. Gill, Mandev S., Philippe Lemey, Nuno R. Faria, Andrew Rambaut, Beth Shapiro, and Marc A. Suchard. 2013. "Improving Bayesian Population Dynamics Inference: A Coalescent-Based Model for Multiple Loci." _Mol. Biol. Evol._ 30(3):713-724. https://doi.org/10.1093/molbev/mss265
 
-13. Guindon, S., and O. Gascuel. 2003. "A Simple, Fast, and Accurate Algorithm to Estimate Large Phylogenies by Maximum Likelihood." _Syst. Biol._ 52(5):696-704. https://doi.org/10.1080/10635150390235520
+13. Guindon, Stephane, and Olivier Gascuel. 2003. "A Simple, Fast, and Accurate Algorithm to Estimate Large Phylogenies by Maximum Likelihood." _Syst. Biol._ 52(5):696-704. https://doi.org/10.1080/10635150390235520
 
-14. Henderson, N. C., and R. Varadhan. 2019. "Damped Anderson Acceleration with Restarts and Monotonicity Control." _J. Comput. Graph. Stat._ 28(4):834-846. https://doi.org/10.1080/10618600.2019.1594835
+14. Henderson, Nicholas C., and Ravi Varadhan. 2019. "Damped Anderson Acceleration with Restarts and Monotonicity Control." _J. Comput. Graph. Stat._ 28(4):834-846. https://doi.org/10.1080/10618600.2019.1594835
 
-15. Holmes, I., and G. M. Rubin. 2002. "An Expectation Maximization Algorithm for Training Hidden Substitution Models." _J. Mol. Biol._ 317(5):753-764. https://doi.org/10.1006/jmbi.2002.5405
+15. Holmes, Ian, and Gerald M. Rubin. 2002. "An Expectation Maximization Algorithm for Training Hidden Substitution Models." _J. Mol. Biol._ 317(5):753-764. https://doi.org/10.1006/jmbi.2002.5405
 
-16. Hyndman, R. J. 1996. "Computing and Graphing Highest Density Regions." _The American Statistician_ 50(2):120-126. https://doi.org/10.1080/00031305.1996.10474359
+16. Hyndman, Rob J. 1996. "Computing and Graphing Highest Density Regions." _The American Statistician_ 50(2):120-126. https://doi.org/10.1080/00031305.1996.10474359
 
-17. Lagarias, J. C., J. A. Reeds, M. H. Wright, and P. E. Wright. 1998. "Convergence Properties of the Nelder-Mead Simplex Method in Low Dimensions." _SIAM J. Optim._ 9(1):112-147. https://doi.org/10.1137/S1052623496303470
+17. Lagarias, Jeffrey C., James A. Reeds, Margaret H. Wright, and Paul E. Wright. 1998. "Convergence Properties of the Nelder-Mead Simplex Method in Low Dimensions." _SIAM J. Optim._ 9(1):112-147. https://doi.org/10.1137/S1052623496303470
 
-18. Lan, S., J. A. Palacios, M. D. Karcher, V. N. Minin, and B. Shahbaba. 2015. "An Efficient Bayesian Inference Framework for Coalescent-Based Nonparametric Phylodynamics." _Bioinformatics_ 31(20):3282-3289. https://doi.org/10.1093/bioinformatics/btv378
+18. Lan, Shiwei, Julia A. Palacios, Michael D. Karcher, Vladimir N. Minin, and Babak Shahbaba. 2015. "An Efficient Bayesian Inference Framework for Coalescent-Based Nonparametric Phylodynamics." _Bioinformatics_ 31(20):3282-3289. https://doi.org/10.1093/bioinformatics/btv378
 
-19. Lewis, P. O., M. T. Holder, and K. E. Holsinger. 2005. "Polytomies and Bayesian Phylogenetic Inference." _Syst. Biol._ 54(2):241-253. https://doi.org/10.1080/10635150590924208
+19. Lewis, Paul O., Mark T. Holder, and Kent E. Holsinger. 2005. "Polytomies and Bayesian Phylogenetic Inference." _Syst. Biol._ 54(2):241-253. https://doi.org/10.1080/10635150590924208
 
-20. Liu, D. C., and J. Nocedal. 1989. "On the Limited Memory BFGS Method for Large Scale Optimization." _Math. Program._ 45(1-3):503-528. https://doi.org/10.1007/BF01589116
+20. Liu, Dong C., and Jorge Nocedal. 1989. "On the Limited Memory BFGS Method for Large Scale Optimization." _Math. Program._ 45(1-3):503-528. https://doi.org/10.1007/BF01589116
 
-21. McKinnon, K. I. M. 1998. "Convergence of the Nelder-Mead Simplex Method to a Nonstationary Point." _SIAM J. Optim._ 9(1):148-158. https://doi.org/10.1137/S1052623496303482
+21. McKinnon, Ken I. M. 1998. "Convergence of the Nelder-Mead Simplex Method to a Nonstationary Point." _SIAM J. Optim._ 9(1):148-158. https://doi.org/10.1137/S1052623496303482
 
-22. Meng, X.-L., and D. B. Rubin. 1993. "Maximum Likelihood Estimation via the ECM Algorithm: A General Framework." _Biometrika_ 80(2):267-278. https://doi.org/10.1093/biomet/80.2.267
+22. Meng, Xiao-Li, and Donald B. Rubin. 1993. "Maximum Likelihood Estimation via the ECM Algorithm: A General Framework." _Biometrika_ 80(2):267-278. https://doi.org/10.1093/biomet/80.2.267
 
-23. Meng, X.-L., and D. B. Rubin. 1994. "On the Global and Componentwise Rates of Convergence of the EM Algorithm." _Lin. Alg. Appl._ 199:413-425. https://doi.org/10.1016/0024-3795(94)90363-8
+23. Meng, Xiao-Li, and Donald B. Rubin. 1994. "On the Global and Componentwise Rates of Convergence of the EM Algorithm." _Lin. Alg. Appl._ 199:413-425. https://doi.org/10.1016/0024-3795(94)90363-8
 
-24. Minin, V. N., E. Bloomquist, and M. A. Suchard. 2008. "Smooth Skyride through a Rough Skyline: Bayesian Coalescent-Based Inference of Population Dynamics." _Mol. Biol. Evol._ 25(7):1459-1471. https://doi.org/10.1093/molbev/msn090
+24. Minin, Vladimir N., Erik Bloomquist, and Marc A. Suchard. 2008. "Smooth Skyride through a Rough Skyline: Bayesian Coalescent-Based Inference of Population Dynamics." _Mol. Biol. Evol._ 25(7):1459-1471. https://doi.org/10.1093/molbev/msn090
 
-25. Nelder, J. A., and R. Mead. 1965. "A Simplex Method for Function Minimization." _The Computer Journal_ 7(4):308-313. https://doi.org/10.1093/COMJNL/7.4.308
+25. Nelder, John A., and Roger Mead. 1965. "A Simplex Method for Function Minimization." _The Computer Journal_ 7(4):308-313. https://doi.org/10.1093/COMJNL/7.4.308
 
-26. Nguyen, L.-T., H. A. Schmidt, A. von Haeseler, and B. Q. Minh. 2015. "IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies." _Mol. Biol. Evol._ 32(1):268-274. https://doi.org/10.1093/molbev/msu300
+26. Nguyen, Lam-Tung, Heiko A. Schmidt, Arndt von Haeseler, and Bui Quang Minh. 2015. "IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies." _Mol. Biol. Evol._ 32(1):268-274. https://doi.org/10.1093/molbev/msu300
 
-27. Pybus, O. G., A. Rambaut, and P. H. Harvey. 2000. "An Integrated Framework for the Inference of Viral Population History from Reconstructed Genealogies." _Genetics_ 155(3):1429-1437. https://doi.org/10.1093/genetics/155.3.1429
+27. Pybus, Oliver G., Andrew Rambaut, and Paul H. Harvey. 2000. "An Integrated Framework for the Inference of Viral Population History from Reconstructed Genealogies." _Genetics_ 155(3):1429-1437. https://doi.org/10.1093/genetics/155.3.1429
 
-28. Rios, L. M., and N. V. Sahinidis. 2013. "Derivative-Free Optimization: A Review of Algorithms and Comparison of Software Implementations." _J. Global Optim._ 56(3):1247-1293. https://doi.org/10.1007/s10898-012-9951-y
+28. Rios, Luis Miguel, and Nikolaos V. Sahinidis. 2013. "Derivative-Free Optimization: A Review of Algorithms and Comparison of Software Implementations." _J. Global Optim._ 56(3):1247-1293. https://doi.org/10.1007/s10898-012-9951-y
 
-29. Sagulenko, P., V. Puller, and R. A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evol._ 4(1):vex042. https://doi.org/10.1093/ve/vex042
+29. Sagulenko, Pavel, Vadim Puller, and Richard A. Neher. 2018. "TreeTime: Maximum-Likelihood Phylodynamic Analysis." _Virus Evol._ 4(1):vex042. https://doi.org/10.1093/ve/vex042
 
-30. Kraft, D. 1988. "A Software Package for Sequential Quadratic Programming." DFVLR-FB 88-28. Deutsche Forschungs- und Versuchsanstalt für Luft- und Raumfahrt, Cologne, Germany
+30. Kraft, Dieter. 1988. "A Software Package for Sequential Quadratic Programming." DFVLR-FB 88-28. Deutsche Forschungs- und Versuchsanstalt fur Luft- und Raumfahrt, Cologne, Germany
 
-31. Stamatakis, A. 2014. "RAxML Version 8." _Bioinformatics_ 30(9):1312-1313. https://doi.org/10.1093/bioinformatics/btu033
+31. Stamatakis, Alexandros. 2014. "RAxML Version 8." _Bioinformatics_ 30(9):1312-1313. https://doi.org/10.1093/bioinformatics/btu033
 
-32. Strimmer, K., and O. G. Pybus. 2001. "Exploring the Demographic History of DNA Sequences Using the Generalized Skyline Plot." _Mol. Biol. Evol._ 18(12):2298-2305. https://doi.org/10.1093/oxfordjournals.molbev.a003776
+32. Strimmer, Korbinian, and Oliver G. Pybus. 2001. "Exploring the Demographic History of DNA Sequences Using the Generalized Skyline Plot." _Mol. Biol. Evol._ 18(12):2298-2305. https://doi.org/10.1093/oxfordjournals.molbev.a003776
 
-33. Sullivan, J., Z. Abdo, P. Joyce, and D. L. Swofford. 2005. "Evaluating the Performance of a Successive-Approximations Approach to Parameter Optimization in Maximum-Likelihood Phylogeny Estimation." _Mol. Biol. Evol._ 22(6):1386-1392. https://doi.org/10.1093/molbev/msi129
+33. Sullivan, Jack, Zaid Abdo, Paul Joyce, and David L. Swofford. 2005. "Evaluating the Performance of a Successive-Approximations Approach to Parameter Optimization in Maximum-Likelihood Phylogeny Estimation." _Mol. Biol. Evol._ 22(6):1386-1392. https://doi.org/10.1093/molbev/msi129
 
-34. Thorne, J. L., H. Kishino, and I. S. Painter. 1998. "Estimating the Rate of Evolution of the Rate of Molecular Evolution." _Mol. Biol. Evol._ 15(12):1647-1657. https://doi.org/10.1093/oxfordjournals.molbev.a025892
+34. Thorne, Jeffrey L., Hirohisa Kishino, and Ian S. Painter. 1998. "Estimating the Rate of Evolution of the Rate of Molecular Evolution." _Mol. Biol. Evol._ 15(12):1647-1657. https://doi.org/10.1093/oxfordjournals.molbev.a025892
 
-35. Varadhan, R., and C. Roland. 2008. "Simple and Globally Convergent Methods for Accelerating the Convergence of Any EM Algorithm." _Scand. J. Stat._ 35(2):335-353. https://doi.org/10.1111/j.1467-9469.2007.00585.x
+35. Varadhan, Ravi, and Christophe Roland. 2008. "Simple and Globally Convergent Methods for Accelerating the Convergence of Any EM Algorithm." _Scand. J. Stat._ 35(2):335-353. https://doi.org/10.1111/j.1467-9469.2007.00585.x
 
-36. Wu, C. F. J. 1983. "On the Convergence Properties of the EM Algorithm." _Ann. Stat._ 11(1):95-103. https://projecteuclid.org/journals/annals-of-statistics/volume-11/issue-1/On-the-Convergence-Properties-of-the-EM-Algorithm/10.1214/aos/1176346060.full (DOI: https://doi.org/10.1214/aos/1176346060)
+36. Wu, C. F. Jeff. 1983. "On the Convergence Properties of the EM Algorithm." _Ann. Stat._ 11(1):95-103. https://doi.org/10.1214/aos/1176346060

--- a/kb/v0-errata/tn93-alphabet-mismatch.md
+++ b/kb/v0-errata/tn93-alphabet-mismatch.md
@@ -26,4 +26,4 @@ v1's GTR system uses explicit alphabet types with compile-time dimension checks.
 
 ## References
 
-- Tamura & Nei (1993). "Estimation of the number of nucleotide substitutions in the control region of mitochondrial DNA in humans and chimpanzees." Mol Biol Evol, 10(3):512-526. doi:10.1093/oxfordjournals.molbev.a040023
+- Tamura, Koichiro, and Masatoshi Nei. 1993. "Estimation of the Number of Nucleotide Substitutions in the Control Region of Mitochondrial DNA in Humans and Chimpanzees." _Molecular Biology and Evolution_ 10(3):512-526. https://doi.org/10.1093/oxfordjournals.molbev.a040023


### PR DESCRIPTION
- Depends on: #665

A batch audit of the 372-file knowledge base found three incompatible citation styles coexisting: numbered anchors with bidirectional backlinks (6 gold-standard files), flat author-year with no anchors (most files), and inline-only without References sections (many files). DOIs were missing from ~30 citations, book references lacked ISBNs, and the `doi:` prefix format was used instead of URL format.

This PR standardizes all `kb/algo/` content files (9 files, ~70 citations) to Style A: numbered anchor IDs, inline `[[N](#ref-N)]` back-references, `[~](#cite-N)` backlinks, consolidated `## References` sections with full Chicago author-date format and DOI URLs. It extends the same treatment to key `kb/decisions/` and `kb/proposals/` files, converts all bare `doi:` prefixes to `https://doi.org/` URLs, and fixes broken glossary links and author name format inconsistencies in the indel-models and optimization-methods reports.

### Work items

- [x] Convert 9 `kb/algo/` content files to Style A with bidirectional anchored references
- [x] Convert `kb/decisions/ancestral-joint-reconstruction-removed.md` to Style A with 3 citations
- [x] Add DOIs and Chicago format to 4 `kb/decisions/` reference sections
- [x] Convert bare `doi:` prefix to URL format in `kb/algo/README.md`, 3 `kb/decisions/`, `kb/features/gtr.md`, `kb/proposals/config-file-multi-partition.md`, `kb/v0-errata/tn93-alphabet-mismatch.md`
- [x] Add References sections to `kb/proposals/optimize-indel-model-alternatives.md` and `optimize-indel-rate-per-iteration-reestimation.md`
- [x] Fix 3 broken glossary links in `kb/reports/indel-models/6-comparison.md`
- [x] Align per-chapter reference display numbers with anchor IDs in indel-models Ch2-Ch5
- [x] Standardize `kb/reports/optimization-methods/references.md` from initials to full author first names (36 entries)