### PR TITLE
docs: catalog codebase duplication and cleanup work

### DIFF
--- a/kb/issues/M-coalescent-skyline-reimplements-piecewise-linear-eval.md
+++ b/kb/issues/M-coalescent-skyline-reimplements-piecewise-linear-eval.md
@@ -1,0 +1,18 @@
+# Skyline build_tc_distribution reimplements PiecewiseLinearFn::eval
+
+`build_tc_distribution` in `coalescent/skyline.rs` contains a closure that performs boundary clamping, `partition_point` lookup, and linear interpolation -- the same algorithm as `PiecewiseLinearFn::eval()` in `treetime-grid`. The skyline module already imports from `treetime-grid` but does not use `PiecewiseLinearFn` for this evaluation.
+
+## Locations
+
+- `packages/treetime/src/coalescent/skyline.rs:230-252:` inline closure reimplementing piecewise linear evaluation over `time_grid` and `tc_values`
+- `packages/treetime-grid/src/piecewise_linear_fn.rs:75-95:` `fn eval()` -- identical algorithm (boundary clamp, `partition_point`, linear interpolation)
+
+Both use the same steps: check boundary conditions, find interval via `partition_point`, compute interpolation fraction `alpha = (t - t0) / (t1 - t0)`, return `v0 + alpha * (v1 - v0)`.
+
+## Impact
+
+If the interpolation algorithm is corrected or extended (e.g., extrapolation behavior), the inline version won't receive the fix.
+
+## Action
+
+Build a `PiecewiseLinearFn` from `(time_grid, tc_values)` and wrap its `.eval()` method in the `DistributionFormula` closure.

--- a/kb/issues/M-gtr-hand-rolled-brent-minimizer-duplication.md
+++ b/kb/issues/M-gtr-hand-rolled-brent-minimizer-duplication.md
@@ -1,0 +1,20 @@
+# GTR rate optimization uses hand-rolled Brent instead of argmin wrapper
+
+`gtr/refinement.rs` contains a 100-line manual Brent minimizer (`brent_minimize_bracketed`) for GTR rate optimization. A production-quality argmin-based Brent wrapper already exists in `optimize/method_brent.rs` with proper error handling via `Result<f64, Report>`, machine-epsilon tolerance, and sqrt-space transform support (`brent_sqrt_inner`).
+
+The hand-rolled version returns a bare `f64` with no error propagation, uses a fixed tolerance of `1e-8` vs machine epsilon, allows 100 iterations vs 50, and silently returns the best guess on exhaustion.
+
+## Locations
+
+- `packages/treetime/src/gtr/refinement.rs:147-247:` `fn brent_minimize_bracketed()` -- hand-rolled 100-line Brent with golden-section fallback
+- `packages/treetime/src/gtr/refinement.rs:130:` sole production caller, in `optimize_gtr_rate()`, operating in sqrt(mu) space
+- `packages/treetime/src/optimize/method_brent.rs:41-67:` `fn brent_inner()` -- argmin `BrentOpt` wrapper with `Result<f64, Report>`
+- `packages/treetime/src/optimize/method_brent.rs:85-114:` `fn brent_sqrt_inner()` -- same wrapper with sqrt-space transform (mirrors `optimize_gtr_rate` usage)
+
+## Impact
+
+Two independent implementations of the same algorithm with divergent error handling and tolerance. Fixes to one do not propagate to the other. The hand-rolled version's silent failure mode masks optimization failures.
+
+## Action
+
+Replace `brent_minimize_bracketed` with the argmin wrapper. The sqrt-space transform in `optimize_gtr_rate` maps directly to `brent_sqrt_inner`. Requires adapting the cost function interface from `FnMut(f64) -> f64` to argmin's `CostFunction` trait.

--- a/kb/issues/N-ancestral-dead-code-infer-gtr-dense.md
+++ b/kb/issues/N-ancestral-dead-code-infer-gtr-dense.md
@@ -1,0 +1,18 @@
+# Dead production code in gtr_inference_dense.rs
+
+`infer_gtr_dense` and its helper `get_mutation_counts_dense` in `gtr_inference_dense.rs` carry `#[allow(dead_code)]` annotations. `infer_gtr_dense` has no production callers. `get_mutation_counts_dense` is used only in tests.
+
+The dense GTR inference functionality overlaps with mugration's `count_transitions_discrete`. The active sparse GTR inference path is `gtr_inference.rs`.
+
+## Locations
+
+- `packages/treetime/src/ancestral/gtr_inference_dense.rs:28-43:` `fn infer_gtr_dense()` -- `#[allow(dead_code)]`, no production callers
+- `packages/treetime/src/ancestral/gtr_inference_dense.rs:145:` `fn get_mutation_counts_dense()` -- `#[allow(dead_code)]`, used only in tests
+
+## Impact
+
+Dead code increases maintenance surface. The `#[allow(dead_code)]` annotations suppress compiler warnings that would otherwise flag the unused code.
+
+## Action
+
+Evaluate whether the dense GTR inference path is needed for future work. If not, remove the dead code. If the test usage of `get_mutation_counts_dense` is valuable, consider whether those tests should use the sparse path instead.

