### PR TITLE
docs: file known issues for sparse marginal correctness gaps

### DIFF
--- a/kb/issues/M-optimize-sparse-stale-fitch-states.md
+++ b/kb/issues/M-optimize-sparse-stale-fitch-states.md
@@ -1,0 +1,29 @@
+# Sparse branch optimization reads stale Fitch-era states
+
+## Summary
+
+`get_coefficients` in sparse branch-length optimization reads parent/child states from Fitch-era `msg.variable.state` fields and `fitch_subs().reff()/qry()`. After marginal inference changes MAP assignments, these states are stale and optimization scores against wrong nucleotides.
+
+## Details
+
+`packages/treetime/src/partition/optimize_sparse.rs`:
+
+The sparse branch optimization builds `SiteContribution` entries using:
+
+- `edge.msg_to_child.variable[pos].state` for parent state
+- `edge.msg_to_parent.variable[pos].state` for child state
+- `edge.fitch_subs()` for substitution positions
+
+These `.state` fields are set during the Fitch forward pass and the initial `process_node_backward` call. After marginal inference (backward + forward passes), the MAP state at variable positions can change, but the `.state` fields are not updated. The optimization then computes branch-length contributions using the Fitch-era nucleotide assignments instead of the current posterior-derived assignments.
+
+## Impact
+
+The bias is proportional to the number of variable sites where the marginal MAP state differs from the Fitch assignment. For low-diversity viral datasets this is a small fraction, but grows with sequence divergence and ambiguity.
+
+## Fix
+
+Read states from the current marginal profiles (argmax of the posterior) instead of the stored `.state` fields. Alternatively, update `.state` fields after each marginal pass.
+
+## Related
+
+- [M-gtr-sparse-composition-stale-after-marginal](M-gtr-sparse-composition-stale-after-marginal.md) - same root cause (Fitch-era data not refreshed after marginal inference), different consumer (GTR inference vs branch optimization)

--- a/kb/issues/M-sparse-marginal-quantitative-site-filtering.md
+++ b/kb/issues/M-sparse-marginal-quantitative-site-filtering.md
@@ -1,0 +1,19 @@
+# Sparse marginal msg_to_child includes near-deterministic variable sites
+
+## Summary
+
+`process_node_forward` unconditionally inserts all variable positions into `msg_to_child.variable`, even when the MAP state matches the fixed-row fallback and the probability is near 1.0. This causes `fixed_counts` to be decremented for positions that contribute no quantitative information beyond the fixed row.
+
+## Details
+
+`packages/treetime/src/partition/marginal_passes.rs:387-411`:
+
+Every variable position is inserted into `msg_to_child.variable` and its character state is decremented from `fixed_counts` (line 411). For near-deterministic positions where `max_prob >= 1.0 - EPS` and the MAP state matches the canonical parent state, the variable row is identical to the fixed row. Moving these from fixed to variable changes their treatment in branch-length optimization: the fixed path uses `fixed_counts` as a bulk multiplicity, while the variable path processes each position individually.
+
+## Impact
+
+The effect is small for typical data where most variable sites have genuine uncertainty. It becomes noticeable with long branches or high-confidence reconstructions where many variable positions are near-deterministic.
+
+## Fix
+
+Filter variable positions before insertion: only keep in the variable map when the MAP state differs from the canonical fallback or the maximum probability is below `1.0 - EPS`.

