### PR TITLE
feat: merge sibling groups with indel support

### DIFF
--- a/kb/decisions/prune-merge-jukes-cantor-branch-length.md
+++ b/kb/decisions/prune-merge-jukes-cantor-branch-length.md
@@ -12,11 +12,11 @@ The `prune --merge-shared-mutations` step groups sibling branches in a polytomy 
 
 ## What v1 does
 
-[`merge_sibling_pair()`](../../packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs#L183) applies the Jukes-Cantor 1969 correction through [`jukes_cantor_distance()`](../../packages/treetime/src/gtr/jc_distance.rs#L50):
+[`merge_sibling_group()`](../../packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs) applies the Jukes-Cantor 1969 correction through [`jukes_cantor_distance()`](../../packages/treetime/src/gtr/jc_distance.rs#L50):
 
 $$ d = -\frac{k-1}{k} \ln\!\left(1 - \frac{k}{k-1}\, p\right) $$
 
-where $p$ is the pooled p-distance (shared substitutions divided by total alignment length across all partitions) and $k$ is the alphabet size read from the first partition. The formula matches the JC69 model currently hardcoded in [`run_prune()`](../../packages/treetime/src/commands/prune/run.rs#L53) and generalises naturally to amino-acid alphabets (k=20) without code changes.
+where $p$ is the pooled p-distance (shared mutations divided by total alignment length across all partitions) and $k$ is the alphabet size read from the first partition. Both substitutions and indels contribute to the shared and remaining mutation counts. The formula matches the JC69 model currently hardcoded in [`run_prune()`](../../packages/treetime/src/commands/prune/run.rs#L53) and generalises naturally to amino-acid alphabets (k=20) without code changes.
 
 Saturation at $p \to (k-1)/k$ is handled by clamping $p$ at $p_{sat}\,(1 - 10^{-6})$ before applying the formula. This keeps the result finite (about 10 substitutions per site for k=4, 13 for k=20), continuous in $p$, and safe from `log(0)` or NaN downstream.
 

--- a/kb/reports/iterative-tree-refinement/7-polytomy-resolution.md
+++ b/kb/reports/iterative-tree-refinement/7-polytomy-resolution.md
@@ -109,27 +109,28 @@ v1: not implemented. Tracked as `N-timetree-stochastic-polytomy-unimplemented`.
 
 ## Strategy 4: Shared-mutation merging (sequence-based)
 
-This strategy does not use time or likelihood. It examines the substitution sets on child branches and groups siblings sharing identical mutations:
+This strategy does not use time or likelihood. It examines the mutation sets (substitutions and indels) on child branches and groups siblings sharing identical mutations:
 
 ```
-Before (A and B share G100T):      After merging:
+Before (A, B, C share G100T):      After merging:
 
-      P                                  P
-    / | \                               / \
-   A  B  C                            N   C
-   |  |  |                           / \
-  G100T  G100T  A200C               A   B
+      P                                    P
+    / | \ \                               / \
+   A  B  C  D                           N    D
+   |  |  |                             / | \
+  G100T  G100T  G100T  A200C         A   B   C
   A200C  T300G
                                     Edge P-N: G100T (shared)
                                     Edge N-A: A200C (unique)
                                     Edge N-B: T300G (unique)
+                                    Edge N-C: (none)
 ```
 
-New branch length = `#shared_mutations / alignment_length`.
+New branch length = JC69-corrected distance from `#shared_mutations / alignment_length`.
 
-The algorithm finds all polytomy nodes, computes substitution intersections for all child pairs, greedily merges the pair with the most shared mutations, and repeats until no pair shares mutations.
+The algorithm builds a mutation index mapping each (partition, mutation) to its carrier edges, finds candidate groups of k >= 2 siblings whose mutation sets share a non-empty intersection, selects a disjoint set of groups via greedy matching, and merges each group under one new internal node. Repeats until no siblings share mutations. Both substitutions and indels participate in sharing detection.
 
-**Complexity:** O(n^2 \* m) where n is polytomy degree and m is mutations per branch.
+**Complexity:** O(n \* m) per round where n is the child count and m is the average number of mutations per edge.
 
 v0: no formal implementation. The design document describes "ad-hoc scripts" in nextstrain pipelines. See the [nextstrain ad-hoc scripts](#the-nextstrain-ad-hoc-scripts) section below for the script locations.
 
@@ -139,7 +140,7 @@ v1 code: `merge_shared_mutation_branches()` in [`packages/treetime/src/represent
 
 | Aspect           | NJ                   | Greedy temporal          | Stochastic coalescent   | Shared-mutation           |
 | ---------------- | -------------------- | ------------------------ | ----------------------- | ------------------------- |
-| Input data       | Distance matrix      | Time distributions       | Mutation counts + times | Substitution sets         |
+| Input data       | Distance matrix      | Time distributions       | Mutation counts + times | Substitution + indel sets |
 | Criterion        | Minimize tree length | Maximize likelihood gain | Simulate coalescent     | Maximize shared mutations |
 | Complexity       | O(n^3)               | O(n^2)                   | O(n)                    | O(n^2 \* m)               |
 | Deterministic    | Yes                  | Yes                      | No                      | Yes                       |

--- a/packages/treetime/src/commands/prune/__tests__/test_run.rs
+++ b/packages/treetime/src/commands/prune/__tests__/test_run.rs
@@ -1263,9 +1263,8 @@ mod tests {
     let merged = merge_shared_mutation_branches(&mut graph, &partitions)?;
     graph.build()?;
 
-    // Greedy merge: first A&B (or any pair sharing A0T), then the merged
-    // node and C also share A0T → two pairwise merges total.
-    assert_eq!(merged, 2, "two pairwise merges should group A, B, C together");
+    // Group merge: A, B, C all share A0T and form one group.
+    assert_eq!(merged, 1, "one group merge should place A, B, C under one node");
 
     // Root should have exactly 2 children: the merged subtree and D
     let root_key = find_node_key_by_name(&graph, "root").unwrap();

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_merge_shared_mutations.rs
@@ -905,4 +905,122 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn test_merge_group_three_siblings_same_mutation() -> Result<(), Report> {
+    // A, B, C all share {A0T}. Group merge puts all 3 under one new node.
+    // Pairwise merge would pick 2, leaving the third at root level.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1,C:0.1,D:0.1)root;")?;
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub(b'A', 0, b'T')]),
+        ("root", "B", vec![sub(b'A', 0, b'T')]),
+        ("root", "C", vec![sub(b'A', 0, b'T')]),
+        ("root", "D", vec![sub(b'G', 5, b'C')]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    let merged = merge_shared_mutation_branches(&mut graph, &partitions)?;
+    assert_eq!(merged, 1);
+    graph.build()?;
+
+    let unnamed = find_unnamed_internal_nodes(&graph);
+    assert_eq!(unnamed.len(), 1);
+
+    let new_node = graph.get_node(unnamed[0]).unwrap();
+    let children_count = new_node.read_arc().degree_out();
+    assert_eq!(children_count, 3, "group merge should place all 3 sharing siblings under one node");
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_shared_indels_only() -> Result<(), Report> {
+    // A and B share an identical deletion but no substitutions.
+    // Only merges when indels participate in sharing detection.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1,C:0.1)root;")?;
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![]),
+        ("root", "B", vec![]),
+        ("root", "C", vec![sub(b'T', 20, b'A')]),
+      ],
+    )?;
+
+    let shared_indel = InDel::del((5, 8), Seq::try_from_str("GTA").unwrap());
+    {
+      let mut p = partition.write_arc();
+      let edge_a = find_edge_key(&graph, "root", "A").unwrap();
+      let edge_b = find_edge_key(&graph, "root", "B").unwrap();
+      p.edges.get_mut(&edge_a).unwrap().indels = vec![shared_indel.clone()];
+      p.edges.get_mut(&edge_b).unwrap().indels = vec![shared_indel];
+    }
+
+    let partitions = vec![partition];
+    let merged = merge_shared_mutation_branches(&mut graph, &partitions)?;
+    assert_eq!(merged, 1, "siblings sharing only indels should merge");
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_shared_subs_and_indels_split_correctly() -> Result<(), Report> {
+    // A and B share 1 sub + 1 indel. A also has 1 unique sub.
+    // After merge: parent edge carries the shared sub AND the shared indel.
+    // Child A edge carries the unique sub and no indels.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1,C:0.1)root;")?;
+    let partition = make_partition(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub(b'A', 0, b'T'), sub(b'G', 15, b'C')]),
+        ("root", "B", vec![sub(b'A', 0, b'T')]),
+        ("root", "C", vec![sub(b'T', 20, b'A')]),
+      ],
+    )?;
+
+    let shared_indel = InDel::del((5, 8), Seq::try_from_str("GTA").unwrap());
+    {
+      let mut p = partition.write_arc();
+      let edge_a = find_edge_key(&graph, "root", "A").unwrap();
+      let edge_b = find_edge_key(&graph, "root", "B").unwrap();
+      p.edges.get_mut(&edge_a).unwrap().indels = vec![shared_indel.clone()];
+      p.edges.get_mut(&edge_b).unwrap().indels = vec![shared_indel];
+    }
+
+    let partitions = vec![partition];
+    merge_shared_mutation_branches(&mut graph, &partitions)?;
+    graph.build()?;
+
+    let p = partitions[0].read_arc();
+    for edge in graph.get_edges() {
+      let edge = edge.read_arc();
+      let target = graph.get_node(edge.target()).unwrap();
+      let target_name = target.read_arc().payload().read_arc().name.clone();
+      if let Some(edge_data) = p.edges.get(&edge.key()) {
+        match target_name.as_deref() {
+          None => {
+            assert_eq!(edge_data.fitch_subs().len(), 1, "parent edge: 1 shared sub");
+            assert_eq!(edge_data.indels.len(), 1, "parent edge: 1 shared indel");
+          },
+          Some("A") => {
+            assert_eq!(edge_data.fitch_subs().len(), 1, "A: 1 unique sub remaining");
+            assert_eq!(edge_data.indels.len(), 0, "A: no remaining indels");
+          },
+          Some("B") => {
+            assert_eq!(edge_data.fitch_subs().len(), 0, "B: no remaining subs");
+            assert_eq!(edge_data.indels.len(), 0, "B: no remaining indels");
+          },
+          _ => {},
+        }
+      }
+    }
+
+    Ok(())
+  }
 }

--- a/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
@@ -8,23 +8,25 @@ use eyre::Report;
 use itertools::Itertools;
 use log::debug;
 use parking_lot::RwLock;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use treetime_graph::edge::GraphEdgeKey;
 use treetime_graph::node::GraphNodeKey;
 use treetime_utils::iterator::difference::iterator_difference;
-use treetime_utils::iterator::intersection::iterator_intersection;
 
 /// Merge sibling branches in polytomies that share identical substitutions.
 ///
-/// Tree builders produce arbitrary binary resolutions of polytomies. When two sibling
-/// branches carry identical substitutions, they represent redundant resolutions. This
-/// function groups such siblings under a new internal node:
+/// Tree builders produce arbitrary binary resolutions of polytomies. When sibling branches
+/// carry identical substitutions, they represent redundant resolutions. This function groups
+/// such siblings (two or more) under a new internal node:
 ///
-/// Before: P-A (subs: {G100T, A200C}), P-B (subs: {G100T, A200C, T300G}), P-C
-/// After:  P-N (subs: {G100T, A200C}), N-A (subs: {}), N-B (subs: {T300G}), P-C
+/// Before: P-A (subs: {G100T, A200C}), P-B (subs: {G100T, A200C, T300G}), P-C (subs: {G100T, A200C})
+/// After:  P-N (subs: {G100T, A200C}), N-A (subs: {}), N-B (subs: {T300G}), N-C (subs: {})
 ///
-/// Greedily merges the pair with the most shared mutations, repeating until no pair
-/// shares any mutations. Returns the total number of new internal nodes created.
+/// Each round finds groups of k >= 2 siblings whose mutation sets share a non-empty
+/// intersection, selects a disjoint set of groups, and merges each group under one new
+/// internal node. Repeats until no siblings share any mutations. Returns the total number
+/// of new internal nodes created.
 pub fn merge_shared_mutation_branches(
   graph: &mut GraphAncestral,
   partitions: &[Arc<RwLock<PartitionMarginalSparse>>],
@@ -39,7 +41,7 @@ pub fn merge_shared_mutation_branches(
   }
 
   if total_merged > 0 {
-    debug!("Merged {total_merged} sibling pairs sharing mutations");
+    debug!("Merged {total_merged} sibling groups sharing mutations");
   } else {
     debug!("No sibling branches sharing mutations found");
   }
@@ -58,7 +60,16 @@ fn find_polytomy_nodes(graph: &GraphAncestral) -> Vec<GraphNodeKey> {
     .collect_vec()
 }
 
-/// Resolve one polytomy by greedy pairwise merging of siblings sharing mutations.
+/// Resolve one polytomy by greedy batch merging of siblings sharing mutations.
+///
+/// Each round builds a mutation->edges index, finds all candidate groups of k >= 2 siblings
+/// whose mutation sets share a non-empty intersection, selects a disjoint set of groups
+/// (no edge in two groups), and merges each group under one new internal node. The number
+/// of children drops by at least one per round, so the loop always terminates.
+///
+/// Groups with k > 2 edges are handled directly in one merge, avoiding the chain of binary
+/// internal nodes that would result from repeated pairwise merging.
+///
 /// Returns number of new internal nodes created.
 fn merge_single_polytomy(
   graph: &mut GraphAncestral,
@@ -73,16 +84,26 @@ fn merge_single_polytomy(
       break;
     }
 
-    let best = find_best_shared_mutation_pair(graph, partitions, &child_edges)?;
-    let Some(best) = best else { break };
+    let index = build_mutation_index(partitions, &child_edges);
+    let candidates = find_merge_groups(&index, partitions.len());
+    let selected = greedy_disjoint_group_matching(candidates);
 
-    debug!(
-      "Merging siblings under node {node_key}: edges {} and {} share {} mutations",
-      best.edge_key_a, best.edge_key_b, best.total_shared
-    );
+    if selected.is_empty() {
+      break;
+    }
 
-    merge_sibling_pair(graph, partitions, node_key, &best)?;
-    nodes_created += 1;
+    for group in selected {
+      let edges_fmt = group.edges.iter().format(", ");
+      let shared_subs_fmt = group.shared_subs.iter().flatten().format(", ");
+      let shared_indels_fmt = group.shared_indels.iter().flatten().format(", ");
+      debug!(
+        "Merging {} siblings under node {node_key}: edges [{edges_fmt}] share {} mutations: subs=[{shared_subs_fmt}] indels=[{shared_indels_fmt}]",
+        group.edges.len(),
+        group.total_shared,
+      );
+      merge_sibling_group(graph, partitions, node_key, &group)?;
+      nodes_created += 1;
+    }
   }
 
   Ok(nodes_created)
@@ -95,82 +116,153 @@ fn collect_child_edge_keys(graph: &GraphAncestral, node_key: GraphNodeKey) -> Ve
   node.outbound().to_vec()
 }
 
-/// Result of finding the best pair of siblings to merge.
-struct SharedMutationPair {
-  edge_key_a: GraphEdgeKey,
-  edge_key_b: GraphEdgeKey,
-  /// Shared substitutions per partition (indexed by partition position).
+/// Unified key for the mutation index: a substitution or an exact-match indel.
+///
+/// Substitutions are keyed by their full (ref, pos, qry) triple. Indels are keyed by their
+/// exact (range, seq, deletion) value -- only identical indels count as shared. Partial
+/// overlaps are ignored; this is conservative but cheap.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum MutationKey {
+  Sub(Sub),
+  InDel(InDel),
+}
+
+/// A group of k >= 2 sibling edges whose mutation sets share a non-empty intersection.
+struct MergeGroup {
+  /// Sorted, deduplicated edge keys.
+  edges: Vec<GraphEdgeKey>,
+  /// Shared substitutions per partition (index matches `partitions` slice).
   shared_subs: Vec<Vec<Sub>>,
+  /// Shared indels per partition.
+  shared_indels: Vec<Vec<InDel>>,
+  /// Total shared mutations across all partitions.
   total_shared: usize,
 }
 
-/// Find the pair of child edges with the most shared mutations across all partitions.
-/// Returns None if no pair shares any mutations.
-fn find_best_shared_mutation_pair(
-  graph: &GraphAncestral,
+/// Maps `(partition_index, MutationKey)` to the list of child edges carrying that mutation.
+type MutationIndex = BTreeMap<(usize, MutationKey), Vec<GraphEdgeKey>>;
+
+/// Build the mutation index for the given set of child edges.
+///
+/// Each substitution and each indel on each edge is entered under its (partition, key) bucket.
+/// Buckets with a single entry contribute no pair scores; buckets with >= 2 entries contribute
+/// +1 to all pairwise scores within the bucket.
+fn build_mutation_index(
   partitions: &[Arc<RwLock<PartitionMarginalSparse>>],
   child_edges: &[GraphEdgeKey],
-) -> Result<Option<SharedMutationPair>, Report> {
-  let n = child_edges.len();
-  let mut best: Option<SharedMutationPair> = None;
-
-  for i in 0..n {
-    for j in (i + 1)..n {
-      let shared_subs = compute_shared_subs_across_partitions(partitions, child_edges[i], child_edges[j])?;
-      let total_shared: usize = shared_subs.iter().map(Vec::len).sum();
-
-      if total_shared > 0 {
-        let is_better = best.as_ref().is_none_or(|b| total_shared > b.total_shared);
-        if is_better {
-          best = Some(SharedMutationPair {
-            edge_key_a: child_edges[i],
-            edge_key_b: child_edges[j],
-            shared_subs,
-            total_shared,
-          });
-        }
+) -> MutationIndex {
+  let mut index: MutationIndex = BTreeMap::new();
+  for &edge_key in child_edges {
+    for (pi, partition) in partitions.iter().enumerate() {
+      let partition = partition.read_arc();
+      let empty_subs: &[Sub] = &[];
+      let edge = partition.edges.get(&edge_key);
+      for sub in edge.map_or(empty_subs, |e| e.fitch_subs()) {
+        index.entry((pi, MutationKey::Sub(sub.clone()))).or_default().push(edge_key);
+      }
+      let empty_indels: &[InDel] = &[];
+      for indel in edge.map_or(empty_indels, |e| e.indels.as_slice()) {
+        index.entry((pi, MutationKey::InDel(indel.clone()))).or_default().push(edge_key);
       }
     }
   }
-
-  Ok(best)
+  index
 }
 
-/// Compute the intersection of substitutions on two edges, per partition.
-fn compute_shared_subs_across_partitions(
-  partitions: &[Arc<RwLock<PartitionMarginalSparse>>],
-  edge_key_a: GraphEdgeKey,
-  edge_key_b: GraphEdgeKey,
-) -> Result<Vec<Vec<Sub>>, Report> {
-  let empty: &[Sub] = &[];
-  partitions
-    .iter()
-    .map(|partition| {
-      let partition = partition.read_arc();
-      let subs_a = partition.edges.get(&edge_key_a).map_or(empty, |e| e.fitch_subs());
-      let subs_b = partition.edges.get(&edge_key_b).map_or(empty, |e| e.fitch_subs());
-      Ok(iterator_intersection(subs_a, subs_b).cloned().collect_vec())
-    })
-    .collect()
-}
-
-/// Saved partition data for two child edges during merge.
-struct ChildPartitionData {
-  remaining_subs_a: Vec<Sub>,
-  remaining_subs_b: Vec<Sub>,
-  indels_a: Vec<InDel>,
-  indels_b: Vec<InDel>,
-}
-
-/// Merge two siblings under a new internal node.
+/// Find all candidate merge groups from the mutation index.
 ///
-/// Creates a new node N between parent P and children A, B:
-/// - Edge P-N carries the shared mutations
-/// - Edges N-A and N-B carry only the remaining unique mutations
-/// - Branch length of P-N is the Jukes-Cantor corrected evolutionary
-///   distance from the pooled p-distance `total_shared_mutations / total_alignment_length`
-///   (see [`jukes_cantor_distance`])
-/// - Branch lengths of N-A, N-B = max(0, original - new_edge_bl)
+/// For each index bucket with k >= 2 edges, the full set of edges in that bucket is a
+/// candidate group. Duplicate candidate sets (same set of edges, different mutation) are
+/// collapsed into one by using the sorted edge list as a dedup key. Each surviving candidate
+/// is scored by intersecting all (partition, mutation) buckets that cover every edge in the
+/// group.
+fn find_merge_groups(index: &MutationIndex, n_partitions: usize) -> Vec<MergeGroup> {
+  let mut seen: HashSet<Vec<GraphEdgeKey>> = HashSet::new();
+  let mut groups = Vec::new();
+
+  for edges in index.values() {
+    if edges.len() < 2 {
+      continue;
+    }
+    let mut group_edges = edges.clone();
+    group_edges.sort_unstable();
+    group_edges.dedup();
+    if !seen.insert(group_edges.clone()) {
+      continue;
+    }
+    let (shared_subs, shared_indels) = shared_mutations_for_group(index, n_partitions, &group_edges);
+    let total_shared: usize =
+      shared_subs.iter().map(|v| v.len()).sum::<usize>() + shared_indels.iter().map(|v| v.len()).sum::<usize>();
+    if total_shared > 0 {
+      groups.push(MergeGroup {
+        edges: group_edges,
+        shared_subs,
+        shared_indels,
+        total_shared,
+      });
+    }
+  }
+  groups
+}
+
+/// Collect per-partition shared substitutions and indels for a group of edges.
+///
+/// A mutation is shared by the group if every edge in `group` appears in the bucket for
+/// that (partition, mutation) key.
+fn shared_mutations_for_group(
+  index: &MutationIndex,
+  n_partitions: usize,
+  group: &[GraphEdgeKey],
+) -> (Vec<Vec<Sub>>, Vec<Vec<InDel>>) {
+  let mut shared_subs: Vec<Vec<Sub>> = vec![Vec::new(); n_partitions];
+  let mut shared_indels: Vec<Vec<InDel>> = vec![Vec::new(); n_partitions];
+  for ((pi, key), edges) in index {
+    if group.iter().all(|e| edges.contains(e)) {
+      match key {
+        MutationKey::Sub(sub) => shared_subs[*pi].push(sub.clone()),
+        MutationKey::InDel(indel) => shared_indels[*pi].push(indel.clone()),
+      }
+    }
+  }
+  (shared_subs, shared_indels)
+}
+
+/// Select a maximal disjoint set of merge groups in one round.
+///
+/// Sorts candidates by descending `total_shared`, breaking ties by descending group size.
+/// Greedily picks groups where no edge has been claimed yet.
+fn greedy_disjoint_group_matching(mut groups: Vec<MergeGroup>) -> Vec<MergeGroup> {
+  groups.sort_unstable_by(|a, b| {
+    b.total_shared
+      .cmp(&a.total_shared)
+      .then(b.edges.len().cmp(&a.edges.len()))
+  });
+  let mut used: HashSet<GraphEdgeKey> = HashSet::new();
+  groups.retain(|g| {
+    if g.edges.iter().all(|e| !used.contains(e)) {
+      used.extend(g.edges.iter().copied());
+      true
+    } else {
+      false
+    }
+  });
+  groups
+}
+
+/// Remaining mutations for one child edge after removing the shared mutations.
+struct ChildEdgeData {
+  remaining_subs: Vec<Sub>,
+  remaining_indels: Vec<InDel>,
+}
+
+/// Merge k >= 2 siblings under a new internal node.
+///
+/// Creates a new node N between parent P and children C_0 ... C_{k-1}:
+/// - Edge P->N carries the shared mutations.
+/// - Edges N->C_i carry only the remaining unique mutations.
+/// - Branch length of P->N is the Jukes-Cantor corrected distance from
+///   `total_shared / total_alignment_length`.
+/// - Branch lengths of N->C_i = JC(remaining_i / total_alignment_length).
 ///
 /// # Model assumption
 ///
@@ -180,44 +272,45 @@ struct ChildPartitionData {
 /// better approximation than the raw p-distance because any symmetric
 /// substitution process underestimates true evolutionary distance by the
 /// same mechanism (back-mutations and parallel substitutions).
-fn merge_sibling_pair(
+fn merge_sibling_group(
   graph: &mut GraphAncestral,
   partitions: &[Arc<RwLock<PartitionMarginalSparse>>],
   parent_key: GraphNodeKey,
-  pair: &SharedMutationPair,
+  group: &MergeGroup,
 ) -> Result<(), Report> {
-  // Read actual child keys from graph edges
-  let child_key_a = graph.get_target_node_key(pair.edge_key_a)?;
-  let child_key_b = graph.get_target_node_key(pair.edge_key_b)?;
+  let child_keys: Vec<GraphNodeKey> = group
+    .edges
+    .iter()
+    .map(|&ek| graph.get_target_node_key(ek))
+    .collect::<Result<Vec<_>, _>>()?;
 
-  let old_partition_data: Vec<_> = partitions
+  let per_edge_data: Vec<Vec<ChildEdgeData>> = partitions
     .iter()
     .enumerate()
     .map(|(pi, partition)| {
       let partition = partition.read_arc();
-      let empty: &[Sub] = &[];
-      let edge_a = partition.edges.get(&pair.edge_key_a);
-      let edge_b = partition.edges.get(&pair.edge_key_b);
-      let subs_a = edge_a.map_or(empty, |e| e.fitch_subs());
-      let subs_b = edge_b.map_or(empty, |e| e.fitch_subs());
-      let indels_a = edge_a.map(|e| e.indels.clone()).unwrap_or_default();
-      let indels_b = edge_b.map(|e| e.indels.clone()).unwrap_or_default();
-      let shared = &pair.shared_subs[pi];
-      let remaining_a = iterator_difference(subs_a, shared).cloned().collect_vec();
-      let remaining_b = iterator_difference(subs_b, shared).cloned().collect_vec();
-      Ok(ChildPartitionData {
-        remaining_subs_a: remaining_a,
-        remaining_subs_b: remaining_b,
-        indels_a,
-        indels_b,
-      })
+      let empty_subs: &[Sub] = &[];
+      let empty_indels: &[InDel] = &[];
+      group
+        .edges
+        .iter()
+        .map(|&ek| {
+          let edge = partition.edges.get(&ek);
+          let all_subs = edge.map_or(empty_subs, |e| e.fitch_subs());
+          let all_indels = edge.map(|e| e.indels.as_slice()).unwrap_or(empty_indels);
+          let shared_subs = &group.shared_subs[pi];
+          let shared_indels = &group.shared_indels[pi];
+          let remaining_subs = iterator_difference(all_subs, shared_subs).cloned().collect_vec();
+          let remaining_indels = iterator_difference(all_indels, shared_indels.as_slice()).cloned().collect_vec();
+          ChildEdgeData {
+            remaining_subs,
+            remaining_indels,
+          }
+        })
+        .collect()
     })
-    .collect::<Result<Vec<_>, Report>>()?;
+    .collect();
 
-  // Pooling across partitions assumes they share an alphabet size, which holds
-  // for every current caller: `prune` hardcodes JC69 over a single alphabet,
-  // and `optimize` reuses this path with a single partition set under one
-  // model name. `n_states` is read from the first partition accordingly.
   let total_alignment_length: usize = partitions.iter().map(|p| p.read_arc().length).sum();
   let n_states = partitions[0].read_arc().alphabet.n_canonical();
   let jc_bl = |count: usize| -> f64 {
@@ -228,26 +321,23 @@ fn merge_sibling_pair(
     }
   };
 
-  let new_edge_bl = jc_bl(pair.total_shared);
-  let remaining_a: usize = old_partition_data
-    .iter()
-    .map(|d| d.remaining_subs_a.len() + d.indels_a.len())
-    .sum();
-  let remaining_b: usize = old_partition_data
-    .iter()
-    .map(|d| d.remaining_subs_b.len() + d.indels_b.len())
-    .sum();
-  let bl_a_adjusted = jc_bl(remaining_a);
-  let bl_b_adjusted = jc_bl(remaining_b);
+  let new_edge_bl = jc_bl(group.total_shared);
+  let child_bls: Vec<f64> = (0..group.edges.len())
+    .map(|i| {
+      let remaining: usize = per_edge_data
+        .iter()
+        .map(|pi_data| pi_data[i].remaining_subs.len() + pi_data[i].remaining_indels.len())
+        .sum();
+      jc_bl(remaining)
+    })
+    .collect();
 
-  // Remove old edges from parent to children
-  graph.remove_edge(pair.edge_key_a)?;
-  graph.remove_edge(pair.edge_key_b)?;
+  for &ek in &group.edges {
+    graph.remove_edge(ek)?;
+  }
 
-  // Create new internal node
   let new_node_key = graph.add_node(NodeAncestral::default());
 
-  // Edge parent-new_node carries shared mutations
   let new_parent_edge_key = graph.add_edge(
     parent_key,
     new_node_key,
@@ -256,55 +346,42 @@ fn merge_sibling_pair(
     },
   )?;
 
-  // Edge new_node-child_a carries remaining mutations
-  let new_edge_a_key = graph.add_edge(
-    new_node_key,
-    child_key_a,
-    EdgeAncestral {
-      branch_length: Some(bl_a_adjusted),
-    },
-  )?;
+  let new_child_edge_keys: Vec<GraphEdgeKey> = child_keys
+    .iter()
+    .zip(child_bls.iter())
+    .map(|(&ck, &bl)| {
+      graph.add_edge(
+        new_node_key,
+        ck,
+        EdgeAncestral {
+          branch_length: Some(bl),
+        },
+      )
+    })
+    .collect::<Result<Vec<_>, _>>()?;
 
-  // Edge new_node-child_b carries remaining mutations
-  let new_edge_b_key = graph.add_edge(
-    new_node_key,
-    child_key_b,
-    EdgeAncestral {
-      branch_length: Some(bl_b_adjusted),
-    },
-  )?;
+  for (pi, partition_arc) in partitions.iter().enumerate() {
+    let mut partition = partition_arc.write_arc();
 
-  // Update partition node and edge data
-  for (pi, partition) in partitions.iter().enumerate() {
-    let mut partition = partition.write_arc();
-    let data = &old_partition_data[pi];
-
-    // Add node entry for the new internal node. Copy the parent's composition
-    // so that the backward pass in combine_messages() computes correct fixed-site
-    // contributions. An empty composition would zero out ~99% of the log-likelihood
-    // signal for the merge-created node and all ancestors.
     let mut new_node = SparseNodePartition::empty(&partition.alphabet);
     let parent_comp = partition.nodes[&parent_key].seq.composition.clone();
     new_node.seq.composition = parent_comp.clone();
     new_node.seq.fitch.composition = parent_comp;
     partition.nodes.entry(new_node_key).or_insert(new_node);
 
-    // Remove old edge entries
-    partition.edges.remove(&pair.edge_key_a);
-    partition.edges.remove(&pair.edge_key_b);
+    for &ek in &group.edges {
+      partition.edges.remove(&ek);
+    }
 
-    // Insert shared mutations on parent-to-new-node edge (no indels - only point mutations are shared)
     let parent_edge = partition.edges.entry(new_parent_edge_key).or_default();
-    parent_edge.set_fitch_subs(pair.shared_subs[pi].clone());
+    parent_edge.set_fitch_subs(group.shared_subs[pi].clone());
+    parent_edge.indels = group.shared_indels[pi].clone();
 
-    // Insert remaining mutations and preserved indels on new-node-to-child edges
-    let edge_a = partition.edges.entry(new_edge_a_key).or_default();
-    edge_a.set_fitch_subs(data.remaining_subs_a.clone());
-    edge_a.indels = data.indels_a.clone();
-
-    let edge_b = partition.edges.entry(new_edge_b_key).or_default();
-    edge_b.set_fitch_subs(data.remaining_subs_b.clone());
-    edge_b.indels = data.indels_b.clone();
+    for (i, &new_ek) in new_child_edge_keys.iter().enumerate() {
+      let child_edge = partition.edges.entry(new_ek).or_default();
+      child_edge.set_fitch_subs(per_edge_data[pi][i].remaining_subs.clone());
+      child_edge.indels = per_edge_data[pi][i].remaining_indels.clone();
+    }
   }
 
   Ok(())

--- a/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/merge_shared_mutations.rs
@@ -297,7 +297,7 @@ fn merge_sibling_group(
         .map(|&ek| {
           let edge = partition.edges.get(&ek);
           let all_subs = edge.map_or(empty_subs, |e| e.fitch_subs());
-          let all_indels = edge.map(|e| e.indels.as_slice()).unwrap_or(empty_indels);
+          let all_indels = edge.map_or(empty_indels, |e| e.indels.as_slice());
           let shared_subs = &group.shared_subs[pi];
           let shared_indels = &group.shared_indels[pi];
           let remaining_subs = iterator_difference(all_subs, shared_subs).cloned().collect_vec();


### PR DESCRIPTION
- Depends on: #671

The pairwise merge algorithm scanned all $O(n^2)$ sibling pairs, merged the best pair, and repeated -- creating chains of binary nodes when three or more siblings shared the same mutation. It also ignored indels entirely, preserving them on child edges without checking for sharing.

This PR replaces the detection and merge logic with an index-based group algorithm. A mutation index maps each (partition, mutation) to its carrier edges, where mutations include both substitutions and indels via a unified `MutationKey` enum. Candidate groups of $k \geq 2$ siblings are extracted from index buckets, scored by shared mutation count, and a disjoint set is selected per round via greedy matching. Each selected group is merged under one new internal node in a single step. Shared indels move to the parent edge; remaining indels stay on child edges.

Three siblings sharing the same mutation now produce one internal node with three children, not a chain of two binary nodes. Siblings sharing only indels (no substitutions) now merge where they previously did not.

### Work items

- [x] Replace pairwise scanning with `build_mutation_index`, `find_merge_groups`, `greedy_disjoint_group_matching`
- [x] Add `MutationKey` enum unifying `Sub` and `InDel` for index keys
- [x] Replace `merge_sibling_pair` with `merge_sibling_group` handling $k \geq 2$ children
- [x] Add 3 regression tests: group topology (3 siblings), indel-only sharing, mixed sub+indel split
- [x] Update existing prune test for new merge count
- [x] Update decision: [prune-merge-jukes-cantor-branch-length.md](https://github.com/neherlab/treetime/blob/f7784c8b/kb/decisions/prune-merge-jukes-cantor-branch-length.md): function rename, indel participation
- [x] Update report: [7-polytomy-resolution.md](https://github.com/neherlab/treetime/blob/f7784c8b/kb/reports/iterative-tree-refinement/7-polytomy-resolution.md): Strategy 4 algorithm description

### Possible improvements

- [ ] Switch topology cleanup to ML substitutions instead of Fitch ([N-optimize-topology-cleanup-fitch-vs-ml-subs.md](https://github.com/neherlab/treetime/blob/f7784c8b/kb/issues/N-optimize-topology-cleanup-fitch-vs-ml-subs.md))
- [ ] Indel event count semantics after composition ([M-optimize-indel-event-count-after-composition.md](https://github.com/neherlab/treetime/blob/f7784c8b/kb/issues/M-optimize-indel-event-count-after-composition.md))