### PR TITLE
docs: add multi-client architecture issue and tickets

### DIFF
--- a/kb/issues/H-core-multi-client-architecture-library-purity.md
+++ b/kb/issues/H-core-multi-client-architecture-library-purity.md
@@ -1,0 +1,52 @@
+# Library crate is not consumable by non-CLI clients
+
+The `treetime` library crate cannot be used by Python bindings, desktop apps, or web frontends. The library depends on `clap` (CLI framework), contains CLI argument structs in domain modules, and has domain logic trapped inside `commands/` (a CLI-layer concept). Any non-CLI consumer inherits the full CLI dependency graph and must construct clap-derived argument structs to call domain functions.
+
+This is a structural blocker for multi-client architecture: `treetime-python` (PyO3 bindings), `treetime-desktop` (Electron/Tauri wrapper), or any future consumer.
+
+## Evidence
+
+An AI refactoring agent moved the entire timetree implementation from the library into the CLI crate, treating `treetime-cli` as the owner of domain logic. This reflects the current blurred boundary: `commands/` in the library crate contains ~15k lines mixing domain algorithms with CLI orchestration, and domain types derive `clap::Args` / `clap::ValueEnum`.
+
+## Scope
+
+### clap contamination in library domain types
+
+6 domain-layer files outside `commands/` use `clap::ValueEnum` or `clap::Args`:
+
+- `alphabet/alphabet.rs` - `AlphabetName`
+- `gtr/get_gtr.rs` - `GtrModelName`
+- `seq/gap_fill.rs` - `GapFillMode`
+- `optimize/args.rs` - `BranchOptMethod`, `InitialGuessMode`
+- `clock/clock_regression.rs` - `ClockParams` has `#[derive(Args)]`
+- `clock/find_best_root/params.rs` - 5 types with `ValueEnum`/`Args`
+
+Library consumers pull in `clap` as transitive dependency. Domain types should not depend on CLI parsing.
+
+### Domain logic in commands/
+
+`commands/timetree/` (~10k lines) and `commands/mugration/` (~2.2k lines) contain domain algorithms that should be top-level modules. Tracked in detail by:
+
+- `H-core-command-module-shared-ops-entanglement.md` (remaining items)
+- `M-core-remaining-architectural-debt-after-extraction.md` (timetree, mugration, representation)
+
+### Missing client crates
+
+No crates exist for non-CLI consumption:
+
+- `treetime-python`: PyO3 bindings + Python CLI wrapping Rust library
+- `treetime-desktop`: thin wrapper with minimal desktop frontend
+
+These crates create structural backpressure: if the library must remain consumable by multiple clients, domain logic cannot drift into any single client crate.
+
+## Impact
+
+- Blocks Python bindings (PyO3 cannot depend on a library that requires `clap`)
+- Blocks desktop app (Electron/Tauri cannot call into CLI-contaminated library)
+- Blocks web assembly target (clap is not wasm-compatible)
+- Encourages AI agents and contributors to treat `treetime-cli` as the primary crate, moving domain logic out of the library
+
+## Related issues
+
+- [Command modules contain shared operations that belong in domain layers](H-core-command-module-shared-ops-entanglement.md)
+- [Remaining architectural debt after domain module extraction](M-core-remaining-architectural-debt-after-extraction.md)

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -43,6 +43,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | High       | Clock          | [ClockSet dateless-leaf contribution biases regression](H-clock-clockset-dateless-leaf-bias.md)                                                     |
 | High       | Clock          | [Clock filter panics on trees with fewer than four dated leaves](H-clock-filter-panic-small-trees.md)                                               |
 | High       | Core           | [Command modules contain shared operations that belong in domain layers](H-core-command-module-shared-ops-entanglement.md)                          |