--- a/kb/issues/M-sparse-marginal-zero-multiplicity-nan.md
+++ b/kb/issues/M-sparse-marginal-zero-multiplicity-nan.md
@@ -1,0 +1,21 @@
+# Sparse marginal fixed_counts zero-multiplicity produces NaN
+
+## Summary
+
+In `combine_messages`, multiplying zero `fixed_counts` by `NEG_INFINITY` log-normalization produces NaN, corrupting the `msg_to_child.log_lh` and downstream branch-length distributions.
+
+## Details
+
+`packages/treetime/src/partition/marginal_helpers.rs`:
+
+The line `seq_dis.log_lh += fixed_counts[&state] * log_norm` is unguarded. When `fixed_counts` is 0 for a character state and `log_norm` is `f64::NEG_INFINITY` (from a zero-sum profile), the result is `0.0 * NEG_INFINITY = NaN`. This NaN propagates through `msg_to_child.log_lh` into branch-length optimization.
+
+Zero multiplicity occurs when a node has no fixed positions for a given character state. This is rare for typical nucleotide data but possible after reroot when the new root node's composition has zero counts for ambiguous characters.
+
+## Fix
+
+Guard the multiplication: skip the term when `fixed_counts` is 0 or when `log_norm` is not finite.
+
+## v0 comparison
+
+v0 uses dense arrays and numpy operations that naturally handle zero multiplication without NaN (numpy's `0 * -inf = nan` but v0's flow avoids the zero-count case by construction since composition is always derived from a full sequence).

--- a/kb/issues/M-sparse-node-reference-state-non-char-precedence.md
+++ b/kb/issues/M-sparse-node-reference-state-non-char-precedence.md
@@ -1,0 +1,27 @@
+# Sparse node_reference_state ignores non-char positions
+
+## Summary
+
+`node_reference_state()` reads `fitch.chosen_state` for variable positions but has no entry for non-variable positions with gaps or N. When a variable position overlaps a node's gap/unknown range, the returned state is a concrete nucleotide instead of gap/N.
+
+## Details
+
+`packages/treetime/src/partition/marginal_passes.rs`:
+
+`node_reference_state()` returns `fitch.chosen_state.get(&pos)`. `chosen_state` is populated during the Fitch forward pass only for variable positions. At a position where the node has N or gap, `chosen_state` may contain the resolved nucleotide (Fitch resolves ambiguity to a concrete state) rather than N/gap.
+
+`node_reference_state_or()` filters non-canonical states and falls back to `p.get_one()` from the Fitch state set. This fallback also returns a concrete nucleotide.
+
+The `state` field in `VarPos` entries is used as the fixed-row lookup key in `msg_to_child`/`msg_to_parent`. A wrong key selects the wrong fixed-row profile, producing incorrect branch-length contributions for that position.
+
+## Impact
+
+Affects variable positions where a node has a gap or N. This is a small fraction of positions for typical viral datasets, but the fraction grows with divergence and ambiguity.
+
+## Fix
+
+Check `non_char` ranges before returning from `node_reference_state`. If the position falls in a gap range, return gap. If in an unknown range, return unknown. This matches the precedence order: gap > unknown > chosen_state > fallback.
+
+## v0 comparison
+
+v0 overwrites `node.cseq` after each marginal pass, embedding gap and N positions directly in the sequence. State lookup reads from `cseq`, which always reflects the correct character including gaps and N.

--- a/kb/issues/N-io-time-based-branch-lengths-not-implemented.md
+++ b/kb/issues/N-io-time-based-branch-lengths-not-implemented.md
@@ -1,0 +1,15 @@
+# Time-based branch lengths not written to Newick/Nexus output
+
+## Summary
+
+The timetree command infers node dates and branch lengths in time units, but the Newick and Nexus output writers only emit divergence-based branch lengths (substitutions per site). v0 writes time-based branch lengths as an alternative output.
+
+## Details
+
+v0 `write_json` and `BranchLengthMode` support emitting branch lengths in calendar time units (`node.branch_length` vs `node.mutation_length`). v1 `write_graph_files` always writes divergence-based lengths from `edge.branch_length()`.
+
+After timetree inference, each node has both a divergence-based branch length and inferred dates. The time-based branch length is the date difference between parent and child. This is available in the graph but not exposed as an output option.
+
+## v0 reference
+
+`packages/legacy/treetime/treetime/treetime.py` `BranchLengthMode` enum, used in `write_json()` and `save_nexus()`.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -74,7 +74,11 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Partition    | [`infer_dense()` stub always returns false](N-representation-infer-dense-stub.md)                                                                   |
 | Negligible | Partition    | [Dense and sparse partition types have structural and naming asymmetries](N-representation-dense-sparse-partition-asymmetry.md)                     |
 | Medium     | Optimize     | [Optimize per-branch lengths diverge from v0 fixture beyond 10% relative tolerance](M-optimize-gm-per-branch-divergence.md)                         |
