### PR TITLE
docs: file timetree node data parity gaps

### DIFF
--- a/kb/issues/N-timetree-node-data-date-string-fp-boundary.md
+++ b/kb/issues/N-timetree-node-data-date-string-fp-boundary.md
@@ -1,0 +1,9 @@
+# Node data `date` string can differ by one day at year-fraction boundaries
+
+The per-node `date` field in timetree node data JSON is the `"YYYY-MM-DD"` string produced from each node's `numdate` by `year_fraction_to_datestring()`. At year-fraction values that fall on a floating-point day boundary, the conversion can round to a day adjacent to the one augur reports from the same `numdate`.
+
+The discrepancy is at most one day. `augur export v2` reads `numdate` for the time tree, not the `date` string, so no downstream auspice output is affected. The mismatch only shows when comparing the `date` field directly against augur's node data JSON.
+
+## Related issues
+
+- [Auspice JSON output missing mutations, branch confidence, and genome annotations](N-timetree-auspice-json-incomplete.md)

--- a/kb/issues/N-timetree-node-data-divergence-units-mutations-unimplemented.md
+++ b/kb/issues/N-timetree-node-data-divergence-units-mutations-unimplemented.md
@@ -1,0 +1,9 @@
+# --divergence-units=mutations not implemented for node data divergence
+
+Augur's refine accepts `--divergence-units {mutations-per-site, mutations}`, controlling whether the divergence that `augur export v2` accumulates into `node_attrs.div` is reported in substitutions per site or in absolute mutation counts (per-site values scaled by alignment length).
+
+Timetree node data JSON emits `mutation_length` only in substitutions per site (the `mutations-per-site` convention). There is no flag to request absolute mutation counts, so a consumer expecting `mutations` units receives per-site values without conversion.
+
+## Related issues
+
+- [Missing output files compared to v0](N-timetree-missing-output-files.md)

--- a/kb/issues/N-timetree-node-data-root-branch-fields-omitted.md
+++ b/kb/issues/N-timetree-node-data-root-branch-fields-omitted.md
@@ -1,0 +1,9 @@
+# Root node omits placeholder branch-length fields in node data JSON
+
+Augur's refine output writes branch-length fields (`branch_length`, `clock_length`, `mutation_length`) for every node, including the root, where they are placeholder values because the root has no parent edge.
+
+Timetree node data JSON omits these fields on the root node. The root carries dates and confidence but no branch metrics. Downstream, `augur export v2` reads branch metrics from child edges when accumulating divergence and time, so the absent root values have no observed effect. The omission is a structural difference from augur's per-node field set.
+
+## Related issues
+
+- [Missing output files compared to v0](N-timetree-missing-output-files.md)

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -119,6 +119,9 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Timetree     | [Stochastic polytomy resolution not implemented](N-timetree-stochastic-polytomy-unimplemented.md)                                                   |
 | Negligible | Timetree     | [Auspice JSON output missing mutations, branch confidence, and genome annotations](N-timetree-auspice-json-incomplete.md)                           |
 | Negligible | Timetree     | [Node data JSON omits input-tree branch confidence](N-timetree-node-data-confidence-not-emitted.md)                                                 |
+| Negligible | Timetree     | [Node data date string can differ by one day at year-fraction boundaries](N-timetree-node-data-date-string-fp-boundary.md)                          |
+| Negligible | Timetree     | [--divergence-units=mutations not implemented for node data divergence](N-timetree-node-data-divergence-units-mutations-unimplemented.md)           |
+| Negligible | Timetree     | [Root node omits placeholder branch-length fields in node data JSON](N-timetree-node-data-root-branch-fields-omitted.md)                            |
 | Negligible | Timetree     | [Rerooted root and polytomy-resolution nodes stay unnamed](N-timetree-unnamed-root-after-reroot.md)                                                 |
 | Negligible | Timetree     | [Polytomy resolution numerical robustness](N-timetree-polytomy-numerical-robustness.md)                                                             |
 | Negligible | Timetree     | [Polytomy resolution test improvements](N-timetree-polytomy-test-improvements.md)                                                                   |


### PR DESCRIPTION
- Depends on: `feat/timetree-write-augur-node-data-json`

The timetree node data writer emits augur-compatible JSON but leaves three known differences from augur's output. None affects downstream auspice rendering, so they were not blockers for the writer, but they are real divergences that should be tracked rather than left in prose.

Record each as a negligible known issue with its scope and observed downstream impact.

### Work items

- [x] File issue: [N-timetree-node-data-date-string-fp-boundary.md](https://github.com/neherlab/treetime/blob/1d7de48a/kb/issues/N-timetree-node-data-date-string-fp-boundary.md): `date` string off by up to one day at year-fraction boundaries
- [x] File issue: [N-timetree-node-data-divergence-units-mutations-unimplemented.md](https://github.com/neherlab/treetime/blob/1d7de48a/kb/issues/N-timetree-node-data-divergence-units-mutations-unimplemented.md): no `mutations` divergence-units option
- [x] File issue: [N-timetree-node-data-root-branch-fields-omitted.md](https://github.com/neherlab/treetime/blob/1d7de48a/kb/issues/N-timetree-node-data-root-branch-fields-omitted.md): root omits placeholder branch fields