--- a/kb/issues/N-ancestral-parallel-traversal-error-boilerplate.md
+++ b/kb/issues/N-ancestral-parallel-traversal-error-boilerplate.md
@@ -1,0 +1,36 @@
+# Ancestral parallel traversals repeat identical error-capture boilerplate
+
+Three parallel traversal sites in ancestral reconstruction repeat a 10-line error-capture pattern: create `Arc<Mutex<Option<Report>>>`, execute `par_iter` closure with error capture, call `extract_parallel_error`.
+
+## Locations
+
+- `packages/treetime/src/ancestral/marginal.rs:83:` forward pass error capture
+- `packages/treetime/src/ancestral/marginal.rs:119:` backward pass error capture
+- `packages/treetime/src/ancestral/fitch.rs:201:` Fitch pass error capture
+
+All three follow the identical pattern:
+
+```rust
+let error: Arc<Mutex<Option<Report>>> = Arc::new(Mutex::new(None));
+graph.par_iter_...(|mut node| {
+  if let Err(e) = operation(&mut node) {
+    let mut guard = error.lock();
+    if guard.is_none() { *guard = Some(e); }
+    return GraphTraversalContinuation::Stop;
+  }
+  GraphTraversalContinuation::Continue
+});
+extract_parallel_error(error)?;
+```
+
+## Impact
+
+Pure maintainability. The pattern is correct and consistent. Adding a new parallel traversal requires copying the boilerplate correctly.
+
+## Action
+
+Extract `par_traversal_with_error(graph, direction, op) -> Result<()>` helper that encapsulates the `Arc<Mutex<Option<Report>>>` + closure + `extract_parallel_error` pattern.
+
+## Related
+
+- `kb/issues/M-timetree-parallel-traversal-unwrap-panic.md` -- timetree traversals use `.unwrap()` instead of this pattern (policy divergence)

--- a/kb/issues/N-coalescent-event-setup-duplication.md
+++ b/kb/issues/N-coalescent-event-setup-duplication.md
@@ -1,0 +1,29 @@
+# Coalescent event setup repeated at four sites
+
+Four coalescent functions repeat a 5-line setup: `collect_tree_events(graph)` -> calendar-to-TBP time conversion -> `compute_lineage_count_distribution`.
+
+## Locations
+
+- `packages/treetime/src/coalescent/coalescent.rs:70-76:` `compute_coalescent_contributions()`
+- `packages/treetime/src/coalescent/total_lh.rs:38-44:` `compute_coalescent_total_lh()`
+- `packages/treetime/src/coalescent/optimize_tc.rs:104-110:` `TcCostFunction::new()`
+- `packages/treetime/src/coalescent/skyline.rs:86-92:` `optimize_skyline()`
+
+Identical pattern at all sites:
+
+```rust
+let (present_time, events_calendar) = collect_tree_events(graph)?;
+let events_tbp: Vec<_> = events_calendar
+  .iter()
+  .map(|(t, delta)| (t.to_tbp(present_time), *delta))
+  .collect();
+let lineage_counts = compute_lineage_count_distribution(&events_tbp)?;
+```
+
+## Impact
+
+Pure maintainability. If the event collection or time conversion logic changes, four sites need updating.
+
+## Action
+
+Extract a `CoalescentPrecomputed` struct with a `from_graph(graph) -> Result<Self>` constructor that bundles `present_time`, `events_tbp`, and `lineage_counts`.

--- a/kb/issues/N-core-edge-to-graphviz-identical-impls.md
+++ b/kb/issues/N-core-edge-to-graphviz-identical-impls.md
@@ -1,0 +1,18 @@
+# EdgeToGraphviz trait has four identical implementations
+
+Four edge types implement `EdgeToGraphviz` with identical method bodies: `to_graphviz_label()` formats `branch_length()` via `format_weight`, `to_graphviz_weight()` returns `branch_length()`. All types already implement `HasBranchLength`.
+
+## Locations
+
+- `packages/treetime/src/payload/timetree.rs:262:` `impl EdgeToGraphviz for EdgeTimetree`
+- `packages/treetime/src/payload/ancestral.rs:94:` `impl EdgeToGraphviz for EdgeAncestral`
+- `packages/treetime/src/clock/clock_graph.rs:106:` `impl EdgeToGraphviz for EdgeClock`
+- `packages/treetime/src/test_utils/graph_fixtures.rs:67:` `impl EdgeToGraphviz for TestEdge`
+
+## Impact
+
+Pure maintainability. New edge types require copying the same boilerplate.
+
+## Action
+
+Add a blanket `impl<T: HasBranchLength> EdgeToGraphviz for T` or provide default method implementations on the trait itself. Types needing custom graphviz rendering can override.

--- a/kb/issues/N-core-gap-fill-args-duplication.md
+++ b/kb/issues/N-core-gap-fill-args-duplication.md
@@ -1,0 +1,25 @@
+# Gap-fill argument logic duplicated across three commands
+
+Three command argument structs implement identical `effective_gap_fill()` methods that return `GapFill::None` when `keep_overhangs` is set, otherwise return the configured `gap_fill` value.
+
+## Locations
+
+- `packages/treetime/src/commands/ancestral/args.rs:133-139:` `TreetimeAncestralArgs::effective_gap_fill()`
+- `packages/treetime/src/commands/optimize/args.rs:127-133:` `TreetimeOptimizeArgs::effective_gap_fill()`
+- `packages/treetime/src/commands/timetree/args.rs:310-316:` `TreetimeTimetreeArgs::effective_gap_fill()`
+
+All identical:
+
+```rust
+fn effective_gap_fill(&self) -> GapFill {
+  if self.keep_overhangs { GapFill::None } else { self.gap_fill }
+}
+```
+
+## Impact
+
+Trivial duplication. User-facing CLI policy logic that must stay consistent across commands.
+
+## Action
+
+Extract a shared clap-flattenable struct `GapFillArgs { gap_fill: GapFill, keep_overhangs: bool }` with `effective_gap_fill()` implemented once. Each command embeds the shared struct via `#[command(flatten)]`.

