### PR TITLE
refactor: use Outlier trait method consistently

### DIFF
--- a/packages/treetime/src/timetree/optimization/clock_filter.rs
+++ b/packages/treetime/src/timetree/optimization/clock_filter.rs
@@ -78,7 +78,7 @@ pub fn apply_outlier_bad_branches(graph: &GraphTimetree) {
   for leaf in graph.get_leaves() {
     let node = leaf.read_arc();
     let mut payload = node.payload().write_arc();
-    if payload.is_outlier {
+    if payload.is_outlier() {
       payload.bad_branch = true;
     }
   }


### PR DESCRIPTION
- Depends on: `refactor/replace-truncate-name`

`apply_outlier_bad_branches` in `timetree/optimization/clock_filter.rs` accessed `payload.is_outlier` as a direct field, while `collect_outliers` in the same file used `payload.is_outlier()` via the `Outlier` trait.

Standardize to the trait method for consistency.

### Work items

- [x] Change `payload.is_outlier` to `payload.is_outlier()` in `apply_outlier_bad_branches`


