### PR TITLE
test: cover sparse transition counting and GTR iteration

### DIFF
--- a/packages/treetime/src/commands/ancestral/__tests__/mod.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/mod.rs
@@ -1,0 +1,1 @@
+mod test_smoke_gtr_iterations;

--- a/packages/treetime/src/commands/ancestral/__tests__/test_smoke_gtr_iterations.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_smoke_gtr_iterations.rs
@@ -1,0 +1,71 @@
+#[cfg(test)]
+mod tests {
+  use crate::commands::ancestral::args::TreetimeAncestralArgs;
+  use crate::commands::ancestral::run::run_ancestral_reconstruction;
+  use crate::gtr::get_gtr::GtrModelName;
+  use crate::progress::NoopProgress;
+  use eyre::Report;
+  use lazy_static::lazy_static;
+  use std::path::PathBuf;
+
+  lazy_static! {
+    static ref PROJECT_ROOT: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .parent()
+      .and_then(|p| p.parent())
+      .expect("Failed to find project root")
+      .to_path_buf();
+  }
+
+  #[test]
+  fn test_smoke_ancestral_gtr_iterations_sparse() -> Result<(), Report> {
+    let outdir = PROJECT_ROOT.join("tmp/test-gtr-iter-sparse");
+    std::fs::create_dir_all(&outdir)?;
+
+    let args = TreetimeAncestralArgs {
+      input_fastas: vec![PROJECT_ROOT.join("data/flu/h3n2/20/aln.fasta.xz")],
+      tree: PROJECT_ROOT.join("data/flu/h3n2/20/tree.nwk"),
+      model_name: GtrModelName::Infer,
+      gtr_iterations: 3,
+      outdir: outdir.clone(),
+      ..TreetimeAncestralArgs::default()
+    };
+
+    let result = run_ancestral_reconstruction(&args, &NoopProgress)?;
+
+    assert!(result.gtr.is_some());
+    let gtr = result.gtr.unwrap();
+    assert!(gtr.mu > 0.0, "mu should be positive after GTR iterations");
+
+    assert!(outdir.join("annotated_tree.nwk").exists());
+    assert!(outdir.join("ancestral_sequences.fasta").exists());
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_smoke_ancestral_gtr_iterations_dense() -> Result<(), Report> {
+    let outdir = PROJECT_ROOT.join("tmp/test-gtr-iter-dense");
+    std::fs::create_dir_all(&outdir)?;
+
+    let args = TreetimeAncestralArgs {
+      input_fastas: vec![PROJECT_ROOT.join("data/flu/h3n2/20/aln.fasta.xz")],
+      tree: PROJECT_ROOT.join("data/flu/h3n2/20/tree.nwk"),
+      model_name: GtrModelName::Infer,
+      dense: Some(true),
+      gtr_iterations: 3,
+      outdir: outdir.clone(),
+      ..TreetimeAncestralArgs::default()
+    };
+
+    let result = run_ancestral_reconstruction(&args, &NoopProgress)?;
+
+    assert!(result.gtr.is_some());
+    let gtr = result.gtr.unwrap();
+    assert!(gtr.mu > 0.0, "mu should be positive after GTR iterations");
+
+    assert!(outdir.join("annotated_tree.nwk").exists());
+    assert!(outdir.join("ancestral_sequences.fasta").exists());
+
+    Ok(())
+  }
+}

--- a/packages/treetime/src/commands/ancestral/mod.rs
+++ b/packages/treetime/src/commands/ancestral/mod.rs
@@ -1,3 +1,6 @@
 pub mod args;
 pub mod result;
 pub mod run;
+
+#[cfg(test)]
+mod __tests__;

--- a/packages/treetime/src/partition/__tests__/mod.rs
+++ b/packages/treetime/src/partition/__tests__/mod.rs
@@ -1,1 +1,2 @@
 mod test_partition_marginal_sparse;
+mod test_sparse_transition_counting;

--- a/packages/treetime/src/partition/__tests__/test_sparse_transition_counting.rs
+++ b/packages/treetime/src/partition/__tests__/test_sparse_transition_counting.rs
@@ -1,0 +1,139 @@
+#[cfg(test)]
+mod tests {
+  use crate::alphabet::alphabet::{Alphabet, AlphabetName};
+  use crate::ancestral::fitch::create_fitch_partition;
+  use crate::ancestral::marginal::update_marginal;
+  use crate::gtr::get_gtr::{JC69Params, jc69};
+  use crate::partition::traits::TransitionCounting;
+  use crate::payload::ancestral::GraphAncestral;
+  use eyre::Report;
+  use indoc::indoc;
+  use lazy_static::lazy_static;
+  use parking_lot::RwLock;
+  use std::sync::Arc;
+  use treetime_io::fasta::read_many_fasta_str;
+  use treetime_io::nwk::nwk_read_str;
+  use treetime_utils::{pretty_assert_array_nonneg, pretty_assert_array_positive};
+
+  lazy_static! {
+    static ref NUC_ALPHABET: Alphabet = Alphabet::new(AlphabetName::Nuc).unwrap();
+  }
+
+  fn setup_sparse(
+    tree_nwk: &str,
+    fasta: &str,
+  ) -> Result<
+    (
+      GraphAncestral,
+      Arc<RwLock<crate::partition::marginal_sparse::PartitionMarginalSparse>>,
+    ),
+    Report,
+  > {
+    let alphabet = NUC_ALPHABET.clone();
+    let aln = read_many_fasta_str(fasta, &alphabet)?;
+    let graph: GraphAncestral = nwk_read_str(tree_nwk)?;
+    let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
+    let gtr = jc69(JC69Params {
+      alphabet: AlphabetName::Nuc,
+      ..JC69Params::default()
+    })?;
+    let partition = Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, &graph)?));
+    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    Ok((graph, partition))
+  }
+
+  #[test]
+  fn test_sparse_transition_counting_nij_nonneg() -> Result<(), Report> {
+    let (graph, partition) = setup_sparse(
+      "((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;",
+      indoc! {r#"
+      >A
+      ACATCGCCGTAGAC
+      >B
+      GCATCCCTGTAGGG
+      >C
+      CCGGCGATGTGTTG
+      >D
+      TCGGCCGTGTGTTG
+      "#},
+    )?;
+
+    let counts = partition.read_arc().count_transitions(&graph)?;
+
+    pretty_assert_array_nonneg!(counts.nij);
+    pretty_assert_array_nonneg!(counts.Ti);
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_sparse_transition_counting_ti_positive() -> Result<(), Report> {
+    let (graph, partition) = setup_sparse(
+      "((A:0.1,B:0.1)AB:0.05,(C:0.1,D:0.1)CD:0.05)root:0.0;",
+      indoc! {r#"
+      >A
+      AACCGGTT
+      >B
+      AACCGGTT
+      >C
+      AACCGGTT
+      >D
+      AACCGGTT
+      "#},
+    )?;
+
+    let counts = partition.read_arc().count_transitions(&graph)?;
+
+    pretty_assert_array_positive!(counts.Ti);
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_sparse_transition_counting_diagonal_zero() -> Result<(), Report> {
+    let (graph, partition) = setup_sparse(
+      "((A:0.1,B:0.2)AB:0.1,(C:0.2,D:0.12)CD:0.05)root:0.01;",
+      indoc! {r#"
+      >A
+      ACATCGCC
+      >B
+      GCATCCCT
+      >C
+      CCGGCGAT
+      >D
+      TCGGCCGT
+      "#},
+    )?;
+
+    let counts = partition.read_arc().count_transitions(&graph)?;
+
+    for i in 0..counts.nij.nrows() {
+      assert_eq!(0.0, counts.nij[[i, i]], "diagonal nij[{i},{i}] should be zero");
+    }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_sparse_transition_counting_root_state_sums_to_length() -> Result<(), Report> {
+    let (graph, partition) = setup_sparse(
+      "((A:0.1,B:0.1)AB:0.05,(C:0.1,D:0.1)CD:0.05)root:0.0;",
+      indoc! {r#"
+      >A
+      AAAAAAAA
+      >B
+      AAAAAAAA
+      >C
+      AAAAAAAA
+      >D
+      CAAAAAAA
+      "#},
+    )?;
+
+    let counts = partition.read_arc().count_transitions(&graph)?;
+
+    assert!(counts.root_state.sum() > 0.0, "root_state should be populated");
+
+    Ok(())
+  }
+}


### PR DESCRIPTION
- Depends on: `refactor/gtr-rate-optimization-configurable`

The sparse `TransitionCounting` implementation and the ancestral iterative GTR path had no direct test coverage after the trait extraction.

Add unit tests for the sparse transition counts and smoke tests for ancestral GTR iteration on both the sparse and dense paths.

### Work items

- [x] Add sparse `count_transitions` unit tests asserting non-negative off-diagonal counts, positive `Ti`, zero diagonal, and populated root state
- [x] Add ancestral `--gtr-iterations` smoke tests for the sparse and dense paths on `flu/h3n2/20`