--- a/kb/issues/N-grid-piecewise-function-shared-skeleton.md
+++ b/kb/issues/N-grid-piecewise-function-shared-skeleton.md
@@ -1,0 +1,16 @@
+# Piecewise constant and linear function structs share identical skeleton
+
+`PiecewiseConstantFn` (100 lines) and `PiecewiseLinearFn` (136 lines) in `treetime-grid` have identical struct layout (`breakpoints: Array1<f64>`, `values: Array1<f64>`), identical `new()` validation (ascending breakpoint check via `windows(2).all()`), identical `breakpoints()` accessor, and identical `eval_many()` tandem-sweep implementation. Only `eval()` differs (step lookup vs linear interpolation) and the value-count invariant (`n+1` constant segments vs `n` linear segments).
+
+## Locations
+
+- `packages/treetime-grid/src/piecewise_constant_fn.rs:1-100:` step function
+- `packages/treetime-grid/src/piecewise_linear_fn.rs:1-136:` linear interpolation function
+
+## Impact
+
+Pure maintainability. Changes to breakpoint validation, storage, or `eval_many` require updating both files.
+
+## Action
+
+Extract a common `PiecewiseFnBase` struct with shared fields, validation, and `eval_many()`. `PiecewiseConstantFn` and `PiecewiseLinearFn` wrap or delegate to the base, providing only their specific `eval()` and value-count invariant.

--- a/kb/issues/N-marginal-inline-1d-normalization-duplication.md
+++ b/kb/issues/N-marginal-inline-1d-normalization-duplication.md
@@ -1,0 +1,29 @@
+# Inline 1D normalization duplicated in sparse marginal passes
+
+Two adjacent code blocks in `marginal_passes.rs` perform identical 6-line sum-and-divide normalization with the same `norm > 0.0 && norm.is_finite()` guard and uniform-profile fallback. This is the 1D specialization of the 2D `normalize_inplace` in `marginal_core.rs`.
+
+## Locations
+
+- `packages/treetime/src/partition/marginal_passes.rs:402-409:` variable-sites normalization loop
+- `packages/treetime/src/partition/marginal_passes.rs:416-423:` fixed-sites normalization loop
+
+Both blocks:
+
+```rust
+let norm = dis.sum();
+if norm > 0.0 && norm.is_finite() {
+  delta_ll += norm.ln();
+  dis / norm
+} else {
+  delta_ll += NEG_INFINITY;
+  uniform
+}
+```
+
+## Impact
+
+If the normalization logic changes (e.g., handling of subnormals, log-space conversion), both blocks need identical updates.
+
+## Action
+
+Extract a `normalize_1d_inplace(dis, uniform) -> (Array1<f64>, f64)` helper that returns the normalized distribution and log-likelihood contribution.

--- a/kb/issues/N-optimize-argmin-observer-boilerplate.md
+++ b/kb/issues/N-optimize-argmin-observer-boilerplate.md
@@ -1,0 +1,27 @@
+# Argmin observer structs duplicated across three optimization sites
+
+Three near-identical `Observe<I>` implementations exist for logging argmin optimization progress. Each defines a unit struct with identical trait bounds, identical body (log on multiples of 10 and early iterations), differing only in label string and early-iteration threshold (3 vs 5).
+
+## Locations
+
+- `packages/treetime/src/coalescent/optimize_tc.rs:139-159:` `TcOptimizationObserver` - logs if `iter % 10 == 0 || iter <= 3`, label `"Tc optimization"`
+- `packages/treetime/src/clock/find_best_root/method_brent.rs:13-33:` `BrentObserver` - logs if `iter % 10 == 0 || iter <= 5`, label `"Brent"`
+- `packages/treetime/src/clock/find_best_root/method_golden_section.rs:13-33:` `GoldenSectionObserver` - logs if `iter % 10 == 0 || iter <= 5`, label `"Golden Section"`
+
+All share identical trait bounds:
+
+```rust
+impl<I> Observe<I> for XxxObserver
+where
+  I: State,
+  <I as State>::Param: std::fmt::Debug,
+  <I as State>::Float: std::fmt::LowerExp,
+```
+
+## Impact
+
+Pure maintainability. Adding a new optimizer requires copying the boilerplate.
+
+## Action
+
+Extract a single `OptimizationObserver { label: &'static str, early_threshold: u64 }` struct with one `Observe` implementation. All three sites instantiate with their label and threshold.

--- a/kb/issues/N-timetree-clock-rate-validation-duplication.md
+++ b/kb/issues/N-timetree-clock-rate-validation-duplication.md
@@ -1,0 +1,28 @@
+# Clock rate non-positive guard duplicated at two sites
+
+Identical `if clock_rate <= 0.0` guard with the same error message appears in two timetree inference functions. Both return `make_error!` with the same multi-line message about negative clock rate and suggesting `--clock-rate`.
+
+## Locations
+
+- `packages/treetime/src/timetree/inference/runner.rs:45-51:` guard in `run_timetree_inference()`
+- `packages/treetime/src/timetree/inference/branch_length_likelihood.rs:34-40:` guard in branch length likelihood computation
+
+Both have identical code:
+
+```rust
+if clock_rate <= 0.0 {
+  return make_error!(
+    "Clock rate estimate is negative ({clock_rate:.6e}). \
+     The data may lack sufficient temporal signal for automatic rate estimation. \
+     Please specify --clock-rate explicitly."
+  );
+}
+```
+
+## Impact
+
+Trivial duplication. If the validation logic or message changes, two sites need updating.
+
+## Action
+
+Extract `validate_clock_rate(rate: f64) -> Result<()>` helper in `timetree/inference/`.

