### PR TITLE
chore: add tickets for dissolving commands/ module

### DIFF
--- a/kb/tickets/architecture-extract-mugration-domain-logic.md
+++ b/kb/tickets/architecture-extract-mugration-domain-logic.md
@@ -1,0 +1,40 @@
+# Extract mugration domain logic from commands
+
+## Description
+
+`commands/mugration/run.rs` contains mugration business logic that belongs in a domain module. No `src/mugration/` module exists. The major domain extraction (GTR refinement, discrete marginal) was completed earlier, but mugration-specific computation remains in the command layer.
+
+Domain functions in `commands/mugration/run.rs`:
+
+- `execute_mugration` (86 lines): core mugration pipeline (state assembly, GTR construction, partition creation, marginal reconstruction, iterative refinement)
+- `validate_weight_coverage` (20 lines): validates discrete attribute coverage against weights
+- `compute_pi_from_weights` (10 lines): computes equilibrium frequencies from weight map
+- `compute_pi_uniform` (3 lines): uniform equilibrium frequencies
+- `apply_pseudo_counts` (9 lines): pseudo-count smoothing of equilibrium frequencies
+- `WeightCoverageResult` struct
+
+Domain types in `commands/mugration/output.rs`:
+
+- `MugrationResult`: holds graph + partition + extracted traits + GTR output. Domain state container
+- `MugrationTraitsOutput`, `MugrationGtrOutput`, `MugrationConfidenceOutput`: data extraction structs with `render_csv()` I/O methods
+
+Create `src/mugration/` module:
+
+- `src/mugration/mugration.rs`: `execute_mugration`, `MugrationInput`, `validate_weight_coverage`, `WeightCoverageResult`, `compute_pi_from_weights`, `compute_pi_uniform`, `apply_pseudo_counts`
+- `src/mugration/result.rs`: `MugrationResult`, `MugrationTraitsOutput`, `MugrationGtrOutput`, `MugrationConfidenceOutput` (data extraction, not file I/O). The `render_csv()` methods can stay on the types since they produce strings rather than writing files.
+
+Keep in `commands/mugration/`:
+
+- `run.rs`: `run_mugration` (file I/O orchestration), `parse_mugration_input` (CLI arg parsing), `write_annotated_tree`, `write_gtr_json_file`, `write_confidence_csv`
+- `comment_provider.rs` (Nexus output formatting)
+- `input.rs` (CLI-specific input struct with arg-derived fields)
+
+## Validation
+
+- `src/mugration/` compiles independently with no `commands/` imports
+- All existing tests pass (including `commands/mugration/__tests__/`)
+- `commands/mugration/run.rs` imports from `crate::mugration` instead of defining functions locally
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-extract-prune-domain-logic.md
+++ b/kb/tickets/architecture-extract-prune-domain-logic.md
@@ -1,0 +1,28 @@
+# Extract prune domain logic from commands
+
+## Description
+
+`commands/prune/run.rs` contains tree-pruning algorithms that belong in a domain module. No `src/prune/` module exists.
+
+Domain functions in `commands/prune/run.rs`:
+
+- `prune_nodes` (pub(super), 12 lines): orchestrates internal-node pruning then leaf pruning
+- `prune_internal_nodes` (37 lines): identifies edges to collapse by short branch length, zero mutations, or name match
+- `prune_leaves` (25 lines): identifies leaf edges to collapse by name match
+- `collapse_sparse_edges_from_leaf_recursive` (pub(super), 23 lines): collapses leaf edge and propagates upward through single-child ancestors
+- `get_edge_num_muts` (pub(super), 16 lines): counts mutations across partitions for one edge
+- `should_collapse_parent` (3 lines): checks single-child non-root condition
+
+These are tree surgery operations. They take graph + partitions, not CLI args.
+
+Create `src/prune/` module with these functions. `commands/prune/run.rs` becomes a thin orchestrator: parse args, load tree, call `prune::prune_nodes()`, call `merge_shared_mutation_branches()`, write output.
+
+## Validation
+
+- `src/prune/` compiles independently with no `commands/` imports
+- All existing tests pass (including `commands/prune/__tests__/`)
+- `commands/prune/run.rs` imports from `crate::prune` instead of defining functions locally
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-extract-timetree-convergence-confidence.md
+++ b/kb/tickets/architecture-extract-timetree-convergence-confidence.md
@@ -1,0 +1,49 @@
+# Extract timetree convergence and confidence domain logic from commands
+
+## Description
+
+`commands/timetree/convergence/` and `commands/timetree/output/confidence.rs` contain domain logic that belongs in `src/timetree/`.
+
+### Convergence domain logic
+
+`commands/timetree/convergence/likelihood.rs` (94 lines): `compute_sequence_likelihood`, `compute_positional_likelihood`, `compute_coalescent_likelihood`. Pure domain computations, no CLI types.
+
+`commands/timetree/convergence/sequence_changes.rs` (77 lines): `capture_ancestral_states`, `count_sequence_changes`, `AncestralStateSnapshot`. Pure domain computations, no CLI types.
+
+`commands/timetree/convergence/metrics.rs`: `ConvergenceMetrics` struct (domain data) mixed with `TimetreeOptimizer` (CLI loop control) and `TreetimeOptimizerTraceCsvWriter` (I/O).
+
+Move to `src/timetree/convergence/`:
+
+- `likelihood.rs` (entire file)
+- `sequence_changes.rs` (entire file)
+- `ConvergenceMetrics` struct and `has_converged()` method
+
+Keep in `commands/timetree/convergence/`:
+
+- `TimetreeOptimizer` (loop control, consumes domain metrics)
+- `TreetimeOptimizerTraceCsvWriter` (I/O)
+
+### Confidence/rate-susceptibility domain logic
+
+`commands/timetree/output/confidence.rs` (375 lines): rate susceptibility analysis, probit function, quadrature CI combination, CI extraction. ~60% domain logic (statistical computation), ~40% I/O and graph traversal.
+
+Move to `src/timetree/confidence.rs`:
+
+- `compute_rate_susceptibility`, `date_uncertainty_due_to_rate`, `combine_confidence`, `quantile_to_zscore`, `determine_rate_std`, `extract_confidence_intervals`, `NodeConfidenceInterval`
+- Private helpers: `save_gammas`, `scale_gammas`, `collect_node_times`
+- Constants: `CI_FRACTION`, `CI_LOWER_QUANTILE`, `CI_UPPER_QUANTILE`
+
+Keep in `commands/timetree/output/confidence.rs`:
+
+- `write_confidence_intervals` (TSV I/O)
+
+## Validation
+
+- `src/timetree/convergence/` compiles independently with no `commands/` imports
+- `src/timetree/confidence.rs` compiles independently with no `commands/` imports
+- All existing tests pass
+- `commands/timetree/` imports from `crate::timetree::convergence` and `crate::timetree::confidence`
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-move-shared-domain-enums-from-commands.md
+++ b/kb/tickets/architecture-move-shared-domain-enums-from-commands.md
@@ -1,0 +1,31 @@
+# Move shared domain enums from commands/shared/ to domain modules
+
+## Description
+
+`commands/shared/args.rs` contains three domain enums with `clap::ValueEnum` derives:
+
+- `BranchLengthMode` (`Input`, `Marginal`): used by optimize and timetree commands
+- `RerootMode` (`LeastSquares`, `MinDev`, `Oldest`, `ClockFilter`, `Mrca`): used by clock and timetree commands
+- `MethodAncestral` (`Joint`, `Marginal`, `Parsimony`): used by ancestral and homoplasy commands
+
+These are domain concepts (how to treat branch lengths, how to root the tree, which reconstruction method to use), not CLI concepts. They belong in domain modules.
+
+### Target locations
+
+- `BranchLengthMode` to `optimize/params.rs` (alongside `BranchOptMethod`, `InitialGuessMode`)
+- `RerootMode` to `clock/find_best_root/params.rs` (alongside `BranchPointOptimizationParams`)
+- `MethodAncestral` to `ancestral/` (new file or existing params module)
+
+Strip `clap::ValueEnum` derives. Replace with `strum::EnumString` + `strum::Display` for string parsing. CLI args files use clap's `value_parser` or wrapper types.
+
+Delete `commands/shared/args.rs` and `commands/shared/mod.rs` after all enums moved.
+
+## Validation
+
+- Domain modules compile without `commands/` imports
+- All existing tests pass
+- CLI enum parsing behavior unchanged
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-remove-clap-from-domain-types.md
+++ b/kb/tickets/architecture-remove-clap-from-domain-types.md
@@ -1,0 +1,36 @@
+# Remove clap derives from domain types
+
+## Description
+
+6 domain files derive `clap::ValueEnum` or `clap::Args`. This prevents the `treetime` library crate from compiling without the `clap` feature. Currently the feature gate is cosmetic: `treetime-cli` always enables `features = ["clap"]`, so the separation is never tested.
+
+### Domain files with clap derives
+
+- `alphabet/alphabet.rs`: `AlphabetName` derives `ValueEnum`
+- `clock/clock_regression.rs`: type with clap derive (verify exact type)
+- `clock/find_best_root/params.rs`: `BranchPointOptimizationParams` or related type
+- `gtr/get_gtr.rs`: `GtrModelName` derives `ValueEnum`
+- `optimize/params.rs`: `BranchOptMethod`, `InitialGuessMode` derive `ValueEnum`
+- `seq/gap_fill.rs`: `GapFillMode` derives `ValueEnum`
+
+### commands/shared/ enums
+
+`commands/shared/args.rs` contains `BranchLengthMode`, `RerootMode`, `MethodAncestral` with `ValueEnum` derives. These are domain enums that should move to their respective domain modules before this ticket.
+
+### Approach
+
+Replace `clap::ValueEnum` with `strum::EnumString` + `strum::Display` (or `strum::AsRefStr`) for string parsing. In CLI args files, use clap's `value_parser` with the strum-derived `FromStr` impl, or create thin wrapper enums with `ValueEnum`.
+
+### Prerequisite
+
+`commands/shared/args.rs` domain enums moved to domain modules (separate ticket).
+
+## Validation
+
+- `treetime` crate compiles without `clap` feature: `cargo check -p treetime --no-default-features`
+- `treetime-cli` builds and all tests pass
+- CLI enum parsing behavior unchanged (same accepted values, same error messages)
+
+## Related issues
+
+Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi-client-architecture-library-purity.md)

