### PR TITLE
refactor: rename Composition sequence methods to accept slices and str

### DIFF
--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -26,7 +26,7 @@ mod tests {
   use treetime_graph::reroot::{RerootChanges, apply_reroot_topology, remove_node_if_trivial, split_edge};
   use treetime_io::fasta::read_many_fasta_str;
   use treetime_io::nwk::nwk_read_str;
-  use treetime_primitives::AlphabetLike;
+  use treetime_primitives::AsciiChar;
   use treetime_utils::io::json::{JsonPretty, json_write_str};
   use treetime_utils::sync::mutex::unwrap_arc_rwlock;
   use treetime_utils::vec_of_owned;
@@ -863,11 +863,18 @@ mod tests {
     assert_eq!(vec_of_owned!["11--13: TT -> --"], orig_root_ab_indels);
 
     // --- G1: new root node composition matches root_sequence ---
+    // ACATCCCTGTA--G--: A=3 C=4 G=2 T=3 -=4
     let root_node = &sparse.nodes[&new_root_key];
-    let expected_comp = Composition::with_sequence(
-      sparse.root_sequence.iter().copied(),
-      sparse.alphabet.chars(),
-      sparse.alphabet.gap(),
+    let c = AsciiChar::from_byte_unchecked;
+    #[rustfmt::skip]
+    let expected_comp = Composition::from_counts(
+      btreemap! {
+        c(b'-') => 4, c(b'A') => 3, c(b'B') => 0, c(b'C') => 4,
+        c(b'D') => 0, c(b'G') => 2, c(b'H') => 0, c(b'K') => 0,
+        c(b'M') => 0, c(b'N') => 0, c(b'R') => 0, c(b'S') => 0,
+        c(b'T') => 3, c(b'V') => 0, c(b'W') => 0, c(b'Y') => 0,
+      },
+      c(b'-'),
     );
     assert_eq!(
       expected_comp, root_node.seq.composition,

--- a/packages/treetime/src/ancestral/fitch_sub.rs
+++ b/packages/treetime/src/ancestral/fitch_sub.rs
@@ -203,6 +203,6 @@ pub fn finalize_sequence_forward(
   }
   if is_root {
     // if the node is the root, the composition is calculated from the full sequence
-    *composition = Composition::with_sequence(sequence.iter().copied(), alphabet.chars(), alphabet.gap());
+    *composition = Composition::with_seq(sequence.as_slice(), alphabet.chars(), alphabet.gap());
   }
 }

--- a/packages/treetime/src/partition/sparse.rs
+++ b/packages/treetime/src/partition/sparse.rs
@@ -63,7 +63,7 @@ impl SparseNodePartition {
         unknown,
         gaps,
         non_char,
-        composition: Composition::with_sequence(seq.iter().copied(), alphabet.chars(), alphabet.gap()),
+        composition: Composition::with_seq(seq, alphabet.chars(), alphabet.gap()),
         sequence: seq.to_owned(), // TODO(perf): try to avoid cloning
         fitch: seq_dis,
       },

--- a/packages/treetime/src/seq/__tests__/test_composition.rs
+++ b/packages/treetime/src/seq/__tests__/test_composition.rs
@@ -30,19 +30,20 @@ mod tests {
   }
 
   #[test]
-  fn test_composition_with_sequence() {
-    let actual = Composition::with_sequence(chars("AAAGCTTACGGGGTCAAGTCC"), chars("ACGT-"), c(b'-'));
+  fn test_composition_with_seq() -> Result<(), Report> {
+    let actual = Composition::with_seq_str("AAAGCTTACGGGGTCAAGTCC", chars("ACGT-"), c(b'-'))?;
     let expected = Composition::from_counts(
       btreemap! { c(b'-') => 0, c(b'A') => 6, c(b'C') => 5, c(b'G') => 6, c(b'T') => 4},
       c(b'-'),
     );
     assert_eq!(expected, actual);
+    Ok(())
   }
 
   #[test]
-  fn test_composition_with_sequence_and_alphabet() {
+  fn test_composition_with_seq_and_alphabet() -> Result<(), Report> {
     let alpha_chars = Alphabet::new(AlphabetName::Nuc).unwrap().chars().collect_vec();
-    let actual = Composition::with_sequence(chars("ACATCGCCNNA--GAC"), alpha_chars, c(b'-'));
+    let actual = Composition::with_seq_str("ACATCGCCNNA--GAC", alpha_chars, c(b'-'))?;
     let expected = Composition::from_counts(
       btreemap! {
         c(b'-') => 2,
@@ -65,24 +66,13 @@ mod tests {
       c(b'-'),
     );
     assert_eq!(expected, actual);
+    Ok(())
   }
 
   #[test]
-  fn test_composition_add_sequence() {
+  fn test_composition_add_seq_str() -> Result<(), Report> {
     let mut actual = Composition::new(chars("ACGT-"), c(b'-'));
-    actual.add_sequence(chars("AAAGCTTACGGGGTCAAGTCC"));
-    let expected = Composition::from_counts(
-      btreemap! { c(b'-') => 0, c(b'A') => 6, c(b'C') => 5, c(b'G') => 6, c(b'T') => 4},
-      c(b'-'),
-    );
-    assert_eq!(expected, actual);
-  }
-
-  #[test]
-  fn test_composition_add_sequence_with_refs() -> Result<(), Report> {
-    let mut actual = Composition::new(chars("ACGT-"), c(b'-'));
-    let sequence = Seq::try_from_str("AAAGCTTACGGGGTCAAGTCC")?;
-    actual.add_sequence(sequence);
+    actual.add_seq_str("AAAGCTTACGGGGTCAAGTCC")?;
     let expected = Composition::from_counts(
       btreemap! { c(b'-') => 0, c(b'A') => 6, c(b'C') => 5, c(b'G') => 6, c(b'T') => 4},
       c(b'-'),
@@ -92,8 +82,21 @@ mod tests {
   }
 
   #[test]
-  fn test_composition_add_mutation() {
-    let mut actual = Composition::with_sequence(chars("AAAGCTTACGGGGTCAAGTCC"), chars("ACGT-"), c(b'-'));
+  fn test_composition_add_seq_with_refs() -> Result<(), Report> {
+    let mut actual = Composition::new(chars("ACGT-"), c(b'-'));
+    let sequence = Seq::try_from_str("AAAGCTTACGGGGTCAAGTCC")?;
+    actual.add_seq(&sequence);
+    let expected = Composition::from_counts(
+      btreemap! { c(b'-') => 0, c(b'A') => 6, c(b'C') => 5, c(b'G') => 6, c(b'T') => 4},
+      c(b'-'),
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+  }
+
+  #[test]
+  fn test_composition_add_mutation() -> Result<(), Report> {
+    let mut actual = Composition::with_seq_str("AAAGCTTACGGGGTCAAGTCC", chars("ACGT-"), c(b'-'))?;
     let mutation = Sub::from_str("A123G").unwrap();
     actual.add_sub(&mutation);
     let expected = Composition::from_counts(
@@ -101,11 +104,12 @@ mod tests {
       c(b'-'),
     );
     assert_eq!(expected, actual);
+    Ok(())
   }
 
   #[test]
   fn test_composition_add_deletion() -> Result<(), Report> {
-    let mut actual = Composition::with_sequence(chars("AAAGCTTACGGGGTCAAGTCC"), chars("ACGT-"), c(b'-'));
+    let mut actual = Composition::with_seq_str("AAAGCTTACGGGGTCAAGTCC", chars("ACGT-"), c(b'-'))?;
     let indel = InDel::del((1, 5), Seq::try_from_str("AAGC")?);
     actual.add_indel(&indel);
     let expected = Composition::from_counts(
@@ -118,7 +122,7 @@ mod tests {
 
   #[test]
   fn test_composition_add_insertion() -> Result<(), Report> {
-    let mut actual = Composition::with_sequence(chars("AAAGCTTACGGGGTCAAGTCC"), chars("ACGT-"), c(b'-'));
+    let mut actual = Composition::with_seq_str("AAAGCTTACGGGGTCAAGTCC", chars("ACGT-"), c(b'-'))?;
     let indel = InDel::ins((3, 6), Seq::try_from_str("ATC")?);
     actual.add_indel(&indel);
     let expected = Composition::from_counts(

--- a/packages/treetime/src/seq/composition.rs
+++ b/packages/treetime/src/seq/composition.rs
@@ -1,5 +1,6 @@
 use crate::seq::indel::InDel;
 use crate::seq::mutation::Sub;
+use eyre::Report;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -37,25 +38,38 @@ impl Composition {
     &self.counts
   }
 
-  /// Initialize counters to the composition of a given sequence
-  pub fn with_sequence<SI, AI>(sequence: SI, alphabet_chars: AI, gap: AsciiChar) -> Self
-  where
-    SI: IntoIterator<Item = AsciiChar>,
-    AI: IntoIterator<Item = AsciiChar>,
-  {
+  pub fn with_seq(
+    sequence: impl AsRef<[AsciiChar]>,
+    alphabet_chars: impl IntoIterator<Item = AsciiChar>,
+    gap: AsciiChar,
+  ) -> Self {
     let mut this = Self::new(alphabet_chars, gap);
-    this.add_sequence(sequence);
+    this.add_seq(sequence);
     this
   }
 
-  /// Add composition of a given sequence to the counts
-  pub fn add_sequence<I>(&mut self, sequence: I)
-  where
-    I: IntoIterator<Item = AsciiChar>,
-  {
-    for (c, n) in sequence.into_iter().counts() {
+  pub fn with_seq_str(
+    sequence: &str,
+    alphabet_chars: impl IntoIterator<Item = AsciiChar>,
+    gap: AsciiChar,
+  ) -> Result<Self, Report> {
+    let seq = Self::str_to_chars(sequence)?;
+    Ok(Self::with_seq(seq, alphabet_chars, gap))
+  }
+
+  pub fn add_seq(&mut self, sequence: impl AsRef<[AsciiChar]>) {
+    for (&c, n) in sequence.as_ref().iter().counts() {
       *self.counts.entry(c).or_default() += n;
     }
+  }
+
+  pub fn add_seq_str(&mut self, sequence: &str) -> Result<(), Report> {
+    self.add_seq(Self::str_to_chars(sequence)?);
+    Ok(())
+  }
+
+  fn str_to_chars(s: &str) -> Result<Vec<AsciiChar>, Report> {
+    s.bytes().map(AsciiChar::try_new).collect::<Result<Vec<_>, _>>()
   }
 
   /// Reflect sequence mutation in the composition counts


### PR DESCRIPTION
- Depends on: `test/sparse-reroot-node-init`

`Composition::with_sequence` and `add_sequence` required `IntoIterator<Item = AsciiChar>`, forcing callers on `&Seq` to write `.iter().copied()`. `Seq` implements `AsRef<[AsciiChar]>` via `Deref`, so callers should pass a `&Seq` or `&[AsciiChar]` directly.

Rename to `with_seq`/`add_seq` with `AsRef<[AsciiChar]>` bound. Add `with_seq_str`/`add_seq_str` for `&str` input with ASCII validation via `AsciiChar::try_new`, returning `Result`.

### Work items

- [x] Rename `with_sequence` -> `with_seq`, `add_sequence` -> `add_seq` with `AsRef<[AsciiChar]>` bound
- [x] Add `with_seq_str`/`add_seq_str` accepting `&str` with error handling
- [x] Update all production call sites to pass bare variables
- [x] Update test call sites to use `_str` variants with string literals