### PR TITLE
test: add property and boundary tests for merge shared mutations

### DIFF
--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/mod.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/mod.rs
@@ -1,3 +1,4 @@
 mod test_collapse_edge;
 mod test_merge_shared_mutations;
+mod test_prop_merge_shared_mutations;
 mod test_reroot;

--- a/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_prop_merge_shared_mutations.rs
+++ b/packages/treetime/src/representation/algo/topology_cleanup/__tests__/test_prop_merge_shared_mutations.rs
@@ -1,0 +1,379 @@
+#[cfg(test)]
+mod tests {
+  use crate::alphabet::alphabet::Alphabet;
+  use crate::gtr::get_gtr::{JC69Params, jc69};
+  use crate::representation::algo::topology_cleanup::merge_shared_mutations::merge_shared_mutation_branches;
+  use crate::representation::partition::marginal_sparse::PartitionMarginalSparse;
+  use crate::representation::payload::ancestral::GraphAncestral;
+  use crate::representation::payload::sparse::{SparseEdgePartition, SparseNodePartition};
+  use crate::seq::mutation::Sub;
+  use crate::test_utils::find_edge_key;
+  use eyre::Report;
+  use itertools::Itertools;
+  use maplit::btreemap;
+  use parking_lot::RwLock;
+  use pretty_assertions::assert_eq;
+  use proptest::prelude::*;
+  use std::collections::BTreeSet;
+  use std::sync::Arc;
+  use treetime_graph::edge::HasBranchLength;
+  use treetime_graph::node::Named;
+  use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::seq;
+  use treetime_primitives::AsciiChar;
+
+  fn c(b: u8) -> AsciiChar {
+    AsciiChar::from_byte_unchecked(b)
+  }
+
+  fn sub_at(pos: usize) -> Sub {
+    let nucs = [b'A', b'C', b'G', b'T'];
+    Sub::new(c(nucs[pos % 4]), pos, c(nucs[(pos + 1) % 4])).unwrap()
+  }
+
+  proptest! {
+    #[test]
+    fn test_prop_merge_preserves_mutation_count(
+      n_children in 3_usize..8,
+      n_shared in 1_usize..6,
+      unique_counts in prop::collection::vec(0_usize..6, 3..8),
+      length in 100_usize..500,
+    ) {
+      let unique_counts = &unique_counts[..n_children.min(unique_counts.len())];
+      let n_children = unique_counts.len();
+      if n_children < 3 { return Ok(()); }
+
+      let (mut graph, edge_mutations, length) =
+        helpers::build_polytomy(n_children, n_shared, unique_counts, length);
+
+      let original_total: usize = edge_mutations.iter().map(|(_, _, subs)| subs.len()).sum();
+      let partition = helpers::make_partition(&graph, length, &edge_mutations);
+      let partitions = vec![partition];
+
+      merge_shared_mutation_branches(&mut graph, &partitions).unwrap();
+      graph.build().unwrap();
+
+      let p = partitions[0].read_arc();
+      let total_after: usize = graph
+        .get_edges()
+        .iter()
+        .filter_map(|e| p.edges.get(&e.read_arc().key()))
+        .map(|e| e.fitch_subs().len())
+        .sum();
+
+      prop_assert!(
+        total_after <= original_total,
+        "mutations created: before={original_total} after={total_after}"
+      );
+    }
+
+    #[test]
+    fn test_prop_merge_branch_lengths_non_negative(
+      n_children in 3_usize..8,
+      n_shared in 1_usize..6,
+      unique_counts in prop::collection::vec(0_usize..6, 3..8),
+      length in 100_usize..500,
+    ) {
+      let unique_counts = &unique_counts[..n_children.min(unique_counts.len())];
+      let n_children = unique_counts.len();
+      if n_children < 3 { return Ok(()); }
+
+      let (mut graph, edge_mutations, length) =
+        helpers::build_polytomy(n_children, n_shared, unique_counts, length);
+      let partition = helpers::make_partition(&graph, length, &edge_mutations);
+      let partitions = vec![partition];
+
+      merge_shared_mutation_branches(&mut graph, &partitions).unwrap();
+      graph.build().unwrap();
+
+      for edge_ref in graph.get_edges() {
+        let edge = edge_ref.read_arc();
+        if let Some(bl) = edge.payload().read_arc().branch_length() {
+          prop_assert!(bl >= 0.0, "negative branch length {bl} on edge {}", edge.key());
+        }
+      }
+    }
+
+    #[test]
+    fn test_prop_merge_idempotent(
+      n_children in 3_usize..6,
+      n_shared in 1_usize..4,
+      unique_counts in prop::collection::vec(0_usize..4, 3..6),
+      length in 100_usize..300,
+    ) {
+      let unique_counts = &unique_counts[..n_children.min(unique_counts.len())];
+      let n_children = unique_counts.len();
+      if n_children < 3 { return Ok(()); }
+
+      let (mut graph, edge_mutations, length) =
+        helpers::build_polytomy(n_children, n_shared, unique_counts, length);
+      let partition = helpers::make_partition(&graph, length, &edge_mutations);
+      let partitions = vec![partition];
+
+      let merged_first = merge_shared_mutation_branches(&mut graph, &partitions).unwrap();
+      graph.build().unwrap();
+
+      let merged_second = merge_shared_mutation_branches(&mut graph, &partitions).unwrap();
+
+      prop_assert_eq!(merged_second, 0);
+    }
+
+    #[test]
+    fn test_prop_merge_preserves_leaves(
+      n_children in 3_usize..8,
+      n_shared in 1_usize..6,
+      unique_counts in prop::collection::vec(0_usize..6, 3..8),
+      length in 100_usize..500,
+    ) {
+      let unique_counts = &unique_counts[..n_children.min(unique_counts.len())];
+      let n_children = unique_counts.len();
+      if n_children < 3 { return Ok(()); }
+
+      let (mut graph, edge_mutations, length) =
+        helpers::build_polytomy(n_children, n_shared, unique_counts, length);
+
+      let leaves_before: BTreeSet<String> = graph
+        .get_leaves()
+        .iter()
+        .filter_map(|n| n.read_arc().payload().read_arc().name().map(|n| n.as_ref().to_owned()))
+        .collect();
+
+      let partition = helpers::make_partition(&graph, length, &edge_mutations);
+      let partitions = vec![partition];
+
+      merge_shared_mutation_branches(&mut graph, &partitions).unwrap();
+      graph.build().unwrap();
+
+      let leaves_after: BTreeSet<String> = graph
+        .get_leaves()
+        .iter()
+        .filter_map(|n| n.read_arc().payload().read_arc().name().map(|n| n.as_ref().to_owned()))
+        .collect();
+
+      prop_assert_eq!(leaves_before, leaves_after);
+    }
+
+    #[test]
+    fn test_prop_merge_no_remaining_shared_mutations(
+      n_children in 3_usize..6,
+      n_shared in 1_usize..4,
+      unique_counts in prop::collection::vec(0_usize..4, 3..6),
+      length in 100_usize..300,
+    ) {
+      let unique_counts = &unique_counts[..n_children.min(unique_counts.len())];
+      let n_children = unique_counts.len();
+      if n_children < 3 { return Ok(()); }
+
+      let (mut graph, edge_mutations, length) =
+        helpers::build_polytomy(n_children, n_shared, unique_counts, length);
+      let partition = helpers::make_partition(&graph, length, &edge_mutations);
+      let partitions = vec![partition];
+
+      merge_shared_mutation_branches(&mut graph, &partitions).unwrap();
+      graph.build().unwrap();
+
+      let p = partitions[0].read_arc();
+      for node_ref in graph.get_nodes() {
+        let node = node_ref.read_arc();
+        let outbound = node.outbound();
+        if outbound.len() <= 1 { continue; }
+
+        let child_sub_sets: Vec<BTreeSet<Sub>> = outbound
+          .iter()
+          .filter_map(|ek| p.edges.get(ek))
+          .map(|e| e.fitch_subs().iter().cloned().collect::<BTreeSet<_>>())
+          .collect();
+
+        for i in 0..child_sub_sets.len() {
+          for j in (i + 1)..child_sub_sets.len() {
+            let shared: Vec<_> = child_sub_sets[i].intersection(&child_sub_sets[j]).collect();
+            prop_assert!(
+              shared.is_empty(),
+              "siblings under node {} still share {} mutations",
+              node.key(),
+              shared.len(),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // === Boundary unit tests ===
+
+  #[test]
+  fn test_merge_all_children_share_same_mutation() -> Result<(), Report> {
+    // Every child shares the same mutation. One group = all children.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1,C:0.1,D:0.1,E:0.1)root;")?;
+    let partition = helpers::make_partition_from_static(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub_at(0)]),
+        ("root", "B", vec![sub_at(0)]),
+        ("root", "C", vec![sub_at(0)]),
+        ("root", "D", vec![sub_at(0)]),
+        ("root", "E", vec![sub_at(0)]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    let merged = merge_shared_mutation_branches(&mut graph, &partitions)?;
+    assert_eq!(merged, 1);
+    graph.build()?;
+
+    // Root has 1 child (the new node), which has all 5 original children.
+    let root = graph.get_roots().into_iter().next().expect("root");
+    assert_eq!(root.read_arc().degree_out(), 1);
+
+    let internal_edge = root.read_arc().outbound()[0];
+    let internal_key = graph.get_target_node_key(internal_edge)?;
+    let internal = graph.get_node(internal_key).expect("internal node");
+    assert_eq!(internal.read_arc().degree_out(), 5);
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_overlapping_groups_greedy_selection() -> Result<(), Report> {
+    // A,B share {sub0}. B,C share {sub1}. B in both groups.
+    // Greedy picks one, second group excluded for this round.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1,C:0.1,D:0.1)root;")?;
+    let partition = helpers::make_partition_from_static(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub_at(0)]),
+        ("root", "B", vec![sub_at(0), sub_at(1)]),
+        ("root", "C", vec![sub_at(1)]),
+        ("root", "D", vec![sub_at(2)]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    let merged = merge_shared_mutation_branches(&mut graph, &partitions)?;
+    assert!(merged >= 1);
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_merge_polytomy_reduced_to_binary_stops() -> Result<(), Report> {
+    // 3 children, 2 share. After merge: binary tree, loop stops.
+    let mut graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1,C:0.1)root;")?;
+    let partition = helpers::make_partition_from_static(
+      &graph,
+      100,
+      &[
+        ("root", "A", vec![sub_at(0)]),
+        ("root", "B", vec![sub_at(0)]),
+        ("root", "C", vec![sub_at(1)]),
+      ],
+    )?;
+    let partitions = vec![partition];
+
+    let merged = merge_shared_mutation_branches(&mut graph, &partitions)?;
+    assert_eq!(merged, 1);
+    graph.build()?;
+
+    let root = graph.get_roots().into_iter().next().expect("root");
+    assert_eq!(root.read_arc().degree_out(), 2);
+
+    Ok(())
+  }
+
+  mod helpers {
+    use super::*;
+
+    pub fn build_polytomy(
+      n_children: usize,
+      n_shared: usize,
+      unique_counts: &[usize],
+      min_length: usize,
+    ) -> (GraphAncestral, Vec<(String, String, Vec<Sub>)>, usize) {
+      let names: Vec<String> = (0..n_children).map(|i| format!("N{i}")).collect();
+      let newick_children = names.iter().map(|n| format!("{n}:0.1")).join(",");
+      let newick = format!("({newick_children})root;");
+      let graph: GraphAncestral = nwk_read_str(&newick).unwrap();
+
+      let mut pos_counter = 0_usize;
+      let shared: Vec<Sub> = (0..n_shared)
+        .map(|_| {
+          let s = sub_at(pos_counter);
+          pos_counter += 1;
+          s
+        })
+        .collect();
+
+      let mut edge_mutations: Vec<(String, String, Vec<Sub>)> = Vec::new();
+      for (i, name) in names.iter().enumerate() {
+        let n_unique = unique_counts[i];
+        let mut subs = shared.clone();
+        for _ in 0..n_unique {
+          subs.push(sub_at(pos_counter));
+          pos_counter += 1;
+        }
+        subs.sort();
+        edge_mutations.push(("root".to_owned(), name.clone(), subs));
+      }
+
+      let length = min_length.max(pos_counter + 1);
+      (graph, edge_mutations, length)
+    }
+
+    pub fn make_partition(
+      graph: &GraphAncestral,
+      length: usize,
+      edge_mutations: &[(String, String, Vec<Sub>)],
+    ) -> Arc<RwLock<PartitionMarginalSparse>> {
+      let refs: Vec<(&str, &str, Vec<Sub>)> = edge_mutations
+        .iter()
+        .map(|(src, tgt, subs)| (src.as_str(), tgt.as_str(), subs.clone()))
+        .collect();
+      make_partition_from_static(graph, length, &refs).unwrap()
+    }
+
+    pub fn make_partition_from_static(
+      graph: &GraphAncestral,
+      length: usize,
+      edge_mutations: &[(&str, &str, Vec<Sub>)],
+    ) -> Result<Arc<RwLock<PartitionMarginalSparse>>, Report> {
+      let mut partition = PartitionMarginalSparse {
+        index: 0,
+        gtr: jc69(JC69Params::default())?,
+        alphabet: Alphabet::new(crate::alphabet::alphabet::AlphabetName::Nuc)?,
+        length,
+        nodes: btreemap! {},
+        edges: btreemap! {},
+        root_sequence: seq![],
+      };
+
+      let mut ref_seq: treetime_primitives::Seq = std::iter::repeat_with(|| c(b'A')).take(length).collect();
+      for (_, _, subs) in edge_mutations {
+        for s in subs {
+          if s.pos() < length {
+            ref_seq[s.pos()] = s.reff();
+          }
+        }
+      }
+      partition.root_sequence = ref_seq.clone();
+
+      for node in graph.get_nodes() {
+        let key = node.read_arc().key();
+        let mut node_part = SparseNodePartition::empty(&partition.alphabet);
+        node_part.seq.sequence = ref_seq.clone();
+        partition.nodes.insert(key, node_part);
+      }
+
+      for (source, target, subs) in edge_mutations {
+        let edge_key = find_edge_key(graph, source, target)
+          .unwrap_or_else(|| panic!("edge {source}->{target} not found"));
+        partition
+          .edges
+          .insert(edge_key, SparseEdgePartition::with_fitch_subs(subs.clone()));
+      }
+
+      Ok(Arc::new(RwLock::new(partition)))
+    }
+  }
+}


### PR DESCRIPTION
The merge shared mutations algorithm has unit tests covering specific scenarios but no invariant-based tests that exercise random input combinations. Edge cases like degenerate groups (all children identical) and overlapping candidate groups are also untested.

Add five property tests using proptest with random polytomy generation (3-8 children, 1-6 shared mutations, 0-6 unique per child): mutation conservation, branch length non-negativity, idempotence, leaf preservation, and post-merge sibling disjointness. Add three boundary unit tests: all-children-same-mutation degenerate group, overlapping groups with greedy selection, and polytomy-to-binary termination.

### Work items

- [x] Add `test_prop_merge_shared_mutations.rs` with 5 property tests and 3 boundary tests
- [x] Add random polytomy generator in `mod helpers`