--- a/kb/tickets/architecture-restructure-packages-for-multi-client.md
+++ b/kb/tickets/architecture-restructure-packages-for-multi-client.md
@@ -18,23 +18,22 @@ Remove `clap` from `treetime` crate's `[dependencies]`. Move CLI-specific derive
 
 ### 2. Extract remaining domain logic from commands/
 
-Two remaining extraction tickets, independent of each other but both depend on step 1:
+Three extraction tickets, independent of each other:
 
-- `architecture-extract-timetree-inference-from-commands.md` - move inference (479 lines) and optimization (802 lines) to `src/timetree/`
-- `architecture-extract-mugration-domain-logic.md` - move GTR refinement (381 lines) and discrete marginal (170 lines) to `src/mugration/`
+- `architecture-extract-timetree-convergence-confidence.md` - move convergence metrics/likelihood and confidence/rate-susceptibility to `src/timetree/`
+- `architecture-extract-mugration-domain-logic.md` - move mugration business logic to `src/mugration/`
+- `architecture-extract-prune-domain-logic.md` - move pruning algorithms to `src/prune/`
 
-### 3. Break dependency cycles in library
+### 3. Move shared domain enums and remove clap from domain
 
-Two tickets, independent of each other, depend on step 2:
-
-- `architecture-break-representation-gtr-cycle.md` - parameterize GTR inference over iterators
-- `architecture-break-representation-ancestral-cycle.md` - move pure functions to `seq/`
+- `architecture-move-shared-domain-enums-from-commands.md` - move `BranchLengthMode`, `RerootMode`, `MethodAncestral` to domain modules
+- `architecture-remove-clap-from-domain-types.md` - strip clap from 6 domain files, use strum
 
 ### 4. Move commands/ shell to CLI crate
 
 After steps 1-3, `commands/` contains only thin orchestration (`args.rs`, `run.rs`, `output/`). Move the entire `commands/` module to `treetime-cli`. The library crate no longer has a `commands/` module.
 
