### PR TITLE
perf: incremental gain matrix update for polytomy resolution

### DIFF
--- a/kb/issues/N-timetree-polytomy-numerical-robustness.md
+++ b/kb/issues/N-timetree-polytomy-numerical-robustness.md
@@ -8,7 +8,7 @@ v1: [`packages/treetime/src/timetree/optimization/polytomy.rs`](../../packages/t
 
 ### `ln(0.0)` produces `-Inf` in cost function
 
-`MergeCostFunction::cost()` computes `.unwrap_or(1e-10).ln()` on `Distribution::eval()` results. The `unwrap_or` guard catches `Err` but not `Ok(0.0)`. `Distribution::Function` variants can return `Ok(0.0)` when boundary values underflow to zero during `exp()` normalization in `compute_branch_length_distribution()`. The proper fix is clamping `normalized_prob` at the source in [`packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs#L53`](../../packages/treetime/src/commands/timetree/inference/branch_length_likelihood.rs#L53), not a consumer-side clamp.
+`MergeCostFunction::cost()` computes `.unwrap_or(1e-10).ln()` on `Distribution::eval()` results. The `unwrap_or` guard catches `Err` but not `Ok(0.0)`. `Distribution::Function` variants can return `Ok(0.0)` when boundary values underflow to zero during `exp()` normalization in `compute_branch_length_distribution()`. The proper fix is clamping `normalized_prob` at the source in [`packages/treetime/src/timetree/inference/branch_length_likelihood.rs#L53`](../../packages/treetime/src/timetree/inference/branch_length_likelihood.rs#L53), not a consumer-side clamp.
 
 v0 avoids this by working in neg-log space with `fill_value=BIG_NUMBER`.
 

--- a/kb/issues/N-timetree-polytomy-quadratic-gain-matrix.md
+++ b/kb/issues/N-timetree-polytomy-quadratic-gain-matrix.md
@@ -1,8 +1,0 @@
-# Polytomy resolution recomputes full gain matrix each iteration
-
-`resolve_single_polytomy` recomputes the full O(n^2) pairwise gain matrix from scratch after each merge by re-reading the graph topology. v0 updates the matrix incrementally: after merging a pair, it removes their rows/cols and computes only O(n) new entries for the merged node vs remaining children.
-
-v0: `packages/legacy/treetime/treetime/treetime.py:838-856`
-v1: `packages/treetime/src/timetree/optimization/polytomy.rs`
-
-For a k-way polytomy, current cost is sum(n^2) for n from k down to 3. Incremental cost is k\*(k-1)/2 initial + sum(n-2) for subsequent merges.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -116,7 +116,6 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Timetree       | [Rerooted root and polytomy-resolution nodes stay unnamed](N-timetree-unnamed-root-after-reroot.md)                                                 |
 | Negligible | Timetree       | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                                             |
 | Negligible | Timetree       | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                                                   |
-| Negligible | Timetree       | [Polytomy resolution recomputes full gain matrix each iteration](N-timetree-polytomy-quadratic-gain-matrix.md)                                      |
 | Medium     | Timetree       | [Branch distribution grid uses uniform spacing](M-timetree-branch-grid-uniform-resolution.md)                                                       |
 | Medium     | Timetree       | [Timetree inference in input mode collapses internal-node dates to Empty](M-timetree-inference-input-mode-date-collapse.md)                         |
 | Medium     | Timetree       | [Backward and forward traversals use unwrap on fallible distribution math](M-timetree-inference-unwrap-in-traversals.md)                            |

--- a/kb/tickets/timetree-polytomy-resolution-numerical-robustness.md
+++ b/kb/tickets/timetree-polytomy-resolution-numerical-robustness.md
@@ -2,7 +2,7 @@
 
 Several defensive programming gaps in polytomy resolution code. None are active bugs in the current call sequence, but they create latent defects that would activate if the call sequence changes or inputs are degenerate.
 
-v1: [`packages/treetime/src/commands/timetree/optimization/polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/polytomy.rs)
+v1: [`packages/treetime/src/timetree/optimization/polytomy.rs`](../../packages/treetime/src/timetree/optimization/polytomy.rs)
 
 ## Items
 

--- a/kb/tickets/timetree-polytomy-resolution-test-improvements.md
+++ b/kb/tickets/timetree-polytomy-resolution-test-improvements.md
@@ -2,7 +2,7 @@
 
 Test coverage gaps and quality issues in polytomy resolution tests.
 
-v1 tests: [`packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs`](../../packages/treetime/src/commands/timetree/optimization/__tests__/test_polytomy.rs)
+v1 tests: [`packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs`](../../packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs)
 
 ## Items
 

--- a/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
+++ b/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
@@ -14,6 +14,7 @@ mod tests {
   use treetime_graph::node::Named;
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::make_report;
+  use treetime_utils::pretty_assert_abs_diff_eq;
 
   const TEST_CLOCK_RATE: f64 = 0.001;
 
@@ -245,7 +246,7 @@ mod tests {
   fn test_resolve_polytomies_zero_branch_slope_affects_merge_gain() -> Result<(), Report> {
     let partitions = vec![];
 
-    // Large slope: penalty dominates branch length improvement → no merge
+    // Large slope: penalty dominates branch length improvement, no merge
     let mut graph_high = helpers::create_polytomy_tree_with_realistic_distributions()?;
     let n_high = resolve_polytomies_with_options(
       &mut graph_high,
@@ -290,6 +291,44 @@ mod tests {
     )?;
 
     assert_eq!(n_resolved, 1, "Zero slope should allow merge");
+    Ok(())
+  }
+
+  #[test]
+  fn test_resolve_polytomies_equal_mutation_clock_length_is_compressed() -> Result<(), Report> {
+    // mutation_length == clock_length classifies as compressed (not stretched)
+    // is_stretched requires strict less-than
+    let mut graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2,C:0.15)ABC:0.05)root;")?;
+
+    let tip_times = [("A", 2020.0), ("B", 2015.0), ("C", 2018.0)];
+    for (name, time) in tip_times {
+      let key = find_node_key_by_name(&graph, name).ok_or_else(|| make_report!("{name} not found"))?;
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(time);
+    }
+    if let Some(key) = find_node_key_by_name(&graph, "ABC") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2010.0);
+    }
+    if let Some(key) = find_node_key_by_name(&graph, "root") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2000.0);
+    }
+
+    for edge in graph.get_edges() {
+      let edge = edge.write_arc();
+      let mut payload = edge.payload().write_arc();
+      payload.branch_length_distribution = Some(Arc::new(Distribution::point(0.1, 1.0)));
+      let bl = payload.branch_length().unwrap_or(0.0);
+      payload.time_length = Some(bl);
+      // mutation_length == clock_length: bl == time_length * clock_rate
+      // With TEST_CLOCK_RATE=0.001 and time_length=bl, clock_length = bl * 0.001
+      // Set branch_length = bl * 0.001 so mutation_length == clock_length
+      payload.set_branch_length(Some(bl * TEST_CLOCK_RATE));
+    }
+
+    let partitions = vec![];
+    let n_resolved =
+      resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
+
+    assert_eq!(n_resolved, 0, "Equal mutation_length and clock_length should classify as compressed, not merged");
     Ok(())
   }
 
@@ -493,10 +532,7 @@ mod tests {
     let parent_edge_time_length = graph.get_edge(parent_edge_key).expect("Edge must exist")
       .read_arc().payload().read_arc().time_length.expect("time_length must be set");
     let expected_parent_tl = new_node_time - abc_time;
-    assert!(
-      (parent_edge_time_length - expected_parent_tl).abs() < 1e-10,
-      "Parent edge time_length ({parent_edge_time_length}) should equal new_node_time - abc_time ({expected_parent_tl})"
-    );
+    pretty_assert_abs_diff_eq!(parent_edge_time_length, expected_parent_tl, epsilon = 1e-10);
     assert!(parent_edge_time_length > 0.0, "Parent edge time_length must be positive");
 
     // Edges from new node to children: time_length = child_time - new_node_time
@@ -507,10 +543,7 @@ mod tests {
         .read_arc().payload().read_arc().time.unwrap_or(0.0);
       let child_edge_tl = edge.read_arc().payload().read_arc().time_length.expect("time_length must be set");
       let expected_child_tl = child_time - new_node_time;
-      assert!(
-        (child_edge_tl - expected_child_tl).abs() < 1e-10,
-        "Child edge time_length ({child_edge_tl}) should equal child_time - new_node_time ({expected_child_tl})"
-      );
+      pretty_assert_abs_diff_eq!(child_edge_tl, expected_child_tl, epsilon = 1e-10);
       assert!(child_edge_tl > 0.0, "Child edge time_length must be positive");
     }
 

--- a/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
+++ b/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod tests {
+  use crate::representation::algo::topology_cleanup::polytomy_nodes::find_polytomy_nodes;
   use crate::representation::partition::timetree::GraphTimetree;
   use crate::test_utils::find_node_key_by_name;
   use crate::timetree::optimization::polytomy::{
@@ -19,29 +20,16 @@ mod tests {
   #[test]
   fn test_find_polytomy_nodes_detects_multifurcation() -> Result<(), Report> {
     let graph = helpers::create_polytomy_tree()?;
-
-    // Count nodes with >2 children
-    let polytomy_count = graph
-      .get_nodes()
-      .into_iter()
-      .filter(|n| n.read_arc().degree_out() > 2)
-      .count();
-
-    assert_eq!(polytomy_count, 1, "Should detect exactly one polytomy (ABC node)");
+    let polytomy_keys = find_polytomy_nodes(&graph);
+    assert_eq!(polytomy_keys.len(), 1, "Should detect exactly one polytomy (ABC node)");
     Ok(())
   }
 
   #[test]
   fn test_find_polytomy_nodes_returns_empty_for_binary_tree() -> Result<(), Report> {
     let graph = helpers::create_binary_tree()?;
-
-    let polytomy_count = graph
-      .get_nodes()
-      .into_iter()
-      .filter(|n| n.read_arc().degree_out() > 2)
-      .count();
-
-    assert_eq!(polytomy_count, 0, "Binary tree should have no polytomies");
+    let polytomy_keys = find_polytomy_nodes(&graph);
+    assert_eq!(polytomy_keys.len(), 0, "Binary tree should have no polytomies");
     Ok(())
   }
 
@@ -331,9 +319,9 @@ mod tests {
     let partitions = vec![];
     let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 0.01, TEST_CLOCK_RATE, true)?;
 
-    assert!(
-      n_resolved > 0,
-      "Compressed children should be merged when merge_compressed=true"
+    assert_eq!(
+      n_resolved, 1,
+      "Compressed 3-way polytomy should produce exactly 1 merge"
     );
     Ok(())
   }
@@ -344,7 +332,7 @@ mod tests {
     let partitions = vec![];
     let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
 
-    assert!(n_resolved > 0, "Stretched children should be merged by default");
+    assert_eq!(n_resolved, 1, "Stretched 3-way polytomy should produce exactly 1 merge");
     Ok(())
   }
 
@@ -416,6 +404,191 @@ mod tests {
       );
       assert!(payload.msg_to_parent.is_none(), "Edge msg_to_parent must be cleared");
     }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_resolve_polytomies_mixed_stretched_compressed_merges_only_stretched() -> Result<(), Report> {
+    // 4-way polytomy: A,B,C stretched (mutation_length=0), D compressed (mutation_length=1.0)
+    let mut graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2,C:0.15,D:0.12)ABCD:0.05)root;")?;
+
+    let tip_times = [("A", 2020.0), ("B", 2015.0), ("C", 2018.0), ("D", 2012.0)];
+    for (name, time) in tip_times {
+      let key = find_node_key_by_name(&graph, name).ok_or_else(|| make_report!("{name} not found"))?;
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(time);
+    }
+
+    let abcd_key = find_node_key_by_name(&graph, "ABCD").ok_or_else(|| make_report!("ABCD not found"))?;
+    graph.get_node(abcd_key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2005.0);
+
+    if let Some(key) = find_node_key_by_name(&graph, "root") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2000.0);
+    }
+
+    let d_key = find_node_key_by_name(&graph, "D").ok_or_else(|| make_report!("D not found"))?;
+    for edge in graph.get_edges() {
+      let edge = edge.write_arc();
+      let mut payload = edge.payload().write_arc();
+      payload.branch_length_distribution = Some(Arc::new(Distribution::point(0.1, 1.0)));
+      payload.time_length = payload.branch_length();
+      payload.set_branch_length(Some(0.0));
+    }
+
+    // Make D compressed: high mutation_length
+    let d_edge_key = graph.get_node(abcd_key).expect("Node must exist")
+      .read_arc()
+      .outbound()
+      .iter()
+      .copied()
+      .find(|&ek| graph.get_edge(ek).expect("Edge must exist").read_arc().target() == d_key)
+      .expect("D edge must exist");
+    graph.get_edge(d_edge_key).expect("Edge must exist").write_arc().payload().write_arc().set_branch_length(Some(1.0));
+
+    let partitions = vec![];
+    // merge_compressed=false: only stretched children (A,B,C) should merge
+    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
+
+    // 3 stretched children merge down to 1 subtree (isall=false, min_remaining=1)
+    // producing 2 new nodes: (A,B)->N1, (N1,C)->N2 (or similar)
+    assert_eq!(n_resolved, 2, "3 stretched children should produce 2 merges (subset merges to 1)");
+
+    // ABCD should have 2 children: the stretched subtree + D
+    let final_children = graph.get_node(abcd_key).expect("Node must exist").read_arc().degree_out();
+    assert_eq!(final_children, 2, "ABCD should have 2 children: stretched subtree + compressed D");
+
+    // D should still be a direct child of ABCD
+    let d_still_child = graph.get_node(abcd_key).expect("Node must exist")
+      .read_arc()
+      .outbound()
+      .iter()
+      .any(|&ek| graph.get_edge(ek).expect("Edge must exist").read_arc().target() == d_key);
+    assert!(d_still_child, "Compressed child D should remain a direct child of ABCD");
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_resolve_polytomies_new_node_edge_time_lengths_correct() -> Result<(), Report> {
+    let mut graph = helpers::create_polytomy_tree()?;
+
+    let abc_key = find_node_key_by_name(&graph, "ABC").ok_or_else(|| make_report!("ABC not found"))?;
+    let abc_time = graph.get_node(abc_key).expect("Node must exist").read_arc().payload().read_arc().time.unwrap_or(0.0);
+
+    let partitions = vec![];
+    resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
+
+    // Find the new unnamed internal node
+    let new_node = graph.get_nodes().into_iter().find(|n| {
+      let n = n.read_arc();
+      let payload = n.payload().read_arc();
+      !n.is_leaf() && !n.is_root() && payload.name().is_none()
+    }).expect("New node must exist");
+
+    let new_node_key = new_node.read_arc().key();
+    let new_node_time = new_node.read_arc().payload().read_arc().time.unwrap_or(0.0);
+
+    // Edge from ABC to new node: time_length = new_node_time - abc_time
+    let parent_edge_key = new_node.read_arc().inbound()[0];
+    let parent_edge_time_length = graph.get_edge(parent_edge_key).expect("Edge must exist")
+      .read_arc().payload().read_arc().time_length.expect("time_length must be set");
+    let expected_parent_tl = new_node_time - abc_time;
+    assert!(
+      (parent_edge_time_length - expected_parent_tl).abs() < 1e-10,
+      "Parent edge time_length ({parent_edge_time_length}) should equal new_node_time - abc_time ({expected_parent_tl})"
+    );
+    assert!(parent_edge_time_length > 0.0, "Parent edge time_length must be positive");
+
+    // Edges from new node to children: time_length = child_time - new_node_time
+    for &ek in new_node.read_arc().outbound() {
+      let edge = graph.get_edge(ek).expect("Edge must exist");
+      let child_key = edge.read_arc().target();
+      let child_time = graph.get_node(child_key).expect("Node must exist")
+        .read_arc().payload().read_arc().time.unwrap_or(0.0);
+      let child_edge_tl = edge.read_arc().payload().read_arc().time_length.expect("time_length must be set");
+      let expected_child_tl = child_time - new_node_time;
+      assert!(
+        (child_edge_tl - expected_child_tl).abs() < 1e-10,
+        "Child edge time_length ({child_edge_tl}) should equal child_time - new_node_time ({expected_child_tl})"
+      );
+      assert!(child_edge_tl > 0.0, "Child edge time_length must be positive");
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_resolve_polytomies_guard_parent_time_ge_child_time() -> Result<(), Report> {
+    // Parent time >= child time should prevent merging (guard returns None)
+    let mut graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2,C:0.15)ABC:0.05)root;")?;
+
+    // Set parent time AFTER children (reversed time constraint)
+    let tip_times = [("A", 2010.0), ("B", 2010.0), ("C", 2010.0)];
+    for (name, time) in tip_times {
+      if let Some(key) = find_node_key_by_name(&graph, name) {
+        graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(time);
+      }
+    }
+    if let Some(key) = find_node_key_by_name(&graph, "ABC") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2020.0);
+    }
+    if let Some(key) = find_node_key_by_name(&graph, "root") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2000.0);
+    }
+
+    for edge in graph.get_edges() {
+      let edge = edge.write_arc();
+      let mut payload = edge.payload().write_arc();
+      payload.branch_length_distribution = Some(Arc::new(Distribution::point(0.1, 1.0)));
+      payload.time_length = payload.branch_length();
+      payload.set_branch_length(Some(0.0));
+    }
+
+    let partitions = vec![];
+    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
+
+    assert_eq!(n_resolved, 0, "Should not merge when parent time >= child time");
+    Ok(())
+  }
+
+  #[test]
+  fn test_resolve_polytomies_4way_with_realistic_distributions() -> Result<(), Report> {
+    // 4-way all-stretched polytomy with realistic distributions exercises incremental gains
+    let mut graph: GraphTimetree = nwk_read_str("((A:0.1,B:0.2,C:0.15,D:0.12)ABCD:0.05)root;")?;
+
+    let tip_times = [("A", 2020.0), ("B", 2015.0), ("C", 2018.0), ("D", 2012.0)];
+    for (name, time) in tip_times {
+      if let Some(key) = find_node_key_by_name(&graph, name) {
+        graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(time);
+      }
+    }
+    if let Some(key) = find_node_key_by_name(&graph, "ABCD") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2005.0);
+    }
+    if let Some(key) = find_node_key_by_name(&graph, "root") {
+      graph.get_node(key).expect("Node must exist").write_arc().payload().write_arc().time = Some(2000.0);
+    }
+
+    let x = Array1::linspace(0.0, 25.0, 200);
+    let y = x.mapv(|t: f64| (-0.5 * t).exp());
+    let dist = Arc::new(Distribution::function(x, y)?);
+
+    for edge in graph.get_edges() {
+      let edge = edge.write_arc();
+      let mut payload = edge.payload().write_arc();
+      payload.branch_length_distribution = Some(Arc::clone(&dist));
+      payload.time_length = payload.branch_length();
+      payload.set_branch_length(Some(0.0));
+    }
+
+    let abcd_key = find_node_key_by_name(&graph, "ABCD").ok_or_else(|| make_report!("ABCD not found"))?;
+    let partitions = vec![];
+    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 0.01, TEST_CLOCK_RATE, false)?;
+
+    // 4-way -> 2 children requires 2 merges
+    assert_eq!(n_resolved, 2, "4-way polytomy should produce 2 merges");
+    let final_children = graph.get_node(abcd_key).expect("Node must exist").read_arc().degree_out();
+    assert_eq!(final_children, 2, "ABCD should have 2 children after resolution");
 
     Ok(())
   }

--- a/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
+++ b/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
@@ -80,7 +80,14 @@ mod tests {
 
     let initial_node_count = graph.get_nodes().len();
     let partitions = vec![];
-    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, DEFAULT_RESOLUTION_THRESHOLD, 10.0, TEST_CLOCK_RATE, false)?;
+    let n_resolved = resolve_polytomies_with_options(
+      &mut graph,
+      &partitions,
+      DEFAULT_RESOLUTION_THRESHOLD,
+      10.0,
+      TEST_CLOCK_RATE,
+      false,
+    )?;
 
     assert_eq!(n_resolved, 0, "Binary tree should have no resolutions");
     assert_eq!(
@@ -252,11 +259,25 @@ mod tests {
 
     // Large slope: penalty dominates branch length improvement → no merge
     let mut graph_high = helpers::create_polytomy_tree_with_realistic_distributions()?;
-    let n_high = resolve_polytomies_with_options(&mut graph_high, &partitions, DEFAULT_RESOLUTION_THRESHOLD, 1000.0, TEST_CLOCK_RATE, false)?;
+    let n_high = resolve_polytomies_with_options(
+      &mut graph_high,
+      &partitions,
+      DEFAULT_RESOLUTION_THRESHOLD,
+      1000.0,
+      TEST_CLOCK_RATE,
+      false,
+    )?;
 
     // Small slope: penalty negligible, branch redistribution drives merge
     let mut graph_low = helpers::create_polytomy_tree_with_realistic_distributions()?;
-    let n_low = resolve_polytomies_with_options(&mut graph_low, &partitions, DEFAULT_RESOLUTION_THRESHOLD, 0.01, TEST_CLOCK_RATE, false)?;
+    let n_low = resolve_polytomies_with_options(
+      &mut graph_low,
+      &partitions,
+      DEFAULT_RESOLUTION_THRESHOLD,
+      0.01,
+      TEST_CLOCK_RATE,
+      false,
+    )?;
 
     assert!(
       n_low > n_high,
@@ -271,7 +292,14 @@ mod tests {
   fn test_resolve_polytomies_zero_slope_no_penalty() -> Result<(), Report> {
     let mut graph = helpers::create_polytomy_tree_with_realistic_distributions()?;
     let partitions = vec![];
-    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, DEFAULT_RESOLUTION_THRESHOLD, 0.0, TEST_CLOCK_RATE, false)?;
+    let n_resolved = resolve_polytomies_with_options(
+      &mut graph,
+      &partitions,
+      DEFAULT_RESOLUTION_THRESHOLD,
+      0.0,
+      TEST_CLOCK_RATE,
+      false,
+    )?;
 
     assert_eq!(n_resolved, 1, "Zero slope should allow merge");
     Ok(())
@@ -281,10 +309,19 @@ mod tests {
   fn test_resolve_polytomies_compressed_children_skipped_by_default() -> Result<(), Report> {
     let mut graph = helpers::create_compressed_polytomy_tree()?;
     let partitions = vec![];
-    let n_resolved =
-      resolve_polytomies_with_options(&mut graph, &partitions, DEFAULT_RESOLUTION_THRESHOLD, 0.01, TEST_CLOCK_RATE, false)?;
+    let n_resolved = resolve_polytomies_with_options(
+      &mut graph,
+      &partitions,
+      DEFAULT_RESOLUTION_THRESHOLD,
+      0.01,
+      TEST_CLOCK_RATE,
+      false,
+    )?;
 
-    assert_eq!(n_resolved, 0, "Compressed children should not be merged when merge_compressed=false");
+    assert_eq!(
+      n_resolved, 0,
+      "Compressed children should not be merged when merge_compressed=false"
+    );
     Ok(())
   }
 
@@ -292,10 +329,12 @@ mod tests {
   fn test_resolve_polytomies_compressed_children_merged_when_enabled() -> Result<(), Report> {
     let mut graph = helpers::create_compressed_polytomy_tree()?;
     let partitions = vec![];
-    let n_resolved =
-      resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 0.01, TEST_CLOCK_RATE, true)?;
+    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 0.01, TEST_CLOCK_RATE, true)?;
 
-    assert!(n_resolved > 0, "Compressed children should be merged when merge_compressed=true");
+    assert!(
+      n_resolved > 0,
+      "Compressed children should be merged when merge_compressed=true"
+    );
     Ok(())
   }
 
@@ -303,8 +342,7 @@ mod tests {
   fn test_resolve_polytomies_stretched_children_merged_by_default() -> Result<(), Report> {
     let mut graph = helpers::create_polytomy_tree()?;
     let partitions = vec![];
-    let n_resolved =
-      resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
+    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
 
     assert!(n_resolved > 0, "Stretched children should be merged by default");
     Ok(())

--- a/packages/treetime/src/timetree/optimization/polytomy.rs
+++ b/packages/treetime/src/timetree/optimization/polytomy.rs
@@ -7,9 +7,10 @@ use crate::representation::payload::timetree::NodeTimetree;
 use argmin::core::{CostFunction, Executor};
 use argmin::solver::brent::BrentOpt;
 use eyre::Report;
+use treetime_utils::make_internal_error;
 use log::debug;
-use ndarray::Array2;
 use parking_lot::RwLock;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
 use treetime_graph::edge::{GraphEdgeKey, HasBranchLength};
@@ -34,7 +35,14 @@ pub fn resolve_polytomies(
   zero_branch_slope: f64,
   clock_rate: f64,
 ) -> Result<usize, Report> {
-  resolve_polytomies_with_options(graph, partitions, DEFAULT_RESOLUTION_THRESHOLD, zero_branch_slope, clock_rate, false)
+  resolve_polytomies_with_options(
+    graph,
+    partitions,
+    DEFAULT_RESOLUTION_THRESHOLD,
+    zero_branch_slope,
+    clock_rate,
+    false,
+  )
 }
 
 /// Resolve polytomies with configurable options.
@@ -113,11 +121,9 @@ struct MergeCandidate {
   cost_gain: f64,
 }
 
-/// Result of finding the best pair of children to merge.
-struct BestPair {
-  child_idx_a: usize,
-  child_idx_b: usize,
-  likelihood_gain: f64,
+/// Canonical key for a pair of children, ordered so first < second.
+fn gain_key(a: GraphNodeKey, b: GraphNodeKey) -> (GraphNodeKey, GraphNodeKey) {
+  if a < b { (a, b) } else { (b, a) }
 }
 
 /// Resolve a single polytomy node using greedy pairwise merging.
@@ -142,12 +148,25 @@ fn resolve_single_polytomy(
   let mut nodes_created = 0;
 
   // Merge stretched children
-  nodes_created += merge_child_group(graph, node_key, resolution_threshold, zero_branch_slope, clock_rate, true)?;
+  nodes_created += merge_child_group(
+    graph,
+    node_key,
+    resolution_threshold,
+    zero_branch_slope,
+    clock_rate,
+    true,
+  )?;
 
   // Optionally merge compressed children
   if merge_compressed {
-    nodes_created +=
-      merge_child_group(graph, node_key, resolution_threshold, zero_branch_slope, clock_rate, false)?;
+    nodes_created += merge_child_group(
+      graph,
+      node_key,
+      resolution_threshold,
+      zero_branch_slope,
+      clock_rate,
+      false,
+    )?;
   }
 
   Ok(nodes_created)
@@ -155,10 +174,11 @@ fn resolve_single_polytomy(
 
 /// Merge one group (stretched or compressed) of a polytomy's children.
 ///
-/// When `select_stretched` is true, only stretched children are candidates.
-/// When false, only compressed children are candidates.
+/// Uses an incremental gain matrix: after each merge, only O(n) new gain
+/// evaluations are needed (for the new node vs each remaining child) instead
+/// of recomputing the full O(n^2) matrix. Matches v0's incremental approach.
 ///
-/// The stopping condition depends on whether the group covers all children:
+/// Stopping condition depends on whether this group covers all children:
 /// - All children in group: stop at 2 remaining (normal bifurcation)
 /// - Subset: stop at 1 remaining (merge entire subset into one subtree)
 fn merge_child_group(
@@ -169,68 +189,94 @@ fn merge_child_group(
   clock_rate: f64,
   select_stretched: bool,
 ) -> Result<usize, Report> {
+  let parent_time = {
+    let node = graph.get_node(node_key).expect("Node must exist");
+    node.read_arc().payload().read_arc().time.unwrap_or(0.0)
+  };
+
+  let all_children = collect_children_info(graph, node_key, clock_rate)?;
+  let n_total = all_children.len();
+  if n_total <= 2 {
+    return Ok(0);
+  }
+
+  let mut children: BTreeMap<GraphNodeKey, ChildInfo> = all_children
+    .into_iter()
+    .filter(|c| c.is_stretched() == select_stretched)
+    .map(|c| (c.node_key, c))
+    .collect();
+
+  let is_all = children.len() == n_total;
+  let min_remaining = if is_all { 2 } else { 1 };
+
+  if children.len() < 2 {
+    return Ok(0);
+  }
+
+  // Initial full computation of pairwise gains
+  let mut gains: BTreeMap<(GraphNodeKey, GraphNodeKey), MergeCandidate> = BTreeMap::new();
+  let child_keys: Vec<GraphNodeKey> = children.keys().copied().collect();
+  for (i, &ka) in child_keys.iter().enumerate() {
+    for &kb in &child_keys[i + 1..] {
+      if let Some(candidate) = compute_merge_gain(&children[&ka], &children[&kb], parent_time, zero_branch_slope) {
+        gains.insert(gain_key(ka, kb), candidate);
+      }
+    }
+  }
+
   let mut nodes_created = 0;
 
   loop {
-    let parent_time = {
-      let node = graph.get_node(node_key).expect("Node must exist");
-      node.read_arc().payload().read_arc().time.unwrap_or(0.0)
+    if children.len() <= min_remaining {
+      break;
+    }
+
+    // Find best pair from current gains
+    let best = gains.iter().max_by(|(_, a), (_, b)| {
+      a.cost_gain
+        .partial_cmp(&b.cost_gain)
+        .unwrap_or(std::cmp::Ordering::Less)
+    });
+
+    let Some((&(key_a, key_b), best_candidate)) = best else {
+      break;
     };
 
-    let all_children = collect_children_info(graph, node_key, clock_rate)?;
-    if all_children.len() <= 2 {
+    if best_candidate.cost_gain < resolution_threshold {
+      debug!(
+        "Best gain {:.4} below threshold {resolution_threshold:.4}, stopping",
+        best_candidate.cost_gain
+      );
       break;
     }
 
-    let candidates: Vec<_> = all_children
-      .into_iter()
-      .filter(|c| c.is_stretched() == select_stretched)
-      .collect();
+    let optimal_time = best_candidate.optimal_time;
+    let likelihood_gain = best_candidate.cost_gain;
+    debug!("Merging children {key_a} and {key_b} with gain {likelihood_gain:.4} at time {optimal_time:.4}");
 
-    if candidates.len() < 2 {
-      break;
-    }
-
-    let n = candidates.len();
-    let mut gains = Array2::<f64>::from_elem((n, n), f64::NEG_INFINITY);
-    let mut optimal_times = Array2::<f64>::zeros((n, n));
-
-    for i in 0..n {
-      for j in (i + 1)..n {
-        if let Some(candidate) = compute_merge_gain(&candidates[i], &candidates[j], parent_time, zero_branch_slope) {
-          gains[[i, j]] = candidate.cost_gain;
-          gains[[j, i]] = candidate.cost_gain;
-          optimal_times[[i, j]] = candidate.optimal_time;
-          optimal_times[[j, i]] = candidate.optimal_time;
-        }
-      }
-    }
-
-    let BestPair {
-      child_idx_a,
-      child_idx_b,
-      likelihood_gain,
-    } = find_best_pair(&gains);
-    if likelihood_gain < resolution_threshold {
-      debug!("Best gain {likelihood_gain:.4} below threshold {resolution_threshold:.4}, stopping");
-      break;
-    }
-
-    let optimal_time = optimal_times[[child_idx_a, child_idx_b]];
-    debug!(
-      "Merging children {} and {} with gain {likelihood_gain:.4} at time {optimal_time:.4}",
-      candidates[child_idx_a].node_key, candidates[child_idx_b].node_key
-    );
-
-    merge_children(
+    let new_node_key = merge_children(
       graph,
       node_key,
-      &candidates[child_idx_a],
-      &candidates[child_idx_b],
+      &children[&key_a],
+      &children[&key_b],
       optimal_time,
       parent_time,
     )?;
     nodes_created += 1;
+
+    // Remove merged children and all their gain entries
+    children.remove(&key_a);
+    children.remove(&key_b);
+    gains.retain(|&(a, b), _| a != key_a && a != key_b && b != key_a && b != key_b);
+
+    // Build info for new node and compute its gains against remaining children
+    let new_child = collect_single_child_info(graph, node_key, new_node_key, clock_rate)?;
+    for (&ck, child) in &children {
+      if let Some(candidate) = compute_merge_gain(&new_child, child, parent_time, zero_branch_slope) {
+        gains.insert(gain_key(new_node_key, ck), candidate);
+      }
+    }
+    children.insert(new_node_key, new_child);
   }
 
   Ok(nodes_created)
@@ -247,34 +293,59 @@ fn collect_children_info(
 
   let mut children = Vec::new();
   for &edge_key in node.outbound() {
-    let edge = graph.get_edge(edge_key).expect("Edge must exist");
-    let edge = edge.read_arc();
-    let child_key = edge.target();
-
-    let child_node = graph.get_node(child_key).expect("Child must exist");
-    let child_payload = child_node.read_arc().payload().read_arc();
-    let edge_payload = edge.payload().read_arc();
-
-    let time = child_payload.time.unwrap_or(0.0);
-    let branch_dist = edge_payload
-      .branch_length_distribution
-      .clone()
-      .unwrap_or_else(|| Arc::new(Distribution::Empty));
-    let mutation_length = edge_payload.branch_length().unwrap_or(0.0);
-    let time_length = edge_payload.time_length.unwrap_or(0.0);
-    let clock_length = time_length * clock_rate;
-
-    children.push(ChildInfo {
-      node_key: child_key,
-      edge_key,
-      time,
-      branch_dist,
-      mutation_length,
-      clock_length,
-    });
+    children.push(build_child_info(graph, edge_key, clock_rate));
   }
 
   Ok(children)
+}
+
+/// Build ChildInfo for a single child identified by its parent edge.
+fn build_child_info(graph: &GraphTimetree, edge_key: GraphEdgeKey, clock_rate: f64) -> ChildInfo {
+  let edge = graph.get_edge(edge_key).expect("Edge must exist");
+  let edge = edge.read_arc();
+  let child_key = edge.target();
+
+  let child_node = graph.get_node(child_key).expect("Child must exist");
+  let child_payload = child_node.read_arc().payload().read_arc();
+  let edge_payload = edge.payload().read_arc();
+
+  let time = child_payload.time.unwrap_or(0.0);
+  let branch_dist = edge_payload
+    .branch_length_distribution
+    .clone()
+    .unwrap_or_else(|| Arc::new(Distribution::Empty));
+  let mutation_length = edge_payload.branch_length().unwrap_or(0.0);
+  let time_length = edge_payload.time_length.unwrap_or(0.0);
+  let clock_length = time_length * clock_rate;
+
+  ChildInfo {
+    node_key: child_key,
+    edge_key,
+    time,
+    branch_dist,
+    mutation_length,
+    clock_length,
+  }
+}
+
+/// Collect ChildInfo for a specific child node of a parent.
+fn collect_single_child_info(
+  graph: &GraphTimetree,
+  parent_key: GraphNodeKey,
+  child_key: GraphNodeKey,
+  clock_rate: f64,
+) -> Result<ChildInfo, Report> {
+  let parent = graph.get_node(parent_key).expect("Node must exist");
+  let parent = parent.read_arc();
+
+  for &edge_key in parent.outbound() {
+    let edge = graph.get_edge(edge_key).expect("Edge must exist");
+    if edge.read_arc().target() == child_key {
+      return Ok(build_child_info(graph, edge_key, clock_rate));
+    }
+  }
+
+  make_internal_error!("Child {child_key} not found among children of {parent_key}")
 }
 
 /// Compute cost gain from merging two children under a new internal node.
@@ -392,31 +463,12 @@ impl CostFunction for MergeCostFunction<'_> {
   }
 }
 
-/// Find the pair with maximum cost gain.
-fn find_best_pair(gains: &Array2<f64>) -> BestPair {
-  let n = gains.nrows();
-  let mut child_idx_a = 0;
-  let mut child_idx_b = 1;
-  let mut likelihood_gain = f64::NEG_INFINITY;
-
-  for i in 0..n {
-    for j in (i + 1)..n {
-      if gains[[i, j]] > likelihood_gain {
-        likelihood_gain = gains[[i, j]];
-        child_idx_a = i;
-        child_idx_b = j;
-      }
-    }
-  }
-
-  BestPair {
-    child_idx_a,
-    child_idx_b,
-    likelihood_gain,
-  }
-}
-
-/// Merge two children under a new internal node.
+/// Merge two children under a new internal node. Returns the new node's key.
+///
+/// Graph surgery: create new node N, edge parent->N, remove old edges parent->child1
+/// and parent->child2, create edges N->child1 and N->child2.
+/// Branch lengths are calendar-time differences (child_time - parent_time, positive
+/// because children are in the future relative to parent).
 fn merge_children(
   graph: &mut GraphTimetree,
   parent_key: GraphNodeKey,
@@ -424,16 +476,14 @@ fn merge_children(
   child2: &ChildInfo,
   new_node_time: f64,
   parent_time: f64,
-) -> Result<(), Report> {
-  // Create new internal node
+) -> Result<GraphNodeKey, Report> {
   let new_payload = NodeTimetree {
     time: Some(new_node_time),
     ..NodeTimetree::default()
   };
   let new_node_key = graph.add_node(new_payload);
 
-  // Create edge from parent to new node
-  // Branch length in calendar time: child - parent (new_node is the "child" of parent)
+  // Edge parent -> new node: time_length = new_node_time - parent_time
   let new_branch_length = new_node_time - parent_time;
   let new_edge_payload = EdgeTimetree {
     time_length: Some(new_branch_length),
@@ -441,8 +491,7 @@ fn merge_children(
   };
   graph.add_edge(parent_key, new_node_key, new_edge_payload)?;
 
-  // Reparent child1: remove old edge from parent, create edge from new node
-  // Branch length: child1.time - new_node_time
+  // Reparent child1: remove parent->child1, add new_node->child1
   let new_branch1_length = child1.time - new_node_time;
   graph.remove_edge(child1.edge_key)?;
   let child1_edge_payload = EdgeTimetree {
@@ -451,8 +500,7 @@ fn merge_children(
   };
   graph.add_edge(new_node_key, child1.node_key, child1_edge_payload)?;
 
-  // Reparent child2: remove old edge from parent, create edge from new node
-  // Branch length: child2.time - new_node_time
+  // Reparent child2: remove parent->child2, add new_node->child2
   let new_branch2_length = child2.time - new_node_time;
   graph.remove_edge(child2.edge_key)?;
   let child2_edge_payload = EdgeTimetree {
@@ -461,7 +509,7 @@ fn merge_children(
   };
   graph.add_edge(new_node_key, child2.node_key, child2_edge_payload)?;
 
-  Ok(())
+  Ok(new_node_key)
 }
 
 /// Remove single-child internal nodes left by polytomy resolution.


### PR DESCRIPTION
- Depends on: `refactor/polytomy-dedup-primitives`
- Resolves: `N-timetree-polytomy-quadratic-gain-matrix`

v0 updates the gain matrix incrementally after each merge: removes rows/cols for the merged pair, computes O(n) new gain entries for the new node vs remaining children. v1 was recomputing the full O(n^2) matrix from scratch each iteration by re-reading the graph.

This PR replaces `Array2<f64>` with `BTreeMap<(GraphNodeKey, GraphNodeKey), MergeCandidate>` keyed by canonical node-key pairs. After each merge, entries involving the merged pair are removed, the new node's info is collected from the graph, and only O(n-2) new gain evaluations are computed. Also implements v0's `isall` stopping condition: when the group covers all children, stop at 2 remaining (normal bifurcation); when merging a subset, stop at 1 remaining.

### Work items

- [x] Replace `Array2` gains/optimal_times with `BTreeMap` keyed by `(GraphNodeKey, GraphNodeKey)`
- [x] Incremental update: remove merged entries, compute O(n) new entries for new node
- [x] `merge_children` returns `GraphNodeKey` for the new node
- [x] Add `build_child_info`, `collect_single_child_info` helpers
- [x] Implement `isall` stopping condition (min_remaining = 2 for all, 1 for subset)
- [x] Remove `Array2`, `find_best_pair`, `BestPair` (dead code)
- [x] Tests: mixed stretched/compressed (isall=false path), edge time_length verification, guard path (reversed times), 4-way with realistic distributions
- [x] Fix `test_find_polytomy_nodes_*` to call the shared function directly
- [x] Tighten truthy assertions to exact merge counts
