### PR TITLE
refactor: restructure apply_reroot into two-phase hierarchy

### DIFF
--- a/kb/algo/ancestral.md
+++ b/kb/algo/ancestral.md
@@ -63,6 +63,18 @@ The backward pass (leaf-to-root) computes partial likelihoods. The forward pass 
 
 v0: [`packages/legacy/treetime/treetime/treeanc.py#L762-L927`](../../packages/legacy/treetime/treetime/treeanc.py#L762-L927).
 
+### Sparse node data model
+
+Each sparse node carries `SparseSeqInfo` with two groups of fields:
+
+Sequence state: `composition` (character counts), `sequence` (resolved nucleotides), `gaps`/`unknown`/`non_char` (position ranges where the node has no informative data).
+
+Fitch state: `fitch.variable` (ambiguous positions from parsimony), `fitch.chosen_state` (resolved state per variable position from Fitch forward pass).
+
+`composition` flows into `fixed_counts` in `msg_to_child` (`process_node_forward`), which provides the per-character multiplicity weights for branch-length optimization (`optimize_sparse.rs`). `non_char` is used to mask positions from state propagation (`process_node_forward`, `process_node_backward`) and to exclude non-evolving positions from `edge_effective_length`.
+
+Non-char (N, gap) differences between parent and child are tracked through `non_char` ranges, not as Fitch substitutions. Applying a child edge's fitch_subs and indels to the parent's composition does not reproduce the child's composition when non-char positions differ. This is by design: Fitch parsimony assigns concrete states at ambiguous positions, and N/gap masking is a separate layer.
+
 ### v0 differences
 
 v1 backward pass uses log-space arithmetic with logsumexp normalization (dense `normalize_from_log()`, sparse `softmax_with_log_norm()` in `combine_messages()`). v1 forward pass uses plain probability space (division). v0 uses neg-log space throughout. v1 dense uses deterministic `argmax_first()` (`#argmax_first`) for sequence extraction (leftmost state wins ties); v0 uses `np.argmax()` which has undefined tie-breaking.
@@ -150,11 +162,11 @@ Both implementations produce the same mutation set for the same reconstruction. 
 
 ## File Index
 
-| File                                                                                                                                             | Algorithms                                                                       |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
-| [`packages/treetime/src/ancestral/fitch.rs`](../../packages/treetime/src/ancestral/fitch.rs)                                   | Fitch parsimony (backward, forward, cleanup)                                     |
-| [`packages/treetime/src/ancestral/marginal.rs`](../../packages/treetime/src/ancestral/marginal.rs)                             | Marginal ML orchestration                                                        |
-| [`packages/treetime/src/commands/ancestral/run.rs`](../../packages/treetime/src/commands/ancestral/run.rs)                                       | Ancestral command entry point, method dispatch                                   |
+| File                                                                                                               | Algorithms                                                                       |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| [`packages/treetime/src/ancestral/fitch.rs`](../../packages/treetime/src/ancestral/fitch.rs)                       | Fitch parsimony (backward, forward, cleanup)                                     |
+| [`packages/treetime/src/ancestral/marginal.rs`](../../packages/treetime/src/ancestral/marginal.rs)                 | Marginal ML orchestration                                                        |
+| [`packages/treetime/src/commands/ancestral/run.rs`](../../packages/treetime/src/commands/ancestral/run.rs)         | Ancestral command entry point, method dispatch                                   |
 | [`packages/treetime/src/partition/marginal_dense.rs`](../../packages/treetime/src/partition/marginal_dense.rs)     | Dense marginal (Felsenstein pruning)                                             |
 | [`packages/treetime/src/partition/marginal_sparse.rs`](../../packages/treetime/src/partition/marginal_sparse.rs)   | Sparse marginal                                                                  |
 | [`packages/treetime/src/partition/marginal_passes.rs`](../../packages/treetime/src/partition/marginal_passes.rs)   | Sparse message passing                                                           |

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -859,6 +859,29 @@ mod tests {
     assert_eq!(vec_of_owned!["G4T", "A7C"], orig_root_ab_subs);
     assert_eq!(vec_of_owned!["11--13: TT -> --"], orig_root_ab_indels);
 
+    // Non-char positions (N, gap) are tracked through non_char ranges, not
+    // Fitch substitutions. Applying child-side subs+indels to root composition
+    // does NOT reproduce child composition when the child has N or gaps that
+    // the root does not.
+    //
+    // Child A has N at positions 8-9 where root has G,T. No Fitch sub exists
+    // for these positions because N is ambiguous (non-informative).
+    let root_node = &sparse.nodes[&new_root_key];
+    let child_node = &sparse.nodes[&a_key];
+    let child_edge = &sparse.edges[&child_side_key];
+
+    let mut derived = root_node.seq.composition.clone();
+    for sub in child_edge.fitch_subs() {
+      derived.add_sub(sub);
+    }
+    for indel in &child_edge.indels {
+      derived.add_indel(indel);
+    }
+    assert_ne!(
+      derived, child_node.seq.composition,
+      "root + subs/indels should NOT equal child composition (non-char positions are not Fitch subs)"
+    );
+
     Ok(())
   }
 }

