### PR TITLE
refactor: extract test_utils into module directory

### DIFF
--- a/kb/tests/supporting.md
+++ b/kb/tests/supporting.md
@@ -750,7 +750,7 @@ Unit and parameterized tests for all BitSet128 operations.
 
 ### Graph
 
-**Test:** [`packages/treetime/src/graph/__tests__/graph.rs`](../../packages/treetime/src/graph/__tests__/graph.rs)
+**Test:** [`packages/treetime/src/graph/__tests__/test_graph.rs`](../../packages/treetime/src/graph/__tests__/test_graph.rs)
 
 **Impl:**
 
@@ -758,31 +758,35 @@ Unit and parameterized tests for all BitSet128 operations.
 - [`packages/treetime-graph/src/graph_traverse.rs`](../../packages/treetime-graph/src/graph_traverse.rs)
 - [`packages/treetime-graph/src/graph_ops.rs`](../../packages/treetime-graph/src/graph_ops.rs)
 
-| Test                                                  | Purpose                                |
-| ----------------------------------------------------- | -------------------------------------- |
-| `test_traversal_serial_depth_first_preorder_forward`  | DFS preorder visits root first         |
-| `test_traversal_serial_depth_first_postorder_forward` | DFS postorder visits leaves first      |
-| `test_traversal_serial_breadth_first_forward`         | BFS forward visits by level            |
-| `test_traversal_serial_breadth_first_reverse`         | BFS reverse visits deepest first       |
-| `test_traversal_parallel_breadth_first_forward`       | Parallel BFS forward order             |
-| `test_traversal_parallel_breadth_first_backward`      | Parallel BFS backward order            |
-| `test_collapse_edge_simple_chain`                     | Collapse single edge in chain          |
-| `test_collapse_edge_binary_tree`                      | Collapse internal node in binary tree  |
-| `test_collapse_edge_complex_tree`                     | Collapse promotes children to parent   |
-| `test_collapse_edge_invalid_edge`                     | Invalid edge key errors                |
-| `test_collapse_edge_leaf_edge`                        | Collapse edge to leaf removes leaf     |
-| `test_collapse_edge_no_duplicate_edges`               | No duplicate edges after collapse      |
-| `test_collapse_edge_adjacency_lists_maintained`       | Adjacency lists correct after collapse |
-| `test_collapse_edge_multiple_inbound_edges`           | Collapse with multiple inbound edges   |
-| `test_collapse_edge_adjacency_consistency`            | Edge-node adjacency stays consistent   |
+**Fixtures:** [`packages/treetime/src/test_utils/graph_fixtures.rs`](../../packages/treetime/src/test_utils/graph_fixtures.rs) (`TestNode`, `TestEdge`)
+
+**Helpers:** [`packages/treetime/src/test_utils/graph_lookup.rs`](../../packages/treetime/src/test_utils/graph_lookup.rs) (`find_node_key_by_name`, `find_edge_key`)
+
+| Test                                                        | Purpose                                |
+| ----------------------------------------------------------- | -------------------------------------- |
+| `test_graph_traversal_serial_depth_first_preorder_forward`  | DFS preorder visits root first         |
+| `test_graph_traversal_serial_depth_first_postorder_forward` | DFS postorder visits leaves first      |
+| `test_graph_traversal_serial_breadth_first_forward`         | BFS forward visits by level            |
+| `test_graph_traversal_serial_breadth_first_reverse`         | BFS reverse visits deepest first       |
+| `test_graph_traversal_parallel_breadth_first_forward`       | Parallel BFS forward order             |
+| `test_graph_traversal_parallel_breadth_first_backward`      | Parallel BFS backward order            |
+| `test_graph_collapse_edge_simple_chain`                     | Collapse single edge in chain          |
+| `test_graph_collapse_edge_binary_tree`                      | Collapse internal node in binary tree  |
+| `test_graph_collapse_edge_complex_tree`                     | Collapse promotes children to parent   |
+| `test_graph_collapse_edge_invalid_edge`                     | Invalid edge key errors                |
+| `test_graph_collapse_edge_leaf_edge`                        | Collapse edge to leaf removes leaf     |
+| `test_graph_collapse_edge_no_duplicate_edges`               | No duplicate edges after collapse      |
+| `test_graph_collapse_edge_adjacency_lists_maintained`       | Adjacency lists correct after collapse |
+| `test_graph_collapse_edge_multiple_inbound_edges`           | Collapse with multiple inbound edges   |
+| `test_graph_collapse_edge_adjacency_consistency`            | Edge-node adjacency stays consistent   |
 
 **Test:** [`packages/treetime/src/graph/__tests__/test_edge.rs`](../../packages/treetime/src/graph/__tests__/test_edge.rs)
 
 **Impl:** [`packages/treetime-graph/src/edge.rs`](../../packages/treetime-graph/src/edge.rs)
 