--- a/kb/issues/N-validation-error-histogram-and-argmax-quality.md
+++ b/kb/issues/N-validation-error-histogram-and-argmax-quality.md
@@ -1,0 +1,25 @@
+# Validation crate histogram and argmax quality issues
+
+Two quality issues in the validation crate's metrics code.
+
+### Error histogram functions share 80% logic
+
+`compute_error_histogram` and `compute_error_histogram_signed` differ only in filter predicate (`x > 0.0` vs `x.is_finite()`) and the `use_log_scale` parameter (unsigned applies `log10()` transform; signed uses raw values). The remaining 25 lines of binning, edge construction, center computation, and return structure are identical.
+
+### argmax uses unspecified tie behavior
+
+Two call sites use `ndarray_stats::argmax()` which has unspecified tie-breaking behavior, instead of the project's `argmax_first()` which guarantees deterministic first-index tie-breaking for Python parity.
+
+## Locations
+
+- `packages/treetime-validation/src/testing/metrics/distribution/histograms.rs:75-133:` `compute_error_histogram()`
+- `packages/treetime-validation/src/testing/metrics/distribution/histograms.rs:135-177:` `compute_error_histogram_signed()`
+- `packages/treetime-validation/src/testing/metrics/aggregate/domain_agreement/peak_metrics.rs:27-28:` two `argmax()` calls
+
+## Impact
+
+Histogram duplication: maintainability. Argmax: on continuous analytical distributions ties are vanishingly improbable, so this is not a correctness risk in practice.
+
+## Action
+
+Unify histogram functions with a config parameter (signed/unsigned mode). Replace `argmax()` with `argmax_first()`.

--- a/kb/issues/N-validation-runner-print-method-boilerplate.md
+++ b/kb/issues/N-validation-runner-print-method-boilerplate.md
@@ -1,0 +1,19 @@
+# ValidationRunner print methods duplicated across three runner implementations
+
+Three `TestRunner` implementations each define 6 print methods that identically delegate to `ValidationConsole::*` static methods (18 identical method bodies total).
+
+## Locations
+
+- `packages/treetime-validation/src/testing/runners/multiplication.rs:46-85:` `MultiplicationRunner` - 6 methods
+- `packages/treetime-validation/src/testing/runners/multiplication.rs:116-153:` `ChainMultiplicationRunner` - 6 methods
+- `packages/treetime-validation/src/testing/runners/convolution.rs:44-84:` `ConvolutionRunner` - 6 methods
+
+Delegated methods: `print_test_configuration`, `print_header`, `print_progress_table_header`, `print_success_row`, `print_failure_row`, `print_error_summary`.
+
+## Impact
+
+Pure maintainability. Adding a runner requires copying 6 trivial delegation methods.
+
+## Action
+
+Add default method implementations to the `TestRunner` trait for all 6 print methods, each delegating to the corresponding `ValidationConsole::*` method.

--- a/kb/issues/N-validation-test-case-accessor-boilerplate.md
+++ b/kb/issues/N-validation-test-case-accessor-boilerplate.md
@@ -1,0 +1,23 @@
+# TestCase trait field accessors duplicated across five test suites
+
+Five `TestCase` implementations each define 5 accessor methods that return `&self.field` identically (25 identical method bodies total).
+
+## Locations
+
+Test suite files in `packages/treetime-validation/src/testing/test_suites/`:
+
+- `gaussian.rs:75:` `GaussianTestCase`
+- `exponential.rs:72:` `ExponentialTestCase`
+- `gaussian_exponential.rs:71:` `GaussianExponentialTestCase`
+- `gaussian_pairwise_multiplication.rs:100:` `GaussianPairwiseMultiplicationTestCase`
+- `gaussian_chain_multiplication.rs:76:` `GaussianChainMultiplicationTestCase`
+
+Duplicated accessors: `name()`, `description()`, `stress_type()`, `analytical_caution()`, `slowness()` - all return `&self.field`.
+
+## Impact
+
+Pure maintainability. Adding a test suite requires copying 5 trivial accessors.
+
+## Action
+
+Extract a `TestCaseBase` struct holding the common fields and implement the accessors once. Each test suite embeds `TestCaseBase` and delegates via a `Deref` impl or explicit forwarding. Alternative: a derive macro for the trait.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -61,6 +61,8 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Core         | [Partition creation is hardcoded per-command instead of configured](M-core-partition-init-orchestration-duplication.md)                             |
 | Medium     | Dates        | [Date parsing discards original input string](M-dates-raw-string-not-preserved.md)                                                                  |
 | Medium     | Dates        | [Column auto-detection gaps in CSV readers](M-dates-column-auto-detection-gaps.md)                                                                  |
+| Medium     | Coalescent   | [Skyline build_tc_distribution reimplements PiecewiseLinearFn::eval](M-coalescent-skyline-reimplements-piecewise-linear-eval.md)                    |
+| Medium     | GTR          | [GTR rate optimization uses hand-rolled Brent instead of argmin wrapper](M-gtr-hand-rolled-brent-minimizer-duplication.md)                          |
 | Medium     | GTR          | [Per-site rate variation not implemented](M-gtr-per-site-rate-variation.md)                                                                         |
 | Medium     | I/O          | [Sequence attachment has O(n squared) complexity](M-io-sequence-attachment-quadratic.md)                                                            |
 | Medium     | I/O          | [Sequence-to-node name matching is unreliable](M-io-sequence-name-matching-unreliable.md)                                                           |
@@ -160,6 +162,18 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Test         | [Loose tolerances in test_gaussian_product.rs](N-test-gaussian-product-loose-tolerances.md)                                                         |
 | Negligible | GTR          | [GTR site-specific interpolation tolerance requires investigation](N-gtr-site-specific-interpolation-tolerance.md)                                  |
 | Negligible | Timetree     | [Coalescent integration test uses grossly loose tolerance](N-timetree-coalescent-integration-grossly-loose-tolerance.md)                            |