+| Medium     | Optimize     | [Sparse branch optimization reads stale Fitch-era states](M-optimize-sparse-stale-fitch-states.md)                                                  |
 | Medium     | GTR          | [Sparse GTR inference mixes MAP mutations with Fitch-era compositions](M-gtr-sparse-composition-stale-after-marginal.md)                            |
+| Medium     | Sparse       | [Sparse marginal fixed_counts zero-multiplicity produces NaN](M-sparse-marginal-zero-multiplicity-nan.md)                                           |
+| Medium     | Sparse       | [Sparse marginal msg_to_child includes near-deterministic variable sites](M-sparse-marginal-quantitative-site-filtering.md)                         |
+| Medium     | Sparse       | [Sparse node_reference_state ignores non-char positions](M-sparse-node-reference-state-non-char-precedence.md)                                      |
 | Medium     | Timetree     | [Coalescent backward pass missing leaf and root contributions](M-timetree-coalescent-missing-leaf-and-root-contributions.md)                        |
 | Medium     | Timetree     | [--coalescent-opt alone skips initial Tc pass](M-timetree-coalescent-opt-skips-initial.md)                                                          |
 | Medium     | Timetree     | [Date column header matching breaks on hash](M-timetree-date-header-hash.md)                                                                        |
@@ -90,6 +94,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Core         | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                                     |
 | Negligible | Dates        | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                                     |
 | Negligible | Distribution | [Formula discretization errors silently swallowed](N-distribution-formula-silent-discretization.md)                                                 |
+| Negligible | I/O          | [Time-based branch lengths not written to Newick/Nexus output](N-io-time-based-branch-lengths-not-implemented.md)                                   |
 | Negligible | I/O          | [write_graph_files missing PhyloXML, Auspice, and UShER MAT formats](N-io-write-graph-files-missing-formats.md)                                     |
 | Negligible | I/O          | [Large datasets require all sequences in memory simultaneously](N-io-large-dataset-memory-constraint.md)                                            |
 | Negligible | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                                          |


### PR DESCRIPTION
Three correctness gaps in the sparse marginal path. M4 (stale composition for GTR) is already tracked as `M-gtr-sparse-composition-stale-after-marginal.md`.

### Work items

- [x] File issue: [`M-sparse-marginal-zero-multiplicity-nan.md`](https://github.com/neherlab/treetime/blob/b75c196c/kb/issues/M-sparse-marginal-zero-multiplicity-nan.md): `fixed_counts * NEG_INFINITY` produces NaN in `combine_messages`
- [x] File issue: [`M-sparse-marginal-quantitative-site-filtering.md`](https://github.com/neherlab/treetime/blob/b75c196c/kb/issues/M-sparse-marginal-quantitative-site-filtering.md): near-deterministic variable sites not filtered from `msg_to_child`
- [x] File issue: [`M-optimize-sparse-stale-fitch-states.md`](https://github.com/neherlab/treetime/blob/b75c196c/kb/issues/M-optimize-sparse-stale-fitch-states.md): sparse branch optimization reads stale Fitch-era `.state` fields
- [x] File issue: [`M-sparse-node-reference-state-non-char-precedence.md`](https://github.com/neherlab/treetime/blob/b75c196c/kb/issues/M-sparse-node-reference-state-non-char-precedence.md): `node_reference_state` returns concrete nucleotide instead of gap/N at non-char positions
- [x] File issue: [`N-io-time-based-branch-lengths-not-implemented.md`](https://github.com/neherlab/treetime/blob/b75c196c/kb/issues/N-io-time-based-branch-lengths-not-implemented.md): time-based branch lengths not written to Newick/Nexus output
- [x] M4 already tracked: `M-gtr-sparse-composition-stale-after-marginal.md`
- [x] Update `kb/issues/README.md` summary table