-No existing ticket for this step - create when prerequisites are met.
+Ticket: `architecture-move-commands-to-cli-crate.md`
 
 ### 5. Add client crates
 
@@ -94,10 +93,11 @@ Source: [H-core-multi-client-architecture-library-purity](../issues/H-core-multi
 
 Coordinates:
 
-- [architecture-remove-clap-from-domain-types.md](architecture-remove-clap-from-domain-types.md)
-- [architecture-extract-timetree-inference-from-commands.md](architecture-extract-timetree-inference-from-commands.md)
+- [architecture-extract-timetree-convergence-confidence.md](architecture-extract-timetree-convergence-confidence.md)
 - [architecture-extract-mugration-domain-logic.md](architecture-extract-mugration-domain-logic.md)
-- [architecture-break-representation-gtr-cycle.md](architecture-break-representation-gtr-cycle.md)
-- [architecture-break-representation-ancestral-cycle.md](architecture-break-representation-ancestral-cycle.md)
+- [architecture-extract-prune-domain-logic.md](architecture-extract-prune-domain-logic.md)
+- [architecture-move-shared-domain-enums-from-commands.md](architecture-move-shared-domain-enums-from-commands.md)
+- [architecture-remove-clap-from-domain-types.md](architecture-remove-clap-from-domain-types.md)
+- [architecture-move-commands-to-cli-crate.md](architecture-move-commands-to-cli-crate.md)
 - [architecture-add-treetime-python-crate.md](architecture-add-treetime-python-crate.md)
 - [architecture-add-treetime-desktop-crate.md](architecture-add-treetime-desktop-crate.md)


### PR DESCRIPTION
- Depends on: `refactor/partition-payload-reorg`

`commands/` in the `treetime` library crate still contains domain logic that blocks multi-client architecture. Previous extraction rounds moved ancestral, clock, optimize, coalescent, and timetree inference/optimization to domain modules. Three areas remain: convergence metrics and rate susceptibility in `commands/timetree/`, pruning algorithms in `commands/prune/`, and mugration business logic in `commands/mugration/`. The clap feature gate on `commands/` is cosmetic since `treetime-cli` always enables it. Two referenced ticket files (mugration extraction, clap removal) were missing from `kb/tickets/`.

This PR adds five tickets covering the remaining extraction work and updates the umbrella ticket to reflect completed prerequisites and new sub-tickets.

### Work items

- [x] Add [architecture-extract-timetree-convergence-confidence](https://github.com/neherlab/treetime/blob/2e8622eb687c5cf129c1e7ea24a262c670cb2c74/kb/tickets/architecture-extract-timetree-convergence-confidence.md): move convergence likelihood, sequence changes, rate susceptibility, CI combination to `src/timetree/`
- [x] Add [architecture-extract-prune-domain-logic](https://github.com/neherlab/treetime/blob/2e8622eb687c5cf129c1e7ea24a262c670cb2c74/kb/tickets/architecture-extract-prune-domain-logic.md): move pruning algorithms to `src/prune/`
- [x] Add [architecture-extract-mugration-domain-logic](https://github.com/neherlab/treetime/blob/2e8622eb687c5cf129c1e7ea24a262c670cb2c74/kb/tickets/architecture-extract-mugration-domain-logic.md): move mugration business logic to `src/mugration/`
- [x] Add [architecture-move-shared-domain-enums-from-commands](https://github.com/neherlab/treetime/blob/2e8622eb687c5cf129c1e7ea24a262c670cb2c74/kb/tickets/architecture-move-shared-domain-enums-from-commands.md): move `BranchLengthMode`, `RerootMode`, `MethodAncestral` to domain modules
- [x] Add [architecture-remove-clap-from-domain-types](https://github.com/neherlab/treetime/blob/2e8622eb687c5cf129c1e7ea24a262c670cb2c74/kb/tickets/architecture-remove-clap-from-domain-types.md): strip clap derives from 6 domain files
- [x] Update [architecture-restructure-packages-for-multi-client](https://github.com/neherlab/treetime/blob/2e8622eb687c5cf129c1e7ea24a262c670cb2c74/kb/tickets/architecture-restructure-packages-for-multi-client.md) with new sub-tickets and remove resolved items
