### PR TITLE
fix: carry inverted_edge_keys through RerootResult

### DIFF
--- a/packages/treetime-graph/src/reroot.rs
+++ b/packages/treetime-graph/src/reroot.rs
@@ -41,6 +41,9 @@ pub struct RerootResult {
   pub edge_split: Option<EdgeSplitInfo>,
   /// Information about edge merge, if a trivial node was removed.
   pub edge_merge: Option<EdgeMergeInfo>,
+  /// Keys of edges whose direction was inverted during rerooting.
+  /// Empty when root did not change.
+  pub inverted_edge_keys: Vec<GraphEdgeKey>,
 }
 
 /// Bundles all topology changes from a reroot operation for partition updates.

--- a/packages/treetime/src/clock/reroot.rs
+++ b/packages/treetime/src/clock/reroot.rs
@@ -57,6 +57,7 @@ where
       new_root_key: old_root_key,
       edge_split: None,
       edge_merge: None,
+      inverted_edge_keys: vec![],
     });
   };
 
@@ -82,22 +83,30 @@ where
     (if split < 0.5 { target_key } else { source_key }, None)
   };
 
-  let edge_merge = if new_root_key != old_root_key {
-    apply_reroot(graph, old_root_key, new_root_key, options)?;
+  let (inverted_edge_keys, edge_merge) = if new_root_key != old_root_key {
+    let mut inverted = apply_reroot(graph, old_root_key, new_root_key, options)?;
 
-    if reroot_params.remove_trivial_root {
+    let merge = if reroot_params.remove_trivial_root {
       remove_node_if_trivial(graph, old_root_key)?
     } else {
       None
+    };
+
+    // Remove edges consumed by the merge (they no longer exist in the graph)
+    if let Some(merge) = &merge {
+      inverted.retain(|k| *k != merge.parent_edge_key && *k != merge.child_edge_key);
     }
+
+    (inverted, merge)
   } else {
-    None
+    (vec![], None)
   };
 
   Ok(RerootResult {
     new_root_key,
     edge_split,
     edge_merge,
+    inverted_edge_keys,
   })
 }
 
@@ -131,16 +140,14 @@ fn apply_reroot<N, E, D>(
   old_root_key: GraphNodeKey,
   new_root_key: GraphNodeKey,
   options: &ClockParams,
-) -> Result<(), Report>
+) -> Result<Vec<GraphEdgeKey>, Report>
 where
   N: GraphNode + ClockNode,
   E: GraphEdge + ClockEdge,
   D: Send + Sync,
 {
-  // Invert edges along the path (generic topology operation)
   let inverted_edge_keys = topology_reroot::apply_reroot_topology(graph, old_root_key, new_root_key)?;
 
-  // Update clock-specific edge messages for inverted edges
   for edge_key in &inverted_edge_keys {
     let edge = graph.get_edge(*edge_key).expect("Inverted edge not found");
     let mut edge_payload = edge.read_arc().payload().write_arc();
@@ -152,5 +159,5 @@ where
     *edge_payload.from_child_mut() = edge_payload.to_parent().propagate_averages(edge_len, branch_variance);
   }
 
-  Ok(())
+  Ok(inverted_edge_keys)
 }

--- a/packages/treetime/src/timetree/optimization/reroot.rs
+++ b/packages/treetime/src/timetree/optimization/reroot.rs
@@ -8,7 +8,6 @@ use crate::partition::traits::PartitionTimetreeAll;
 use crate::payload::timetree::EdgeTimetree;
 use crate::payload::timetree::NodeTimetree;
 use eyre::{Report, WrapErr};
-use itertools::Itertools;
 use log::info;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -26,8 +25,6 @@ pub fn reroot_tree(
   branch_params: &BranchPointOptimizationParams,
   force_positive_rate: bool,
 ) -> Result<ClockModel, Report> {
-  let old_root_key = graph.get_exactly_one_root()?.read_arc().key();
-
   let reroot_params = RerootParams {
     force_positive_rate,
     ..RerootParams::default()
@@ -50,34 +47,12 @@ pub fn reroot_tree(
   )
   .wrap_err("Failed to estimate clock model with reroot")?;
 
-  let new_root_key = graph.get_exactly_one_root()?.read_arc().key();
-
-  // Update partitions if we have any and rerooting occurred
   if let Some(reroot_result) = &clock_reroot_result.reroot_result {
     if !partitions.is_empty() {
-      // Build inverted edge keys: edges on path from old root to new root (if old root still exists)
-      let inverted_edge_keys = if new_root_key != old_root_key && graph.get_node(old_root_key).is_some() {
-        info!(
-          "Root changed from {} to {} - computing reroot path",
-          old_root_key.0, new_root_key.0
-        );
-
-        let path = graph
-          .path_from_node_to_node(old_root_key, new_root_key)
-          .wrap_err("Failed to compute path from old root to new root")?;
-
-        path
-          .iter()
-          .filter_map(|(_, edge)| edge.as_ref().map(|e| e.read_arc().key()))
-          .collect_vec()
-      } else {
-        vec![]
-      };
-
       let changes = RerootChanges {
         edge_split: reroot_result.edge_split.clone(),
         edge_merge: reroot_result.edge_merge.clone(),
-        inverted_edge_keys,
+        inverted_edge_keys: reroot_result.inverted_edge_keys.clone(),
       };
 
       info!("Applying reroot changes to {} partitions", partitions.len());
@@ -88,7 +63,6 @@ pub fn reroot_tree(
           .wrap_err("Failed to apply reroot changes to partition")?;
       }
 
-      // Recompute marginal messages after partition state update
       update_marginal(graph, partitions).wrap_err("Failed to update marginal after reroot")?;
     }
   }


### PR DESCRIPTION
- Depends on: `refactor/outlier-trait-method`

`apply_reroot_topology` computed `inverted_edge_keys` but discarded them after clock message updates. `reroot_tree` then reconstructed them by walking `path_from_node_to_node` on the post-reroot graph. This reconstruction produced empty keys when `remove_trivial_root` merged the old root away, causing partitions to miss edge inversions.

Add `inverted_edge_keys` to `RerootResult` so the caller receives the computed keys directly instead of reconstructing them from an invalidated graph.

### Work items

- [x] Add `inverted_edge_keys: Vec<GraphEdgeKey>` field to `RerootResult`
- [x] Return inverted edge keys from `apply_reroot` in `clock/reroot.rs`
- [x] Filter out edges consumed by `remove_node_if_trivial` merge
- [x] Use `reroot_result.inverted_edge_keys` directly in `reroot_tree`
- [x] Remove fragile `path_from_node_to_node` reconstruction and unused `old_root_key`
- [x] Remove unused `itertools` import