+| Negligible | Ancestral    | [Ancestral parallel traversals repeat identical error-capture boilerplate](N-ancestral-parallel-traversal-error-boilerplate.md)                     |
+| Negligible | Ancestral    | [Dead production code in gtr_inference_dense.rs](N-ancestral-dead-code-infer-gtr-dense.md)                                                          |
+| Negligible | Coalescent   | [Coalescent event setup repeated at four sites](N-coalescent-event-setup-duplication.md)                                                            |
+| Negligible | Core         | [EdgeToGraphviz trait has four identical implementations](N-core-edge-to-graphviz-identical-impls.md)                                               |
+| Negligible | Core         | [Gap-fill argument logic duplicated across three commands](N-core-gap-fill-args-duplication.md)                                                     |
+| Negligible | Grid         | [Piecewise constant and linear function structs share identical skeleton](N-grid-piecewise-function-shared-skeleton.md)                             |
+| Negligible | Marginal     | [Inline 1D normalization duplicated in sparse marginal passes](N-marginal-inline-1d-normalization-duplication.md)                                   |
+| Negligible | Optimize     | [Argmin observer structs duplicated across three optimization sites](N-optimize-argmin-observer-boilerplate.md)                                     |
+| Negligible | Timetree     | [Clock rate non-positive guard duplicated at two sites](N-timetree-clock-rate-validation-duplication.md)                                            |
+| Negligible | Validation   | [Validation crate histogram and argmax quality issues](N-validation-error-histogram-and-argmax-quality.md)                                          |
+| Negligible | Validation   | [ValidationRunner print methods duplicated across three runner implementations](N-validation-runner-print-method-boilerplate.md)                    |
+| Negligible | Validation   | [TestCase trait field accessors duplicated across five test suites](N-validation-test-case-accessor-boilerplate.md)                                 |
 
 ## Cross-references
 

--- a/kb/tickets/ancestral-extract-parallel-traversal-error-helper.md
+++ b/kb/tickets/ancestral-extract-parallel-traversal-error-helper.md
@@ -1,0 +1,24 @@
+# Extract parallel traversal error-capture helper from ancestral boilerplate
+
+Three ancestral traversal sites duplicate the 10-line `Arc<Mutex<Option<Report>>>` error-capture pattern.
+
+## Current state
+
+`ancestral/marginal.rs:83,119` and `ancestral/fitch.rs:201` each manually create the error arc, wrap the closure, and call `extract_parallel_error`.
+
+## Target state
+
+A `par_traversal_with_error(graph, direction, op) -> Result<()>` helper encapsulates the pattern. All three ancestral sites and the two timetree traversal sites (currently using `.unwrap()`) use the helper.
+
+## Implementation
+
+1. Define `par_traversal_with_error` in a shared location (e.g., `ancestral/` or a graph utilities module)
+2. The helper takes a graph reference, traversal direction (forward/backward), and a fallible operation closure
+3. Internally creates the `Arc<Mutex<Option<Report>>>`, executes the parallel traversal, and calls `extract_parallel_error`
+4. Replace the 3 ancestral sites with calls to the helper
+5. Optionally: convert the 2 timetree traversal sites (`forward_pass.rs:17`, `backward_pass.rs:26`) from `.unwrap()` to the helper (see related ticket `timetree-traversals-unwrap-on-fallible-distribution-math.md`)
+
+## Related issues
+
+Source: `kb/issues/N-ancestral-parallel-traversal-error-boilerplate.md`
+Related: `kb/issues/M-timetree-parallel-traversal-unwrap-panic.md`

--- a/kb/tickets/ancestral-remove-dead-infer-gtr-dense.md
+++ b/kb/tickets/ancestral-remove-dead-infer-gtr-dense.md
@@ -1,0 +1,22 @@
+# Evaluate and remove dead infer_gtr_dense code
+
+`infer_gtr_dense` has no production callers and carries `#[allow(dead_code)]`.
+
+## Current state
+
+`ancestral/gtr_inference_dense.rs:28-43` defines `infer_gtr_dense()` with `#[allow(dead_code)]`. Its helper `get_mutation_counts_dense` (line 145) is also marked dead but used in tests. The active GTR inference path is `gtr_inference.rs` (sparse).
+
+## Target state
+
+If dense GTR inference is not needed: delete `infer_gtr_dense` and `get_mutation_counts_dense`, migrate any valuable test assertions to use the sparse inference path. If dense GTR inference is planned: remove `#[allow(dead_code)]` and wire it into production code.
+
+## Implementation
+
+1. Check whether any planned feature (e.g., dense-mode GTR inference, site-specific rates) requires `infer_gtr_dense`
+2. If not needed: delete `gtr_inference_dense.rs` entirely, update `mod.rs`
+3. If test coverage from `get_mutation_counts_dense` is valuable, port those test cases to use `gtr_inference.rs` equivalents
+4. If needed: remove `#[allow(dead_code)]`, add production callers, add integration tests
+
+## Related issues
+
+Source: `kb/issues/N-ancestral-dead-code-infer-gtr-dense.md`

