### PR TITLE
chore: add polytomy resolution issues

### DIFF
--- a/kb/issues/M-timetree-polytomy-missing-stretched-compressed-split.md
+++ b/kb/issues/M-timetree-polytomy-missing-stretched-compressed-split.md
@@ -1,0 +1,30 @@
+# Polytomy resolution merges all children indiscriminately
+
+v0 classifies polytomy children as "stretched" (fewer mutations than clock predicts: `mutation_length < clock_length`) or "compressed" before merging. Only stretched children are merged by default (`merge_compressed=False`). Stretched branches are the ones where an intermediate ancestor could shorten the time-branch while keeping the mutation-branch short. Compressed branches (more mutations than clock predicts) are unlikely to benefit from an intermediate ancestor.
+
+v1 merges all children without this classification, producing different resolution outcomes than v0.
+
+v0: `packages/legacy/treetime/treetime/treetime.py:860-868`
+v1: `packages/treetime/src/timetree/optimization/polytomy.rs`
+
+## v0 reference
+
+```python
+stretched = [c for c in clade.clades if c.mutation_length < c.clock_length]
+compressed = [c for c in clade.clades if c not in stretched]
+
+if len(stretched) < 2 and merge_compressed is False:
+    return 0.0
+
+LH = merge_nodes(stretched, isall=len(stretched) == len(clade.clades))
+if merge_compressed and len(compressed) > 1:
+    LH += merge_nodes(compressed, isall=len(compressed) == len(clade.clades))
+```
+
+## Required changes
+
+- Add `clock_rate` parameter to compute `clock_length = time_length * clock_rate` per child
+- Classify children using `mutation_length` (from `edge.branch_length`) vs `clock_length`
+- Only merge stretched children by default
+- Add `merge_compressed` option
+- Implement v0's `isall` stopping condition (stop at 2 when all children in group, 1 for subset)

--- a/kb/issues/N-timetree-polytomy-duplicated-topology-primitives.md
+++ b/kb/issues/N-timetree-polytomy-duplicated-topology-primitives.md
@@ -1,0 +1,11 @@
+# Polytomy resolution duplicates topology primitives
+
+Two code quality problems in `packages/treetime/src/timetree/optimization/polytomy.rs`:
+
+## Duplicated find_polytomy_nodes
+
+`find_polytomy_nodes` is implemented identically in both `polytomy.rs` and `merge_shared_mutations.rs`. Both filter graph nodes by `degree_out() > 2`. Should be a single generic function since the logic depends only on `Graph<N, E, D>` traits.
+
+## remove_obsolete_nodes does not sum branch lengths
+
+`remove_obsolete_nodes` collapses single-child internal nodes using `graph.collapse_edge()`, which reparents children but does not sum branch lengths into the merged edge. The correct implementation `remove_node_if_trivial` in `reroot.rs` uses `graph.remove_node()` + `graph.add_edge()` with summed branch lengths. The bug is currently masked because `prepare_tree_after_topology_change` wipes all cached distributions afterward, but branch length information is lost.

--- a/kb/issues/N-timetree-polytomy-numerical-robustness.md
+++ b/kb/issues/N-timetree-polytomy-numerical-robustness.md
@@ -2,7 +2,7 @@
 
 Several defensive programming gaps in polytomy resolution code. None are active bugs in the current call sequence, but they create latent defects that would activate if the call sequence changes or inputs are degenerate.
 
