### PR TITLE
test: use exact equality for integer-valued mutation counts

### DIFF
--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
@@ -7,6 +7,7 @@
 //! - Root state correctness for known ancestral sequences
 
 #[cfg(test)]
+#[allow(clippy::float_cmp, reason = "integer-valued f64s from += 1.0 accumulation and explicit = 0.0 assignment")]
 mod tests {
   use crate::alphabet::alphabet::{Alphabet, AlphabetName};
   use crate::ancestral::fitch::create_fitch_partition;
@@ -18,6 +19,7 @@ mod tests {
   use crate::partition::marginal_dense::PartitionMarginalDense;
   use crate::pretty_assert_ulps_eq;
   use crate::seq::alignment::get_common_length;
+  use pretty_assertions::assert_eq;
 
   use crate::payload::ancestral::GraphAncestral;
   use eyre::Report;
@@ -133,8 +135,8 @@ mod tests {
     let counts = get_mutation_counts_fitch(&graph, &fitch)?;
 
     // Sparse gives exact integer counts: one A->C substitution
-    pretty_assert_ulps_eq!(1.0, counts.nij[[IDX_C, IDX_A]], epsilon = 1e-9);
-    pretty_assert_ulps_eq!(0.0, counts.nij[[IDX_A, IDX_C]], epsilon = 1e-9);
+    assert_eq!(1.0, counts.nij[[IDX_C, IDX_A]]);
+    assert_eq!(0.0, counts.nij[[IDX_A, IDX_C]]);
 
     Ok(())
   }
@@ -290,7 +292,7 @@ mod tests {
     // root_state: both should agree on total and dominant state
     let dense_total = dense.root_state.sum();
     let sparse_total = sparse.root_state.sum();
-    pretty_assert_ulps_eq!(dense_total, sparse_total, epsilon = 1e-9);
+    assert_eq!(dense_total, sparse_total);
 
     let dense_argmax = dense
       .root_state
@@ -346,7 +348,7 @@ mod tests {
       counts.root_state[IDX_A]
     );
     // Total should equal alignment length
-    pretty_assert_ulps_eq!(8.0, counts.root_state.sum(), epsilon = 1e-9);
+    assert_eq!(8.0, counts.root_state.sum());
 
     Ok(())
   }
@@ -376,10 +378,10 @@ mod tests {
 
     // Sparse root_state comes from Fitch composition counts.
     // All 8 positions should be A at root (3/4 leaves have A at pos 0).
-    pretty_assert_ulps_eq!(8.0, counts.root_state[IDX_A], epsilon = 1e-9);
-    pretty_assert_ulps_eq!(0.0, counts.root_state[IDX_C], epsilon = 1e-9);
-    pretty_assert_ulps_eq!(0.0, counts.root_state[IDX_G], epsilon = 1e-9);
-    pretty_assert_ulps_eq!(0.0, counts.root_state[IDX_T], epsilon = 1e-9);
+    assert_eq!(8.0, counts.root_state[IDX_A]);
+    assert_eq!(0.0, counts.root_state[IDX_C]);
+    assert_eq!(0.0, counts.root_state[IDX_G]);
+    assert_eq!(0.0, counts.root_state[IDX_T]);
 
     Ok(())
   }
@@ -436,8 +438,8 @@ mod tests {
 
     // C->A and T->C reverses are zero (no such mutations in input).
     // A->G and G->A are mutual reverses: both nij[G,A] and nij[A,G] are non-zero.
-    pretty_assert_ulps_eq!(0.0, counts.nij[[IDX_A, IDX_C]], epsilon = 1e-9); // nij[A, C] = 0
-    pretty_assert_ulps_eq!(0.0, counts.nij[[IDX_C, IDX_T]], epsilon = 1e-9); // nij[C, T] = 0
+    assert_eq!(0.0, counts.nij[[IDX_A, IDX_C]]);
+    assert_eq!(0.0, counts.nij[[IDX_C, IDX_T]]);
 
     Ok(())
   }
@@ -516,9 +518,9 @@ mod tests {
     let counts = get_mutation_counts_fitch(&graph, &fitch)?;
 
     // All Ti values should be equal (uniform composition, no mutations)
-    pretty_assert_ulps_eq!(counts.Ti[IDX_A], counts.Ti[IDX_C], epsilon = 1e-9);
-    pretty_assert_ulps_eq!(counts.Ti[IDX_C], counts.Ti[IDX_G], epsilon = 1e-9);
-    pretty_assert_ulps_eq!(counts.Ti[IDX_G], counts.Ti[IDX_T], epsilon = 1e-9);
+    assert_eq!(counts.Ti[IDX_A], counts.Ti[IDX_C]);
+    assert_eq!(counts.Ti[IDX_C], counts.Ti[IDX_G]);
+    assert_eq!(counts.Ti[IDX_G], counts.Ti[IDX_T]);
 
     Ok(())
   }
@@ -598,7 +600,7 @@ mod tests {
     let counts = get_mutation_counts_dense(&graph, &partition)?;
 
     // root_state sums to alignment length (one count per position)
-    pretty_assert_ulps_eq!(14.0, counts.root_state.sum(), epsilon = 1e-9);
+    assert_eq!(14.0, counts.root_state.sum());
 
     Ok(())
   }
@@ -632,8 +634,8 @@ mod tests {
     let sparse = get_mutation_counts_fitch(&graph_s, &fitch_s)?;
 
     for k in 0..4 {
-      pretty_assert_ulps_eq!(0.0, dense.nij[[k, k]], epsilon = 1e-15);
-      pretty_assert_ulps_eq!(0.0, sparse.nij[[k, k]], epsilon = 1e-15);
+      assert_eq!(0.0, dense.nij[[k, k]]);
+      assert_eq!(0.0, sparse.nij[[k, k]]);
     }
 
     Ok(())

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs
@@ -9,12 +9,12 @@ mod tests {
   use crate::gtr::infer_gtr::common::{InferGtrOptions, infer_gtr_impl};
   use crate::partition::marginal_dense::PartitionMarginalDense;
   use crate::payload::ancestral::GraphAncestral;
-  use crate::pretty_assert_abs_diff_eq;
   use crate::pretty_assert_ulps_eq;
   use crate::seq::alignment::get_common_length;
   use eyre::Report;
   use indoc::indoc;
   use lazy_static::lazy_static;
+  use pretty_assertions::assert_eq;
 
   use ndarray::{Array1, Array2, array};
   use parking_lot::RwLock;
@@ -92,7 +92,7 @@ mod tests {
     }
 
     // Root composition: 1 of each nucleotide (ACGT)
-    pretty_assert_ulps_eq!(array![1.0, 1.0, 1.0, 1.0], counts.root_state, epsilon = 1e-9);
+    assert_eq!(array![1.0, 1.0, 1.0, 1.0], counts.root_state);
 
     Ok(())
   }
@@ -227,13 +227,13 @@ mod tests {
     accumulate_mutation_counts(&mut_stack, 0.0, &mut nij, &mut ti);
 
     // Ti == 0: no evolutionary time at zero branch length
-    let expected_ti = Array1::zeros(n_states);
-    pretty_assert_abs_diff_eq!(expected_ti, ti, epsilon = 1e-15);
+    let expected_ti: Array1<f64> = Array1::zeros(n_states);
+    assert_eq!(expected_ti, ti);
 
     // nij == I: identity expQt means child = parent at every site, so each of the 4
     // sites contributes P(child=k, parent=k) = 1.0 on the diagonal, zero off-diagonal
-    let expected_nij = Array2::eye(n_states);
-    pretty_assert_abs_diff_eq!(expected_nij, nij, epsilon = 1e-15);
+    let expected_nij: Array2<f64> = Array2::eye(n_states);
+    assert_eq!(expected_nij, nij);
 
     Ok(())
   }

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_fitch.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_fitch.rs
@@ -12,6 +12,7 @@ mod tests {
   use indoc::indoc;
   use lazy_static::lazy_static;
   use ndarray::array;
+  use pretty_assertions::assert_eq;
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
 
@@ -41,12 +42,11 @@ mod tests {
     let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
 
     let counts_actual = get_mutation_counts_fitch(&graph, &fitch)?;
-    pretty_assert_ulps_eq!(
+    assert_eq!(
       counts_actual.nij,
-      array![[0., 0., 0., 0.], [2., 0., 0., 1.], [3., 2., 0., 0.], [0., 1., 1., 0.]],
-      epsilon = 1e-9
+      array![[0., 0., 0., 0.], [2., 0., 0., 1.], [3., 2., 0., 0.], [0., 1., 1., 0.]]
     );
-    pretty_assert_ulps_eq!(counts_actual.root_state, array![4.0, 3.0, 3.0, 4.0], epsilon = 1e-9);
+    assert_eq!(counts_actual.root_state, array![4.0, 3.0, 3.0, 4.0]);
     pretty_assert_ulps_eq!(
       counts_actual.Ti,
       array![


### PR DESCRIPTION
- Depends on: `fix/carry-inverted-edge-keys`

GTR inference contract, Fitch, and dense tests used `pretty_assert_ulps_eq!` with `epsilon = 1e-9` or `1e-15` on values that are bitwise-exact f64 integers. Sparse Fitch `nij` counts accumulate via `+= 1.0`, `root_state` values come from `usize as f64` or `+= 1.0`, dense diagonal zeros are explicit `= 0.0` assignments, and zero-branch unclamped results are exact from `0.0 * x`. The epsilon created ambiguity about whether these values had floating-point error.

Replace with `assert_eq!` (from `pretty_assertions`) for all provably exact values. Ti scaling tests retain `pretty_assert_ulps_eq!` with `epsilon = 1e-7` since those values come from independent floating-point computation paths.

### Work items

- [x] Replace `pretty_assert_ulps_eq!` with `assert_eq!` in `test_contract.rs` (nij, root_state, diagonal zeros, Ti proportionality)
- [x] Replace `pretty_assert_ulps_eq!` with `assert_eq!` in `test_fitch.rs` (nij matrix, root_state)
- [x] Replace approximate assertions with `assert_eq!` in `test_dense.rs` (root_state, zero-branch Ti and nij)
- [x] Add `use pretty_assertions::assert_eq` import to all 3 files


