### PR TITLE
refactor: use unwrap_arc_rwlock helper

### DIFF
--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -24,6 +24,7 @@ mod tests {
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
   use treetime_utils::io::json::{JsonPretty, json_write_str};
+  use treetime_utils::sync::mutex::unwrap_arc_rwlock;
   use treetime_utils::vec_of_owned;
 
   /// Retrieve the name of a graph node by its key. Panics if the node is missing or unnamed.
@@ -727,9 +728,7 @@ mod tests {
 
     compress_sequences(&graph, &partitions, &aln)?;
 
-    let fitch = Arc::try_unwrap(partitions.into_iter().next().unwrap())
-      .map(|rw| rw.into_inner())
-      .map_err(|_e| eyre::eyre!("Fitch partition still shared"))?;
+    let fitch = unwrap_arc_rwlock(partitions.into_iter().next().unwrap())?;
 
     let gtr = jc69(JC69Params {
       alphabet: AlphabetName::Nuc,

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -27,7 +27,7 @@ use treetime_graph::node::{GraphNode, NodeAncestralOps};
 use treetime_io::fasta::FastaRecord;
 use treetime_primitives::{AlphabetLike, Seq, seq};
 use treetime_utils::collections::container::get_exactly_one;
-use treetime_utils::sync::mutex::extract_parallel_error;
+use treetime_utils::sync::mutex::{extract_parallel_error, unwrap_arc_rwlock};
 
 pub fn create_fitch_partition<N, E>(
   graph: &Graph<N, E, ()>,
@@ -48,9 +48,7 @@ where
     edges: btreemap! {},
   }));
   compress_sequences(graph, std::slice::from_ref(&partition), aln)?;
-  Arc::try_unwrap(partition)
-    .map(|rw| rw.into_inner())
-    .map_err(|_arc| make_report!("create_fitch_partition: Arc still shared after compress_sequences"))
+  unwrap_arc_rwlock(partition)
 }
 
 pub(crate) fn attach_seqs_to_graph<N, E, P>(


### PR DESCRIPTION
Two call sites manually unwrap `Arc<RwLock<T>>` with a three-step `Arc::try_unwrap().map(into_inner).map_err(...)` chain. The `unwrap_arc_rwlock` helper in `treetime-utils` already encapsulates this pattern.

Replace both manual unwrap chains with the existing helper.

### Work items

- [x] Replace manual `Arc::try_unwrap` chain in `create_fitch_partition` with `unwrap_arc_rwlock`
- [x] Replace manual `Arc::try_unwrap` chain in reroot test with `unwrap_arc_rwlock`