### PR TITLE
chore: add optimize/ internal file cohesion issue and ticket

### DIFF
--- a/kb/issues/N-optimize-internal-file-cohesion.md
+++ b/kb/issues/N-optimize-internal-file-cohesion.md
@@ -1,0 +1,33 @@
+# optimize/ internal file cohesion
+
+Two files in `optimize/` combine multiple responsibilities that would be clearer as separate modules.
+
+## optimize_unified.rs (701 lines, 12 public/pub(crate) items)
+
+Three distinct responsibilities in one file:
+
+1. Data types and evaluation combinators: `OptimizationMetrics`, `evaluate_mixed`, `evaluate_with_indels`, `evaluate_mixed_log_lh_only`, `evaluate_with_indels_log_lh_only`
+2. Zero-boundary decision logic: `is_zero_branch_optimal`, `is_zero_better_than_grid_best`, `reconcile_zero_boundary`, `min_branch_length_for_indels` (~130 lines of dense doc comments explaining multimodal surface edge cases)
+3. Per-edge dispatch and initial guess: `run_optimize_mixed`, `run_optimize_mixed_inner`, `run_optimize_mixed_with_indel_rate`, `initial_guess_mixed`
+
+Grid search (`grid_search_branch_lengths`, `grid_search_inner`) and Newton tolerance functions (`newton_tolerance_t`, `newton_tolerance_sqrt`, `newton_tolerance_log`) are also here, loosely coupled to group 3.
+
+## iteration.rs (336 lines, 10 public items)
+
+Mixed abstraction levels under an opaque name:
+
+- Loop bookkeeping: `save_branch_lengths`, `restore_branch_lengths`, `apply_damping` (branch-length save/restore/damping between iterations)
+- Topology surgery: `prune_and_merge_in_loop`, `find_zero_optimal_internal_edges` (calls into `representation/algo/topology_cleanup/`)
+- Setup/initialization: `apply_initial_guess_mode`, `normalize_partition_rates`, `any_edge_missing_branch_length`, `any_indel_edge_has_zero_branch_length`
+
+"Iteration" describes when these run (during the loop), not what they do.
+
+## Naming inconsistencies
+
+- `optimize/` vs `timetree/optimization/` for sibling modules
+- `optimize_eval.rs`, `optimize_unified.rs`, `optimize_indel.rs` stutter the parent module name. `method_brent.rs` and `method_newton.rs` use a different prefix convention. No consistent scheme within the module
+- `args.rs` contains domain enums (`BranchOptMethod`, `InitialGuessMode`) used deep in the optimizer, not CLI argument types
+
+## Impact
+
+Negligible. No correctness or performance issue. Navigation friction when reading or modifying the optimizer.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -148,6 +148,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Alphabet       | [Alphabet serialization format design](N-alphabet-serialization-format-design.md)                                                                   |
 | Negligible | Core           | [Code quality and convention violations](N-code-quality-conventions.md)                                                                             |
 | Negligible | Core           | [Architectural debt (documented, low priority)](N-architectural-debt-documented.md)                                                                 |
+| Negligible | Optimize       | [optimize/ internal file cohesion](N-optimize-internal-file-cohesion.md)                                                                            |
 | Negligible | Core           | [Production unwrap/expect/assert audit](N-production-unwrap-expect-audit.md)                                                                        |
 | Negligible | Test           | [Test coverage gaps across production functions](N-test-coverage-gaps.md)                                                                           |
 | Negligible | Test           | [Test quality deficiencies](N-test-quality-deficiencies.md)                                                                                         |

--- a/kb/tickets/optimize-improve-internal-file-cohesion.md
+++ b/kb/tickets/optimize-improve-internal-file-cohesion.md
@@ -1,0 +1,38 @@
+# Improve optimize/ internal file cohesion
+
+## Description
+
+Split `optimize_unified.rs` and `iteration.rs` along responsibility boundaries. Rename files to remove stutter and apply consistent naming.
+
+## Proposed splits
+
+### optimize_unified.rs -> 3 files
+
+1. `likelihood.rs` - `OptimizationMetrics` struct, `evaluate_mixed`, `evaluate_with_indels`, log-likelihood-only variants
+2. `zero_boundary.rs` - `is_zero_branch_optimal`, `is_zero_better_than_grid_best`, `reconcile_zero_boundary`, `min_branch_length_for_indels`, grid search functions
+3. `dispatch.rs` - `run_optimize_mixed`, `run_optimize_mixed_inner`, `run_optimize_mixed_with_indel_rate`, `initial_guess_mixed`
+
+Newton tolerance functions (`newton_tolerance_t`, `newton_tolerance_sqrt`, `newton_tolerance_log`) move to `method_newton.rs` alongside the constants they reference.
+
+### iteration.rs cleanup
+
+1. Keep `iteration.rs` with branch-length bookkeeping: `save_branch_lengths`, `restore_branch_lengths`, `apply_damping`, `DAMPING_FLOOR`
+2. Move `prune_and_merge_in_loop`, `find_zero_optimal_internal_edges` to `run_loop.rs` (only caller)
+3. Move `apply_initial_guess_mode`, `normalize_partition_rates`, `any_edge_missing_branch_length`, `any_indel_edge_has_zero_branch_length` to `run_loop.rs` (only production caller)
+
+### Naming cleanup
+
+- Remove `optimize_` prefix from `optimize_eval.rs`, `optimize_indel.rs`, `optimize_dense_eval.rs`, `optimize_sparse_eval.rs`
+- Rename `args.rs` to `params.rs` (contents are domain enums, not CLI args)
+
+## Constraints
+
+- Pure refactoring: no behavior change, no public API change beyond module paths
+- All `pub(crate)` visibility stays the same (narrowing tracked separately in `architecture-tighten-optimize-visibility`)
+- Test files stay in `__tests__/` - update import paths only
+
+## Related issues
+
+- Source: [N-optimize-internal-file-cohesion](../issues/N-optimize-internal-file-cohesion.md)
+- Adjacent: [architecture-tighten-optimize-visibility](architecture-tighten-optimize-visibility.md) (visibility narrowing, orthogonal)
+- Adjacent: [M-core-remaining-architectural-debt-after-extraction](../issues/M-core-remaining-architectural-debt-after-extraction.md) (inter-module concerns, separate scope)


### PR DESCRIPTION
- Depends on: `refactor/extract-timetree-inference`

The `optimize/` module has two files with mixed responsibilities: `optimize_unified.rs` (701 lines) combines evaluation, zero-boundary decision logic, and per-edge dispatch. `iteration.rs` (336 lines) mixes branch-state bookkeeping with topology surgery and setup helpers. Five files stutter the parent module name (`optimize_eval.rs` inside `optimize/`), and `args.rs` holds domain enums, not CLI argument types.

Add a knowledge base issue and ticket documenting these concerns with proposed splits and naming fixes.

### Work items

- [x] Add `kb/issues/N-optimize-internal-file-cohesion.md` describing file cohesion concerns
- [x] Add `kb/tickets/optimize-improve-internal-file-cohesion.md` with proposed splits and constraints
- [x] Update `kb/issues/README.md` with new entry
