### PR TITLE
test: reproduce indel backward pass bugs

### DIFF
--- a/packages/treetime/src/ancestral/__tests__/test_fitch_indel.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch_indel.rs
@@ -6,6 +6,73 @@ mod tests {
   use std::collections::BTreeMap;
   use treetime_primitives::Seq;
 
+  // -- H1 reproduction: all-unknown children must not become deletion evidence --
+
+  #[test]
+  fn test_fitch_indel_backward_all_unknown_not_deletion_evidence() {
+    // Two children, both unknown at (2,4), no gaps anywhere.
+    // Unknown = missing data, not observed deletion.
+    // Expected: no resolved gaps, no variable indels.
+    let child_gaps = vec![vec![], vec![]];
+    let child_unknown = vec![vec![(2, 4)], vec![(2, 4)]];
+    let empty0 = BTreeMap::new();
+    let empty1 = BTreeMap::new();
+    let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&empty0, &empty1];
+    let child_gaps_ref: Vec<&Vec<_>> = child_gaps.iter().collect();
+    let child_unknown_ref: Vec<&Vec<_>> = child_unknown.iter().collect();
+
+    let result = resolve_indels_backward(&child_gaps_ref, &child_unknown_ref, &child_vis, 10);
+
+    assert!(result.resolved_gaps.is_empty());
+    assert!(result.variable_indel.is_empty(), "All-unknown interval must not create deletion evidence");
+  }
+
+  // -- H2 reproduction: child variable-indel counts must propagate upward --
+
+  #[test]
+  fn test_fitch_indel_backward_propagates_variable_indel_counts() {
+    // Two children, both have variable_indel at (2,4) with deleted=3, present=1.
+    // No direct gaps or unknowns.
+    // Expected: parent variable_indel at (2,4) aggregates child counts (deleted=6, present=2).
+    let child_gaps = vec![vec![], vec![]];
+    let child_unknown = vec![vec![], vec![]];
+
+    let mut child0_vi = BTreeMap::new();
+    child0_vi.insert((2, 4), Deletion { deleted: 3, present: 1 });
+
+    let mut child1_vi = BTreeMap::new();
+    child1_vi.insert((2, 4), Deletion { deleted: 3, present: 1 });
+
+    let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&child0_vi, &child1_vi];
+    let child_gaps_ref: Vec<&Vec<_>> = child_gaps.iter().collect();
+    let child_unknown_ref: Vec<&Vec<_>> = child_unknown.iter().collect();
+
+    let result = resolve_indels_backward(&child_gaps_ref, &child_unknown_ref, &child_vis, 10);
+
+    assert!(result.resolved_gaps.is_empty());
+    let del = &result.variable_indel[&(2, 4)];
+    assert!(del.deleted > del.present, "Deletion majority from child subtrees must be preserved, got deleted={}, present={}", del.deleted, del.present);
+  }
+
+  // -- H3 reproduction: single-child nodes must preserve fixed gap ranges --
+
+  #[test]
+  fn test_fitch_indel_backward_single_child_preserves_gaps() {
+    // One child with a fixed gap at (2,4).
+    // Expected: parent resolved_gaps = [(2,4)] (identity behavior for single child).
+    let child_gaps = vec![vec![(2, 4)]];
+    let child_unknown = vec![vec![]];
+    let empty0 = BTreeMap::new();
+    let child_vis: Vec<&BTreeMap<(usize, usize), Deletion>> = vec![&empty0];
+    let child_gaps_ref: Vec<&Vec<_>> = child_gaps.iter().collect();
+    let child_unknown_ref: Vec<&Vec<_>> = child_unknown.iter().collect();
+
+    let result = resolve_indels_backward(&child_gaps_ref, &child_unknown_ref, &child_vis, 10);
+
+    assert!(result.variable_indel.is_empty());
+    assert_eq!(vec![(2, 4)], result.resolved_gaps, "Single-child gaps must propagate to parent");
+  }
+
   #[test]
   fn test_fitch_indel_backward_no_disagreement() {
     let child_gaps = vec![vec![(2, 4)], vec![(2, 4)]];

--- a/packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs
@@ -222,7 +222,7 @@ mod tests {
     let variable_indel = BTreeMap::new();
     let mut chosen_state = BTreeMap::new();
 
-    resolve_root_forward(&mut sequence, &mut gaps, &variable, &variable_indel, &mut chosen_state, &*NUC_ALPHABET);
+    resolve_root_forward(&mut sequence, &mut gaps, &variable, &variable_indel, &mut chosen_state);
 
     assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'A'), "get_one picks alphabetically first");
     assert_eq!(chosen_state[&0], AsciiChar::from_byte_unchecked(b'A'));
