### PR TITLE
feat: add iterative GTR refinement to ancestral command

### DIFF
--- a/packages/treetime/src/commands/ancestral/args.rs
+++ b/packages/treetime/src/commands/ancestral/args.rs
@@ -104,6 +104,14 @@ pub struct TreetimeAncestralArgs {
   #[clap(long, short = 'O')]
   pub outdir: PathBuf,
 
+  /// Number of outer GTR refinement iterations.
+  ///
+  /// Re-estimates the rate matrix from marginal posterior profiles after each
+  /// reconstruction pass. Only effective with `--model infer`. Default 0 preserves
+  /// the current single-pass behavior. Mugration uses 5 by default.
+  #[clap(long, default_value_t = 0)]
+  pub gtr_iterations: usize,
+
   /// Use site-specific GTR model with per-site equilibrium frequencies.
   ///
   /// Requires `--model infer` and `--dense true`. Incompatible with sequence compression

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -5,11 +5,12 @@ use crate::ancestral::marginal::{ancestral_reconstruction_marginal, initialize_m
 use crate::ancestral::params::MethodAncestral;
 use crate::commands::ancestral::args::TreetimeAncestralArgs;
 use crate::gtr::get_gtr::{GtrModelName, get_gtr_by_name, log_gtr, write_gtr_json};
+use crate::gtr::refinement::refine_gtr_iterative;
 use crate::make_error;
 use crate::partition::algo::infer_dense::infer_dense;
 use crate::partition::fitch::PartitionFitch;
 use crate::partition::marginal_dense::PartitionMarginalDense;
-use crate::partition::traits::MutationCommentProvider;
+use crate::partition::traits::{HasGtr, MutationCommentProvider};
 use crate::payload::ancestral::GraphAncestral;
 use crate::seq::alignment::get_common_length;
 use crate::seq::gap_fill::apply_gap_fill;
@@ -39,6 +40,7 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
     reconstruct_tip_states,
     method_anc,
     dense,
+    gtr_iterations,
     outdir,
     site_specific_gtr,
     ..
@@ -113,17 +115,23 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
           GtrModelName::Infer => infer_gtr_fitch(&fitch, &graph)?,
           _ => get_gtr_by_name(*model_name)?,
         };
-        write_gtr_json(&gtr, *model_name, outdir, None)?;
         log_gtr(&gtr, *model_name);
         let partition = fitch.into_marginal_sparse(gtr, &graph)?;
         let partitions = vec![Arc::new(RwLock::new(partition))];
 
         update_marginal(&graph, &partitions)?;
+
+        if *gtr_iterations > 0 && *model_name == GtrModelName::Infer {
+          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None)?;
+        }
+
         ancestral_reconstruction_marginal(&graph, *reconstruct_tip_states, &partitions, |node, seq| {
           let name = node.name.as_deref().unwrap_or("");
           let desc = &node.desc;
           output_fasta.write(name, desc, seq)
         })?;
+
+        write_gtr_json(partitions[0].read_arc().gtr(), *model_name, outdir, None)?;
 
         let partition_guard = partitions[0].read_arc();
         let provider = MutationCommentProvider::new(&*partition_guard, &graph);
@@ -132,7 +140,6 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
       } else if *model_name == GtrModelName::Infer {
         let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
         let gtr = infer_gtr_fitch(&fitch, &graph)?;
-        write_gtr_json(&gtr, *model_name, outdir, None)?;
         log_gtr(&gtr, *model_name);
         let partition = fitch.into_marginal_dense(gtr);
         let partitions = vec![Arc::new(RwLock::new(partition))];
@@ -140,11 +147,17 @@ pub fn run_ancestral_reconstruction(ancestral_args: &TreetimeAncestralArgs) -> R
         initialize_marginal(&graph, &partitions, &aln)?;
         update_marginal(&graph, &partitions)?;
 
+        if *gtr_iterations > 0 {
+          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None)?;
+        }
+
         ancestral_reconstruction_marginal(&graph, *reconstruct_tip_states, &partitions, |node, seq| {
           let name = node.name.as_deref().unwrap_or("");
           let desc = &node.desc;
           output_fasta.write(name, desc, seq)
         })?;
