### PR TITLE
fix: re-add Joint variant with removed-method error

### DIFF
--- a/packages/treetime/src/ancestral/params.rs
+++ b/packages/treetime/src/ancestral/params.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
+use strum_macros::VariantNames;
 
-#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, VariantNames)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
+#[strum(serialize_all = "kebab-case")]
 #[derive(Default)]
 pub enum MethodAncestral {
   #[default]
   Marginal,
   Parsimony,
+  Joint,
 }

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -24,6 +24,7 @@ use log::info;
 use maplit::btreemap;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use strum::VariantNames;
 use treetime_io::fasta::{FastaReader, FastaRecord, FastaWriter, read_many_fasta};
 use treetime_io::graph::write_graph_files_with;
 use treetime_io::nwk::CommentProviders;
@@ -301,6 +302,15 @@ pub fn run_ancestral_reconstruction(
           model_name: *model_name,
         })
       }
+    },
+    MethodAncestral::Joint => {
+      let available = MethodAncestral::VARIANTS
+        .iter()
+        .filter(|v| **v != "joint")
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+      make_error!("Joint ancestral reconstruction has been removed. Available methods: {available}")
     },
   }
 }


### PR DESCRIPTION
An earlier cleanup removed `MethodAncestral::Joint` entirely, making `--method-anc=joint` an unrecognized value at the parser level with a generic clap error. Users migrating from v0 would get no guidance on what to use instead.

Re-add the variant so the CLI accepts it, but return a runtime error that names the available methods. The method list is derived from `strum::VariantNames` so it stays current if the enum changes.

### Work items

- [x] Re-add `Joint` variant to `MethodAncestral` with `strum::VariantNames` derive
- [x] Add match arm returning `make_error!` with dynamically listed alternatives