--- a/packages/treetime/src/partition/marginal_sparse.rs
+++ b/packages/treetime/src/partition/marginal_sparse.rs
@@ -15,12 +15,11 @@ use crate::{make_error, make_internal_report};
 use eyre::Report;
 use ndarray::{Array1, Array2};
 use std::collections::{BTreeMap, BTreeSet};
-use std::mem;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
-use treetime_graph::reroot::{EdgeMergeInfo, EdgeSplitInfo, RerootChanges};
+use treetime_graph::reroot::{EdgeMergeInfo, RerootChanges};
 use treetime_io::fasta::FastaRecord;
 use treetime_primitives::{Seq, seq};
 use treetime_utils::array::ndarray::argmax_first;
@@ -281,39 +280,51 @@ impl PartitionMarginalSparse {
     result
   }
 
-  fn reroot_split_edges(&mut self, info: &EdgeSplitInfo) -> Result<(), Report> {
-    let mut old_edge_data = self
-      .edges
-      .remove(&info.old_edge_key)
-      .ok_or_else(|| make_internal_report!("Old edge {:?} must exist for split", info.old_edge_key))?;
+  // Phase 1: topology changes + root_sequence derivation + new node init.
+  // Must complete before remove_trivial_root (phase 2) because
+  // derive_root_sequence reads the parent_edge that phase 2 deletes.
+  //
+  // Note: root_composition + child-side fitch_subs + indels != child_composition.
+  // Non-char (N, gap) differences between nodes are not encoded as Fitch subs -
+  // they are tracked through non_char ranges on each node instead.
+  fn apply_reroot_changes(&mut self, changes: &RerootChanges) -> Result<(), Report> {
+    // Split edge: child-side gets all mutations, parent-side is empty
+    if let Some(info) = &changes.edge_split {
+      let mut old_edge_data = self
+        .edges
+        .remove(&info.old_edge_key)
+        .ok_or_else(|| make_internal_report!("Old edge {:?} must exist for split", info.old_edge_key))?;
+      old_edge_data.clear_ml_subs();
+      self.edges.insert(info.child_side_edge_key, old_edge_data);
+      self
+        .edges
+        .insert(info.parent_side_edge_key, SparseEdgePartition::default());
+    }
 
-    old_edge_data.clear_ml_subs();
-    self.edges.insert(info.child_side_edge_key, old_edge_data);
-    self
-      .edges
-      .insert(info.parent_side_edge_key, SparseEdgePartition::default());
-    Ok(())
-  }
-
-  fn reroot_invert_edges(&mut self, inverted_edge_keys: &[GraphEdgeKey]) -> Result<(), Report> {
-    for edge_key in inverted_edge_keys {
+    // Invert edges on the reroot path
+    for edge_key in &changes.inverted_edge_keys {
       let edge_data = self
         .edges
         .get_mut(edge_key)
         .ok_or_else(|| make_internal_report!("Edge {edge_key:?} must exist on reroot path"))?;
-
-      edge_data.invert_fitch_subs();
-      edge_data.clear_ml_subs();
-      for indel in &mut edge_data.indels {
-        indel.invert();
-      }
-      mem::swap(&mut edge_data.msg_to_parent, &mut edge_data.msg_to_child);
-      edge_data.msg_from_child = SparseSeqDistribution::default();
+      edge_data.invert_for_reroot();
     }
+
+    // Derive root_sequence for the new root
+    self.derive_root_sequence(changes);
+
+    // Initialize the new split node from the finalized root_sequence
+    if let Some(info) = &changes.edge_split {
+      self.nodes.insert(
+        info.new_node_key,
+        SparseNodePartition::new(&self.root_sequence, &self.alphabet)?,
+      );
+    }
+
     Ok(())
   }
 
-  fn reroot_merge_edges(&mut self, info: &EdgeMergeInfo) -> Result<(), Report> {
+  fn remove_trivial_root(&mut self, info: &EdgeMergeInfo) -> Result<(), Report> {
     let parent_edge = self
       .edges
       .remove(&info.parent_edge_key)
@@ -336,12 +347,7 @@ impl PartitionMarginalSparse {
     Ok(())
   }
 
-  /// Derive root_sequence for the new root. Two cases:
-  /// - Inverted edges present: walk the inverted path from old root to new root,
-  ///   applying post-inversion subs and indels at each step.
-  /// - No inverted edges (trivial root removal only): apply the parent_edge subs
-  ///   that describe the old-root-to-removed-node transition.
-  fn reroot_derive_root_sequence(&mut self, changes: &RerootChanges) {
+  fn derive_root_sequence(&mut self, changes: &RerootChanges) {
     if !changes.inverted_edge_keys.is_empty() {
       let mut new_root_seq = self.root_sequence.clone();
       for edge_key in &changes.inverted_edge_keys {
@@ -351,10 +357,6 @@ impl PartitionMarginalSparse {
       }
       self.root_sequence = new_root_seq;
     } else if let Some(info) = &changes.edge_merge {
-      // No inversion: the merge removed the old root. The parent_edge
-      // described the path from new-root-side to the removed node.
-      // sub.reff() = new-root-side state. Apply to root_sequence before
-      // the edge is discarded by merge.
       if let Some(parent_edge) = self.edges.get(&info.parent_edge_key) {
         let parent_edge = parent_edge.clone();
         Self::apply_edge_to_sequence(&mut self.root_sequence, &parent_edge, &self.alphabet);
@@ -392,23 +394,10 @@ where
 
 impl PartitionRerootOps for PartitionMarginalSparse {
   fn apply_reroot(&mut self, changes: &RerootChanges) -> Result<(), Report> {
-    if let Some(info) = &changes.edge_split {
-      self.reroot_split_edges(info)?;
-    }
-
-    self.reroot_invert_edges(&changes.inverted_edge_keys)?;
-
-    self.reroot_derive_root_sequence(changes);
+    self.apply_reroot_changes(changes)?;
 
     if let Some(info) = &changes.edge_merge {
-      self.reroot_merge_edges(info)?;
-    }
-
-    if let Some(info) = &changes.edge_split {
-      self.nodes.insert(
-        info.new_node_key,
-        SparseNodePartition::new(&self.root_sequence, &self.alphabet)?,
-      );
+      self.remove_trivial_root(info)?;
     }
 
     Ok(())

--- a/packages/treetime/src/partition/sparse.rs
+++ b/packages/treetime/src/partition/sparse.rs
@@ -8,6 +8,7 @@ use maplit::btreemap;
 use ndarray::Array1;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::mem;
 use treetime_primitives::AlphabetLike;
 use treetime_primitives::{AsciiChar, Seq, StateSet, seq};
 use treetime_utils::interval::range_union::range_union;
@@ -158,6 +159,16 @@ impl SparseEdgePartition {
 
   pub fn clear_ml_subs(&mut self) {
     self.subs_ml = None;
+  }
+
+  pub fn invert_for_reroot(&mut self) {
+    self.invert_fitch_subs();
+    self.clear_ml_subs();
+    for indel in &mut self.indels {
+      indel.invert();
+    }
+    mem::swap(&mut self.msg_to_parent, &mut self.msg_to_child);
+    self.msg_from_child = SparseSeqDistribution::default();
   }
 }
 


### PR DESCRIPTION
- Follow-up to: #739

`apply_reroot` has two logical phases: (1) all topology changes and root-sequence updates, then (2) optionally remove the old root if it is a trivial node. `derive_root_sequence` reads the parent_edge that `remove_trivial_root` deletes, so the phase boundary must enforce this ordering structurally.

`apply_reroot_changes` (phase 1) contains edge split, path inversion, root_sequence derivation, and new node initialization. `remove_trivial_root` (phase 2) composes and merges edges around the old root. The function boundary between the two phases prevents accidental reordering that would cause a silent data loss. Edge inversion logic moves to `SparseEdgePartition::invert_for_reroot`.

### Work items

- [x] Group split, invert, derive, init into `apply_reroot_changes` (phase 1)
- [x] Extract merge into `remove_trivial_root` (phase 2)
- [x] Move edge inversion to `SparseEdgePartition::invert_for_reroot`