+
+        write_gtr_json(partitions[0].read_arc().gtr(), *model_name, outdir, None)?;
 
         let partition_guard = partitions[0].read_arc();
         let provider = MutationCommentProvider::new(&*partition_guard, &graph);

--- a/packages/treetime/src/gtr/infer_gtr/mod.rs
+++ b/packages/treetime/src/gtr/infer_gtr/mod.rs
@@ -1,4 +1,4 @@
 #[cfg(test)]
 mod __tests__;
-pub(crate) mod common;
+pub mod common;
 pub mod site_specific;

--- a/packages/treetime/src/gtr/refinement.rs
+++ b/packages/treetime/src/gtr/refinement.rs
@@ -1,21 +1,15 @@
-use crate::ancestral::gtr_inference_dense::{accumulate_mutation_counts, get_branch_mutation_matrix};
 use crate::ancestral::marginal::{marginal_backward, update_marginal};
-use crate::constants::SUPERTINY_NUMBER;
 use crate::gtr::gtr::{GTR, GTRParams};
-use crate::gtr::infer_gtr::common::{
-  InferGtrOptions, InferGtrResult, MutationCounts, infer_gtr_impl, is_profile_informative,
-};
-use crate::partition::marginal_core::MarginalPartition;
-use crate::partition::traits::PartitionMarginalPasses;
+use crate::gtr::infer_gtr::common::{InferGtrOptions, InferGtrResult, infer_gtr_impl};
+use crate::partition::traits::{HasGtr, PartitionMarginalPasses, TransitionCounting};
 use eyre::Report;
 use log::{debug, info, warn};