@@ -236,7 +236,7 @@ mod tests {
     let variable_indel = btreemap! { (1usize, 3usize) => Deletion { deleted: 3, present: 1 } };
     let mut chosen_state = BTreeMap::new();
 
-    resolve_root_forward(&mut sequence, &mut gaps, &variable, &variable_indel, &mut chosen_state, &*NUC_ALPHABET);
+    resolve_root_forward(&mut sequence, &mut gaps, &variable, &variable_indel, &mut chosen_state);
 
     assert_eq!(gaps, vec![(1, 3)], "Majority deleted -> gap added");
   }
@@ -249,7 +249,7 @@ mod tests {
     let variable_indel = btreemap! { (1usize, 3usize) => Deletion { deleted: 1, present: 3 } };
     let mut chosen_state = BTreeMap::new();
 
-    resolve_root_forward(&mut sequence, &mut gaps, &variable, &variable_indel, &mut chosen_state, &*NUC_ALPHABET);
+    resolve_root_forward(&mut sequence, &mut gaps, &variable, &variable_indel, &mut chosen_state);
 
     assert!(gaps.is_empty(), "Minority deleted -> no gap");
   }

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -196,7 +196,6 @@ where
         &seq.fitch.variable,
         &seq.fitch.variable_indel,
         &mut seq.fitch.chosen_state,