-| Test           | Purpose                                |
-| -------------- | -------------------------------------- |
-| `edge_inverts` | Edge inversion swaps source and target |
+| Test                | Purpose                                |
+| ------------------- | -------------------------------------- |
+| `test_edge_inverts` | Edge inversion swaps source and target |
 
 ### Commands: Prune
 

--- a/packages/treetime/src/graph/__tests__/mod.rs
+++ b/packages/treetime/src/graph/__tests__/mod.rs
@@ -1,2 +1,2 @@
-pub mod graph;
 mod test_edge;
+mod test_graph;

--- a/packages/treetime/src/graph/__tests__/test_edge.rs
+++ b/packages/treetime/src/graph/__tests__/test_edge.rs
@@ -3,12 +3,12 @@ mod tests {
   use eyre::Report;
   use pretty_assertions::assert_eq;
 
-  use crate::graph::__tests__::graph::tests::{TestEdge, TestNode};
+  use crate::test_utils::{TestEdge, TestNode};
   use treetime_graph::edge::{GraphEdgeKey, invert_edge};
   use treetime_io::nwk::nwk_read_str;
 
   #[test]
-  fn edge_inverts() -> Result<(), Report> {
+  fn test_edge_inverts() -> Result<(), Report> {
     let mut graph =
       nwk_read_str::<TestNode, TestEdge, ()>("((((h:0.7)e:0.6)d:0.4)b:0.,((g:0.5)c:0.2,(i:0.8)f:0.3)a:0.1)r1;")?;
 

--- a/packages/treetime/src/graph/__tests__/test_graph.rs
+++ b/packages/treetime/src/graph/__tests__/test_graph.rs
@@ -1,94 +1,22 @@
 #[cfg(test)]
-pub mod tests {
-  use std::collections::{BTreeMap, BTreeSet};
+mod tests {
+  use std::collections::BTreeSet;
   use std::sync::Arc;
 
   use eyre::Report;
   use parking_lot::RwLock;
   use pretty_assertions::assert_eq;
-  use serde::{Deserialize, Serialize};
 
   use treetime_graph::breadth_first::GraphTraversalContinuation;
-  use treetime_graph::edge::{GraphEdge, GraphEdgeKey, HasBranchLength};
+  use treetime_graph::edge::GraphEdgeKey;
   use treetime_graph::graph::Graph;
-  use treetime_graph::node::{GraphNode, Named};
-  use treetime_io::graphviz::{EdgeToGraphviz, NodeToGraphviz};
-  use treetime_io::nwk::{
-    EdgeFromNwk, EdgeToNwk, NodeFromNwk, NodeToNwk, NwkWriteOptions, format_weight, nwk_read_str, nwk_write_str,
-  };
+  use treetime_graph::node::Named;
+  use treetime_io::nwk::{NwkWriteOptions, nwk_read_str, nwk_write_str};
 
-  use crate::test_utils::{find_edge_key, find_node_key_by_name};
-
-  #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-  pub struct TestNode(pub Option<String>);
-
-  impl GraphNode for TestNode {}
-
-  impl Named for TestNode {
-    fn name(&self) -> Option<impl AsRef<str>> {
-      self.0.as_deref()
-    }
-    fn set_name(&mut self, name: Option<impl AsRef<str>>) {
-      self.0 = name.map(|n| n.as_ref().to_owned());
-    }
-  }
-
-  impl NodeFromNwk for TestNode {
-    fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
-      Ok(Self(name.map(|n| n.as_ref().to_owned())))
-    }
-  }
-
-  impl NodeToNwk for TestNode {
-    fn nwk_name(&self) -> Option<impl AsRef<str>> {
-      self.0.as_deref()
-    }
-  }
-
-  impl NodeToGraphviz for TestNode {
-    fn to_graphviz_label(&self) -> Option<impl AsRef<str>> {
-      self.0.as_deref()
-    }
-  }
-
-  #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-  pub struct TestEdge(pub Option<f64>);
-
-  impl GraphEdge for TestEdge {}
-
-  impl HasBranchLength for TestEdge {
-    fn branch_length(&self) -> Option<f64> {
-      self.0
-    }
-    fn set_branch_length(&mut self, weight: Option<f64>) {
-      self.0 = weight;
-    }
-  }
-
-  impl EdgeFromNwk for TestEdge {
-    fn from_nwk(weight: Option<f64>) -> Result<Self, Report> {
-      Ok(Self(weight))
-    }
-  }
-
-  impl EdgeToNwk for TestEdge {
-    fn nwk_weight(&self) -> Option<f64> {
-      self.0
-    }
-  }
-
-  impl EdgeToGraphviz for TestEdge {
-    fn to_graphviz_label(&self) -> Option<impl AsRef<str>> {
-      self.0.map(|weight| format_weight(weight, &NwkWriteOptions::default()))
-    }
-
-    fn to_graphviz_weight(&self) -> Option<f64> {
-      self.0
-    }
-  }
+  use crate::test_utils::{TestEdge, TestNode, find_edge_key, find_node_key_by_name};
 
   #[test]
-  fn test_traversal_serial_depth_first_preorder_forward() -> Result<(), Report> {
+  fn test_graph_traversal_serial_depth_first_preorder_forward() -> Result<(), Report> {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let mut actual = vec![];
@@ -102,7 +30,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_traversal_serial_depth_first_postorder_forward() -> Result<(), Report> {
+  fn test_graph_traversal_serial_depth_first_postorder_forward() -> Result<(), Report> {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let mut actual = vec![];
@@ -116,7 +44,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_traversal_serial_breadth_first_forward() -> Result<(), Report> {
+  fn test_graph_traversal_serial_breadth_first_forward() -> Result<(), Report> {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let mut actual = vec![];
@@ -130,7 +58,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_traversal_serial_breadth_first_reverse() -> Result<(), Report> {
+  fn test_graph_traversal_serial_breadth_first_reverse() -> Result<(), Report> {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let mut actual = vec![];
@@ -144,7 +72,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_traversal_parallel_breadth_first_forward() -> Result<(), Report> {
+  fn test_graph_traversal_parallel_breadth_first_forward() -> Result<(), Report> {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let actual = Arc::new(RwLock::new(vec![]));
@@ -161,7 +89,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_traversal_parallel_breadth_first_backward() -> Result<(), Report> {
+  fn test_graph_traversal_parallel_breadth_first_backward() -> Result<(), Report> {
     let graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;")?;
 
     let actual = Arc::new(RwLock::new(vec![]));
@@ -178,7 +106,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_collapse_edge_simple_chain() -> Result<(), Report> {
+  fn test_graph_collapse_edge_simple_chain() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.2)internal:0.1)root;")?;
 
     let root_to_internal = find_edge_key(&graph, "root", "internal").unwrap();
@@ -191,7 +119,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_collapse_edge_binary_tree() -> Result<(), Report> {
+  fn test_graph_collapse_edge_binary_tree() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.2)internal:0.1,B:0.3)root;")?;
 
     let root_to_internal = find_edge_key(&graph, "root", "internal").unwrap();
@@ -204,7 +132,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_collapse_edge_complex_tree() -> Result<(), Report> {
+  fn test_graph_collapse_edge_complex_tree() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.3,B:0.4)left:0.1,(C:0.5,D:0.6)right:0.2)root;")?;
 
     let root_to_left = find_edge_key(&graph, "root", "left").unwrap();
@@ -218,7 +146,7 @@ pub mod tests {
 
   #[allow(clippy::assertions_on_result_states)]
   #[test]
-  fn test_collapse_edge_invalid_edge() -> Result<(), Report> {
+  fn test_graph_collapse_edge_invalid_edge() -> Result<(), Report> {
     let mut graph = Graph::<TestNode, TestEdge, ()>::new();
 
     let root_node = graph.add_node(TestNode(Some("root".to_owned())));
@@ -235,7 +163,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_collapse_edge_leaf_edge() -> Result<(), Report> {
+  fn test_graph_collapse_edge_leaf_edge() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("(A:0.1,B:0.2)root;")?;
 
     let root_to_a = find_edge_key(&graph, "root", "A").unwrap();
@@ -248,18 +176,16 @@ pub mod tests {
   }
 
   #[test]
-  fn test_collapse_edge_no_duplicate_edges() -> Result<(), Report> {
+  fn test_graph_collapse_edge_no_duplicate_edges() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.2)internal:0.1)root;")?;
 
     let root_to_internal = find_edge_key(&graph, "root", "internal").unwrap();
     graph.collapse_edge(root_to_internal)?;
 
-    // After collapse: root -> A (internal node removed)
     let root_key = find_node_key_by_name(&graph, "root").unwrap();
     let root_node = graph.get_node(root_key).unwrap();
     let root_node = root_node.read_arc();
 
-    // Verify no duplicate edges in adjacency lists
     let outbound_edges = root_node.outbound();
     let unique_outbound: BTreeSet<_> = outbound_edges.iter().collect();
     assert_eq!(
@@ -276,14 +202,13 @@ pub mod tests {
       "Duplicate inbound edges detected"
     );
 
-    // Should have one outbound edge (to leaf)
     assert_eq!(outbound_edges.len(), 1);
 
     Ok(())
   }
 
   #[test]
-  fn test_collapse_edge_adjacency_lists_maintained() -> Result<(), Report> {
+  fn test_graph_collapse_edge_adjacency_lists_maintained() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("((A:0.3,B:0.4)left:0.1,right:0.2)root;")?;
 
     let root_to_left = find_edge_key(&graph, "root", "left").unwrap();
@@ -296,9 +221,7 @@ pub mod tests {
   }
 
   #[test]
-  fn test_collapse_edge_multiple_inbound_edges() -> Result<(), Report> {
-    // This test verifies handling when target node has multiple inbound edges
-    // (though in a tree this shouldn't happen, we test the general case)
+  fn test_graph_collapse_edge_multiple_inbound_edges() -> Result<(), Report> {
     let mut graph = Graph::<TestNode, TestEdge, ()>::new();
 
     let source1_node = graph.add_node(TestNode(Some("source1".to_owned())));
@@ -306,67 +229,55 @@ pub mod tests {
     let target_node = graph.add_node(TestNode(Some("target".to_owned())));
     let leaf_node = graph.add_node(TestNode(Some("leaf".to_owned())));
 
-    // Create edges: source1 -> target, source2 -> target, target -> leaf
     let edge_to_collapse = graph.add_edge(source1_node, target_node, TestEdge(Some(0.1)))?;
     let _other_inbound = graph.add_edge(source2_node, target_node, TestEdge(Some(0.2)))?;
     let _outbound_edge = graph.add_edge(target_node, leaf_node, TestEdge(Some(0.3)))?;
 
     graph.build()?;
 
-    // Collapse source1 -> target edge
     graph.collapse_edge(edge_to_collapse)?;
 
-    // Verify source1 now has the outbound edge to leaf
     let source1_ref = graph.get_node(source1_node).unwrap();
     let source1_binding = source1_ref.read_arc();
     let source1_outbound = source1_binding.outbound();
     assert_eq!(source1_outbound.len(), 1);
 
-    // Verify the edge now goes from source1 to leaf
     if let Some(edge) = graph.get_edge(source1_outbound[0]) {
       let edge_ref = edge.read_arc();
       assert_eq!(edge_ref.source(), source1_node);
       assert_eq!(edge_ref.target(), leaf_node);
     }
 
-    // Verify source1 also inherited the other inbound edge (source2 -> source1)
     let source1_inbound = source1_binding.inbound();
     assert_eq!(source1_inbound.len(), 1);
 
-    // Verify that source2 -> target edge now points to source1
     if let Some(edge) = graph.get_edge(source1_inbound[0]) {
       let edge_ref = edge.read_arc();
       assert_eq!(edge_ref.source(), source2_node);
       assert_eq!(edge_ref.target(), source1_node);
     }
 
-    // Verify target node was removed
     assert!(graph.get_node(target_node).is_none());
 
     Ok(())
   }
 
   #[test]
-  fn test_collapse_edge_adjacency_consistency() -> Result<(), Report> {
-    // Test that after edge collapse, all edge references in adjacency lists
-    // correspond to actual edges that exist and point correctly
+  fn test_graph_collapse_edge_adjacency_consistency() -> Result<(), Report> {
     let mut graph = nwk_read_str::<TestNode, TestEdge, ()>("((leaf1:0.2,leaf2:0.3)internal:0.1)root;")?;
 
     let root_to_internal = find_edge_key(&graph, "root", "internal").unwrap();
     graph.collapse_edge(root_to_internal)?;
 
-    // Verify consistency: every edge key in node adjacency lists corresponds to a real edge
     for node in graph.get_nodes() {
       let node_ref = node.read_arc();
 
-      // Check outbound edges
       for &edge_key in node_ref.outbound() {
         let edge = graph.get_edge(edge_key).expect("Outbound edge should exist");
         let edge_ref = edge.read_arc();
         assert_eq!(edge_ref.source(), node_ref.key(), "Edge source should match node");
       }
 
-      // Check inbound edges
       for &edge_key in node_ref.inbound() {
         let edge = graph.get_edge(edge_key).expect("Inbound edge should exist");
         let edge_ref = edge.read_arc();

--- a/packages/treetime/src/graph/mod.rs
+++ b/packages/treetime/src/graph/mod.rs
@@ -1,2 +1,2 @@
 #[cfg(test)]
-pub(crate) mod __tests__;
+mod __tests__;

--- a/packages/treetime/src/io/__tests__/test_nwk.rs
+++ b/packages/treetime/src/io/__tests__/test_nwk.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-  use crate::graph::__tests__::graph::tests::{TestEdge, TestNode};
+  use crate::test_utils::{TestEdge, TestNode};
   use approx::assert_abs_diff_eq;
   use eyre::Report;
   use pretty_assertions::assert_eq;

--- a/packages/treetime/src/lib.rs
+++ b/packages/treetime/src/lib.rs
@@ -5,7 +5,6 @@ pub mod coalescent;
 #[cfg(feature = "clap")]
 pub mod commands;
 pub mod constants;
-pub mod graph;
 pub mod gtr;
 pub mod hacks;
 pub mod io;
@@ -17,6 +16,9 @@ pub mod timetree;
 
 #[cfg(test)]
 pub mod test_utils;
+
+#[cfg(test)]
+mod graph;
 
 pub use treetime_utils::{
   make_error, make_internal_error, make_internal_report, make_report, o, pretty_assert_abs_diff_eq,

--- a/packages/treetime/src/seq/__tests__/test_div.rs
+++ b/packages/treetime/src/seq/__tests__/test_div.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
   use crate::clock::clock_graph::GraphClock;
-  use crate::graph::__tests__::graph::tests::{TestEdge, TestNode};
   use crate::o;
   use crate::seq::div::{OnlyLeaves, compute_divs};
+  use crate::test_utils::{TestEdge, TestNode};
   use approx::assert_abs_diff_eq;
   use eyre::Report;
   use maplit::btreemap;

--- a/packages/treetime/src/test_utils/graph_fixtures.rs
+++ b/packages/treetime/src/test_utils/graph_fixtures.rs
@@ -1,0 +1,75 @@
+use eyre::Report;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use treetime_graph::edge::{GraphEdge, HasBranchLength};
+use treetime_graph::node::{GraphNode, Named};
+use treetime_io::graphviz::{EdgeToGraphviz, NodeToGraphviz};
+use treetime_io::nwk::{EdgeFromNwk, EdgeToNwk, NodeFromNwk, NodeToNwk, NwkWriteOptions, format_weight};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestNode(pub Option<String>);
+
+impl GraphNode for TestNode {}
+
+impl Named for TestNode {
+  fn name(&self) -> Option<impl AsRef<str>> {
+    self.0.as_deref()
+  }
+  fn set_name(&mut self, name: Option<impl AsRef<str>>) {
+    self.0 = name.map(|n| n.as_ref().to_owned());
+  }
+}
+
+impl NodeFromNwk for TestNode {
+  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+    Ok(Self(name.map(|n| n.as_ref().to_owned())))
+  }
+}
+
+impl NodeToNwk for TestNode {
+  fn nwk_name(&self) -> Option<impl AsRef<str>> {
+    self.0.as_deref()
+  }
+}
+
+impl NodeToGraphviz for TestNode {
+  fn to_graphviz_label(&self) -> Option<impl AsRef<str>> {
+    self.0.as_deref()
+  }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TestEdge(pub Option<f64>);
+
+impl GraphEdge for TestEdge {}
+
+impl HasBranchLength for TestEdge {
+  fn branch_length(&self) -> Option<f64> {
+    self.0
+  }
+  fn set_branch_length(&mut self, weight: Option<f64>) {
+    self.0 = weight;
+  }
+}
+
+impl EdgeFromNwk for TestEdge {
+  fn from_nwk(weight: Option<f64>) -> Result<Self, Report> {
+    Ok(Self(weight))
+  }
+}
+
+impl EdgeToNwk for TestEdge {
+  fn nwk_weight(&self) -> Option<f64> {
+    self.0
+  }
+}
+
+impl EdgeToGraphviz for TestEdge {
+  fn to_graphviz_label(&self) -> Option<impl AsRef<str>> {
+    self.0.map(|weight| format_weight(weight, &NwkWriteOptions::default()))
+  }
+
+  fn to_graphviz_weight(&self) -> Option<f64> {
+    self.0
+  }
+}

--- a/packages/treetime/src/test_utils/graph_lookup.rs
+++ b/packages/treetime/src/test_utils/graph_lookup.rs
@@ -1,0 +1,37 @@
+use treetime_graph::edge::{GraphEdge, GraphEdgeKey};
+use treetime_graph::graph::Graph;
+use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
+
+pub fn find_node_key_by_name<N, E, D>(graph: &Graph<N, E, D>, name: &str) -> Option<GraphNodeKey>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Send + Sync,
+{
+  for node in graph.get_nodes() {
+    let node = node.read_arc();
+    let payload = node.payload().read_arc();
+    if payload.name().is_some_and(|n| n.as_ref() == name) {
+      return Some(node.key());
+    }
+  }
+  None
+}
+
+pub fn find_edge_key<N, E, D>(graph: &Graph<N, E, D>, source_name: &str, target_name: &str) -> Option<GraphEdgeKey>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Send + Sync,
+{
+  let source_key = find_node_key_by_name(graph, source_name)?;
+  let target_key = find_node_key_by_name(graph, target_name)?;
+
+  for edge in graph.get_edges() {
+    let edge = edge.read_arc();
+    if edge.source() == source_key && edge.target() == target_key {
+      return Some(edge.key());
+    }
+  }
+  None
+}

--- a/packages/treetime/src/test_utils/marginal.rs
+++ b/packages/treetime/src/test_utils/marginal.rs
@@ -8,21 +8,11 @@ use crate::seq::alignment::get_common_length;
 use eyre::Report;
 use parking_lot::RwLock;
 use std::sync::{Arc, LazyLock};
-use treetime_graph::edge::GraphEdge;
-use treetime_graph::edge::GraphEdgeKey;
-use treetime_graph::graph::Graph;
-use treetime_graph::node::GraphNode;
-use treetime_graph::node::GraphNodeKey;
-use treetime_graph::node::Named;
 use treetime_io::fasta::read_many_fasta_str;
 use treetime_io::nwk::nwk_read_str;
 
-/// Default nucleotide alphabet for test helpers.
 pub static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
 
-/// Run dense marginal reconstruction on a tree given as Newick string.
-///
-/// Returns the log-likelihood of the reconstruction.
 pub fn run_dense_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) -> Result<f64, Report> {
   let graph: GraphAncestral = nwk_read_str(newick)?;
   let aln = read_many_fasta_str(aln_str, &*NUC_ALPHABET)?;
@@ -34,9 +24,6 @@ pub fn run_dense_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) -> 
   initialize_marginal(&graph, &partitions, &aln)
 }
 
-/// Run sparse marginal reconstruction on a tree given as Newick string.
-///
-/// Returns the log-likelihood of the reconstruction.
 pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) -> Result<f64, Report> {
   let graph: GraphAncestral = nwk_read_str(newick)?;
   let aln = read_many_fasta_str(aln_str, &*NUC_ALPHABET)?;
@@ -47,40 +34,4 @@ pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) ->
   let partitions = [Arc::new(RwLock::new(partition))];
 
   update_marginal(&graph, &partitions)
-}
-
-/// Find a node key by its name in a graph where nodes implement `Named`.
-pub fn find_node_key_by_name<N, E, D>(graph: &Graph<N, E, D>, name: &str) -> Option<GraphNodeKey>
-where
-  N: GraphNode + Named,
-  E: GraphEdge,
-  D: Send + Sync,
-{
-  for node in graph.get_nodes() {
-    let node = node.read_arc();
-    let payload = node.payload().read_arc();
-    if payload.name().is_some_and(|n| n.as_ref() == name) {
-      return Some(node.key());
-    }
-  }
-  None
-}
-
-/// Find an edge key by source and target node names.
-pub fn find_edge_key<N, E, D>(graph: &Graph<N, E, D>, source_name: &str, target_name: &str) -> Option<GraphEdgeKey>
-where
-  N: GraphNode + Named,
-  E: GraphEdge,
-  D: Send + Sync,
-{
-  let source_key = find_node_key_by_name(graph, source_name)?;
-  let target_key = find_node_key_by_name(graph, target_name)?;
-
-  for edge in graph.get_edges() {
-    let edge = edge.read_arc();
-    if edge.source() == source_key && edge.target() == target_key {
-      return Some(edge.key());
-    }
-  }
-  None
 }

--- a/packages/treetime/src/test_utils/mod.rs
+++ b/packages/treetime/src/test_utils/mod.rs
@@ -1,0 +1,7 @@
+mod graph_fixtures;
+mod graph_lookup;
+mod marginal;
+
+pub use graph_fixtures::{TestEdge, TestNode};
+pub use graph_lookup::{find_edge_key, find_node_key_by_name};
+pub use marginal::{NUC_ALPHABET, run_dense_marginal_with_newick, run_sparse_marginal_with_newick};


### PR DESCRIPTION
- Depends on: `refactor/move-piecewise-fns-to-grid`

`test_utils.rs` in the `treetime` crate is a flat file mixing graph test fixtures (`TestNode`/`TestEdge`), graph lookup helpers (`find_node_key_by_name`, `find_edge_key`), and marginal reconstruction test drivers. The graph fixtures were also defined inline in `graph/__tests__/graph.rs` and imported by other test modules through the internal path `crate::graph::__tests__::graph::tests::{TestEdge, TestNode}`.

This PR splits `test_utils.rs` into a module directory with three files organized by purpose: `graph_fixtures.rs`, `graph_lookup.rs`, and `marginal.rs`. The `TestNode`/`TestEdge` types move from the graph test file into the shared fixtures, and all consumers switch to `crate::test_utils::{TestEdge, TestNode}`. The graph module becomes `#[cfg(test)]` since it contains no production code.

### Work items

- [x] Split `test_utils.rs` into `test_utils/{graph_fixtures,graph_lookup,marginal}.rs`
- [x] Move `TestNode`/`TestEdge` from `graph/__tests__/graph.rs` to shared fixtures
- [x] Rename graph test file and prefix test functions with `test_graph_`/`test_edge_`
- [x] Make graph module `#[cfg(test)]` only (no production code)
- [x] Update test inventory with new paths and fixture references