--- a/kb/tickets/coalescent-extract-event-setup-precomputed-struct.md
+++ b/kb/tickets/coalescent-extract-event-setup-precomputed-struct.md
@@ -1,0 +1,22 @@
+# Extract coalescent event setup into CoalescentPrecomputed struct
+
+Four coalescent functions duplicate 5 lines for tree event collection and lineage count computation.
+
+## Current state
+
+`coalescent.rs:70-76`, `total_lh.rs:38-44`, `optimize_tc.rs:104-110`, `skyline.rs:86-92` each call `collect_tree_events` -> time conversion -> `compute_lineage_count_distribution`.
+
+## Target state
+
+A `CoalescentPrecomputed` struct bundles `present_time`, `events_tbp`, and `lineage_counts` with a `from_graph(graph) -> Result<Self>` constructor. All four sites create the struct and destructure or borrow fields.
+
+## Implementation
+
+1. Define `CoalescentPrecomputed { present_time, events_tbp, lineage_counts }` in `coalescent/` (e.g., `coalescent/precomputed.rs` or in an existing module)
+2. Implement `CoalescentPrecomputed::from_graph(graph) -> Result<Self>` with the 5-line setup
+3. Replace the 4 call sites with `CoalescentPrecomputed::from_graph(graph)?`
+4. Each site accesses fields via the struct (some need `lineage_counts`, some also need `events_tbp`)
+
+## Related issues
+
+Source: `kb/issues/N-coalescent-event-setup-duplication.md`

--- a/kb/tickets/coalescent-skyline-use-piecewise-linear-fn-eval.md
+++ b/kb/tickets/coalescent-skyline-use-piecewise-linear-fn-eval.md
@@ -1,0 +1,22 @@
+# Replace inline interpolation in skyline with PiecewiseLinearFn
+
+`build_tc_distribution` reimplements `PiecewiseLinearFn::eval()` as an inline closure instead of using the existing struct from `treetime-grid`.
+
+## Current state
+
+`coalescent/skyline.rs:230-252` contains a closure that performs boundary clamping, `partition_point` lookup, and linear interpolation over `time_grid` and `tc_values`. `treetime-grid::PiecewiseLinearFn::eval()` implements the identical algorithm.
+
+## Target state
+
+`build_tc_distribution` constructs a `PiecewiseLinearFn` from `(time_grid, tc_values)` and wraps `.eval()` in the `DistributionFormula` closure.
+
+## Implementation
+
+1. In `build_tc_distribution`, construct `let pwl = PiecewiseLinearFn::new(time_grid.clone(), tc_values.clone())?;`
+2. Replace the inline interpolation closure with `move |t| Ok(pwl.eval(t))`
+3. Verify that boundary behavior matches (both clamp to first/last value)
+4. Run coalescent tests to confirm identical results
+
+## Related issues
+
+Source: `kb/issues/M-coalescent-skyline-reimplements-piecewise-linear-eval.md`

--- a/kb/tickets/core-blanket-impl-edge-to-graphviz.md
+++ b/kb/tickets/core-blanket-impl-edge-to-graphviz.md
@@ -1,0 +1,22 @@
+# Add blanket or default implementation for EdgeToGraphviz trait
+
+Four edge types implement EdgeToGraphviz with identical bodies that format branch_length.
+
+## Current state
+
+`EdgeTimetree`, `EdgeAncestral`, `EdgeClock`, and `TestEdge` each implement `to_graphviz_label()` and `to_graphviz_weight()` identically. All implement `HasBranchLength`.
+
+## Target state
+
+Either a blanket `impl<T: HasBranchLength> EdgeToGraphviz for T` or default methods on the `EdgeToGraphviz` trait itself. Types needing custom graphviz rendering override.
+
+## Implementation
+
+1. Check if `EdgeToGraphviz` is defined in a crate that can see `HasBranchLength` (for blanket impl) or if default methods are more appropriate
+2. Add default method implementations using `self.branch_length()` and `format_weight`
+3. Remove the four identical explicit implementations
+4. Verify graphviz output unchanged for all edge types
+
+## Related issues
+
+Source: `kb/issues/N-core-edge-to-graphviz-identical-impls.md`

--- a/kb/tickets/core-extract-shared-gap-fill-args.md
+++ b/kb/tickets/core-extract-shared-gap-fill-args.md
@@ -1,0 +1,23 @@
+# Extract shared gap-fill CLI argument struct
+
+Three command argument structs implement identical `effective_gap_fill()` methods.
+
+## Current state
+
+`commands/ancestral/args.rs:133-139`, `commands/optimize/args.rs:127-133`, and `commands/timetree/args.rs:310-316` each define `effective_gap_fill()` with the same `if keep_overhangs { None } else { gap_fill }` logic.
+
+## Target state
+
+A shared `GapFillArgs { gap_fill: GapFill, keep_overhangs: bool }` struct in `commands/shared/` with `effective_gap_fill()` implemented once. Each command embeds via `#[command(flatten)]`.
+
+## Implementation
+
+1. Define `GapFillArgs` in `commands/shared/args.rs` (or a new file) with clap derive attributes matching the current fields
+2. Implement `effective_gap_fill()` on `GapFillArgs`
+3. Replace the `gap_fill` and `keep_overhangs` fields in all three command arg structs with `#[command(flatten)] gap_fill_args: GapFillArgs`
+4. Update all call sites from `args.effective_gap_fill()` to `args.gap_fill_args.effective_gap_fill()`
+5. Verify CLI help text unchanged
+
+## Related issues
+
+Source: `kb/issues/N-core-gap-fill-args-duplication.md`

