### PR TITLE
fix: compute child branch lengths from remaining mutation count

### DIFF
--- a/kb/decisions/prune-merge-jukes-cantor-branch-length.md
+++ b/kb/decisions/prune-merge-jukes-cantor-branch-length.md
@@ -24,7 +24,7 @@ Saturation at $p \to (k-1)/k$ is handled by clamping $p$ at $p_{sat}\,(1 - 10^{-
 
 Raw p-distance systematically underestimates evolutionary distance. Under JC69 the bias reaches 7% at $p = 0.1$ and 22% at $p = 0.25$. The corrected value is the maximum-likelihood estimate of the branch length under the model the prune command is already assuming (JC69), so applying it at edge creation time is strictly better than deferring the correction to a later ML optimization pass.
 
-The child-branch adjustment `max(0, original - new_edge_bl)` still clamps at zero, so the sum of the new internal edge and a child edge may differ slightly from the child's original length when the correction pushes the internal edge longer than the child. This is unchanged from the raw p-distance behaviour: the same clamp applied before the fix.
+Child branch lengths are computed from remaining (non-shared) mutations using the same JC69 correction: `jc(remaining_mutations / total_alignment_length)`. Remaining mutations include both substitutions and indels on the child edge. This replaces the earlier `max(0, original_newick_bl - new_edge_bl)` formula, which depended on the input tree's branch lengths and ignored per-child mutation counts.
 
 ## Affected commands
 

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
@@ -10,7 +10,6 @@ mod tests {
   use crate::seq::indel::InDel;
   use crate::seq::mutation::Sub;
   use crate::test_utils::{find_edge_key, find_node_key_by_name};
-  use treetime_primitives::Seq;
   use approx::assert_relative_eq;
   use eyre::Report;
   use maplit::btreemap;
@@ -19,8 +18,8 @@ mod tests {
   use std::sync::Arc;
   use treetime_graph::node::GraphNodeKey;
   use treetime_io::nwk::nwk_read_str;
-  use treetime_primitives::AsciiChar;
   use treetime_primitives::seq;
+  use treetime_primitives::{AsciiChar, Seq};
 
   fn c(b: u8) -> AsciiChar {
     AsciiChar::from_byte_unchecked(b)
@@ -48,7 +47,7 @@ mod tests {
     // Build root reference sequence consistent with edge subs.
     // Set each position to the sub's ref character so that edge_subs()
     // produces the same mutations as the stored subs.
-    let mut ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(length).collect();
+    let mut ref_seq: Seq = std::iter::repeat_with(|| c(b'A')).take(length).collect();
     for (_, _, subs) in edge_mutations {
       for s in subs {
         if s.pos() < length {
@@ -395,7 +394,7 @@ mod tests {
       edges: btreemap! {},
       root_sequence: seq![],
     };
-    let mut p2_ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(200).collect();
+    let mut p2_ref_seq: Seq = std::iter::repeat_with(|| c(b'A')).take(200).collect();
     p2_ref_seq[50] = c(b'C'); // sub C50G uses ref='C'
     p2_inner.root_sequence = p2_ref_seq.clone();
     for node in graph.get_nodes() {
@@ -631,7 +630,11 @@ mod tests {
       100,
       &[
         ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]),
-        ("root", "B", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')]),
+        (
+          "root",
+          "B",
+          vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')],
+        ),
         ("root", "C", vec![sub(b'T', 20, b'A')]),
       ],
     )?;
@@ -756,7 +759,11 @@ mod tests {
       100,
       &[
         ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]),
-        ("root", "B", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')]),
+        (
+          "root",
+          "B",
+          vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')],
+        ),
         ("root", "C", vec![sub(b'T', 20, b'A')]),
       ],
     )?;
@@ -836,7 +843,11 @@ mod tests {
       &graph,
       100,
       &[
-        ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')]),
+        (
+          "root",
+          "A",
+          vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')],
+        ),
         ("root", "B", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]),
         ("root", "C", vec![sub(b'T', 20, b'A')]),
       ],

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
@@ -7,8 +7,10 @@ mod tests {
   use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
   use crate::representation::payload::ancestral::GraphAncestral;
   use crate::representation::payload::sparse::{SparseEdgePartition, SparseNodePartition};
+  use crate::seq::indel::InDel;
   use crate::seq::mutation::Sub;
   use crate::test_utils::{find_edge_key, find_node_key_by_name};
+  use treetime_primitives::Seq;
   use approx::assert_relative_eq;
   use eyre::Report;
   use maplit::btreemap;
@@ -616,6 +618,289 @@ mod tests {
         // accommodates the parser's f32-level precision. The distance `d` is
         // computed from integer mutation counts in pure f64 arithmetic.
         Some("A" | "B") => assert_relative_eq!(bl.unwrap(), 0.5 - d, epsilon = 1e-6),
+        _ => {},
+      }
+    }
+
+    Ok(())
+  }
+
+  fn jc_bl(count: usize, length: usize) -> f64 {
+    if length == 0 || count == 0 {
+      return 0.0;
+    }
+    let p = count as f64 / length as f64;
+    -0.75 * f64::ln(1.0 - 4.0 * p / 3.0)
+  }
+
+  #[test]
+  fn test_merge_child_bl_from_remaining_mutations() -> Result<(), Report> {
+    // A has 2 shared subs only, B has 2 shared + 1 unique.
+    //   bl_a = jc(0/100) = 0.0
+    //   bl_b = jc(1/100)
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.2,C:0.3)root;")?;
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]),
+        ("root", "B", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')]),
+        ("root", "C", vec![sub(b'T', 20, b'A')]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      let bl = edge.payload().read_arc().branch_length;
+
+      match target_name.as_deref() {
+        Some("A") => assert_relative_eq!(bl.unwrap(), jc_bl(0, 100), epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), jc_bl(1, 100), epsilon = 1e-15),
+        _ => {},
+      }
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_child_bl_zero_when_no_unique_mutations() -> Result<(), Report> {
+    // Both children have only shared mutations. Newick BLs are nonzero (0.1, 0.2).
+    // New formula: jc(0) = 0.0 regardless of original BL.
+    // Old formula: max(0, 0.1 - d) and max(0, 0.2 - d) -- both positive.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.2,C:0.3)root;")?;
+    let shared = vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')];
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", shared.clone()),
+        ("root", "B", shared),
+        ("root", "C", vec![sub(b'T', 10, b'A')]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      let bl = edge.payload().read_arc().branch_length;
+
+      match target_name.as_deref() {
+        Some("A") => assert_relative_eq!(bl.unwrap(), 0.0, epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), 0.0, epsilon = 1e-15),
+        _ => {},
+      }
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_child_bl_asymmetric_remaining() -> Result<(), Report> {
+    // A has 3 shared + 2 unique, B has 3 shared + 5 unique.
+    // Each child's BL reflects its own remaining mutation count.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.5,B:0.5,C:0.5)root;")?;
+    let shared = vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')];
+    let unique_a = vec![sub(b'C', 20, b'G'), sub(b'A', 25, b'T')];
+    let unique_b = vec![
+      sub(b'C', 30, b'G'),
+      sub(b'A', 35, b'T'),
+      sub(b'G', 40, b'C'),
+      sub(b'T', 45, b'A'),
+      sub(b'C', 50, b'G'),
+    ];
+
+    let mut subs_a = shared.clone();
+    subs_a.extend(unique_a);
+    subs_a.sort();
+
+    let mut subs_b = shared;
+    subs_b.extend(unique_b);
+    subs_b.sort();
+
+    let partition = make_partition(
+      &graph,
+      1000,
+      &[
+        ("root", "A", subs_a),
+        ("root", "B", subs_b),
+        ("root", "C", vec![sub(b'A', 60, b'T')]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      let bl = edge.payload().read_arc().branch_length;
+
+      match target_name.as_deref() {
+        Some("A") => assert_relative_eq!(bl.unwrap(), jc_bl(2, 1000), epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), jc_bl(5, 1000), epsilon = 1e-15),
+        _ => {},
+      }
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_child_bl_independent_of_newick_branch_length() -> Result<(), Report> {
+    // Newick BL is deliberately extreme (99.0). Child BL should still be
+    // jc(remaining/length), proving the formula ignores original branch lengths.
+    let mut graph: GraphAncestral = nwk_read_str("(A:99.0,B:99.0,C:0.1)root;")?;
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]),
+        ("root", "B", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')]),
+        ("root", "C", vec![sub(b'T', 20, b'A')]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      let bl = edge.payload().read_arc().branch_length;
+
+      match target_name.as_deref() {
+        Some("A") => assert_relative_eq!(bl.unwrap(), jc_bl(0, 100), epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), jc_bl(1, 100), epsilon = 1e-15),
+        _ => {},
+      }
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_child_bl_includes_indels_in_remaining() -> Result<(), Report> {
+    // A has 2 shared subs + 1 indel (not shared, counted in remaining).
+    // B has 2 shared subs only.
+    //   bl_a = jc((0 remaining subs + 1 indel) / 100) = jc(1/100)
+    //   bl_b = jc(0/100) = 0.0
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.5,B:0.5,C:0.5)root;")?;
+    let shared = vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')];
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", shared.clone()),
+        ("root", "B", shared),
+        ("root", "C", vec![sub(b'T', 20, b'A')]),
+      ],
+    )?;
+
+    {
+      let mut p = partition.write_arc();
+      let edge_a = find_edge_key(&graph, "root", "A").unwrap();
+      p.edges.get_mut(&edge_a).unwrap().indels = vec![InDel::del((10, 13), Seq::try_from_str("GTA").unwrap())];
+    }
+
+    let partitions = vec![partition];
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      let bl = edge.payload().read_arc().branch_length;
+
+      match target_name.as_deref() {
+        Some("A") => assert_relative_eq!(bl.unwrap(), jc_bl(1, 100), epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), jc_bl(0, 100), epsilon = 1e-15),
+        _ => {},
+      }
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_child_bl_across_partitions() -> Result<(), Report> {
+    // Two partitions: A has 1 unique sub in p1, 2 unique subs in p2.
+    // Total remaining for A = 3 across total length 100 + 200 = 300.
+    // bl_a = jc(3/300)
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.5,B:0.5,C:0.5)root;")?;
+
+    let p1 = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C'), sub(b'T', 10, b'A')]),
+        ("root", "B", vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')]),
+        ("root", "C", vec![sub(b'T', 20, b'A')]),
+      ],
+    )?;
+
+    let mut p2_inner = PartitionMarginalSparse {
+      index: 1,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: Alphabet::new(crate::alphabet::alphabet::AlphabetName::Nuc)?,
+      length: 200,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+      root_sequence: seq![],
+    };
+    let mut p2_ref_seq: Seq = std::iter::repeat_with(|| c(b'A')).take(200).collect();
+    p2_ref_seq[50] = c(b'C');
+    p2_ref_seq[60] = c(b'G');
+    p2_ref_seq[70] = c(b'T');
+    p2_inner.root_sequence = p2_ref_seq.clone();
+    for node in graph.get_nodes() {
+      let key = node.read_arc().key();
+      let mut node_part = SparseNodePartition::empty(&p2_inner.alphabet);
+      node_part.seq.sequence = p2_ref_seq.clone();
+      p2_inner.nodes.insert(key, node_part);
+    }
+    let edge_a = find_edge_key(&graph, "root", "A").unwrap();
+    let edge_b = find_edge_key(&graph, "root", "B").unwrap();
+    let edge_c = find_edge_key(&graph, "root", "C").unwrap();
+    p2_inner.edges.insert(
+      edge_a,
+      SparseEdgePartition::with_fitch_subs(vec![sub(b'C', 50, b'G'), sub(b'G', 60, b'T'), sub(b'T', 70, b'A')]),
+    );
+    p2_inner
+      .edges
+      .insert(edge_b, SparseEdgePartition::with_fitch_subs(vec![sub(b'C', 50, b'G')]));
+    p2_inner.edges.insert(edge_c, SparseEdgePartition::default());
+    let p2 = Arc::new(RwLock::new(p2_inner));
+
+    let partitions = vec![p1, p2];
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      let bl = edge.payload().read_arc().branch_length;
+
+      match target_name.as_deref() {
+        Some("A") => assert_relative_eq!(bl.unwrap(), jc_bl(3, 300), epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), jc_bl(0, 300), epsilon = 1e-15),
         _ => {},
       }
     }

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
@@ -299,11 +299,9 @@ mod tests {
 
   #[test]
   fn test_merge_branch_length_adjustment() -> Result<(), Report> {
-    // A and B share 2 mutations out of length 100 => p = 2/100 = 0.02
-    // Jukes-Cantor 1969 correction with k=4 states:
-    //   d = -3/4 * ln(1 - 4*0.02/3) = 0.02027025193702054...
-    // A original bl = 0.1, adjusted = max(0, 0.1 - d) ≈ 0.0797297480629...
-    // B original bl = 0.2, adjusted = max(0, 0.2 - d) ≈ 0.1797297480629...
+    // A and B share 2 mutations out of length 100. Both have 0 unique mutations.
+    // Parent edge: jc(2/100).
+    // Child edges: jc(0/100) = 0.0 (no remaining mutations).
     let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.2,C:0.3)root;")?;
     let shared = vec![sub(b'A', 0, b'T'), sub(b'G', 5, b'C')];
     let partition = make_partition(
@@ -327,14 +325,10 @@ mod tests {
       let target_name = target.read_arc().payload().read_arc().name.clone();
       let bl = edge.payload().read_arc().branch_length;
 
-      // The new internal edge length `d` is computed from integer mutation
-      // counts and pure f64 arithmetic, matching 1e-15. The child edges and C
-      // carry newick-parsed branch lengths, so their comparison tolerance is
-      // set to 1e-6 to accommodate the parser's f32-level precision.
       match target_name.as_deref() {
         None => assert_relative_eq!(bl.unwrap(), d, epsilon = 1e-15),
-        Some("A") => assert_relative_eq!(bl.unwrap(), 0.1 - d, epsilon = 1e-6),
-        Some("B") => assert_relative_eq!(bl.unwrap(), 0.2 - d, epsilon = 1e-6),
+        Some("A") => assert_relative_eq!(bl.unwrap(), 0.0, epsilon = 1e-15),
+        Some("B") => assert_relative_eq!(bl.unwrap(), 0.0, epsilon = 1e-15),
         Some("C") => assert_relative_eq!(bl.unwrap(), 0.3, epsilon = 1e-6),
         _ => {},
       }
@@ -344,10 +338,9 @@ mod tests {
   }
 
   #[test]
-  fn test_merge_branch_length_clamp_to_zero() -> Result<(), Report> {
-    // 10 shared mutations out of length 100 => p = 0.1
-    // JC69 correction: d = -3/4 * ln(1 - 4*0.1/3) ≈ 0.1073
-    // A original bl = 0.05 < d, so adjusted clamps to 0.0
+  fn test_merge_child_bl_zero_when_all_shared() -> Result<(), Report> {
+    // 10 shared mutations out of length 100. Both children have only shared
+    // mutations (0 remaining), so child BLs are jc(0) = 0.0.
     let mut graph: GraphAncestral = nwk_read_str("(A:0.05,B:0.2,C:0.3)root;")?;
     let shared: Vec<Sub> = (0..10).map(|i| sub(b'A', i, b'T')).collect();
     let partition = make_partition(
@@ -582,11 +575,8 @@ mod tests {
   #[test]
   fn test_merge_branch_length_jc_correction_differs_from_raw() -> Result<(), Report> {
     // 10 shared mutations out of length 100 places the pooled p-distance at
-    // 0.10, where Jukes-Cantor 1969 correction differs from the raw ratio by
-    // about 7%. The new internal edge must carry the corrected distance, and
-    // the child adjustment must subtract that same corrected distance - any
-    // regression to raw p = 0.1 would show up as a 7% discrepancy between
-    // both assertions below.
+    // 0.10, where JC69 correction differs from the raw ratio by about 7%.
+    // Both children have 0 unique mutations, so child BLs are 0.0.
     let mut graph: GraphAncestral = nwk_read_str("(A:0.5,B:0.5,C:0.5)root;")?;
     let shared: Vec<Sub> = (0..10).map(|i| sub(b'A', i, b'T')).collect();
     let partition = make_partition(
@@ -614,10 +604,7 @@ mod tests {
 
       match target_name.as_deref() {
         None => assert_relative_eq!(bl.unwrap(), d, epsilon = 1e-15),
-        // Child edges inherit newick-parsed branch lengths, so 1e-6
-        // accommodates the parser's f32-level precision. The distance `d` is
-        // computed from integer mutation counts in pure f64 arithmetic.
-        Some("A" | "B") => assert_relative_eq!(bl.unwrap(), 0.5 - d, epsilon = 1e-6),
+        Some("A" | "B") => assert_relative_eq!(bl.unwrap(), 0.0, epsilon = 1e-15),
         _ => {},
       }
     }

--- a/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
@@ -229,8 +229,14 @@ fn merge_sibling_pair(
   };
 
   let new_edge_bl = jc_bl(pair.total_shared);
-  let remaining_a: usize = old_partition_data.iter().map(|d| d.remaining_subs_a.len() + d.indels_a.len()).sum();
-  let remaining_b: usize = old_partition_data.iter().map(|d| d.remaining_subs_b.len() + d.indels_b.len()).sum();
+  let remaining_a: usize = old_partition_data
+    .iter()
+    .map(|d| d.remaining_subs_a.len() + d.indels_a.len())
+    .sum();
+  let remaining_b: usize = old_partition_data
+    .iter()
+    .map(|d| d.remaining_subs_b.len() + d.indels_b.len())
+    .sum();
   let bl_a_adjusted = jc_bl(remaining_a);
   let bl_b_adjusted = jc_bl(remaining_b);
 

--- a/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use log::debug;
 use parking_lot::RwLock;
 use std::sync::Arc;
-use treetime_graph::edge::{GraphEdgeKey, HasBranchLength};
+use treetime_graph::edge::GraphEdgeKey;
 use treetime_graph::node::GraphNodeKey;
 use treetime_utils::iterator::difference::iterator_difference;
 use treetime_utils::iterator::intersection::iterator_intersection;
@@ -190,14 +190,6 @@ fn merge_sibling_pair(
   let child_key_a = graph.get_target_node_key(pair.edge_key_a)?;
   let child_key_b = graph.get_target_node_key(pair.edge_key_b)?;
 
-  // Read original branch lengths before removing edges
-  let bl_a = graph
-    .get_edge(pair.edge_key_a)
-    .and_then(|e| e.read_arc().payload().read_arc().branch_length());
-  let bl_b = graph
-    .get_edge(pair.edge_key_b)
-    .and_then(|e| e.read_arc().payload().read_arc().branch_length());
-
   let old_partition_data: Vec<_> = partitions
     .iter()
     .enumerate()
@@ -222,28 +214,25 @@ fn merge_sibling_pair(
     })
     .collect::<Result<Vec<_>, Report>>()?;
 
-  // Compute new branch length from the pooled p-distance across partitions.
-  // The raw Hamming ratio shared/length underestimates evolutionary distance
-  // because multiple substitutions at the same site can revert or mask earlier
-  // ones. The Jukes-Cantor 1969 correction inverts the JC substitution model
-  // to recover expected substitutions per site from observed differences.
-  //
   // Pooling across partitions assumes they share an alphabet size, which holds
   // for every current caller: `prune` hardcodes JC69 over a single alphabet,
   // and `optimize` reuses this path with a single partition set under one
   // model name. `n_states` is read from the first partition accordingly.
   let total_alignment_length: usize = partitions.iter().map(|p| p.read_arc().length).sum();
-  let new_edge_bl = if total_alignment_length > 0 {
-    let p = pair.total_shared as f64 / total_alignment_length as f64;
-    let n_states = partitions[0].read_arc().alphabet.n_canonical();
-    jukes_cantor_distance(p, n_states)
-  } else {
-    0.0
+  let n_states = partitions[0].read_arc().alphabet.n_canonical();
+  let jc_bl = |count: usize| -> f64 {
+    if total_alignment_length > 0 {
+      jukes_cantor_distance(count as f64 / total_alignment_length as f64, n_states)
+    } else {
+      0.0
+    }
   };
 
-  // Adjust children branch lengths
-  let bl_a_adjusted = bl_a.map(|bl| f64::max(0.0, bl - new_edge_bl));
-  let bl_b_adjusted = bl_b.map(|bl| f64::max(0.0, bl - new_edge_bl));
+  let new_edge_bl = jc_bl(pair.total_shared);
+  let remaining_a: usize = old_partition_data.iter().map(|d| d.remaining_subs_a.len() + d.indels_a.len()).sum();
+  let remaining_b: usize = old_partition_data.iter().map(|d| d.remaining_subs_b.len() + d.indels_b.len()).sum();
+  let bl_a_adjusted = jc_bl(remaining_a);
+  let bl_b_adjusted = jc_bl(remaining_b);
 
   // Remove old edges from parent to children
   graph.remove_edge(pair.edge_key_a)?;
@@ -266,7 +255,7 @@ fn merge_sibling_pair(
     new_node_key,
     child_key_a,
     EdgeAncestral {
-      branch_length: bl_a_adjusted,
+      branch_length: Some(bl_a_adjusted),
     },
   )?;
 
@@ -275,7 +264,7 @@ fn merge_sibling_pair(
     new_node_key,
     child_key_b,
     EdgeAncestral {
-      branch_length: bl_b_adjusted,
+      branch_length: Some(bl_b_adjusted),
     },
   )?;
 


### PR DESCRIPTION
- Depends on: #670

When `merge_shared_mutation_branches` creates a new internal node to group siblings sharing mutations, each child edge needs a branch length reflecting its remaining (non-shared) mutations. The old formula $\max(0,\; b_{\text{orig}} - d_{\text{JC}}(\text{shared}))$ depended on the input tree's branch lengths and ignored the actual per-child mutation counts.

This PR replaces it with $d_{\text{JC}}(n_{\text{remaining}} / L)$, computed purely from the substitution and indel counts on each child edge after removing shared mutations. The Jukes-Cantor correction is applied identically to the parent edge (already JC-corrected) and the child edges.

The new formula is the maximum-likelihood branch length estimate under JC69 (Jukes and Cantor 1969, https://doi.org/10.1016/B978-1-4832-3211-9.50009-7) given the observed mutation count -- the same model the `prune` command already uses. Children with no unique mutations get zero-length branches, which is correct: no observed divergence on that edge segment.

### Work items

- [x] Replace child BL formula with `jc_bl(remaining)` in `merge_sibling_pair`
- [x] Add 6 regression tests covering remaining count, zero remaining, asymmetric counts, newick independence, indels in remaining, cross-partition summation
- [x] Update 2 existing BL tests for new expected values, rename stale test
- [x] Update decision: [prune-merge-jukes-cantor-branch-length.md](https://github.com/neherlab/treetime/blob/2c860273/kb/decisions/prune-merge-jukes-cantor-branch-length.md): document new child BL formula

### Possible improvements

- [ ] Switch topology cleanup to ML substitutions instead of Fitch ([N-optimize-topology-cleanup-fitch-vs-ml-subs.md](https://github.com/neherlab/treetime/blob/2c860273/kb/issues/N-optimize-topology-cleanup-fitch-vs-ml-subs.md))