-v1: [`packages/treetime/src/commands/timetree/optimization/polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/polytomy.rs)
+v1: [`packages/treetime/src/timetree/optimization/polytomy.rs`](../../packages/treetime/src/timetree/optimization/polytomy.rs)
 
 ## Items
 

--- a/kb/issues/N-timetree-polytomy-quadratic-gain-matrix.md
+++ b/kb/issues/N-timetree-polytomy-quadratic-gain-matrix.md
@@ -1,0 +1,8 @@
+# Polytomy resolution recomputes full gain matrix each iteration
+
+`resolve_single_polytomy` recomputes the full O(n^2) pairwise gain matrix from scratch after each merge by re-reading the graph topology. v0 updates the matrix incrementally: after merging a pair, it removes their rows/cols and computes only O(n) new entries for the merged node vs remaining children.
+
+v0: `packages/legacy/treetime/treetime/treetime.py:838-856`
+v1: `packages/treetime/src/timetree/optimization/polytomy.rs`
+
+For a k-way polytomy, current cost is sum(n^2) for n from k down to 3. Incremental cost is k\*(k-1)/2 initial + sum(n-2) for subsequent merges.

--- a/kb/issues/N-timetree-polytomy-test-improvements.md
+++ b/kb/issues/N-timetree-polytomy-test-improvements.md
@@ -2,7 +2,7 @@
 
 Test coverage gaps and quality issues in polytomy resolution tests.
 
-v1 tests: [`packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs)
+v1 tests: [`packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs`](../../packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs)
 
 ## Items
 

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -116,6 +116,8 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Timetree       | [Rerooted root and polytomy-resolution nodes stay unnamed](N-timetree-unnamed-root-after-reroot.md)                                                 |
 | Negligible | Timetree       | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                                             |
 | Negligible | Timetree       | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                                                   |
+| Negligible | Timetree       | [Polytomy resolution duplicates topology primitives](N-timetree-polytomy-duplicated-topology-primitives.md)                                         |
+| Negligible | Timetree       | [Polytomy resolution recomputes full gain matrix each iteration](N-timetree-polytomy-quadratic-gain-matrix.md)                                      |
 | Medium     | Timetree       | [Branch distribution grid uses uniform spacing](M-timetree-branch-grid-uniform-resolution.md)                                                       |
 | Medium     | Timetree       | [Timetree inference in input mode collapses internal-node dates to Empty](M-timetree-inference-input-mode-date-collapse.md)                         |
 | Medium     | Timetree       | [Backward and forward traversals use unwrap on fallible distribution math](M-timetree-inference-unwrap-in-traversals.md)                            |
@@ -135,6 +137,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Marginal       | [Marginal forward pass NEG_INFINITY produces NaN](M-marginal-forward-pass-neg-infinity-nan.md)                                                      |
 | Medium     | Marginal       | [normalize_inplace NEG_INFINITY masks all contributions](M-marginal-normalize-neg-infinity-masks-total.md)                                          |
 | Medium     | Timetree       | [Polytomy resolution leaves stale fields after topology change](M-timetree-polytomy-stale-fields-after-topology-change.md)                          |
+| Medium     | Timetree       | [Polytomy resolution merges all children indiscriminately](M-timetree-polytomy-missing-stretched-compressed-split.md)                               |
 | Medium     | Timetree       | [Timetree convergence metric deficiencies](M-timetree-convergence-metric-deficiencies.md)                                                           |
 | Medium     | Timetree       | [Timetree confidence interval computation deficiencies](M-timetree-confidence-interval-deficiencies.md)                                             |
 | Medium     | Coalescent     | [Coalescent leaf survival formula sign convention requires investigation](M-coalescent-leaf-survival-sign-convention.md)                            |


### PR DESCRIPTION
- Depends on: `refactor/optimize-file-cohesion`

Three issues in polytomy resolution identified by comparing v0 and v1 implementations: indiscriminate child merging, duplicated topology primitives, and quadratic gain matrix recomputation.

### Work items

- [x] Add `M-timetree-polytomy-missing-stretched-compressed-split` (v1 merges all children, v0 filters by mutation vs clock length)
- [x] Add `N-timetree-polytomy-duplicated-topology-primitives` (duplicated `find_polytomy_nodes`, `remove_obsolete_nodes` loses branch lengths)
- [x] Add `N-timetree-polytomy-quadratic-gain-matrix` (full O(n^2) recompute vs v0's O(n) incremental)
- [x] Fix stale file paths in two existing polytomy issues after timetree extraction