+| High       | Core           | [Library crate is not consumable by non-CLI clients](H-core-multi-client-architecture-library-purity.md)                                            |
 | High       | Homoplasy      | [Homoplasy command is unimplemented](H-homoplasy-command-unimplemented.md)                                                                          |
 | Medium     | Optimize       | [`--no-indels` flag does not gate `initial_guess_mixed()`](M-optimize-no-indels-initial-guess-not-gated.md)                                         |
 | High       | Timetree       | [Coalescent backward pass grid explosion](H-timetree-coalescent-grid-explosion.md)                                                                  |

--- a/kb/tickets/architecture-add-treetime-desktop-crate.md
+++ b/kb/tickets/architecture-add-treetime-desktop-crate.md
@@ -1,0 +1,49 @@
+# Add treetime-desktop crate as thin library wrapper with Electron frontend
+
+## Description
+
+Create `packages/treetime-desktop/` as a workspace crate providing a minimal desktop application wrapping the Rust library. The Rust side exposes an IPC/command API. The frontend is a minimal Electron (or Tauri) shell.
+
+The crate serves as structural backpressure: a second non-CLI consumer that depends on the `treetime` library crate, reinforcing that domain logic must stay in the library. Implementation of the full desktop UI is deferred - the initial crate establishes the architecture and a minimal proof-of-concept.
+
+## Crate structure
+
+```
+packages/treetime-desktop/
+  Cargo.toml          # workspace inheritance, tauri or napi dependencies
+  src/
+    lib.rs            # command/IPC handlers calling treetime library
+    commands.rs       # desktop command definitions (run_ancestral, run_clock, etc.)
+  frontend/           # minimal Electron/Tauri frontend (deferred)
+    package.json
+    src/
+      index.html
+      main.js
+```
+
+## Dependencies
+
+- `treetime` (workspace) - core library
+- `treetime-io` (workspace) - file format I/O
+- `treetime-utils` (workspace) - error handling
+- `serde` + `serde_json` (workspace) - IPC serialization
+- `tauri` or `napi-rs` - desktop integration (decision deferred)
+
+## Scope
+
+Initial implementation:
+
+- Cargo.toml with workspace inheritance
+- `src/lib.rs` with a single command handler calling `treetime::commands::ancestral`
+- Proof that the library API is consumable without clap
+- No frontend UI (placeholder HTML only)
+
+Full desktop UI implementation is out of scope for this ticket.
+
+## Prerequisites
+
+- clap removed from `treetime` library crate (ticket: `architecture-remove-clap-from-domain-types.md`)
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-add-treetime-python-crate.md
+++ b/kb/tickets/architecture-add-treetime-python-crate.md
@@ -1,0 +1,63 @@
+# Add treetime-python crate with PyO3 bindings and Python CLI
+
+## Description
+
+Create `packages/treetime-python/` as a workspace crate providing Python bindings via PyO3 and a Python CLI wrapping the Rust library. This crate depends on the `treetime` library crate and exposes domain functions as a Python module.
+
+The crate serves two purposes:
+
+1. Structural backpressure: its existence as a library consumer prevents domain logic from migrating into `treetime-cli`. If a function is needed by both CLI and Python, it must live in the library.
+2. Python ecosystem access: replaces the legacy Python implementation (`packages/legacy/treetime/`) with a Rust-backed Python package using modern Python tooling.
+
+## Crate structure
+
+```
+packages/treetime-python/
+  Cargo.toml          # PyO3 cdylib + workspace inheritance
+  pyproject.toml      # maturin build backend, uv/hatch project
+  python/
+    treetime/
+      __init__.py     # re-exports from Rust module
+      cli.py          # click/typer CLI wrapping Rust functions
+  src/
+    lib.rs            # PyO3 module definition
+    ancestral.rs      # Python-facing ancestral API
+    clock.rs          # Python-facing clock API
+    timetree.rs       # Python-facing timetree API
+    mugration.rs      # Python-facing mugration API
+    types.rs          # Python type conversions (PyGraph, PyGTR, etc.)
+```
+
+## Dependencies
+
+- `treetime` (workspace) - core library
+- `treetime-io` (workspace) - file format I/O
+- `treetime-graph` (workspace) - graph types
+- `treetime-utils` (workspace) - error handling
+- `pyo3` - Rust-Python bindings
+- `numpy` (via `pyo3`) - ndarray <-> numpy conversion
+
+Python side:
+
+- `maturin` - build backend
+- `click` or `typer` - Python CLI framework
+- `numpy` - array interop
+
+## Workspace integration
+
+- Add to `[workspace.members]` in root `Cargo.toml`
+- Add `pyo3` and `numpy` to `[workspace.dependencies]`
+- CI: build wheel, run Python tests
+
+## Scope
+
+Initial implementation should expose a minimal API surface covering one command (e.g., `ancestral`) end-to-end. Expand incrementally as the library API stabilizes.
+
+## Prerequisites
+
+- clap removed from `treetime` library crate (ticket: `architecture-remove-clap-from-domain-types.md`)
+- timetree domain logic extracted from `commands/` (ticket: `architecture-extract-timetree-inference-from-commands.md`)
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-extract-coalescent-from-timetree.md
+++ b/kb/tickets/architecture-extract-coalescent-from-timetree.md
@@ -23,3 +23,4 @@ Move `commands/timetree/coalescent/` (1444 lines, 13 files) to top-level `src/co
 ## Related issues
 
 - Source: [M-core-remaining-architectural-debt-after-extraction](../issues/M-core-remaining-architectural-debt-after-extraction.md)
+- Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-extract-mugration-domain-logic.md
+++ b/kb/tickets/architecture-extract-mugration-domain-logic.md
@@ -21,3 +21,4 @@ Move domain algorithms from `commands/mugration/` to top-level `src/mugration/`.
 ## Related issues
 
 - Source: [M-core-remaining-architectural-debt-after-extraction](../issues/M-core-remaining-architectural-debt-after-extraction.md)
+- Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-extract-timetree-inference-from-commands.md
+++ b/kb/tickets/architecture-extract-timetree-inference-from-commands.md
@@ -38,3 +38,4 @@ Create top-level `src/timetree/` domain module. Move inference (479 lines), opti
 ## Related issues
 
 - Source: [M-core-remaining-architectural-debt-after-extraction](../issues/M-core-remaining-architectural-debt-after-extraction.md)
+- Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-move-commands-to-cli-crate.md
+++ b/kb/tickets/architecture-move-commands-to-cli-crate.md
@@ -1,0 +1,49 @@
+# Move commands/ orchestration shell from library to CLI crate
+
+## Description
+
+After domain logic extraction (ancestral, clock, optimize, coalescent, timetree inference, mugration) and clap removal from domain types, the `commands/` module in the `treetime` library contains only thin CLI orchestration: argument structs (`args.rs`), command runners (`run.rs`), and output formatting (`output/`). Move this entire module to `treetime-cli`.
+
+This is the final step that makes the `treetime` library crate a pure domain library with no CLI concepts.
+
+## What to move
+
+All of `packages/treetime/src/commands/` to `packages/treetime-cli/src/commands/`:
+
+- `ancestral/` - args.rs, run.rs
+- `clock/` - args.rs, run.rs
+- `homoplasy/` - args.rs, run.rs
+- `mugration/` - args.rs, run.rs, input.rs, output.rs
+- `optimize/` - args.rs, run.rs
+- `prune/` - args.rs, run.rs
+- `timetree/` - args.rs, run.rs, output/, convergence/
+- `shared/` - args.rs (shared CLI argument types)
+- `mod.rs`
+
+## What stays in treetime library
+
+Nothing from `commands/`. The library crate exposes domain modules only:
+
+- `alphabet/`, `ancestral/`, `clock/`, `coalescent/`, `constants/`, `gtr/`, `mugration/`, `optimize/`, `representation/`, `seq/`, `timetree/`
+
+## Prerequisites
+
+All of these must be completed first:
+
+- `architecture-remove-clap-from-domain-types.md`
+- `architecture-extract-coalescent-from-timetree.md`
+- `architecture-extract-timetree-inference-from-commands.md`
+- `architecture-extract-mugration-domain-logic.md`
+- `architecture-break-representation-gtr-cycle.md`
+- `architecture-break-representation-ancestral-cycle.md`
+
+## Validation
+
+- `treetime` library crate has no `commands/` module
+- `treetime` library crate has no `clap` dependency
+- `treetime-cli` builds and passes all existing tests
+- No circular dependencies between `treetime` and `treetime-cli`
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-remove-clap-from-domain-types.md
+++ b/kb/tickets/architecture-remove-clap-from-domain-types.md
@@ -17,6 +17,14 @@
 
 Create CLI wrapper types in `commands/` args files with `ValueEnum`/`Args` derives. Use `From` impls to convert to domain types. Domain types keep `Serialize`/`Deserialize` but drop `clap` dependency.
 
+## Validation
+
+- `clap` removed from `treetime` crate `[dependencies]` in `Cargo.toml`
+- `cargo build` succeeds
+- All existing tests pass
+- CLI behavior unchanged
+
 ## Related issues
 
 - Source: [M-core-remaining-architectural-debt-after-extraction](../issues/M-core-remaining-architectural-debt-after-extraction.md)
+- Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-restructure-packages-for-multi-client.md
+++ b/kb/tickets/architecture-restructure-packages-for-multi-client.md
@@ -1,0 +1,105 @@
+# Restructure existing packages for multi-client architecture
+
+## Description
+
+Reorganize the existing workspace so that the `treetime` library crate is a pure domain library consumable by any client (CLI, Python, desktop, WASM). The `treetime-cli` crate becomes one of several thin client crates.
+
+This is an umbrella ticket coordinating prerequisite work items. Each item has its own ticket.
+
+## Execution order
+
+The work items have a dependency chain. Execute in this order:
+
+### 1. Remove clap from library domain types
+
+Ticket: `architecture-remove-clap-from-domain-types.md`
+
+Remove `clap` from `treetime` crate's `[dependencies]`. Move CLI-specific derives to wrapper types in `treetime-cli` or `commands/*/args.rs`. Domain types use `strum` for string parsing.
+
+### 2. Extract remaining domain logic from commands/
+
+Three extraction tickets, independent of each other but all depend on step 1:
+
+- `architecture-extract-coalescent-from-timetree.md` - move `commands/timetree/coalescent/` (1444 lines) to `src/coalescent/`
+- `architecture-extract-timetree-inference-from-commands.md` - move inference (479 lines) and optimization (802 lines) to `src/timetree/`
+- `architecture-extract-mugration-domain-logic.md` - move GTR refinement (381 lines) and discrete marginal (170 lines) to `src/mugration/`
+
+### 3. Break dependency cycles in library
+
+Two tickets, independent of each other, depend on step 2:
+
+- `architecture-break-representation-gtr-cycle.md` - parameterize GTR inference over iterators
+- `architecture-break-representation-ancestral-cycle.md` - move pure functions to `seq/`
+
+### 4. Move commands/ shell to CLI crate
+
+After steps 1-3, `commands/` contains only thin orchestration (`args.rs`, `run.rs`, `output/`). Move the entire `commands/` module to `treetime-cli`. The library crate no longer has a `commands/` module.
+
+No existing ticket for this step - create when prerequisites are met.
+
+### 5. Add client crates
+
+Two tickets, depend on steps 1-4:
+
+- `architecture-add-treetime-python-crate.md` - PyO3 bindings + Python CLI
+- `architecture-add-treetime-desktop-crate.md` - thin desktop wrapper
+
+## Target architecture
+
+```
+treetime (library)
+  +-- alphabet/
+  +-- ancestral/
+  +-- clock/
+  +-- coalescent/
+  +-- constants/
+  +-- gtr/
+  +-- mugration/
+  +-- optimize/
+  +-- representation/
+  +-- seq/
+  +-- timetree/
+
+treetime-cli (client)
+  +-- commands/        (moved from treetime, thin orchestration only)
+  |   +-- ancestral/
+  |   +-- clock/
+  |   +-- homoplasy/
+  |   +-- mugration/
+  |   +-- optimize/
+  |   +-- prune/
+  |   +-- shared/
+  |   +-- timetree/
+  +-- bin/
+
+treetime-python (client)
+  +-- src/             (PyO3 bindings)
+  +-- python/          (Python package + CLI)
+
+treetime-desktop (client)
+  +-- src/             (IPC handlers)
+  +-- frontend/        (minimal UI, deferred)
+```
+
+## Validation
+
+- `treetime` crate compiles without `clap` dependency
+- `treetime` crate has no `commands/` module
+- `treetime-cli` builds and passes all existing tests
+- `treetime-python` builds a wheel and runs a smoke test
+- `treetime-desktop` compiles (frontend deferred)
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)
+
+Coordinates:
+
+- [architecture-remove-clap-from-domain-types.md](architecture-remove-clap-from-domain-types.md)
+- [architecture-extract-coalescent-from-timetree.md](architecture-extract-coalescent-from-timetree.md)
+- [architecture-extract-timetree-inference-from-commands.md](architecture-extract-timetree-inference-from-commands.md)
+- [architecture-extract-mugration-domain-logic.md](architecture-extract-mugration-domain-logic.md)
+- [architecture-break-representation-gtr-cycle.md](architecture-break-representation-gtr-cycle.md)
+- [architecture-break-representation-ancestral-cycle.md](architecture-break-representation-ancestral-cycle.md)
+- [architecture-add-treetime-python-crate.md](architecture-add-treetime-python-crate.md)
+- [architecture-add-treetime-desktop-crate.md](architecture-add-treetime-desktop-crate.md)


### PR DESCRIPTION
- Depends on: #669

The `treetime` library crate depends on `clap`, contains CLI argument derives in domain types, and has ~15k lines of domain logic trapped in `commands/`. Non-CLI consumers (Python bindings, desktop app, WASM) cannot use the library without pulling in the full CLI dependency graph.

An AI agent moved the entire timetree implementation into `treetime-cli` during a refactoring attempt, demonstrating that the library/CLI boundary is not structurally enforced. Adding client crates creates backpressure: if the library must remain consumable by multiple clients, domain logic cannot drift into any single client crate.

### Work items

- [x] Add issue [H-core-multi-client-architecture-library-purity.md](https://github.com/neherlab/treetime/blob/e54557e5/kb/issues/H-core-multi-client-architecture-library-purity.md)
- [x] Add ticket [architecture-add-treetime-python-crate.md](https://github.com/neherlab/treetime/blob/e54557e5/kb/tickets/architecture-add-treetime-python-crate.md)
- [x] Add ticket [architecture-add-treetime-desktop-crate.md](https://github.com/neherlab/treetime/blob/e54557e5/kb/tickets/architecture-add-treetime-desktop-crate.md)
- [x] Add ticket [architecture-move-commands-to-cli-crate.md](https://github.com/neherlab/treetime/blob/e54557e5/kb/tickets/architecture-move-commands-to-cli-crate.md)
- [x] Add umbrella ticket [architecture-restructure-packages-for-multi-client.md](https://github.com/neherlab/treetime/blob/e54557e5/kb/tickets/architecture-restructure-packages-for-multi-client.md)
- [x] Link existing tickets (A10-A14, A17) to new issue as additional source
- [x] Add validation criteria to `architecture-remove-clap-from-domain-types.md`