### PR TITLE
fix: initialize new root node with SparseNodePartition::new

### DIFF
--- a/packages/treetime-graph/src/reroot.rs
+++ b/packages/treetime-graph/src/reroot.rs
@@ -11,10 +11,6 @@ pub struct EdgeSplitInfo {
   pub old_edge_key: GraphEdgeKey,
   /// The new node created at the split point.
   pub new_node_key: GraphNodeKey,
-  /// The original source node (parent side of the split).
-  pub parent_node_key: GraphNodeKey,
-  /// The original target node (child side of the split).
-  pub child_node_key: GraphNodeKey,
   /// The edge from the original source to the new node.
   pub parent_side_edge_key: GraphEdgeKey,
   /// The edge from the new node to the original target.
@@ -105,8 +101,6 @@ where
   Ok(EdgeSplitInfo {
     old_edge_key: edge_key,
     new_node_key,
-    parent_node_key: source_key,
-    child_node_key: target_key,
     parent_side_edge_key,
     child_side_edge_key,
     split_position,

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -719,7 +719,7 @@ mod tests {
 
     let partitions = [Arc::new(RwLock::new(PartitionFitch {
       index: 0,
-      alphabet: alphabet.clone(),
+      alphabet,
       length: get_common_length(&aln)?,
       nodes: btreemap! {},
       edges: btreemap! {},
@@ -729,7 +729,7 @@ mod tests {
 
     let fitch = Arc::try_unwrap(partitions.into_iter().next().unwrap())
       .map(|rw| rw.into_inner())
-      .map_err(|_| eyre::eyre!("Fitch partition still shared"))?;
+      .map_err(|_e| eyre::eyre!("Fitch partition still shared"))?;
 
     let gtr = jc69(JC69Params { alphabet: AlphabetName::Nuc, ..JC69Params::default() })?;
     let mut sparse = fitch.into_marginal_sparse(gtr, &graph)?;
@@ -780,7 +780,7 @@ mod tests {
     let changes = RerootChanges {
       edge_split: Some(split_info),
       edge_merge: None,
-      inverted_edge_keys: inverted_edge_keys.clone(),
+      inverted_edge_keys,
     };
 
     sparse.apply_reroot(&changes)?;

--- a/packages/treetime/src/partition/marginal_passes.rs
+++ b/packages/treetime/src/partition/marginal_passes.rs
@@ -168,7 +168,7 @@ where
     let mut variable_pos = btreemap! {};
     let mut child_states = vec![];
     let mut child_messages: Vec<SparseSeqDistribution> = vec![];
-    for (ci, (child_key, edge_key)) in node.child_keys.iter().enumerate() {
+    for (ci, (_child_key, edge_key)) in node.child_keys.iter().enumerate() {
       child_states.push(btreemap! {});
       let edge_data = &partition.edges[edge_key];
       for m in edge_data.fitch_subs() {
@@ -181,6 +181,7 @@ where
       }
       child_messages.push(edge_data.msg_from_child.clone());
     }
+
     // Fill in child states for variable positions without edge substitutions.
     let alphabet = &partition.alphabet;
     for (ci, (child_key, _)) in node.child_keys.iter().enumerate() {

--- a/packages/treetime/src/partition/marginal_sparse.rs
+++ b/packages/treetime/src/partition/marginal_sparse.rs
@@ -10,7 +10,6 @@ use crate::partition::traits::{
   BranchTopology, HasGtr, HasLogLh, PartitionBranchOps, PartitionMarginalOps, PartitionMarginalPasses,
   PartitionOptimizeOps, PartitionRerootOps, PartitionTimetreeOps, TransitionCounting,
 };
-use crate::seq::composition::Composition;
 use crate::seq::mutation::Sub;
 use crate::{make_error, make_internal_report};
 use eyre::Report;
@@ -23,7 +22,7 @@ use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_graph::reroot::RerootChanges;
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::{AlphabetLike, Seq, seq};
+use treetime_primitives::{Seq, seq};
 use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::interval::range_union::range_union;
@@ -295,11 +294,9 @@ where
 
 impl PartitionRerootOps for PartitionMarginalSparse {
   fn apply_reroot(&mut self, changes: &RerootChanges) -> Result<(), Report> {
-    // Handle edge split: create new node entry, move mutations to child-side edge
+    // Handle edge split: create new node entry, move mutations to child-side edge.
+    // Node initialization is deferred until root_sequence is finalized (below).
     if let Some(info) = &changes.edge_split {
-      self
-        .nodes
-        .insert(info.new_node_key, SparseNodePartition::empty(&self.alphabet));
 
       let mut old_edge_data = self
         .edges
@@ -417,46 +414,15 @@ impl PartitionRerootOps for PartitionMarginalSparse {
       self.root_sequence = new_root_seq;
     }
 
-    // After all root_sequence updates, initialize the new split node's composition
-    // from root_sequence so that process_node_forward correctly seeds fixed_counts
-    // in msg_to_child (without this, fixed sites have zero multiplicity and the
-    // branch length distribution peaks at the grid boundary instead of a realistic value).
+    // Initialize the new split node from the finalized root_sequence.
+    // SparseNodePartition::new computes composition, gaps, unknown, and non_char
+    // from the sequence. These fields are read by process_node_forward (fixed_counts
+    // in msg_to_child) and edge_effective_length (non_char exclusion).
     if let Some(info) = &changes.edge_split {
-      if let Some(node_data) = self.nodes.get_mut(&info.new_node_key) {
-        node_data.seq.composition = Composition::with_sequence(
-          self.root_sequence.iter().copied(),
-          self.alphabet.chars(),
-          self.alphabet.gap(),
-        );
-        node_data.seq.sequence = self.root_sequence.clone();
-      }
-    }
-
-    // Consistency check (debug builds only): applying child_side subs/indels to the
-    // root composition must reproduce the child node's composition.
-    // This verifies that root_sequence, the edge mutations, and the child composition
-    // are all mutually consistent after the reroot.
-    #[cfg(debug_assertions)]
-    if let Some(info) = &changes.edge_split {
-      if let (Some(root_node), Some(child_node)) = (
-        self.nodes.get(&info.new_node_key),
-        self.nodes.get(&info.child_node_key),
-      ) {
-        if let Some(child_edge) = self.edges.get(&info.child_side_edge_key) {
-          let mut derived = root_node.seq.composition.clone();
-          for sub in child_edge.fitch_subs() {
-            derived.add_sub(sub);
-          }
-          for indel in &child_edge.indels {
-            derived.add_indel(indel);
-          }
-          debug_assert_eq!(
-            derived,
-            child_node.seq.composition,
-            "Root composition + child_side subs/indels must equal child composition after reroot"
-          );
-        }
-      }
+      self.nodes.insert(
+        info.new_node_key,
+        SparseNodePartition::new(&self.root_sequence, &self.alphabet)?,
+      );
     }
 
     Ok(())

--- a/packages/treetime/src/timetree/inference/runner.rs
+++ b/packages/treetime/src/timetree/inference/runner.rs
@@ -120,7 +120,6 @@ where
         .map(|partition| partition.read_arc().edge_indel_count(edge_key))
         .sum()
     };
-
     let distribution = compute_branch_length_distribution(
       &contributions,
       indel_count,


### PR DESCRIPTION
- Depends on: #737

`apply_reroot` creates the new split-point node with `SparseNodePartition::empty()`, then patches `composition` and `sequence` from `root_sequence`. This leaves `gaps`, `unknown`, and `non_char` ranges as empty vecs, causing `edge_effective_length()` to count gap positions as evolving and `process_node_forward()` to treat gap/N positions as having defined sequence.

`SparseNodePartition::new(&root_sequence, &alphabet)` computes all five fields from the actual sequence. The debug assertion (root composition + child-side subs/indels = child composition) does not hold by design: non-char (N, gap) differences between nodes are not encoded as Fitch substitutions.

### Work items

- [x] Replace `SparseNodePartition::empty()` + field patching with `SparseNodePartition::new()` using finalized root_sequence
- [x] Remove debug assertion (invariant invalid for non-char positions)
- [x] Remove `parent_node_key`/`child_node_key` from `EdgeSplitInfo`
- [x] Fix clippy errors in test (redundant clones, `map_err_ignore`)