-use ndarray::{Array1, Array2};
+use ndarray::Array1;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
-use treetime_utils::array::ndarray::argmax_first;
 
 pub fn refine_gtr_iterative<N, E, P>(
   graph: &Graph<N, E, ()>,
@@ -28,46 +22,46 @@ pub fn refine_gtr_iterative<N, E, P>(
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
-  P: MarginalPartition<N, E> + PartitionMarginalPasses<N, E>,
+  P: TransitionCounting<N, E> + PartitionMarginalPasses<N, E> + HasGtr,
 {
-  let n_states = partition.read_arc().marginal_data().gtr.pi.len();
+  let n_states = partition.read_arc().gtr().pi.len();
   let options = InferGtrOptions {
     fixed_pi: fixed_pi.cloned(),
     pc,
     ..InferGtrOptions::default()
   };
 
-  let counts = count_transitions(graph, partition)?;
+  let counts = partition.read_arc().count_transitions(graph)?;
   let result = infer_gtr_impl(&counts, &options)?;
-  partition.write_arc().marginal_data_mut().gtr = build_gtr_from_inference(n_states, &result)?;
+  *partition.write_arc().gtr_mut() = build_gtr_from_inference(n_states, &result)?;
   debug!(
     "GTR refinement: initial inference, mu = {:.6}",
-    partition.read_arc().marginal_data().gtr.mu
+    partition.read_arc().gtr().mu
   );
 
   optimize_gtr_rate(graph, partition)?;
   debug!(
     "GTR refinement: initial rate optimization, mu = {:.6}",
-    partition.read_arc().marginal_data().gtr.mu
+    partition.read_arc().gtr().mu
   );
 
   for i in 0..iterations {
-    let counts = count_transitions(graph, partition)?;
+    let counts = partition.read_arc().count_transitions(graph)?;
     let result = infer_gtr_impl(&counts, &options)?;
-    partition.write_arc().marginal_data_mut().gtr = build_gtr_from_inference(n_states, &result)?;
+    *partition.write_arc().gtr_mut() = build_gtr_from_inference(n_states, &result)?;
 
     optimize_gtr_rate(graph, partition)?;
     debug!(
       "GTR refinement: iteration {i}, mu = {:.6}",
-      partition.read_arc().marginal_data().gtr.mu
+      partition.read_arc().gtr().mu
     );
   }
 
   if let Some(correction) = sampling_bias_correction {
-    partition.write_arc().marginal_data_mut().gtr.mu *= correction;
+    partition.write_arc().gtr_mut().mu *= correction;
     info!(
       "Applied sampling bias correction {correction:.4}, mu = {:.6}",
-      partition.read_arc().marginal_data().gtr.mu
+      partition.read_arc().gtr().mu
     );
   }
 
@@ -75,52 +69,13 @@ where
   let log_lh = update_marginal(graph, partitions)?;
 
   let guard = partition.read_arc();
-  let data = guard.marginal_data();
+  let gtr = guard.gtr();
   info!(
     "GTR refinement: final log likelihood = {log_lh:.4}, mu = {:.6}, pi = {:?}",
-    data.gtr.mu, data.gtr.pi
+    gtr.mu, gtr.pi
   );
 
   Ok(log_lh)
-}
-
-fn count_transitions<N, E, P>(graph: &Graph<N, E, ()>, partition: &Arc<RwLock<P>>) -> Result<MutationCounts, Report>
-where
-  N: GraphNode + Named,
-  E: EdgeOptimizeOps,
-  P: MarginalPartition<N, E>,
-{
-  let guard = partition.read_arc();
-  let data = guard.marginal_data();
-  let n_states = data.gtr.pi.len();
-  let mut nij = Array2::zeros((n_states, n_states));
-  let mut Ti = Array1::zeros(n_states);
-
-  for edge in graph.get_edges() {
-    let edge_arc = edge.read_arc();
-    let branch_length = data.effective_branch_length(edge_arc.payload().read_arc().branch_length().unwrap_or(0.0));
-    let edge_key = edge_arc.key();
-
-    let edge_data = &data.edges[&edge_key];
-
-    let exp_qt = data.gtr.expQt(branch_length) + SUPERTINY_NUMBER;
-    let mut_stack = get_branch_mutation_matrix(&edge_data.msg_to_child.dis, &edge_data.msg_to_parent.dis, &exp_qt);
-    accumulate_mutation_counts(&mut_stack, branch_length, &mut nij, &mut Ti);
-  }
-
-  let root = graph.get_exactly_one_root()?;
-  let root_key = root.read_arc().key();
-  let root_profile = data.nodes[&root_key].profile.dis.row(0);
-  let mut root_state = Array1::zeros(n_states);
-  if is_profile_informative(root_profile, n_states) {
-    if let Some(root_idx) = argmax_first(&root_profile) {
-      root_state[root_idx] = 1.0;
-    }
-  }
-
-  nij.diag_mut().fill(0.0);
-
-  Ok(MutationCounts { nij, Ti, root_state })
 }
 
 fn build_gtr_from_inference(n_states: usize, result: &InferGtrResult) -> Result<GTR, Report> {
@@ -136,9 +91,9 @@ fn optimize_gtr_rate<N, E, P>(graph: &Graph<N, E, ()>, partition: &Arc<RwLock<P>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
-  P: MarginalPartition<N, E> + PartitionMarginalPasses<N, E>,
+  P: PartitionMarginalPasses<N, E> + HasGtr,
 {
-  let old_mu = partition.read_arc().marginal_data().gtr.mu;
+  let old_mu = partition.read_arc().gtr().mu;
   let sqrt_old_mu = old_mu.sqrt();
   let root_key = graph.get_exactly_one_root()?.read_arc().key();
 
@@ -150,11 +105,8 @@ where
   let run_backward = |sqrt_mu: f64| -> f64 {
     {
       let mut guard = partition.write_arc();
-      let data = guard.marginal_data_mut();
-      data.gtr.mu = sqrt_mu * sqrt_mu;
-      for node_data in data.nodes.values_mut() {
-        node_data.profile.log_lh = 0.0;
-      }
+      guard.gtr_mut().mu = sqrt_mu * sqrt_mu;
+      guard.reset_node_log_likelihoods();
     }
     match marginal_backward(graph, partitions) {
       Ok(()) => -partition.read_arc().get_log_lh(root_key),
@@ -180,11 +132,11 @@ where
     run_backward(optimal_sqrt_mu);
     debug!(
       "GTR rate optimization: optimized mu = {:.6} (from {:.6})",
-      partition.read_arc().marginal_data().gtr.mu,
+      partition.read_arc().gtr().mu,
       old_mu
     );
   } else {
-    partition.write_arc().marginal_data_mut().gtr.mu = old_mu;
+    partition.write_arc().gtr_mut().mu = old_mu;
     debug!("GTR rate optimization: skipped (no bracket), keeping mu = {old_mu:.6}");
   }
 

--- a/packages/treetime/src/partition/marginal_core.rs
+++ b/packages/treetime/src/partition/marginal_core.rs
@@ -1,13 +1,17 @@
+use crate::ancestral::gtr_inference_dense::{accumulate_mutation_counts, get_branch_mutation_matrix};
+use crate::constants::SUPERTINY_NUMBER;
 use crate::gtr::gtr::GTR;
+use crate::gtr::infer_gtr::common::{MutationCounts, is_profile_informative};
 use crate::partition::dense::{DenseEdgePartition, DenseNodePartition, DenseSeqDistribution, DenseSeqInfo};
 use eyre::Report;
 use itertools::izip;
 use ndarray::prelude::*;
 use std::collections::BTreeMap;
-use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
+use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey, HasBranchLength};
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
+use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::array::softmax_with_log_norm::softmax_with_log_norm;
 use treetime_utils::collections::container::get_exactly_one;
 
@@ -187,6 +191,48 @@ pub fn normalize_inplace(dis: &mut Array2<f64>) -> f64 {
     }
   }
   log_lh
+}
+
+/// Count posterior-weighted transitions from `MarginalData`.
+///
+/// Shared by dense and discrete partitions (both store full profile matrices).
+pub fn count_transitions_from_marginal_data<N, E>(
+  data: &MarginalData,
+  graph: &Graph<N, E, ()>,
+) -> Result<MutationCounts, Report>
+where
+  N: GraphNode,
+  E: GraphEdge + HasBranchLength,
+{
+  let n_states = data.gtr.pi.len();
+  let mut nij = Array2::zeros((n_states, n_states));
+  let mut Ti = Array1::zeros(n_states);
+
+  for edge in graph.get_edges() {
+    let edge_arc = edge.read_arc();
+    let branch_length = data.effective_branch_length(edge_arc.payload().read_arc().branch_length().unwrap_or(0.0));
+    let edge_key = edge_arc.key();
+
+    let edge_data = &data.edges[&edge_key];
+
+    let exp_qt = data.gtr.expQt(branch_length) + SUPERTINY_NUMBER;
+    let mut_stack = get_branch_mutation_matrix(&edge_data.msg_to_child.dis, &edge_data.msg_to_parent.dis, &exp_qt);
+    accumulate_mutation_counts(&mut_stack, branch_length, &mut nij, &mut Ti);
+  }
+
+  let root = graph.get_exactly_one_root()?;
+  let root_key = root.read_arc().key();
+  let root_profile = data.nodes[&root_key].profile.dis.row(0);
+  let mut root_state = Array1::zeros(n_states);
+  if is_profile_informative(root_profile, n_states) {
+    if let Some(root_idx) = argmax_first(&root_profile) {
+      root_state[root_idx] = 1.0;
+    }
+  }
+
+  nij.diag_mut().fill(0.0);
+
+  Ok(MutationCounts { nij, Ti, root_state })
 }
 
 pub fn normalize_from_log(log_dis: &Array2<f64>) -> (Array2<f64>, f64) {

--- a/packages/treetime/src/partition/marginal_dense.rs
+++ b/packages/treetime/src/partition/marginal_dense.rs
@@ -1,15 +1,17 @@
 use crate::alphabet::alphabet::Alphabet;
 use crate::constants::MIN_BRANCH_LENGTH_FRACTION;
 use crate::gtr::gtr::GTR;
+use crate::gtr::infer_gtr::common::MutationCounts;
 use crate::make_report;
 use crate::partition::dense::{DenseEdgePartition, DenseNodePartition, DenseSeqDistribution, DenseSeqInfo};
 use crate::partition::marginal_core::{
-  MarginalData, MarginalPartition, marginal_process_node_backward, marginal_process_node_forward,
+  MarginalData, MarginalPartition, count_transitions_from_marginal_data, marginal_process_node_backward,
+  marginal_process_node_forward,
 };
 use crate::partition::optimization_contribution::OptimizationContribution;
 use crate::partition::traits::{
   BranchTopology, HasGtr, HasLogLh, PartitionBranchOps, PartitionMarginalOps, PartitionMarginalPasses,
-  PartitionOptimizeOps, PartitionRerootOps, PartitionTimetreeOps,
+  PartitionOptimizeOps, PartitionRerootOps, PartitionTimetreeOps, TransitionCounting,
 };
 use crate::seq::indel::{resolve_indels_backward, resolve_indels_forward};
 use crate::seq::mutation::Sub;
@@ -75,9 +77,25 @@ impl HasLogLh for PartitionMarginalDense {
   fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
     self.data.nodes.get(&node_key).map_or(0.0, |node| node.profile.log_lh)
   }
+
+  fn reset_node_log_likelihoods(&mut self) {
+    for node_data in self.data.nodes.values_mut() {
+      node_data.profile.log_lh = 0.0;
+    }
+  }
 }
 
 impl PartitionRerootOps for PartitionMarginalDense {}
+
+impl<N, E> TransitionCounting<N, E> for PartitionMarginalDense
+where
+  N: GraphNode,
+  E: EdgeOptimizeOps,
+{
+  fn count_transitions(&self, graph: &Graph<N, E, ()>) -> Result<MutationCounts, Report> {
+    count_transitions_from_marginal_data(&self.data, graph)
+  }
+}
 
 impl PartitionBranchOps for PartitionMarginalDense {
   fn sequence_length(&self) -> usize {

--- a/packages/treetime/src/partition/marginal_discrete.rs
+++ b/packages/treetime/src/partition/marginal_discrete.rs
@@ -1,11 +1,13 @@
 use crate::gtr::gtr::GTR;
+use crate::gtr::infer_gtr::common::MutationCounts;
 use crate::make_error;
 use crate::partition::dense::{DenseEdgePartition, DenseNodePartition, DenseSeqDistribution, DenseSeqInfo};
 use crate::partition::discrete_states::DiscreteStates;
 use crate::partition::marginal_core::{
-  MarginalData, MarginalPartition, marginal_process_node_backward, marginal_process_node_forward,
+  MarginalData, MarginalPartition, count_transitions_from_marginal_data, marginal_process_node_backward,
+  marginal_process_node_forward,
 };
-use crate::partition::traits::{HasGtr, HasLogLh, PartitionMarginalPasses};
+use crate::partition::traits::{HasGtr, HasLogLh, PartitionMarginalPasses, TransitionCounting};
 use eyre::Report;
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -117,6 +119,22 @@ impl HasGtr for PartitionMarginalDiscrete {
 impl HasLogLh for PartitionMarginalDiscrete {
   fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
     self.data.nodes.get(&node_key).map_or(0.0, |node| node.profile.log_lh)
+  }
+
+  fn reset_node_log_likelihoods(&mut self) {
+    for node_data in self.data.nodes.values_mut() {
+      node_data.profile.log_lh = 0.0;
+    }
+  }
+}
+
+impl<N, E> TransitionCounting<N, E> for PartitionMarginalDiscrete
+where
+  N: GraphNode,
+  E: EdgeOptimizeOps,
+{
+  fn count_transitions(&self, graph: &Graph<N, E, ()>) -> Result<MutationCounts, Report> {
+    count_transitions_from_marginal_data(&self.data, graph)
   }
 }
 

--- a/packages/treetime/src/partition/marginal_sparse.rs
+++ b/packages/treetime/src/partition/marginal_sparse.rs
@@ -1,15 +1,18 @@
 use crate::alphabet::alphabet::Alphabet;
+use crate::constants::SUPERTINY_NUMBER;
 use crate::gtr::gtr::GTR;
+use crate::gtr::infer_gtr::common::{MutationCounts, is_profile_informative};
 use crate::partition::marginal_passes;
 use crate::partition::optimization_contribution::OptimizationContribution;
-use crate::partition::sparse::{SparseEdgePartition, SparseNodePartition, SparseSeqDistribution};
+use crate::partition::sparse::{SparseEdgePartition, SparseNodePartition, SparseSeqDistribution, VarPos};
 use crate::partition::traits::{
   BranchTopology, HasGtr, HasLogLh, PartitionBranchOps, PartitionMarginalOps, PartitionMarginalPasses,
-  PartitionOptimizeOps, PartitionRerootOps, PartitionTimetreeOps,
+  PartitionOptimizeOps, PartitionRerootOps, PartitionTimetreeOps, TransitionCounting,
 };
 use crate::seq::mutation::Sub;
 use crate::{make_error, make_internal_report};
 use eyre::Report;
+use ndarray::{Array1, Array2};
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
@@ -91,6 +94,169 @@ impl HasLogLh for PartitionMarginalSparse {
   fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
     self.nodes.get(&node_key).map_or(0.0, |node| node.profile.log_lh)
   }
+
+  fn reset_node_log_likelihoods(&mut self) {
+    for node_data in self.nodes.values_mut() {
+      node_data.profile.log_lh = 0.0;
+    }
+  }
+}
+
+impl<N, E> TransitionCounting<N, E> for PartitionMarginalSparse
+where
+  N: GraphNode,
+  E: EdgeOptimizeOps,
+{
+  fn count_transitions(&self, graph: &Graph<N, E, ()>) -> Result<MutationCounts, Report> {
+    let n_states = self.gtr.pi.len();
+    let min_bl = crate::constants::MIN_BRANCH_LENGTH_FRACTION / self.length as f64;
+    let mut nij = Array2::zeros((n_states, n_states));
+    let mut Ti = Array1::zeros(n_states);
+
+    for edge in graph.get_edges() {
+      let edge_arc = edge.read_arc();
+      let branch_length = edge_arc.payload().read_arc().branch_length().unwrap_or(0.0).max(min_bl);
+      let edge_key = edge_arc.key();
+      let edge_data = &self.edges[&edge_key];
+
+      let exp_qt = self.gtr.expQt(branch_length) + SUPERTINY_NUMBER;
+
+      accumulate_sparse_transitions(
+        &edge_data.msg_to_child,
+        &edge_data.msg_to_parent,
+        &exp_qt,
+        branch_length,
+        n_states,
+        &mut nij,
+        &mut Ti,
+      );
+    }
+
+    let root = graph.get_exactly_one_root()?;
+    let root_key = root.read_arc().key();
+    let root_profile = &self.nodes[&root_key].profile;
+    let mut root_state = Array1::zeros(n_states);
+    let root_dis = aggregate_sparse_profile(root_profile, n_states);
+    if is_profile_informative(root_dis.view(), n_states) {
+      if let Some(root_idx) = argmax_first(&root_dis.view()) {
+        root_state[root_idx] = 1.0;
+      }
+    }
+
+    nij.diag_mut().fill(0.0);
+
+    Ok(MutationCounts { nij, Ti, root_state })
+  }
+}
+
+fn accumulate_sparse_transitions(
+  msg_to_child: &SparseSeqDistribution,
+  msg_to_parent: &SparseSeqDistribution,
+  exp_qt: &Array2<f64>,
+  branch_length: f64,
+  n_states: usize,
+  nij: &mut Array2<f64>,
+  Ti: &mut Array1<f64>,
+) {
+  // Variable positions: marginal passes propagate variable sets symmetrically,
+  // so msg_to_parent and msg_to_child have the same variable positions.
+  for (pos, pp_var) in &msg_to_parent.variable {
+    let pc = msg_to_child
+      .variable
+      .get(pos)
+      .map_or_else(|| fixed_profile_for_var(msg_to_child, pp_var), |v| &v.dis);
+    accumulate_site_transition(&pp_var.dis, pc, exp_qt, branch_length, n_states, nij, Ti);
+  }
+
+  // Fixed positions: all positions with the same character share identical
+  // profiles. Accumulate once per character, weighted by count.
+  for (ch, parent_fixed) in &msg_to_parent.fixed {
+    let count = msg_to_parent.fixed_counts.get(*ch).unwrap_or(0);
+    if count == 0 {
+      continue;
+    }
+    let child_fixed = msg_to_child.fixed.get(ch).unwrap_or(parent_fixed);
+    accumulate_site_transition_weighted(parent_fixed, child_fixed, exp_qt, branch_length, n_states, nij, Ti, count);
+  }
+}
+
+fn fixed_profile_for_var<'a>(dist: &'a SparseSeqDistribution, var: &'a VarPos) -> &'a Array1<f64> {
+  dist.fixed.get(&var.state).unwrap_or(&var.dis)
+}
+
+fn accumulate_site_transition(
+  pp: &Array1<f64>,
+  pc: &Array1<f64>,
+  exp_qt: &Array2<f64>,
+  branch_length: f64,
+  n_states: usize,
+  nij: &mut Array2<f64>,
+  Ti: &mut Array1<f64>,
+) {
+  accumulate_site_transition_weighted(pp, pc, exp_qt, branch_length, n_states, nij, Ti, 1);
+}
+
+fn accumulate_site_transition_weighted(
+  pp: &Array1<f64>,
+  pc: &Array1<f64>,
+  exp_qt: &Array2<f64>,
+  branch_length: f64,
+  n_states: usize,
+  nij: &mut Array2<f64>,
+  Ti: &mut Array1<f64>,
+  weight: usize,
+) {
+  let weight = weight as f64;
+  let mut site_sum = 0.0;
+  let mut joint = Array2::zeros((n_states, n_states));
+
+  for i in 0..n_states {
+    for j in 0..n_states {
+      let val = pp[i] * exp_qt[[i, j]] * pc[j];
+      joint[[i, j]] = val;
+      site_sum += val;
+    }
+  }
+
+  if site_sum > 0.0 {
+    joint /= site_sum;
+  }
+
+  for i in 0..n_states {
+    for j in 0..n_states {
+      nij[[i, j]] += weight * joint[[i, j]];
+    }
+  }
+
+  for k in 0..n_states {
+    let mut parent_sum = 0.0;
+    let mut child_sum = 0.0;
+    for s in 0..n_states {
+      parent_sum += joint[[s, k]];
+      child_sum += joint[[k, s]];
+    }
+    Ti[k] += weight * 0.5 * branch_length * (parent_sum + child_sum);
+  }
+}
+
+fn aggregate_sparse_profile(profile: &SparseSeqDistribution, n_states: usize) -> Array1<f64> {
+  let mut result = Array1::zeros(n_states);
+  for var in profile.variable.values() {
+    if is_profile_informative(var.dis.view(), n_states) {
+      if let Some(idx) = argmax_first(&var.dis.view()) {
+        result[idx] += 1.0;
+      }
+    }
+  }
+  for (ch, fixed_profile) in &profile.fixed {
+    let count = profile.fixed_counts.get(*ch).unwrap_or(0) as f64;
+    if count > 0.0 && is_profile_informative(fixed_profile.view(), n_states) {
+      if let Some(idx) = argmax_first(&fixed_profile.view()) {
+        result[idx] += count;
+      }
+    }
+  }
+  result
 }
 
 impl PartitionRerootOps for PartitionMarginalSparse {

--- a/packages/treetime/src/partition/traits.rs
+++ b/packages/treetime/src/partition/traits.rs
@@ -1,5 +1,6 @@
 use crate::alphabet::alphabet::Alphabet;
 use crate::gtr::gtr::GTR;
+use crate::gtr::infer_gtr::common::MutationCounts;
 use crate::make_internal_error;
 use crate::make_internal_report;
 use crate::partition::optimization_contribution::OptimizationContribution;
@@ -199,8 +200,22 @@ pub trait PartitionCompressed: Sync + Send {
 }
 
 pub trait HasLogLh {
-  /// Get the log likelihood contribution for a given node
   fn get_log_lh(&self, node_key: GraphNodeKey) -> f64;
+
+  fn reset_node_log_likelihoods(&mut self);
+}
+
+/// Compute posterior-weighted transition counts from marginal profiles.
+///
+/// Each marginal partition type implements this over its native data layout:
+/// dense and discrete iterate `Array2<f64>` matrices, sparse iterates
+/// per-variable-site profiles and aggregates fixed-site contributions.
+pub trait TransitionCounting<N, E>: HasGtr + Send + Sync
+where
+  N: GraphNode,
+  E: EdgeOptimizeOps,
+{
+  fn count_transitions(&self, graph: &Graph<N, E, ()>) -> Result<MutationCounts, Report>;
 }
 
 /// Operations that `optimize` needs from a sequence partition.


### PR DESCRIPTION
- Depends on: `test/gtr-output-discrete-states`

`refine_gtr_iterative` required the `MarginalPartition` bound, which exposes the internal `marginal_data()` accessor. This couples refinement to the internal data layout rather than the operation it needs: counting posterior-weighted transitions.

Replace the `MarginalPartition` bound with a `TransitionCounting` trait. Dense and discrete partitions delegate to a shared implementation over full profile matrices. Sparse partitions iterate variable sites and aggregate fixed-site contributions weighted by character counts. The trait also adds `reset_node_log_likelihoods()` to `HasLogLh`, replacing direct field access in `optimize_gtr_rate`.

The ancestral command gains a `--gtr-iterations` flag (default 0). When >0 and `--model=infer`, `refine_gtr_iterative` runs after the initial marginal pass for both sparse and dense partitions. GTR JSON output writes the final model.

### Work items

- [x] Add `TransitionCounting` trait with `count_transitions()` method
- [x] Implement for dense and discrete via shared `count_transitions_from_marginal_data`
- [x] Implement for sparse: variable-site iteration + fixed-site weighted aggregation
- [x] Add `reset_node_log_likelihoods()` to `HasLogLh` trait (all 3 partition types)
- [x] Replace `MarginalPartition` bound in `refine_gtr_iterative` and `optimize_gtr_rate` with `TransitionCounting + HasGtr + PartitionMarginalPasses`
- [x] Add `--gtr-iterations` flag to ancestral command, wire into sparse and dense paths
- [x] Move `write_gtr_json` after refinement so output reflects final model

### Possible improvements

- [ ] Add convergence-based stopping (monitor log-likelihood delta) instead of fixed iteration count ([ancestral-iterative-gtr-refinement](https://github.com/neherlab/treetime/blob/223d1f5a/kb/proposals/ancestral-iterative-gtr-refinement.md))