--- a/kb/tickets/grid-extract-piecewise-function-common-base.md
+++ b/kb/tickets/grid-extract-piecewise-function-common-base.md
@@ -1,0 +1,23 @@
+# Extract common base from piecewise constant and linear function structs
+
+Two piecewise function structs share identical struct layout, validation, and eval_many logic.
+
+## Current state
+
+`treetime-grid/src/piecewise_constant_fn.rs` (100 lines) and `piecewise_linear_fn.rs` (136 lines) duplicate struct fields, `new()` breakpoint validation, `breakpoints()` accessor, and `eval_many()` tandem sweep. Only `eval()` and the value-count invariant differ.
+
+## Target state
+
+A `PiecewiseFnBase` struct (or trait with default methods) handles shared storage, validation, and `eval_many()`. `PiecewiseConstantFn` and `PiecewiseLinearFn` provide only their specific `eval()` and value-count check.
+
+## Implementation
+
+1. Define `PiecewiseFnBase { breakpoints: Array1<f64>, values: Array1<f64> }` with shared validation in `new()`
+2. Implement `breakpoints()`, `values()`, and `eval_many()` on the base
+3. Define an `Evaluator` trait or strategy enum for the `eval()` behavior (step vs interpolation)
+4. Wrap or compose the base in both concrete types, forwarding shared methods
+5. Verify all existing tests pass unchanged
+
+## Related issues
+
+Source: `kb/issues/N-grid-piecewise-function-shared-skeleton.md`

--- a/kb/tickets/gtr-replace-hand-rolled-brent-with-argmin-wrapper.md
+++ b/kb/tickets/gtr-replace-hand-rolled-brent-with-argmin-wrapper.md
@@ -1,0 +1,23 @@
+# Replace hand-rolled Brent minimizer with argmin wrapper in GTR rate optimization
+
+`optimize_gtr_rate()` uses a 100-line manual Brent implementation with no error handling. The existing argmin-based `brent_sqrt_inner` already supports the same sqrt-space transform.
+
+## Current state
+
+`gtr/refinement.rs:147-247` contains `brent_minimize_bracketed()` returning bare `f64`. Called at line 130 in sqrt(mu) space with tolerance `1e-8` and 100 iterations.
+
+## Target state
+
+`optimize_gtr_rate()` uses `brent_sqrt_inner` (or a new variant) from `optimize/method_brent.rs`, gaining `Result<f64, Report>` error propagation and machine-epsilon tolerance. `brent_minimize_bracketed` is deleted.
+
+## Implementation
+
+1. Adapt `optimize_gtr_rate`'s cost function to implement argmin's `CostFunction` trait (or use the existing generic interface in `method_brent.rs`)
+2. Replace the `brent_minimize_bracketed` call at `refinement.rs:130` with `brent_sqrt_inner` or equivalent
+3. Propagate the `Result` return type through `optimize_gtr_rate` callers
+4. Delete `brent_minimize_bracketed` and its tests (move any valuable test cases to `optimize/__tests__/`)
+5. Verify GTR rate optimization produces identical results on test datasets
+
+## Related issues
+
+Source: `kb/issues/M-gtr-hand-rolled-brent-minimizer-duplication.md`

--- a/kb/tickets/marginal-extract-normalize-1d-helper.md
+++ b/kb/tickets/marginal-extract-normalize-1d-helper.md
@@ -1,0 +1,21 @@
+# Extract 1D normalization helper from sparse marginal passes
+
+Two adjacent code blocks in marginal_passes.rs perform identical 6-line sum-and-divide normalization.
+
+## Current state
+
+`partition/marginal_passes.rs:402-409` (variable sites) and `:416-423` (fixed sites) each inline the same normalization: compute sum, check `> 0.0 && is_finite()`, divide or fall back to uniform, accumulate log-likelihood.
+
+## Target state
+
+A `normalize_1d(dis: ArrayView1<f64>, uniform: &Array1<f64>) -> (Array1<f64>, f64)` helper returns the normalized distribution and the log-likelihood contribution (`norm.ln()` or `NEG_INFINITY`).
+
+## Implementation
+
+1. Define `normalize_1d` in `partition/marginal_passes.rs` or `partition/marginal_core.rs` near the existing 2D `normalize_inplace`
+2. Replace both inline blocks with calls to the helper
+3. Verify sparse marginal pass tests produce identical results
+
+## Related issues
+
+Source: `kb/issues/N-marginal-inline-1d-normalization-duplication.md`

--- a/kb/tickets/optimize-unify-argmin-observer-structs.md
+++ b/kb/tickets/optimize-unify-argmin-observer-structs.md
@@ -1,0 +1,24 @@
+# Unify argmin observer structs into single parameterized type
+
+Three optimization sites define near-identical `Observe<I>` implementations differing only in label and early-iteration threshold.
+
+## Current state
+
+`TcOptimizationObserver` (coalescent), `BrentObserver` (clock/find_best_root), and `GoldenSectionObserver` (clock/find_best_root) are separate unit structs with identical trait bounds and body structure.
+
+## Target state
+
+A single `OptimizationObserver { label: &'static str, early_threshold: u64 }` struct with one `Observe` implementation. All three sites instantiate with their specific label and threshold.
+
+## Implementation
+
+1. Define `OptimizationObserver` in a shared location (e.g., `optimize/observer.rs` or `optimize/mod.rs`)
+2. Implement `Observe<I>` once with parameterized label and threshold
+3. Replace `TcOptimizationObserver` in `coalescent/optimize_tc.rs:139-159` with `OptimizationObserver { label: "Tc optimization", early_threshold: 3 }`
+4. Replace `BrentObserver` in `clock/find_best_root/method_brent.rs:13-33` with `OptimizationObserver { label: "Brent", early_threshold: 5 }`
+5. Replace `GoldenSectionObserver` in `clock/find_best_root/method_golden_section.rs:13-33` with `OptimizationObserver { label: "Golden Section", early_threshold: 5 }`
+6. Delete the three original structs
+
+## Related issues
+
+Source: `kb/issues/N-optimize-argmin-observer-boilerplate.md`