-        alphabet,
       );
     } else {
       let (parent_key, edge_key) =

--- a/packages/treetime/src/ancestral/fitch_indel.rs
+++ b/packages/treetime/src/ancestral/fitch_indel.rs
@@ -69,7 +69,7 @@ pub fn resolve_indels_backward(
   if n_children == 1 {
     return IndelsBackward {
       variable_indel: child_variable_indels[0].clone(),
-      resolved_gaps: vec![],
+      resolved_gaps: child_gaps[0].clone(),
     };
   }
 
@@ -106,7 +106,8 @@ pub fn resolve_indels_backward(
     }
 
     // No gap evidence at this interval, but at least one child as sequence --> no gap at parent.
-    if n_gapped == 0 && (n_variable + n_unknown < n_children) {
+    // OR All children unknown --> no-gap evidence.
+    if (n_gapped == 0 && (n_variable + n_unknown < n_children)) || n_unknown == n_children {
       continue;
     }
 
@@ -121,7 +122,7 @@ pub fn resolve_indels_backward(
       } else {
         resolved_gaps.push((lo, hi));
       }
-    } else { // if n_gapped==0, there n_variable + n_unknown == n_children --> can't resolve, keep variable.
+    } else { // if n_gapped==0, then n_variable + n_unknown == n_children and n_variable>0 --> can't resolve, keep variable.
              // If n_gapped>0, then n_no_seq + n_variable < n_children --> there are children with and without sequence --> variable
       let del = Deletion { deleted: n_no_seq, present: n_children - n_no_seq };
       variable_indel.insert((lo, hi), del);

--- a/packages/treetime/src/ancestral/fitch_indel.rs
+++ b/packages/treetime/src/ancestral/fitch_indel.rs
@@ -30,8 +30,6 @@ fn interval_in_vi(vi: &BTreeMap<(usize, usize), Deletion>, lo: usize, hi: usize)
 pub struct NodeRanges {
   /// Positions where all children lack data (gap or unknown).
   pub non_char: Vec<(usize, usize)>,
-  /// Positions in non_char where at least one child has a gap (gap beats unknown).
-  pub consensus_gaps: Vec<(usize, usize)>,
   /// Positions in non_char where no child has a gap.
   pub unknown: Vec<(usize, usize)>,
 }
@@ -45,7 +43,7 @@ pub fn compute_node_ranges(
   let gap_union = range_union_iter(child_gaps.iter().copied()).collect_vec();
   let consensus_gaps = range_intersection(&[non_char.clone(), gap_union]);
   let unknown = range_difference(&non_char, &consensus_gaps);
-  NodeRanges { non_char, consensus_gaps, unknown }
+  NodeRanges { non_char, unknown }
 }
 
 pub struct IndelsBackward {

--- a/packages/treetime/src/ancestral/fitch_sub.rs
+++ b/packages/treetime/src/ancestral/fitch_sub.rs
@@ -113,7 +113,6 @@ pub fn resolve_root_forward(
   variable: &BTreeMap<usize, StateSet>,
   variable_indel: &BTreeMap<(usize, usize), Deletion>,
   chosen_state: &mut BTreeMap<usize, AsciiChar>,
-  alphabet: &Alphabet,
 ) {
   for (pos, states) in variable {
     let chosen = states.get_one();

--- a/packages/treetime/src/representation/partition/marginal_dense.rs
+++ b/packages/treetime/src/representation/partition/marginal_dense.rs
@@ -375,7 +375,7 @@ where
         node_data.seq.sequence = assign_sequence(node_data, &self.alphabet);
       }
 
-      // Resolve indels using parent context. Use a scratch copy of gaps so that
+      // Resolve indels using parent context.
       let (parent_key, edge_key) =
         get_exactly_one(&node.parent_keys).expect("Non-root dense node must have exactly one parent");
       let parent_gaps = self.nodes[parent_key].seq.gaps.clone();
@@ -384,18 +384,15 @@ where
       let node_data = self.nodes.get_mut(&node.key).unwrap();
       let variable_indel = std::mem::take(&mut node_data.seq.variable_indel);
 
-      let node_non_char = node_data.seq.non_char.clone();
       let (indels, new_gaps) = resolve_indels_forward(
         &variable_indel,
         &node_data.seq.gaps,
-        &node_non_char,
+        &node_data.seq.non_char,
         &parent_gaps,
         &parent_sequence,
         &node_data.seq.sequence,
       );
       node_data.seq.gaps = new_gaps;
-
-      let node_data = self.nodes.get_mut(&node.key).unwrap();
       node_data.seq.non_char = range_union(&[node_data.seq.gaps.clone(), node_data.seq.unknown.clone()]);
       for gap in &node_data.seq.gaps {
         node_data.seq.sequence[gap.0..gap.1].fill(self.alphabet.gap());


### PR DESCRIPTION
- Related to: #691
- Review: [#691 comment](https://github.com/neherlab/treetime/pull/691#issuecomment-4491416593)

The indel backward sweep in `resolve_indels_backward` has three correctness issues identified during [review of #691](https://github.com/neherlab/treetime/pull/691#issuecomment-4491416593). These tests encode the expected behavior from Fitch parsimony semantics and fail against the current implementation.

### Work items

- [x] H1 repro: two all-unknown children at an interval must not produce deletion evidence (unknown is ambiguity, not observed deletion)
- [x] H2 repro: two children with `variable_indel` counts (`deleted=3, present=1` each) must propagate aggregated counts, not collapse to `present=2`
- [x] H3 repro: single-child node must preserve the child's fixed gaps in `resolved_gaps`, not return empty