### PR TITLE
refactor: make GTR rate optimization configurable

### DIFF
--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -146,7 +146,7 @@ pub fn run_ancestral_reconstruction(
         update_marginal(&graph, &partitions)?;
 
         if *gtr_iterations > 0 && *model_name == GtrModelName::Infer {
-          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None)?;
+          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None, false)?;
         }
 
         progress.check_cancelled()?;
@@ -185,7 +185,7 @@ pub fn run_ancestral_reconstruction(
         update_marginal(&graph, &partitions)?;
 
         if *gtr_iterations > 0 {
-          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None)?;
+          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None, false)?;
         }
 
         progress.check_cancelled()?;

--- a/packages/treetime/src/gtr/refinement.rs
+++ b/packages/treetime/src/gtr/refinement.rs
@@ -18,6 +18,7 @@ pub fn refine_gtr_iterative<N, E, P>(
   fixed_pi: Option<&Array1<f64>>,
   pc: f64,
   sampling_bias_correction: Option<f64>,
+  optimize_rate: bool,
 ) -> Result<f64, Report>
 where
   N: GraphNode + Named,
@@ -39,18 +40,22 @@ where
     partition.read_arc().gtr().mu
   );
 
-  optimize_gtr_rate(graph, partition)?;
-  debug!(
-    "GTR refinement: initial rate optimization, mu = {:.6}",
-    partition.read_arc().gtr().mu
-  );
+  if optimize_rate {
+    optimize_gtr_rate(graph, partition)?;
+    debug!(
+      "GTR refinement: initial rate optimization, mu = {:.6}",
+      partition.read_arc().gtr().mu
+    );
+  }
 
   for i in 0..iterations {
     let counts = partition.read_arc().count_transitions(graph)?;
     let result = infer_gtr_impl(&counts, &options)?;
     *partition.write_arc().gtr_mut() = build_gtr_from_inference(n_states, &result)?;
 
-    optimize_gtr_rate(graph, partition)?;
+    if optimize_rate {
+      optimize_gtr_rate(graph, partition)?;
+    }
     debug!(
       "GTR refinement: iteration {i}, mu = {:.6}",
       partition.read_arc().gtr().mu

--- a/packages/treetime/src/mugration/mugration.rs
+++ b/packages/treetime/src/mugration/mugration.rs
@@ -155,6 +155,7 @@ pub fn execute_mugration(
     fixed_pi.as_ref(),
     pc.unwrap_or(1.0),
     sampling_bias_correction,
+    true,
   )?;
 
   let partition = Arc::into_inner(partition)


### PR DESCRIPTION
- Depends on: `refactor/move-gtr-counting-helpers`

`refine_gtr_iterative` unconditionally ran Brent-style optimization of the overall substitution rate after each GTR re-estimation, regardless of caller.

Add an `optimize_rate` flag to `refine_gtr_iterative`. Mugration passes `true`, ancestral `false`.

For multi-site sequence data, `infer_gtr_impl` already estimates the rate from large transition counts, so the extra Brent step is redundant for the ancestral command. Mugration infers a single discrete trait column where counts are small, so it keeps rate optimization for parity with v0's discrete-trait refinement loop.

### Work items

- [x] Add the `optimize_rate: bool` parameter to `refine_gtr_iterative`
- [x] Pass `true` from mugration and `false` from ancestral