--- a/kb/tickets/timetree-extract-clock-rate-validation-helper.md
+++ b/kb/tickets/timetree-extract-clock-rate-validation-helper.md
@@ -1,0 +1,21 @@
+# Extract clock rate validation helper
+
+Two timetree inference functions duplicate the same non-positive clock rate guard with identical error message.
+
+## Current state
+
+`timetree/inference/runner.rs:45-51` and `timetree/inference/branch_length_likelihood.rs:34-40` both check `clock_rate <= 0.0` and return `make_error!` with the same message.
+
+## Target state
+
+A `validate_clock_rate(rate: f64) -> Result<()>` helper in `timetree/inference/` encapsulates the check. Both sites call the helper.
+
+## Implementation
+
+1. Define `fn validate_clock_rate(clock_rate: f64) -> Result<()>` in `timetree/inference/` (e.g., in a shared module or one of the existing files)
+2. Move the guard logic and error message into the helper
+3. Replace both call sites with `validate_clock_rate(clock_rate)?;`
+
+## Related issues
+
+Source: `kb/issues/N-timetree-clock-rate-validation-duplication.md`

--- a/kb/tickets/validation-add-default-methods-to-test-runner-trait.md
+++ b/kb/tickets/validation-add-default-methods-to-test-runner-trait.md
@@ -1,0 +1,21 @@
+# Add default methods to TestRunner trait for print delegation
+
+Three TestRunner implementations each define 6 identical print methods delegating to ValidationConsole.
+
+## Current state
+
+`MultiplicationRunner`, `ChainMultiplicationRunner`, and `ConvolutionRunner` each implement `print_test_configuration`, `print_header`, `print_progress_table_header`, `print_success_row`, `print_failure_row`, `print_error_summary` with identical bodies.
+
+## Target state
+
+The `TestRunner` trait provides default implementations for all 6 print methods. Runner implementations inherit them without boilerplate.
+
+## Implementation
+
+1. Add default method bodies to the `TestRunner` trait definition, each delegating to the corresponding `ValidationConsole::*` method
+2. Remove the 18 explicit method implementations from the three runner structs
+3. Verify test output unchanged
+
+## Related issues
+
+Source: `kb/issues/N-validation-runner-print-method-boilerplate.md`

--- a/kb/tickets/validation-extract-test-case-base-struct.md
+++ b/kb/tickets/validation-extract-test-case-base-struct.md
@@ -1,0 +1,24 @@
+# Extract TestCaseBase struct for shared field accessors
+
+Five TestCase implementations each define 5 identical accessor methods returning &self.field.
+
+## Current state
+
+`GaussianTestCase`, `ExponentialTestCase`, `GaussianExponentialTestCase`, `GaussianPairwiseMultiplicationTestCase`, and `GaussianChainMultiplicationTestCase` each implement `name()`, `description()`, `stress_type()`, `analytical_caution()`, `slowness()` identically.
+
+## Target state
+
+A `TestCaseBase` struct holds the common fields (`name`, `description`, `stress_type`, `analytical_caution`, `slowness`) with accessors implemented once. Each test case embeds `TestCaseBase` and forwards via delegation.
+
+## Implementation
+
+1. Define `TestCaseBase` struct with the 5 common fields
+2. Implement the 5 accessor methods on `TestCaseBase`
+3. Add a `base()` method to the `TestCase` trait returning `&TestCaseBase`
+4. Provide default implementations for all 5 accessor methods via `self.base().field()`
+5. Update all 5 test suites to embed `TestCaseBase` and implement `base()`
+6. Remove the 25 explicit accessor implementations
+
+## Related issues
+
+Source: `kb/issues/N-validation-test-case-accessor-boilerplate.md`

--- a/kb/tickets/validation-unify-error-histogram-and-fix-argmax.md
+++ b/kb/tickets/validation-unify-error-histogram-and-fix-argmax.md
@@ -1,0 +1,24 @@
+# Unify error histogram functions and replace argmax with argmax_first
+
+Two quality issues in validation metrics: duplicated histogram logic and non-deterministic argmax.
+
+## Current state
+
+`histograms.rs:75-133` (`compute_error_histogram`) and `:135-177` (`compute_error_histogram_signed`) share 80% logic, differing in filter predicate and log-scale option. `peak_metrics.rs:27-28` uses `ndarray_stats::argmax()` instead of project's `argmax_first()`.
+
+## Target state
+
+A single `compute_error_histogram(errors, config)` function with a config enum or parameter controlling signed/unsigned mode. `argmax()` replaced with `argmax_first()`.
+
+## Implementation
+
+1. Define `enum HistogramMode { Unsigned, Signed }` or equivalent parameter
+2. Merge `compute_error_histogram` and `compute_error_histogram_signed` into one function parameterized by mode
+3. Mode controls: filter predicate (`x > 0.0` vs `x.is_finite()`) and value transform (`log10` vs identity)
+4. Update all callers to pass the appropriate mode
+5. Replace `argmax()` with `argmax_first()` in `peak_metrics.rs:27-28`
+6. Verify validation test output unchanged
+
+## Related issues
+
+Source: `kb/issues/N-validation-error-histogram-and-argmax-quality.md`


### PR DESCRIPTION
- Depends on: `docs/kb-partition-config`

Duplication and boilerplate patterns recur across the ancestral, coalescent, core, grid, GTR, marginal, optimize, timetree, and validation crates with no tracked cleanup plan.

Catalog each pattern as an issue paired with a cleanup ticket carrying an extraction or unification plan.

### Work items

- [x] File the per-crate duplication issues, indexed in [kb/issues/README.md](https://github.com/neherlab/treetime/blob/c3e49d99/kb/issues/README.md)
- [x] File a paired cleanup ticket for each issue with an extraction or unification plan
