### PR TITLE
refactor: add pipeline layer separating algorithms from I/O

### DIFF
--- a/kb/issues/H-core-command-module-shared-ops-entanglement.md
+++ b/kb/issues/H-core-command-module-shared-ops-entanglement.md
@@ -58,3 +58,4 @@ Traits and types moved to `partition/` and `payload/`: partition traits (`Partit
 
 - `homoplasy` -> `ancestral`: `TreetimeAncestralArgs` CLI struct embedding (minor)
 - Output helpers: `write_graph()` duplicated across `ancestral`, `optimize`, `prune` (tracked separately, not yet filed)
+- Pipeline layer added: all commands now have `<module>/pipeline.rs` with pure computation functions. `commands/*/run.rs` are thin I/O wrappers delegating to pipelines. Next step: move `commands/` (args + I/O handlers) from library to consumer crates (`app-api`, `app-cli`)

--- a/kb/issues/M-core-partition-init-orchestration-duplication.md
+++ b/kb/issues/M-core-partition-init-orchestration-duplication.md
@@ -1,5 +1,11 @@
 # Partition creation is hardcoded per-command instead of configured
 
+## Status: partially resolved
+
+`partition/create.rs` provides `create_marginal_partition()` consolidating the 3-way branch (sparse, dense+infer, dense+named) without `write_gtr_json` during init. All pipeline functions use it. The full `PartitionSpec`/config layer for multi-partition support is not yet implemented.
+
+## Original description
+
 Four commands construct partitions inline with procedural code: `create_fitch_partition` -> GTR resolution -> `log_gtr` -> `into_marginal_sparse`/`into_marginal_dense`. Each command implements its own variant with different models, different dense/sparse decisions, different `write_gtr_json` placement, and different post-init handling. These are not duplicated identical partitions but independent partition setups that share no configuration layer.
 
 The multi-partition infrastructure (`Vec<Arc<RwLock<dyn PartitionTimetreeAll>>>`) exists and works (mugration adds a discrete partition), but no command creates more than one sequence partition. No `PartitionConfig` or `PartitionSpec` type exists. Partition creation is entangled with command orchestration.

--- a/kb/tickets/architecture-clock-pipeline-params-naming.md
+++ b/kb/tickets/architecture-clock-pipeline-params-naming.md
@@ -1,0 +1,9 @@
+# Rename ClockParams\_ to avoid underscore suffix
+
+## Description
+
+`packages/treetime/src/clock/pipeline.rs` defines `pub struct ClockParams_` with an underscore suffix to avoid collision with `ClockParams` from `clock/clock_regression.rs`. The underscore naming is a hack. Rename to `ClockPipelineParams` or restructure imports.
+
+## Related issues
+
+- Source: [H-core-command-module-shared-ops-entanglement.md](../issues/H-core-command-module-shared-ops-entanglement.md)

--- a/kb/tickets/architecture-migrate-command-tests-with-dissolution.md
+++ b/kb/tickets/architecture-migrate-command-tests-with-dissolution.md
@@ -1,0 +1,54 @@
+# Migrate command tests during commands/ dissolution
+
+## Description
+
+When `commands/` moves from the `treetime` library to consumer crates (`app-api`, `app-cli`), the tests in `commands/__tests__/` must be triaged and migrated:
+
+- Tests that exercise CLI arg construction, file I/O, or end-to-end command execution through `run_*` functions: move to the consumer crate that owns the handler (likely `app-api` or `app-cli`)
+- Tests that exercise domain functions (algorithm correctness, data transformations): keep in the library, move to the domain module's `__tests__/` directory
+- Tests that use nonexistent file paths to verify fail-fast validation ordering: these test handler behavior, not domain logic. Move with the handler.
+
+Unit tests are not suitable for testing file I/O operations. Integration tests or smoke tests are the right tool for verifying that the handler reads files, calls the pipeline, and writes output correctly.
+
+## Specific tests to triage
+
+Confidence tests in `commands/timetree/output/__tests__/`:
+
+- `test_confidence_combine.rs`: tests `timetree::confidence::combine_confidence` (domain) -> move to `timetree/__tests__/`
+- `test_confidence_extract.rs`: tests `timetree::confidence::extract_confidence_intervals` (domain) -> move to `timetree/__tests__/`
+- `test_confidence_rate.rs`: tests `timetree::confidence::determine_rate_std` (domain) -> move to `timetree/__tests__/`
+
+Mugration tests in `commands/mugration/__tests__/`:
+
+- `test_discrete_marginal.rs`: tests domain marginal reconstruction -> move to `mugration/__tests__/`
+- `test_gm_mugration.rs`: golden master test calling `execute_mugration` -> move to `mugration/__tests__/`
+- `test_run.rs`: calls `run_mugration` with real files -> move to consumer crate
+- `test_comment_output.rs`: tests `DiscreteCommentProvider` (domain) -> move to `mugration/__tests__/` or `partition/__tests__/`
+- `test_augur_node_data.rs`: tests augur JSON formatting -> stays with augur builder location
+
+Ancestral tests in `commands/ancestral/__tests__/`:
+
+- `test_smoke_sample_from_profile.rs`: calls `run_ancestral_reconstruction` with real files + validation guard test with fake paths -> move to consumer crate
+- `test_smoke_gtr_iterations.rs`: calls `run_ancestral_reconstruction` with real files -> move to consumer crate
+- `test_augur_node_data.rs`: tests augur JSON formatting -> stays with augur builder
+
+Optimize tests in `commands/optimize/__tests__/`:
+
+- `test_augur_node_data.rs`: tests augur JSON formatting -> stays with augur builder
+
+Timetree tests in `commands/timetree/__tests__/`:
+
+- `test_pipeline.rs`: constructs `TreetimeTimetreeArgs` and calls `run_timetree_estimation` -> move to consumer crate
+- `test_augur_node_data.rs`: tests augur JSON formatting -> stays with augur builder
+- `test_auspice.rs`: tests auspice JSON output -> move to `timetree/output/__tests__/` (tests domain builder)
+
+Stray tests outside commands/ that import `commands::shared::*`:
+
+- `optimize/__tests__/test_args.rs`: tests clap parsing of opt-method args -> move to consumer crate
+- `seq/__tests__/test_gap_fill.rs`: tests clap parsing of gap fill args -> move to consumer crate
+
+## Related issues
+
+- Source: [H-core-command-module-shared-ops-entanglement.md](../issues/H-core-command-module-shared-ops-entanglement.md)
+- Source: [H-core-multi-client-architecture-library-purity.md](../issues/H-core-multi-client-architecture-library-purity.md)
+- Prerequisite: `architecture-move-commands-to-cli-crate.md` (the dissolution itself)

--- a/packages/app-api/src/lib.rs
+++ b/packages/app-api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod datasets;
+pub mod pipelines;
 pub mod progress;
 
 pub use treetime::version;

--- a/packages/app-api/src/pipelines.rs
+++ b/packages/app-api/src/pipelines.rs
@@ -1,0 +1,25 @@
+pub mod ancestral {
+  pub use treetime::ancestral::pipeline::{
+    AncestralInput, AncestralOutput, AncestralOutputFull, AncestralParams, AncestralPartition, run,
+  };
+}
+
+pub mod clock {
+  pub use treetime::clock::pipeline::{ClockInput, ClockOutput, ClockParams_, run};
+}
+
+pub mod optimize {
+  pub use treetime::optimize::pipeline::{OptimizeInput, OptimizeOutput, OptimizeParams, run};
+}
+
+pub mod prune {
+  pub use treetime::prune::pipeline::{PruneInput, PruneOutput, PruneParams, run};
+}
+
+pub mod mugration {
+  pub use treetime::mugration::pipeline::{MugrationResult, run};
+}
+
+pub mod timetree {
+  pub use treetime::timetree::pipeline::{TimetreeInput, TimetreeOutput, TimetreeParams, run};
+}

--- a/packages/treetime/src/ancestral/mod.rs
+++ b/packages/treetime/src/ancestral/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod gtr_inference;
 pub mod marginal;
 pub mod mask;
 pub mod params;
+pub mod pipeline;
 pub mod sample;
 
 #[cfg(test)]

--- a/packages/treetime/src/ancestral/pipeline.rs
+++ b/packages/treetime/src/ancestral/pipeline.rs
@@ -1,0 +1,215 @@
+use crate::alphabet::alphabet::Alphabet;
+use crate::ancestral::fitch::{ancestral_reconstruction_fitch, compress_sequences};
+use crate::ancestral::marginal::{ancestral_reconstruction_marginal, initialize_marginal, update_marginal};
+use crate::ancestral::mask::create_mask;
+use crate::ancestral::params::MethodAncestral;
+use crate::ancestral::sample::SampleMode;
+use crate::gtr::get_gtr::GtrModelName;
+use crate::gtr::gtr::GTR;
+use crate::gtr::refinement::refine_gtr_iterative;
+use crate::partition::create::{MarginalPartition, create_marginal_partition};
+use crate::partition::fitch::PartitionFitch;
+use crate::partition::marginal_dense::PartitionMarginalDense;
+use crate::partition::traits::HasGtr;
+use crate::payload::ancestral::{GraphAncestral, NodeAncestral};
+use crate::progress::ProgressSink;
+use crate::seq::alignment::get_common_length;
+use eyre::Report;
+use maplit::btreemap;
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::sync::Arc;
+use strum::VariantNames;
+use treetime_io::fasta::FastaRecord;
+use treetime_primitives::Seq;
+use treetime_utils::make_error;
+use treetime_utils::sync::random::get_random_number_generator;
+
+pub struct AncestralParams {
+  pub method: MethodAncestral,
+  pub model: GtrModelName,
+  pub dense: Option<bool>,
+  pub reconstruct_tip_states: bool,
+  pub gtr_iterations: usize,
+  pub site_specific_gtr: bool,
+  pub seed: Option<u64>,
+  pub sample_from_profile: SampleMode,
+}
+
+pub struct AncestralInput {
+  pub graph: GraphAncestral,
+  pub alphabet: Alphabet,
+  pub sequences: Vec<FastaRecord>,
+}
+
+/// Partition variant returned from ancestral reconstruction, allowing the caller to build comment providers.
+pub enum AncestralPartition {
+  Fitch(Arc<RwLock<PartitionFitch>>),
+  Sparse(Arc<RwLock<crate::partition::marginal_sparse::PartitionMarginalSparse>>),
+  Dense(Arc<RwLock<PartitionMarginalDense>>),
+}
+
+#[derive(Debug, Serialize)]
+pub struct AncestralOutput {
+  #[serde(skip)]
+  pub graph: GraphAncestral,
+  #[serde(skip)]
+  pub gtr: Option<GTR>,
+  pub model_name: GtrModelName,
+  #[serde(skip)]
+  pub mask: Vec<bool>,
+}
+
+pub struct AncestralOutputFull {
+  pub output: AncestralOutput,
+  pub partition: Option<AncestralPartition>,
+}
+
+pub fn run<F>(
+  params: &AncestralParams,
+  input: AncestralInput,
+  mut on_sequence: F,
+  progress: &dyn ProgressSink,
+) -> Result<AncestralOutputFull, Report>
+where
+  F: FnMut(&NodeAncestral, &Seq) -> Result<(), Report>,
+{
+  if params.site_specific_gtr {
+    return make_error!(
+      "--site-specific-gtr is not yet integrated into the ancestral reconstruction pipeline. \
+       The mathematical core (GTRSiteSpecific) is implemented but partition system wiring is pending."
+    );
+  }
+
+  if params.sample_from_profile != SampleMode::Argmax && params.method != MethodAncestral::Marginal {
+    return make_error!(
+      "--sample-from-profile={:?} requires --method-anc=marginal. Posterior sampling is only defined \
+       for marginal reconstruction; {:?} has no posterior profile to sample.",
+      params.sample_from_profile,
+      params.method
+    );
+  }
+
+  let alignment_length = get_common_length(&input.sequences)?;
+  let mask = create_mask(&input.sequences, alignment_length, &input.alphabet);
+  let mut rng = get_random_number_generator(params.seed);
+
+  match params.method {
+    MethodAncestral::Parsimony => {
+      progress.check_cancelled()?;
+      progress.report("Fitch parsimony", 0.3, "");
+      let partition = Arc::new(RwLock::new(PartitionFitch {
+        index: 0,
+        alphabet: input.alphabet,
+        length: alignment_length,
+        nodes: btreemap! {},
+        edges: btreemap! {},
+      }));
+      let partitions_parsimony = vec![Arc::clone(&partition)];
+
+      compress_sequences(&input.graph, &partitions_parsimony, &input.sequences)?;
+
+      ancestral_reconstruction_fitch(&input.graph, params.reconstruct_tip_states, &partitions_parsimony, |node, seq| {
+        on_sequence(&node.payload, seq)
+      })?;
+
+      progress.report("Done", 1.0, "");
+      Ok(AncestralOutputFull {
+        output: AncestralOutput {
+          graph: input.graph,
+          gtr: None,
+          model_name: params.model,
+          mask,
+        },
+        partition: Some(AncestralPartition::Fitch(partition)),
+      })
+    },
+    MethodAncestral::Marginal => {
+      progress.check_cancelled()?;
+      progress.report("Inferring GTR model", 0.2, "");
+
+      let created = create_marginal_partition(&input.graph, 0, input.alphabet, &input.sequences, params.model, params.dense)?;
+
+      match created.partition {
+        MarginalPartition::Sparse(partition) => {
+          let partitions = vec![Arc::new(RwLock::new(partition))];
+
+          progress.check_cancelled()?;
+          progress.report("Marginal reconstruction", 0.4, "");
+          update_marginal(&input.graph, &partitions)?;
+
+          if params.gtr_iterations > 0 && params.model == GtrModelName::Infer {
+            refine_gtr_iterative(&input.graph, &partitions[0], params.gtr_iterations, None, 1.0, None, false)?;
+          }
+
+          progress.check_cancelled()?;
+          progress.report("Reconstructing sequences", 0.6, "");
+          ancestral_reconstruction_marginal(
+            &input.graph,
+            params.reconstruct_tip_states,
+            &partitions,
+            params.sample_from_profile,
+            &mut rng,
+            |node, seq| on_sequence(node, seq),
+          )?;
+
+          let gtr = partitions[0].read_arc().gtr().clone();
+          progress.report("Done", 1.0, "");
+          Ok(AncestralOutputFull {
+            output: AncestralOutput {
+              graph: input.graph,
+              gtr: Some(gtr),
+              model_name: created.model_name,
+              mask,
+            },
+            partition: Some(AncestralPartition::Sparse(partitions.into_iter().next().expect("partition vec not empty"))),
+          })
+        },
+        MarginalPartition::Dense(partition) => {
+          let partitions = vec![Arc::new(RwLock::new(partition))];
+
+          progress.check_cancelled()?;
+          progress.report("Marginal reconstruction", 0.4, "");
+          initialize_marginal(&input.graph, &partitions, &input.sequences)?;
+          update_marginal(&input.graph, &partitions)?;
+
+          if params.gtr_iterations > 0 && params.model == GtrModelName::Infer {
+            refine_gtr_iterative(&input.graph, &partitions[0], params.gtr_iterations, None, 1.0, None, false)?;
+          }
+
+          progress.check_cancelled()?;
+          progress.report("Reconstructing sequences", 0.6, "");
+          ancestral_reconstruction_marginal(
+            &input.graph,
+            params.reconstruct_tip_states,
+            &partitions,
+            params.sample_from_profile,
+            &mut rng,
+            |node, seq| on_sequence(node, seq),
+          )?;
+
+          let gtr = partitions[0].read_arc().gtr().clone();
+          progress.report("Done", 1.0, "");
+          Ok(AncestralOutputFull {
+            output: AncestralOutput {
+              graph: input.graph,
+              gtr: Some(gtr),
+              model_name: created.model_name,
+              mask,
+            },
+            partition: Some(AncestralPartition::Dense(partitions.into_iter().next().expect("partition vec not empty"))),
+          })
+        },
+      }
+    },
+    MethodAncestral::Joint => {
+      let available = MethodAncestral::VARIANTS
+        .iter()
+        .filter(|v| **v != "joint")
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+      make_error!("Joint ancestral reconstruction has been removed. Available methods: {available}")
+    },
+  }
+}

--- a/packages/treetime/src/clock/mod.rs
+++ b/packages/treetime/src/clock/mod.rs
@@ -3,6 +3,7 @@ mod __tests__;
 
 pub mod assign_dates;
 pub mod clock_filter;
+pub mod pipeline;
 pub mod clock_graph;
 pub mod clock_model;
 pub mod clock_output;

--- a/packages/treetime/src/clock/pipeline.rs
+++ b/packages/treetime/src/clock/pipeline.rs
@@ -1,0 +1,113 @@
+use crate::clock::assign_dates::assign_dates;
+use crate::clock::clock_filter::clock_filter_inplace;
+use crate::clock::clock_graph::GraphClock;
+use crate::clock::clock_model::ClockModel;
+use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
+use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::reroot::RerootParams;
+use crate::clock::rtt::{ClockRegressionResult, gather_clock_regression_results};
+use crate::progress::ProgressSink;
+use eyre::{Report, WrapErr};
+use log::info;
+use serde::Serialize;
+use treetime_io::dates_csv::DatesMap;
+
+pub struct ClockParams_ {
+  pub clock_params: ClockParams,
+  pub clock_filter: f64,
+  pub keep_root: bool,
+  pub allow_negative_rate: bool,
+  pub branch_params: BranchPointOptimizationParams,
+}
+
+pub struct ClockInput {
+  pub graph: GraphClock,
+  pub dates: DatesMap,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClockOutput {
+  #[serde(skip)]
+  pub graph: GraphClock,
+  pub clock_model: ClockModel,
+  pub regression_results: Vec<ClockRegressionResult>,
+}
+
+pub fn run(params: &ClockParams_, mut input: ClockInput, progress: &dyn ProgressSink) -> Result<ClockOutput, Report> {
+  progress.check_cancelled()?;
+  progress.report("Assigning dates", 0.1, "");
+  assign_dates(&input.graph, &input.dates)?;
+
+  progress.check_cancelled()?;
+  progress.report("Clock regression", 0.3, "");
+  let (clock_model, new_outliers) = estimate_clock_model_with_prefilter(
+    &mut input.graph,
+    &params.clock_params,
+    params.keep_root,
+    &params.branch_params,
+    params.clock_filter,
+    params.allow_negative_rate,
+  )?;
+
+  if let Some(delta) = new_outliers {
+    info!("Clock filter changed outlier status for {delta} leaf nodes");
+  }
+
+  let regression_results = gather_clock_regression_results(&input.graph, &clock_model);
+
+  progress.report("Done", 1.0, "");
+  Ok(ClockOutput {
+    graph: input.graph,
+    clock_model,
+    regression_results,
+  })
+}
+
+fn estimate_clock_model_with_prefilter(
+  graph: &mut GraphClock,
+  options: &ClockParams,
+  keep_root: bool,
+  branch_params: &BranchPointOptimizationParams,
+  clock_filter_threshold: f64,
+  allow_negative_rate: bool,
+) -> Result<(ClockModel, Option<i32>), Report> {
+  let delta = (clock_filter_threshold > 0.0)
+    .then(|| -> Result<i32, Report> {
+      let reroot_params = RerootParams {
+        force_positive_rate: false,
+        ..RerootParams::default()
+      };
+      let result = estimate_clock_model_with_reroot_policy(
+        graph,
+        &ClockParams::default(),
+        None,
+        keep_root,
+        branch_params,
+        &reroot_params,
+        None,
+      )?;
+      let pre_clock_model = result.clock_model;
+      if pre_clock_model.clock_rate() < 0.0 {
+        log::warn!(
+          "Pre-filter clock rate is negative ({:.6e}). Outlier detection proceeds with this model.",
+          pre_clock_model.clock_rate()
+        );
+      }
+      Ok(clock_filter_inplace(graph, &pre_clock_model, clock_filter_threshold).new_outliers)
+    })
+    .transpose()?;
+
+  let reroot_params = RerootParams {
+    force_positive_rate: !allow_negative_rate,
+    ..RerootParams::default()
+  };
+  let result = estimate_clock_model_with_reroot_policy(graph, options, None, keep_root, branch_params, &reroot_params, None)
+    .wrap_err_with(|| {
+      if delta.is_some() {
+        "Clock model estimation failed after outlier filtering. The pre-filter step removed outliers but the clock rate remains negative at all root positions.".to_owned()
+      } else {
+        "Clock model estimation failed".to_owned()
+      }
+    })?;
+  Ok((result.clock_model, delta))
+}

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -1,76 +1,52 @@
 use crate::alphabet::alphabet::Alphabet;
-use crate::ancestral::fitch::{ancestral_reconstruction_fitch, compress_sequences, create_fitch_partition};
-use crate::ancestral::gtr_inference::infer_gtr_fitch;
-use crate::ancestral::marginal::{ancestral_reconstruction_marginal, initialize_marginal, update_marginal};
-use crate::ancestral::mask::create_mask;
 use crate::ancestral::params::MethodAncestral;
+use crate::ancestral::pipeline::{self, AncestralInput, AncestralParams, AncestralPartition};
 use crate::ancestral::sample::SampleMode;
 use crate::commands::ancestral::args::TreetimeAncestralArgs;
 use crate::commands::ancestral::augur_node_data::write_augur_node_data_json;
 use crate::commands::ancestral::result::AncestralResult;
-use crate::gtr::get_gtr::{GtrModelName, get_gtr_by_name, log_gtr, write_gtr_json};
-use crate::gtr::refinement::refine_gtr_iterative;
-use crate::make_error;
-use crate::partition::algo::infer_dense::infer_dense;
-use crate::partition::fitch::PartitionFitch;
-use crate::partition::marginal_dense::PartitionMarginalDense;
-use crate::partition::traits::{HasGtr, MutationCommentProvider};
-use crate::payload::ancestral::GraphAncestral;
+use crate::gtr::get_gtr::write_gtr_json;
+use crate::partition::traits::MutationCommentProvider;
 use crate::progress::ProgressSink;
-use crate::seq::alignment::get_common_length;
 use crate::seq::gap_fill::apply_gap_fill;
 use eyre::Report;
 use log::info;
-use maplit::btreemap;
-use parking_lot::RwLock;
-use std::sync::Arc;
-use strum::VariantNames;
 use treetime_io::fasta::{FastaReader, FastaRecord, FastaWriter, read_many_fasta};
 use treetime_io::graph::write_graph_files_with;
 use treetime_io::nwk::CommentProviders;
 use treetime_io::nwk::nwk_read_file;
 use treetime_utils::io::file::{create_file_or_stdout, open_stdin};
-use treetime_utils::sync::random::get_random_number_generator;
+use treetime_utils::make_error;
 
 pub fn run_ancestral_reconstruction(
   ancestral_args: &TreetimeAncestralArgs,
   progress: &dyn ProgressSink,
 ) -> Result<AncestralResult, Report> {
-  let input_fastas = &ancestral_args.alignment.alignment;
-  let tree = &ancestral_args.tree;
-  let model_name = &ancestral_args.model_args.model;
-  let reconstruct_tip_states = &ancestral_args.reconstruct_tip_states;
-  let method_anc = &ancestral_args.method_anc;
-  let dense = &ancestral_args.dense;
-  let gtr_iterations = &ancestral_args.gtr_iterations;
-  let outdir = &ancestral_args.output.outdir;
-  let site_specific_gtr = &ancestral_args.site_specific_gtr;
-
-  if *site_specific_gtr {
+  if ancestral_args.site_specific_gtr {
     return make_error!(
       "--site-specific-gtr is not yet integrated into the ancestral reconstruction pipeline. \
        The mathematical core (GTRSiteSpecific) is implemented but partition system wiring is pending."
     );
   }
 
-  if ancestral_args.sample_from_profile != SampleMode::Argmax && *method_anc != MethodAncestral::Marginal {
+  if ancestral_args.sample_from_profile != SampleMode::Argmax && ancestral_args.method_anc != MethodAncestral::Marginal {
     return make_error!(
       "--sample-from-profile={:?} requires --method-anc=marginal. Posterior sampling is only defined \
        for marginal reconstruction; {:?} has no posterior profile to sample. Use --method-anc=marginal, \
        or --sample-from-profile=argmax.",
       ancestral_args.sample_from_profile,
-      method_anc
+      ancestral_args.method_anc
     );
   }
 
-  let dense = dense.unwrap_or_else(infer_dense);
-
+  let outdir = &ancestral_args.output.outdir;
+  let gap_fill_mode = ancestral_args.gap_fill_args.effective_gap_fill();
   let alphabet = Alphabet::new(ancestral_args.alphabet_args.alphabet.unwrap_or_default())?;
 
-  let gap_fill_mode = ancestral_args.gap_fill_args.effective_gap_fill();
+  progress.check_cancelled()?;
+  progress.report("Reading input", 0.0, "");
 
-  // TODO: avoid reading all sequences into memory somehow?
-  let mut aln = if input_fastas.is_empty() {
+  let mut aln = if ancestral_args.alignment.alignment.is_empty() {
     info!("Reading input fasta from standard input");
     let mut reader = FastaReader::new(open_stdin()?, &alphabet);
     let mut records = Vec::new();
@@ -84,7 +60,7 @@ pub fn run_ancestral_reconstruction(
     }
     records
   } else {
-    read_many_fasta(input_fastas, &alphabet)?
+    read_many_fasta(&ancestral_args.alignment.alignment, &alphabet)?
   };
 
   for record in &mut aln {
@@ -92,225 +68,82 @@ pub fn run_ancestral_reconstruction(
   }
 
   progress.check_cancelled()?;
-  progress.report("Reading input", 0.0, "");
+  progress.report("Parsing tree", 0.1, "");
+  let graph = nwk_read_file(&ancestral_args.tree)?;
 
   let output_fasta = create_file_or_stdout(outdir.join("ancestral_sequences.fasta"))?;
   let mut output_fasta = FastaWriter::new(output_fasta);
 
-  progress.check_cancelled()?;
-  progress.report("Parsing tree", 0.1, "");
-  let graph: GraphAncestral = nwk_read_file(tree)?;
+  let params = AncestralParams {
+    method: ancestral_args.method_anc,
+    model: ancestral_args.model_args.model,
+    dense: ancestral_args.dense,
+    reconstruct_tip_states: ancestral_args.reconstruct_tip_states,
+    gtr_iterations: ancestral_args.gtr_iterations,
+    site_specific_gtr: ancestral_args.site_specific_gtr,
+    seed: ancestral_args.seed,
+    sample_from_profile: ancestral_args.sample_from_profile,
+  };
 
-  // Per-position ambiguity mask and augur node data output path are shared by
-  // all reconstruction paths below. The mask is derived from the alignment, so
-  // it is computed once here while `aln` and `alphabet` are still available.
-  let alignment_length = get_common_length(&aln)?;
-  let mask = create_mask(&aln, alignment_length, &alphabet);
+  let input = AncestralInput {
+    graph,
+    alphabet,
+    sequences: aln,
+  };
+
+  let result = pipeline::run(
+    &params,
+    input,
+    |node, seq| {
+      let name = node.name.as_deref().unwrap_or("");
+      let desc = &node.desc;
+      output_fasta.write(name, desc, seq)
+    },
+    progress,
+  )?;
+
+  progress.report("Writing output", 0.9, "");
   let augur_node_data_path = ancestral_args
     .output_augur_node_data
     .clone()
     .unwrap_or_else(|| outdir.join("ancestral.augur-node-data.json"));
 
-  // Posterior-profile sampling for marginal reconstruction. `Argmax` (default) is deterministic and
-  // ignores the RNG; `Root`/`All` draw from the per-node posterior. The RNG is seeded from `--seed`
-  // for reproducibility, or from entropy when unset.
-  let sample_mode = ancestral_args.sample_from_profile;
-  let mut rng = get_random_number_generator(ancestral_args.seed);
+  if let Some(gtr) = &result.output.gtr {
+    write_gtr_json(gtr, result.output.model_name, outdir, None)?;
+  }
 
-  match method_anc {
-    MethodAncestral::Parsimony => {
-      progress.check_cancelled()?;
-      progress.report("Fitch parsimony", 0.3, "");
-      let partitions_parsimony = vec![Arc::new(RwLock::new(PartitionFitch {
-        index: 0,
-        alphabet,
-        length: get_common_length(&aln)?,
-        nodes: btreemap! {},
-        edges: btreemap! {},
-      }))];
-
-      if !partitions_parsimony.is_empty() {
-        compress_sequences(&graph, &partitions_parsimony, &aln)?;
-
-        ancestral_reconstruction_fitch(&graph, *reconstruct_tip_states, &partitions_parsimony, |node, seq| {
-          let name = node.payload.name.as_deref().unwrap_or("");
-          let desc = &node.payload.desc;
-          output_fasta.write(name, desc, seq)
-        })?;
-      }
-
-      progress.report("Writing output", 0.9, "");
-      write_augur_node_data_json(
-        &graph,
-        &*partitions_parsimony[0].read_arc(),
-        &mask,
-        &augur_node_data_path,
-      )?;
+  match &result.partition {
+    Some(AncestralPartition::Fitch(partition)) => {
+      let guard = partition.read_arc();
+      write_augur_node_data_json(&result.output.graph, &*guard, &result.output.mask, &augur_node_data_path)?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
-      write_graph_files_with(outdir, "annotated_tree", &graph, &CommentProviders::new())?;
-
-      progress.report("Done", 1.0, "");
-      Ok(AncestralResult {
-        graph,
-        gtr: None,
-        model_name: *model_name,
-      })
+      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &CommentProviders::new())?;
     },
-    MethodAncestral::Marginal => {
-      progress.check_cancelled()?;
-      progress.report("Inferring GTR model", 0.2, "");
-      if !dense {
-        let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
-        let gtr = match *model_name {
-          GtrModelName::Infer => infer_gtr_fitch(&fitch, &graph)?,
-          _ => get_gtr_by_name(*model_name)?,
-        };
-        log_gtr(&gtr, *model_name);
-        let partition = fitch.into_marginal_sparse(gtr, &graph)?;
-        let partitions = vec![Arc::new(RwLock::new(partition))];
-
-        progress.check_cancelled()?;
-        progress.report("Marginal reconstruction", 0.4, "");
-        update_marginal(&graph, &partitions)?;
-
-        if *gtr_iterations > 0 && *model_name == GtrModelName::Infer {
-          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None, false)?;
-        }
-
-        progress.check_cancelled()?;
-        progress.report("Reconstructing sequences", 0.6, "");
-        ancestral_reconstruction_marginal(
-          &graph,
-          *reconstruct_tip_states,
-          &partitions,
-          sample_mode,
-          &mut rng,
-          |node, seq| {
-            let name = node.name.as_deref().unwrap_or("");
-            let desc = &node.desc;
-            output_fasta.write(name, desc, seq)
-          },
-        )?;
-
-        progress.report("Writing output", 0.9, "");
-        let gtr = partitions[0].read_arc().gtr().clone();
-        write_gtr_json(&gtr, *model_name, outdir, None)?;
-
-        let partition_guard = partitions[0].read_arc();
-        write_augur_node_data_json(&graph, &*partition_guard, &mask, &augur_node_data_path)?;
-        info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
-        let provider = MutationCommentProvider::new(&*partition_guard, &graph);
-        let providers = CommentProviders::new().with(&provider);
-        write_graph_files_with(outdir, "annotated_tree", &graph, &providers)?;
-
-        progress.report("Done", 1.0, "");
-        Ok(AncestralResult {
-          graph,
-          gtr: Some(gtr),
-          model_name: *model_name,
-        })
-      } else if *model_name == GtrModelName::Infer {
-        let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
-        let gtr = infer_gtr_fitch(&fitch, &graph)?;
-        log_gtr(&gtr, *model_name);
-        let partition = fitch.into_marginal_dense(gtr);
-        let partitions = vec![Arc::new(RwLock::new(partition))];
-
-        progress.check_cancelled()?;
-        progress.report("Marginal reconstruction", 0.4, "");
-        initialize_marginal(&graph, &partitions, &aln)?;
-        update_marginal(&graph, &partitions)?;
-
-        if *gtr_iterations > 0 {
-          refine_gtr_iterative(&graph, &partitions[0], *gtr_iterations, None, 1.0, None, false)?;
-        }
-
-        progress.check_cancelled()?;
-        progress.report("Reconstructing sequences", 0.6, "");
-        ancestral_reconstruction_marginal(
-          &graph,
-          *reconstruct_tip_states,
-          &partitions,
-          sample_mode,
-          &mut rng,
-          |node, seq| {
-            let name = node.name.as_deref().unwrap_or("");
-            let desc = &node.desc;
-            output_fasta.write(name, desc, seq)
-          },
-        )?;
-
-        progress.report("Writing output", 0.9, "");
-        let gtr = partitions[0].read_arc().gtr().clone();
-        write_gtr_json(&gtr, *model_name, outdir, None)?;
-
-        let partition_guard = partitions[0].read_arc();
-        write_augur_node_data_json(&graph, &*partition_guard, &mask, &augur_node_data_path)?;
-        info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
-        let provider = MutationCommentProvider::new(&*partition_guard, &graph);
-        let providers = CommentProviders::new().with(&provider);
-        write_graph_files_with(outdir, "annotated_tree", &graph, &providers)?;
-
-        progress.report("Done", 1.0, "");
-        Ok(AncestralResult {
-          graph,
-          gtr: Some(gtr),
-          model_name: *model_name,
-        })
-      } else {
-        let length = get_common_length(&aln)?;
-        let gtr = get_gtr_by_name(*model_name)?;
-        write_gtr_json(&gtr, *model_name, outdir, None)?;
-        log_gtr(&gtr, *model_name);
-        let partition = PartitionMarginalDense::new(0, gtr, alphabet, length);
-        let partitions = vec![Arc::new(RwLock::new(partition))];
-
-        progress.check_cancelled()?;
-        progress.report("Marginal reconstruction", 0.4, "");
-        initialize_marginal(&graph, &partitions, &aln)?;
-        update_marginal(&graph, &partitions)?;
-
-        progress.check_cancelled()?;
-        progress.report("Reconstructing sequences", 0.6, "");
-        ancestral_reconstruction_marginal(
-          &graph,
-          *reconstruct_tip_states,
-          &partitions,
-          sample_mode,
-          &mut rng,
-          |node, seq| {
-            let name = node.name.as_deref().unwrap_or("");
-            let desc = &node.desc;
-            output_fasta.write(name, desc, seq)
-          },
-        )?;
-
-        progress.report("Writing output", 0.9, "");
-        let gtr = partitions[0].read_arc().gtr().clone();
-
-        let partition_guard = partitions[0].read_arc();
-        write_augur_node_data_json(&graph, &*partition_guard, &mask, &augur_node_data_path)?;
-        info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
-        let provider = MutationCommentProvider::new(&*partition_guard, &graph);
-        let providers = CommentProviders::new().with(&provider);
-        write_graph_files_with(outdir, "annotated_tree", &graph, &providers)?;
-
-        progress.report("Done", 1.0, "");
-        Ok(AncestralResult {
-          graph,
-          gtr: Some(gtr),
-          model_name: *model_name,
-        })
-      }
+    Some(AncestralPartition::Sparse(partition)) => {
+      let guard = partition.read_arc();
+      write_augur_node_data_json(&result.output.graph, &*guard, &result.output.mask, &augur_node_data_path)?;
+      info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
+      let provider = MutationCommentProvider::new(&*guard, &result.output.graph);
+      let providers = CommentProviders::new().with(&provider);
+      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &providers)?;
     },
-    MethodAncestral::Joint => {
-      let available = MethodAncestral::VARIANTS
-        .iter()
-        .filter(|v| **v != "joint")
-        .copied()
-        .collect::<Vec<_>>()
-        .join(", ");
-      make_error!("Joint ancestral reconstruction has been removed. Available methods: {available}")
+    Some(AncestralPartition::Dense(partition)) => {
+      let guard = partition.read_arc();
+      write_augur_node_data_json(&result.output.graph, &*guard, &result.output.mask, &augur_node_data_path)?;
+      info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
+      let provider = MutationCommentProvider::new(&*guard, &result.output.graph);
+      let providers = CommentProviders::new().with(&provider);
+      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &providers)?;
+    },
+    None => {
+      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &CommentProviders::new())?;
     },
   }
+
+  progress.report("Done", 1.0, "");
+  Ok(AncestralResult {
+    graph: result.output.graph,
+    gtr: result.output.gtr,
+    model_name: result.output.model_name,
+  })
 }

--- a/packages/treetime/src/commands/clock/run.rs
+++ b/packages/treetime/src/commands/clock/run.rs
@@ -1,17 +1,14 @@
-use crate::clock::assign_dates::assign_dates;
-use crate::clock::clock_filter::clock_filter_inplace;
+use crate::clock::clock_output::write_clock_model;
 use crate::clock::clock_graph::GraphClock;
 use crate::clock::clock_model::ClockModel;
-use crate::clock::clock_output::write_clock_model;
-use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
-use crate::clock::find_best_root::params::{BranchPointOptimizationParams, OptimizationMethod};
-use crate::clock::reroot::RerootParams;
-use crate::clock::rtt::{ClockRegressionResult, gather_clock_regression_results, write_clock_regression_result_csv};
+use crate::clock::pipeline::{self, ClockInput, ClockParams_};
+use crate::clock::rtt::{ClockRegressionResult, write_clock_regression_result_csv};
 use crate::commands::clock::args::{BranchSplitArgs, TreetimeClockArgs};
+use crate::clock::clock_regression::ClockParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, OptimizationMethod};
 use crate::make_error;
 use crate::make_report;
 use eyre::{Report, WrapErr};
-use log::info;
 use treetime_io::dates_csv::read_dates;
 use treetime_io::graph::write_graph_files;
 use treetime_io::nwk::nwk_read_file;
@@ -36,145 +33,61 @@ pub fn run_clock(
   clock_args: &TreetimeClockArgs,
   progress: &dyn crate::progress::ProgressSink,
 ) -> Result<ClockResult, Report> {
-  let tree = &clock_args.tree;
-  let sequence_length = &clock_args.sequence_length;
-  let clock_filter = &clock_args.clock_filter;
-  let keep_root = &clock_args.keep_root;
-  let tip_slack = &clock_args.tip_slack;
-  let covariation = &clock_args.covariation;
-  let allow_negative_rate = &clock_args.allow_negative_rate;
-  let outdir = &clock_args.output.outdir;
-  let branch_split = &clock_args.branch_split;
-  let clock_regression = &clock_args.clock_regression;
-
   progress.check_cancelled()?;
   progress.report("Reading input", 0.0, "");
-  let mut graph: GraphClock = if let Some(tree) = tree {
+
+  let graph: GraphClock = if let Some(tree) = &clock_args.tree {
     nwk_read_file(tree)
   } else {
     return make_error!("Tree inference is not implemented. Provide a tree file with --tree");
   }?;
 
-  {
-    let dates = read_dates(
-      &clock_args.metadata,
-      &clock_args.metadata_id.metadata_id_columns,
-      &None,
-      &clock_args.date_column.date_column,
-    )
-    .wrap_err("When reading dates")?;
-    assign_dates(&graph, &dates)?;
-  }
+  let dates = read_dates(
+    &clock_args.metadata,
+    &clock_args.metadata_id.metadata_id_columns,
+    &None,
+    &clock_args.date_column.date_column,
+  )
+  .wrap_err("When reading dates")?;
 
-  progress.check_cancelled()?;
-  progress.report("Clock regression", 0.3, "");
-  let (clock_model, new_outliers) = if *covariation {
-    let seq_len = sequence_length
+  let clock_params = if clock_args.covariation {
+    let seq_len = clock_args
+      .sequence_length
       .ok_or_else(|| make_report!("--sequence-length is required when --covariation is enabled"))?
       as f64;
-    let tip_slack = tip_slack.unwrap_or(3.0);
-    let overdispersion = 2.0; // TODO: empirical value for now, need to think of a better parameter than `tip_slack`
-    let options = ClockParams {
+    let tip_slack = clock_args.tip_slack.unwrap_or(3.0);
+    let overdispersion = 2.0;
+    ClockParams {
       variance_factor: overdispersion / seq_len,
       variance_offset: 0.0,
       variance_offset_leaf: tip_slack * tip_slack / seq_len / seq_len,
-    };
-
-    estimate_clock_model_with_prefilter(
-      &mut graph,
-      &options,
-      *keep_root,
-      branch_split,
-      *clock_filter,
-      *allow_negative_rate,
-    )?
+    }
   } else {
-    estimate_clock_model_with_prefilter(
-      &mut graph,
-      &clock_regression.clock_params,
-      *keep_root,
-      branch_split,
-      *clock_filter,
-      *allow_negative_rate,
-    )?
+    clock_args.clock_regression.clock_params.clone()
   };
 
-  if let Some(delta) = new_outliers {
-    info!("Clock filter changed outlier status for {delta} leaf nodes");
-  }
+  let params = ClockParams_ {
+    clock_params,
+    clock_filter: clock_args.clock_filter,
+    keep_root: clock_args.keep_root,
+    allow_negative_rate: clock_args.allow_negative_rate,
+    branch_params: branch_split_to_params(&clock_args.branch_split),
+  };
+
+  let input = ClockInput { graph, dates };
+
+  let output = pipeline::run(&params, input, progress)?;
 
   progress.report("Writing output", 0.8, "");
-  write_graph_files(outdir, "rerooted", &graph)?;
-
-  write_clock_model(&clock_model, &outdir.join("clock_model"))?;
-
-  let regression_results = gather_clock_regression_results(&graph, &clock_model);
-
-  write_clock_regression_result_csv(&regression_results, outdir.join("clock.csv"), b',')?;
+  let outdir = &clock_args.output.outdir;
+  write_graph_files(outdir, "rerooted", &output.graph)?;
+  write_clock_model(&output.clock_model, &outdir.join("clock_model"))?;
+  write_clock_regression_result_csv(&output.regression_results, outdir.join("clock.csv"), b',')?;
 
   progress.report("Done", 1.0, "");
   Ok(ClockResult {
-    graph,
-    clock_model,
-    regression_results,
+    graph: output.graph,
+    clock_model: output.clock_model,
+    regression_results: output.regression_results,
   })
-}
-
-fn estimate_clock_model_with_prefilter(
-  graph: &mut GraphClock,
-  options: &ClockParams,
-  keep_root: bool,
-  branch_split: &BranchSplitArgs,
-  clock_filter_threshold: f64,
-  allow_negative_rate: bool,
-) -> Result<(ClockModel, Option<i32>), Report> {
-  let delta = (clock_filter_threshold > 0.0)
-    .then(|| -> Result<i32, Report> {
-      let params = branch_split_to_params(branch_split);
-      // Allow negative rates during pre-filter root finding. Some datasets (e.g. dengue/100)
-      // have negative estimated rate at ALL root positions when outliers are included.
-      // The pre-filter clock model only needs to be good enough for IQD-based outlier detection.
-      let reroot_params = RerootParams {
-        force_positive_rate: false,
-        ..RerootParams::default()
-      };
-      let result = estimate_clock_model_with_reroot_policy(
-        graph,
-        &ClockParams::default(),
-        None,
-        keep_root,
-        &params,
-        &reroot_params,
-        None,
-      )?;
-      let pre_clock_model = result.clock_model;
-      if pre_clock_model.clock_rate() < 0.0 {
-        // IQD-based filtering uses |deviation| > IQD * threshold, so the absolute-value
-        // comparison is slope-sign-invariant: outliers are identified by distance from the
-        // fitted line regardless of slope direction.
-        log::warn!(
-          "Pre-filter clock rate is negative ({:.6e}). Outlier detection proceeds with this model.",
-          pre_clock_model.clock_rate()
-        );
-      }
-      Ok(clock_filter_inplace(graph, &pre_clock_model, clock_filter_threshold).new_outliers)
-    })
-    .transpose()?;
-
-  let params = branch_split_to_params(branch_split);
-  let reroot_params = RerootParams {
-    force_positive_rate: !allow_negative_rate,
-    ..RerootParams::default()
-  };
-  let result = estimate_clock_model_with_reroot_policy(graph, options, None, keep_root, &params, &reroot_params, None)
-    .wrap_err_with(|| {
-      if delta.is_some() {
-        "Clock model estimation failed after outlier filtering. \
-         The pre-filter step removed outliers but the clock rate remains negative at all root positions."
-          .to_owned()
-      } else {
-        "Clock model estimation failed".to_owned()
-      }
-    })?;
-  Ok((result.clock_model, delta))
 }

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -1,162 +1,79 @@
 use crate::alphabet::alphabet::Alphabet;
-use crate::ancestral::fitch::create_fitch_partition;
-use crate::ancestral::gtr_inference::infer_gtr_fitch;
-use crate::ancestral::marginal::{initialize_marginal, update_marginal};
 use crate::commands::optimize::args::TreetimeOptimizeArgs;
 use crate::commands::optimize::augur_node_data::write_augur_node_data_json;
 use crate::commands::optimize::result::OptimizeResult;
-use crate::gtr::get_gtr::{GtrModelName, get_gtr_by_name, log_gtr, write_gtr_json};
-use crate::optimize::run_loop::{apply_initial_guess_mode, normalize_partition_rates};
-use crate::optimize::run_loop::{collect_optimize_partitions, run_optimize_loop};
-use crate::partition::algo::infer_dense::infer_dense;
-use crate::partition::marginal_dense::PartitionMarginalDense;
-use crate::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::gtr::get_gtr::write_gtr_json;
+use crate::optimize::pipeline::{self, OptimizeInput, OptimizeParams};
 use crate::partition::traits::MutationCommentProvider;
-use crate::payload::ancestral::GraphAncestral;
-use crate::seq::alignment::get_common_length;
 use crate::seq::gap_fill::apply_gap_fill;
 use eyre::Report;
 use log::info;
-use parking_lot::RwLock;
 use std::path::PathBuf;
-use std::sync::Arc;
 use treetime_io::fasta::read_many_fasta;
 use treetime_io::graph::write_graph_files_with;
 use treetime_io::nwk::CommentProviders;
 use treetime_io::nwk::nwk_read_file;
-use treetime_utils::make_error;
 
 pub fn run_optimize(
   args: &TreetimeOptimizeArgs,
   progress: &dyn crate::progress::ProgressSink,
 ) -> Result<OptimizeResult, Report> {
-  let input_fastas = &args.alignment.alignment;
-  let tree = &args.tree;
-  let model_name = &args.model_args.model;
-  let dense = &args.dense;
-  let outdir = &args.output.outdir;
-  let max_iter = &args.max_iter;
-  let dp = &args.dp;
-  let damping = &args.damping;
-  let branch_length_initial_guess = &args.branch_length_initial_guess;
-  let opt_method = &args.opt_method;
-  let no_indels = &args.no_indels;
-  let gap_fill = args.gap_fill_args.effective_gap_fill();
-
-  if !(0.0..1.0).contains(damping) {
-    return make_error!("--damping must be in [0.0, 1.0), got {damping}");
-  }
-
   progress.check_cancelled()?;
   progress.report("Reading input", 0.0, "");
-  let dense = dense.unwrap_or_else(infer_dense);
+
   let alphabet = Alphabet::new(args.alphabet_args.alphabet.unwrap_or_default())?;
-  let mut aln = read_many_fasta(input_fastas, &alphabet)?;
+  let gap_fill = args.gap_fill_args.effective_gap_fill();
+  let mut aln = read_many_fasta(&args.alignment.alignment, &alphabet)?;
   for record in &mut aln {
     apply_gap_fill(&mut record.seq, gap_fill, alphabet.gap(), alphabet.unknown());
   }
-  let mut graph: GraphAncestral = nwk_read_file(tree)?;
+  let graph = nwk_read_file(&args.tree)?;
 
-  let sparse_partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>> = if !dense {
-    let fitch = create_fitch_partition(&graph, 0, alphabet.clone(), &aln)?;
-    let gtr = match *model_name {
-      GtrModelName::Infer => infer_gtr_fitch(&fitch, &graph)?,
-      _ => get_gtr_by_name(*model_name)?,
-    };
-    log_gtr(&gtr, *model_name);
-    let partition = fitch.into_marginal_sparse(gtr, &graph)?;
-    vec![Arc::new(RwLock::new(partition))]
-  } else {
-    vec![]
+  let params = OptimizeParams {
+    model: args.model_args.model,
+    dense: args.dense,
+    max_iter: args.max_iter,
+    dp: args.dp,
+    damping: args.damping,
+    opt_method: args.opt_method,
+    initial_guess: args.branch_length_initial_guess,
+    no_indels: args.no_indels,
   };
 
-  let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = if dense {
-    if *model_name == GtrModelName::Infer {
-      let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
-      let gtr = infer_gtr_fitch(&fitch, &graph)?;
-      log_gtr(&gtr, *model_name);
-      let partition = fitch.into_marginal_dense(gtr);
-      vec![Arc::new(RwLock::new(partition))]
-    } else {
-      let length = get_common_length(&aln)?;
-      let gtr = get_gtr_by_name(*model_name)?;
-      log_gtr(&gtr, *model_name);
-      let partition = PartitionMarginalDense::new(0, gtr, alphabet, length);
-      vec![Arc::new(RwLock::new(partition))]
-    }
-  } else {
-    vec![]
+  let input = OptimizeInput {
+    graph,
+    alphabet,
+    sequences: aln,
   };
 
-  // Initialize marginal data for whichever partitions are active
-  update_marginal(&graph, &sparse_partitions)?;
-  if !dense_partitions.is_empty() {
-    initialize_marginal(&graph, &dense_partitions, &aln)?;
-    update_marginal(&graph, &dense_partitions)?;
-  }
-
-  let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
-
-  if *model_name == GtrModelName::Infer {
-    normalize_partition_rates(&graph, &sparse_partitions);
-    normalize_partition_rates(&graph, &dense_partitions);
-  }
-
-  for partition in &sparse_partitions {
-    write_gtr_json(&partition.read_arc().gtr, *model_name, outdir, None)?;
-  }
-  for partition in &dense_partitions {
-    write_gtr_json(&partition.read_arc().data.gtr, *model_name, outdir, None)?;
-  }
-
-  apply_initial_guess_mode(&graph, &mixed_partitions, *branch_length_initial_guess, *no_indels)?;
-
-  progress.check_cancelled()?;
-  progress.report("Optimizing branch lengths", 0.3, "");
-  run_optimize_loop(
-    &mut graph,
-    &sparse_partitions,
-    &dense_partitions,
-    &mixed_partitions,
-    *max_iter,
-    *dp,
-    *damping,
-    *opt_method,
-    *no_indels,
-  )?;
+  let output = pipeline::run(&params, input, progress)?;
 
   progress.report("Writing output", 0.9, "");
-  // Re-run marginal to populate subs_ml after the loop (the last iteration
-  // may have changed topology, clearing ML subs on affected edges).
-  update_marginal(&graph, &sparse_partitions)?;
-  update_marginal(&graph, &dense_partitions)?;
+  let outdir = &args.output.outdir;
 
-  if dense {
-    let guard = dense_partitions[0].read_arc();
-    let provider = MutationCommentProvider::new(&*guard, &graph);
+  write_gtr_json(&output.gtr, output.model_name, outdir, None)?;
+
+  let dense = !output.sparse_partitions.is_empty();
+  if !output.dense_partitions.is_empty() {
+    let guard = output.dense_partitions[0].read_arc();
+    let provider = MutationCommentProvider::new(&*guard, &output.graph);
     let providers = CommentProviders::new().with(&provider);
-    write_graph_files_with(outdir, "annotated_tree", &graph, &providers)?;
-  } else {
-    let guard = sparse_partitions[0].read_arc();
-    let provider = MutationCommentProvider::new(&*guard, &graph);
+    write_graph_files_with(outdir, "annotated_tree", &output.graph, &providers)?;
+  } else if !output.sparse_partitions.is_empty() {
+    let guard = output.sparse_partitions[0].read_arc();
+    let provider = MutationCommentProvider::new(&*guard, &output.graph);
     let providers = CommentProviders::new().with(&provider);
-    write_graph_files_with(outdir, "annotated_tree", &graph, &providers)?;
+    write_graph_files_with(outdir, "annotated_tree", &output.graph, &providers)?;
   }
 
-  // Augur-compatible node data JSON (treetime equivalent of `augur refine` run
-  // without `--timetree`). Branch lengths come from the optimized graph edges;
-  // no clock or date fields are produced.
   let augur_node_data_path = args
     .output_augur_node_data
     .clone()
     .unwrap_or_else(|| outdir.join("optimize.augur-node-data.json"));
-  let alignment = input_fastas.first().map(PathBuf::as_path);
-  write_augur_node_data_json(&graph, alignment, Some(tree.as_path()), &augur_node_data_path)?;
-  info!(
-    "Wrote augur node data JSON to {path}",
-    path = augur_node_data_path.display()
-  );
+  let alignment = args.alignment.alignment.first().map(PathBuf::as_path);
+  write_augur_node_data_json(&output.graph, alignment, Some(args.tree.as_path()), &augur_node_data_path)?;
+  info!("Wrote augur node data JSON to {path}", path = augur_node_data_path.display());
 
   progress.report("Done", 1.0, "");
-  Ok(OptimizeResult { graph })
+  Ok(OptimizeResult { graph: output.graph })
 }

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -1,24 +1,20 @@
 use crate::alphabet::alphabet::Alphabet;
-use crate::ancestral::fitch::create_fitch_partition;
 use crate::commands::prune::args::TreetimePruneArgs;
 use crate::commands::prune::result::PruneResult;
-use crate::gtr::get_gtr::{GtrModelName, get_gtr_by_name, log_gtr, write_gtr_json};
+use crate::gtr::get_gtr::{GtrModelName, write_gtr_json};
 use crate::make_error;
-use crate::optimize::topology::merge_shared_mutations::merge_shared_mutation_branches;
-use crate::partition::marginal_sparse::PartitionMarginalSparse;
-use crate::payload::ancestral::GraphAncestral;
-use crate::prune::prune::prune_nodes;
+use crate::prune::pipeline::{self, PruneInput, PruneParams};
 use eyre::Report;
 use itertools::Itertools;
 use maplit::btreeset;
-use parking_lot::RwLock;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
-use std::sync::Arc;
 use treetime_io::fasta::read_many_fasta;
 use treetime_io::graph::write_graph_files;
 use treetime_io::nwk::nwk_read_file;
 use treetime_io::parse_delimited::{parse_delimited_file, parse_delimited_str};
+
+use crate::payload::ancestral::GraphAncestral;
 
 pub fn run_prune(
   args: &TreetimePruneArgs,
@@ -28,55 +24,49 @@ pub fn run_prune(
 
   progress.check_cancelled()?;
   progress.report("Reading input", 0.0, "");
-  let input_fastas = &args.alignment.alignment;
-  let tree = &args.tree;
-  let outdir = &args.output.outdir;
-  let prune_short = &args.prune_short;
-  let prune_empty = &args.prune_empty;
-  let merge_shared_mutations = &args.merge_shared_mutations;
-  let prune_nodes_list = &args.prune_nodes_list;
-  let prune_nodes_list_delimiter = &args.prune_nodes_list_delimiter;
-  let prune_nodes_list_file = &args.prune_nodes_list_file;
-  let prune_nodes_list_file_delimiter = &args.prune_nodes_list_file_delimiter;
 
-  let mut graph: GraphAncestral = nwk_read_file(tree)?;
+  let graph: GraphAncestral = nwk_read_file(&args.tree)?;
+  let alphabet = Alphabet::new(args.alphabet_args.alphabet.unwrap_or_default())?;
 
-  let needs_sequences = *prune_empty || *merge_shared_mutations;
-  let partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>> = if needs_sequences {
-    let alphabet = Alphabet::new(args.alphabet_args.alphabet.unwrap_or_default())?;
-    let aln = read_many_fasta(input_fastas, &alphabet)?;
-
-    let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
-    let gtr = get_gtr_by_name(GtrModelName::JC69)?;
-    log_gtr(&gtr, GtrModelName::JC69);
-    write_gtr_json(&gtr, GtrModelName::JC69, outdir, None)?;
-    let partition = fitch.into_marginal_sparse(gtr, &graph)?;
-    vec![Arc::new(RwLock::new(partition))]
+  let sequences = if !args.alignment.alignment.is_empty() {
+    Some(read_many_fasta(&args.alignment.alignment, &alphabet)?)
   } else {
-    vec![]
+    None
   };
 
   let node_names = parse_node_names(
-    prune_nodes_list.as_ref(),
-    *prune_nodes_list_delimiter,
-    prune_nodes_list_file.as_ref(),
-    *prune_nodes_list_file_delimiter,
+    args.prune_nodes_list.as_ref(),
+    args.prune_nodes_list_delimiter,
+    args.prune_nodes_list_file.as_ref(),
+    args.prune_nodes_list_file_delimiter,
   )?;
+
+  let params = PruneParams {
+    prune_short: args.prune_short,
+    prune_empty: args.prune_empty,
+    merge_shared_mutations: args.merge_shared_mutations,
+    node_names,
+  };
+
+  let input = PruneInput {
+    graph,
+    alphabet,
+    sequences,
+  };
 
   progress.check_cancelled()?;
   progress.report("Pruning", 0.4, "");
-  prune_nodes(&mut graph, &partitions, *prune_short, *prune_empty, &node_names)?;
-
-  if *merge_shared_mutations {
-    merge_shared_mutation_branches(&mut graph, &partitions)?;
-    graph.build()?;
-  }
+  let output = pipeline::run(&params, input)?;
 
   progress.report("Writing output", 0.8, "");
-  write_graph_files(outdir, "pruned_tree", &graph)?;
+  let outdir = &args.output.outdir;
+  if let Some(gtr) = &output.gtr {
+    write_gtr_json(gtr, GtrModelName::JC69, outdir, None)?;
+  }
+  write_graph_files(outdir, "pruned_tree", &output.graph)?;
 
   progress.report("Done", 1.0, "");
-  Ok(PruneResult { graph })
+  Ok(PruneResult { graph: output.graph })
 }
 
 fn validate_args(args: &TreetimePruneArgs) -> Result<(), Report> {

--- a/packages/treetime/src/commands/timetree/args.rs
+++ b/packages/treetime/src/commands/timetree/args.rs
@@ -23,15 +23,7 @@ fn parse_n_skyline(s: &str) -> Result<usize, String> {
   Ok(n)
 }
 
-#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, SmartDefault, Serialize, Deserialize)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
-#[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
-pub enum TimeMarginalMode {
-  #[default]
-  Never,
-  Always,
-  OnlyFinal,
-}
+pub use crate::timetree::params::TimeMarginalMode;
 
 #[derive(Debug, SmartDefault, Serialize, Deserialize)]
 #[serde(default)]

--- a/packages/treetime/src/commands/timetree/output/auspice.rs
+++ b/packages/treetime/src/commands/timetree/output/auspice.rs
@@ -1,179 +1,20 @@
 use crate::payload::timetree::{EdgeTimetree, NodeTimetree};
 use crate::timetree::confidence::NodeConfidenceInterval;
+use crate::timetree::output::auspice::build_timetree_auspice;
 use eyre::{Report, WrapErr};
 use log::info;
-use serde_json::Value;
-use std::collections::BTreeMap;
 use std::path::Path;
 use treetime_graph::graph::Graph;
-use treetime_graph::node::{GraphNodeKey, Named};
-use treetime_io::auspice::{AuspiceGraphContext, AuspiceWrite, auspice_from_graph_with};
-use treetime_io::auspice_types::{
-  AuspiceColoring, AuspiceDisplayDefaults, AuspiceNumDate, AuspiceTreeBranchAttrs, AuspiceTreeData, AuspiceTreeMeta,
-  AuspiceTreeNode, AuspiceTreeNodeAttr, AuspiceTreeNodeAttrs,
-};
 use treetime_utils::io::json::{JsonPretty, json_write_file};
-use treetime_utils::make_error;
 
-/// Write partial auspice v2 JSON for timetree results.
-///
-/// Produces `auspice_tree.json` with node dates (with optional confidence
-/// intervals), cumulative divergence, and bad branch status. Branch mutations,
-/// branch-support confidence, and genome annotations are not yet included
-/// (see `N-timetree-auspice-json-incomplete`).
 pub fn write_auspice_json(
   graph: &Graph<NodeTimetree, EdgeTimetree, ()>,
   confidence_intervals: Option<&[NodeConfidenceInterval]>,
   outdir: &Path,
 ) -> Result<(), Report> {
-  let ci_map = confidence_intervals.map_or_else(BTreeMap::new, build_ci_map);
-  let mut writer = TimetreeAuspiceWriter { ci_map };
-  let tree = auspice_from_graph_with(&mut writer, graph)?;
+  let tree = build_timetree_auspice(graph, confidence_intervals)?;
   let filepath = outdir.join("auspice_tree.json");
   json_write_file(&filepath, &tree, JsonPretty(true)).wrap_err("Failed to write auspice JSON")?;
   info!("Wrote auspice JSON to {filepath}", filepath = filepath.display());
   Ok(())
-}
-
-/// Auspice v2 JSON writer for timetree output.
-///
-/// Uses authoritative `NodeTimetree.div` for cumulative divergence
-/// and looks up confidence intervals by `GraphNodeKey`.
-struct TimetreeAuspiceWriter {
-  ci_map: BTreeMap<GraphNodeKey, ConfidenceBounds>,
-}
-
-impl AuspiceWrite<NodeTimetree, EdgeTimetree, ()> for TimetreeAuspiceWriter {
-  fn new(_graph: &Graph<NodeTimetree, EdgeTimetree, ()>) -> Result<Self, Report> {
-    make_error!(
-      "TimetreeAuspiceWriter must be constructed directly with a CI map. \
-       Use write_auspice_json() or auspice_from_graph_with() instead of auspice_from_graph()."
-    )
-  }
-
-  fn auspice_data_from_graph_data(
-    &self,
-    _graph: &Graph<NodeTimetree, EdgeTimetree, ()>,
-  ) -> Result<AuspiceTreeData, Report> {
-    let colorings = vec![
-      AuspiceColoring {
-        title: "Date".to_owned(),
-        type_: "continuous".to_owned(),
-        key: "num_date".to_owned(),
-        ..AuspiceColoring::default()
-      },
-      AuspiceColoring {
-        title: "Excluded".to_owned(),
-        type_: "categorical".to_owned(),
-        key: "bad_branch".to_owned(),
-        ..AuspiceColoring::default()
-      },
-    ];
-
-    Ok(AuspiceTreeData {
-      version: Some("v2".to_owned()),
-      meta: AuspiceTreeMeta {
-        title: Some("TreeTime timetree analysis".to_owned()),
-        updated: Some(chrono::Utc::now().format("%Y-%m-%d").to_string()),
-        panels: vec!["tree".to_owned()],
-        colorings,
-        display_defaults: AuspiceDisplayDefaults {
-          color_by: Some("bad_branch".to_owned()),
-          ..AuspiceDisplayDefaults::default()
-        },
-        filters: vec!["bad_branch".to_owned()],
-        ..AuspiceTreeMeta::default()
-      },
-      root_sequence: None,
-      other: Value::default(),
-    })
-  }
-
-  fn auspice_node_from_graph_components(
-    &mut self,
-    context: &AuspiceGraphContext<NodeTimetree, EdgeTimetree, ()>,
-  ) -> Result<AuspiceTreeNode, Report> {
-    let &AuspiceGraphContext { node_key, node, .. } = context;
-
-    let name = node
-      .name()
-      .map_or_else(|| format!("node_{}", node_key.as_usize()), |n| n.as_ref().to_owned());
-
-    // JSON (RFC 8259) does not permit NaN or Infinity. Guard here with
-    // actionable diagnostics rather than letting serde_json fail opaquely.
-    if !node.div.is_finite() {
-      return make_error!("Node '{name}' has non-finite div={div}", div = node.div);
-    }
-    if let Some(t) = node.time {
-      if !t.is_finite() {
-        return make_error!("Node '{name}' has non-finite time={t}");
-      }
-    }
-
-    // Numeric date with optional confidence interval (looked up by GraphNodeKey)
-    let num_date = node.time.map(|t| {
-      let confidence = self.ci_map.get(&node_key).map(|ci| {
-        if !ci.lower.is_finite() || !ci.upper.is_finite() {
-          log::warn!(
-            "Node '{name}' has non-finite CI bounds: [{lower}, {upper}]",
-            lower = ci.lower,
-            upper = ci.upper
-          );
-        }
-        debug_assert!(
-          ci.lower <= ci.upper,
-          "CI bounds inverted for node '{name}': [{lower}, {upper}]",
-          lower = ci.lower,
-          upper = ci.upper
-        );
-        [ci.lower, ci.upper]
-      });
-      AuspiceNumDate { value: t, confidence }
-    });
-
-    let bad_branch = Some(AuspiceTreeNodeAttr::new(if node.bad_branch { "Yes" } else { "No" }));
-
-    Ok(AuspiceTreeNode {
-      name,
-      branch_attrs: AuspiceTreeBranchAttrs {
-        mutations: BTreeMap::new(),
-        labels: None,
-        other: Value::default(),
-      },
-      node_attrs: AuspiceTreeNodeAttrs {
-        div: Some(node.div),
-        num_date,
-        bad_branch,
-        clade_membership: None,
-        region: None,
-        country: None,
-        division: None,
-        other: Value::default(),
-      },
-      children: vec![],
-      other: Value::default(),
-    })
-  }
-}
-
-struct ConfidenceBounds {
-  lower: f64,
-  upper: f64,
-}
-
-/// Build CI lookup map keyed by `GraphNodeKey` for stable lookup
-/// independent of display naming.
-fn build_ci_map(intervals: &[NodeConfidenceInterval]) -> BTreeMap<GraphNodeKey, ConfidenceBounds> {
-  intervals
-    .iter()
-    .map(|ci| {
-      (
-        ci.key,
-        ConfidenceBounds {
-          lower: ci.lower,
-          upper: ci.upper,
-        },
-      )
-    })
-    .collect()
 }

--- a/packages/treetime/src/commands/timetree/refinement.rs
+++ b/packages/treetime/src/commands/timetree/refinement.rs
@@ -1,18 +1,13 @@
-use crate::ancestral::marginal::update_marginal;
 use crate::clock::clock_model::ClockModel;
-use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot};
+use crate::clock::clock_regression::ClockParams;
 use crate::clock::find_best_root::params::BranchPointOptimizationParams;
 use crate::commands::timetree::args::TreetimeTimetreeArgs;
 use crate::partition::timetree::GraphTimetree;
 use crate::partition::traits::PartitionTimetreeAll;
 use crate::payload::timetree::EdgeTimetree;
 use crate::payload::timetree::NodeTimetree;
-use crate::timetree::convergence::sequence_changes::{capture_ancestral_states, count_sequence_changes};
-use crate::timetree::inference::runner::run_timetree;
-use crate::timetree::optimization::polytomy::{prepare_tree_after_topology_change, resolve_polytomies};
-use crate::timetree::optimization::relaxed_clock::apply_relaxed_clock;
-use eyre::{Report, WrapErr};
-use log::info;
+use crate::timetree::refinement::{self, RefinementParams};
+use eyre::Report;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
@@ -26,81 +21,11 @@ pub fn run_refinement_iteration(
   branch_params: &BranchPointOptimizationParams,
   coalescent_tc: Option<&Distribution>,
 ) -> Result<(usize, usize), Report> {
-  let total_length: usize = partitions.iter().map(|p| p.read_arc().get_sequence_length()).sum();
-
-  if !args.relax.is_empty() {
-    if total_length == 0 {
-      info!("Skipping relaxed clock: no sequence data (partitions empty or zero-length)");
-    } else {
-      let one_mutation = 1.0 / total_length as f64;
-      info!(
-        "Applying relaxed clock with slack={}, coupling={}",
-        args.relax.first().copied().unwrap_or(1.0),
-        args.relax.get(1).copied().unwrap_or(1.0)
-      );
-      apply_relaxed_clock(graph, &args.relax, one_mutation);
-    }
-  }
-
-  // Snapshot ancestral states before polytomy resolution and reconstruction.
-  // Capturing before polytomy resolution avoids inflating n_diff with positions
-  // from newly created nodes that have no prior state.
-  let prev_states = capture_ancestral_states(graph, partitions);
-
-  let n_resolved = if args.resolve_polytomies {
-    let zero_branch_slope = clock_model.clock_rate() * total_length as f64;
-    let n = resolve_polytomies(graph, partitions, zero_branch_slope, clock_model.clock_rate())
-      .wrap_err("Polytomy resolution failed")?;
-    if n > 0 {
-      info!("Resolved polytomies, introduced {n} new nodes");
-      prepare_tree_after_topology_change(graph).wrap_err("Failed to prepare tree after topology change")?;
-
-      // Ensure partition entries exist for new nodes/edges created by polytomy resolution
-      for partition in partitions {
-        partition.write_arc().reconcile_topology(graph);
-      }
-    }
-    n
-  } else {
-    0
+  let params = RefinementParams {
+    relax: args.relax.clone(),
+    resolve_polytomies: args.resolve_polytomies,
+    clock_rate: args.clock_rate,
+    no_indels: args.no_indels,
   };
-
-  let is_tree_dirty = n_resolved > 0;
-
-  if is_tree_dirty {
-    info!("Tree structure changed - recomputing timetree then marginal");
-    run_timetree(graph, partitions, clock_model, coalescent_tc, args.no_indels)
-      .wrap_err("Timetree inference failed")?;
-
-    if !partitions.is_empty() {
-      update_marginal(graph, partitions)?;
-    }
-  } else {
-    if !partitions.is_empty() {
-      info!("Updating ancestral sequences via marginal reconstruction");
-      update_marginal(graph, partitions)?;
-    }
-
-    info!("Updating node times via timetree inference");
-    run_timetree(graph, partitions, clock_model, coalescent_tc, args.no_indels)
-      .wrap_err("Timetree inference failed")?;
-  }
-
-  // Compute n_diff from ancestral state changes
-  let curr_states = capture_ancestral_states(graph, partitions);
-  let n_diff = count_sequence_changes(&prev_states, &curr_states);
-
-  // Re-estimate clock model without rerooting (v0 does not reroot inside the loop).
-  // Pass previous clock rate so regression uses solver-updated time lengths.
-  *clock_model = estimate_clock_model_with_reroot(
-    graph,
-    clock_params,
-    args.clock_rate,
-    true,
-    branch_params,
-    Some(clock_model.clock_rate()),
-  )
-  .wrap_err("Failed to update clock model")?;
-
-  Ok((n_diff, n_resolved))
+  refinement::run_refinement_iteration(&params, graph, partitions, clock_model, clock_params, branch_params, coalescent_tc)
 }

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -7,12 +7,13 @@ use crate::clock::find_best_root::params::BranchPointOptimizationParams;
 use crate::clock::reroot::RerootParams;
 use crate::coalescent::optimize_tc::optimize_tc;
 use crate::coalescent::skyline::{SkylineParams, optimize_skyline};
-use crate::commands::timetree::args::{TimeMarginalMode, TreetimeTimetreeArgs};
+use crate::commands::timetree::args::TreetimeTimetreeArgs;
 use crate::commands::timetree::initialization::{InputData, initialize_partitions, load_input_data};
 use crate::commands::timetree::output::augur_node_data::write_augur_node_data_json;
 use crate::commands::timetree::output::auspice::write_auspice_json;
-use crate::commands::timetree::refinement::run_refinement_iteration;
 use crate::commands::timetree::result::TimetreeResult;
+use crate::timetree::params::{TimeMarginalMode, build_covariation_clock_params, compute_effective_time_marginal};
+use crate::timetree::refinement::{RefinementParams, run_refinement_iteration};
 use crate::optimize::dispatch::{run_optimize_mixed, run_optimize_mixed_inner};
 use crate::optimize::iteration::{apply_damping, save_branch_lengths};
 use crate::optimize::params::BranchLengthMode;
@@ -21,7 +22,6 @@ use crate::partition::timetree::GraphTimetree;
 use crate::partition::traits::{MutationCommentProvider, PartitionTimetreeAll};
 use crate::payload::timetree::EdgeTimetree;
 use crate::payload::timetree::NodeTimetree;
-use crate::seq::alignment::get_common_length;
 use crate::timetree::confidence::{
   NodeConfidenceInterval, compute_rate_susceptibility, determine_rate_std, extract_confidence_intervals,
   write_confidence_intervals_file,
@@ -31,7 +31,7 @@ use crate::timetree::inference::runner::run_timetree;
 use crate::timetree::optimization::clock_filter::{apply_outlier_bad_branches, report_bad_branches};
 use crate::timetree::optimization::reroot::reroot_tree;
 use crate::timetree::utils::initialize_clock_totals_from_time_distributions;
-use crate::{make_error, make_report};
+use crate::make_error;
 use eyre::{Report, WrapErr};
 use log::{debug, info, warn};
 use parking_lot::RwLock;
@@ -39,7 +39,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
 use treetime_io::dates_csv::DatesMap;
-use treetime_io::fasta::FastaRecord;
 use treetime_io::graph::write_graph_files_with;
 use treetime_io::nwk::CommentProviders;
 use treetime_utils::io::file::create_file_or_stdout;
@@ -63,7 +62,7 @@ pub fn run_timetree_estimation(
   //   - --confidence with --covariation or --clock-std-dev: set time_marginal='confidence-only'
   //     (equivalent to v1's OnlyFinal -- runs a final marginal pass for CI estimation)
   //   - --confidence without prerequisites: warn and disable confidence
-  let time_marginal = compute_effective_time_marginal(args);
+  let time_marginal = compute_effective_time_marginal(args.time_marginal, args.confidence, args.clock_std_dev, args.covariation);
 
   progress.check_cancelled()?;
   progress.report("Loading input", 0.0, "");
@@ -95,7 +94,7 @@ pub fn run_timetree_estimation(
   // v0 uses default (non-covariation) params for the initial regression and clock
   // filter, switching to covariation params only during iteration-loop reroots
   // (treetime.py:488,491 vs 643-644). We follow the same pattern.
-  let covariation_clock_params = build_covariation_clock_params(args, aln.as_deref())?;
+  let covariation_clock_params = build_covariation_clock_params(args.covariation, args.sequence_length, args.tip_slack, aln.as_deref())?;
   let branch_params = BranchPointOptimizationParams::default();
 
   progress.check_cancelled()?;
@@ -298,8 +297,14 @@ pub fn run_timetree_estimation(
       }
     }
 
+    let refinement_params = RefinementParams {
+      relax: args.relax.clone(),
+      resolve_polytomies: args.resolve_polytomies,
+      clock_rate: args.clock_rate,
+      no_indels: args.no_indels,
+    };
     let (n_diff, n_resolved) = run_refinement_iteration(
-      args,
+      &refinement_params,
       &mut graph,
       &partitions,
       &mut clock_model,
@@ -436,71 +441,6 @@ pub fn run_timetree_estimation(
   })
 }
 
-/// Compute effective time_marginal mode, promoting Never to OnlyFinal when
-/// --confidence is set with rate uncertainty prerequisites.
-///
-/// v0 (wrappers.py:478):
-///   time_marginal = 'confidence-only' if (calc_confidence and time_marginal == 'never') else time_marginal
-fn compute_effective_time_marginal(args: &TreetimeTimetreeArgs) -> TimeMarginalMode {
-  if args.confidence && args.time_marginal == TimeMarginalMode::Never {
-    if args.clock_std_dev.is_some() || args.covariation {
-      info!("--confidence: promoting time-marginal from never to only-final for CI estimation");
-      TimeMarginalMode::OnlyFinal
-    } else {
-      warn!(
-        "Cannot estimate confidence intervals without clock rate uncertainty. \
-         Specify --clock-std-dev or rerun with --covariation. \
-         Proceeding without confidence estimation."
-      );
-      TimeMarginalMode::Never
-    }
-  } else {
-    args.time_marginal
-  }
-}
-
-/// Build covariation-aware ClockParams when --covariation is enabled.
-///
-/// v0 (clock_tree.py:277-285):
-///   branch_variance = (max(0, clock_length) + tip_slack^2 * om) * om   [leaves]
-///   branch_variance = max(0, clock_length) * om                         [internal]
-/// where om = 1/seq_len, tip_slack = OVER_DISPERSION = 10 (config.py:8)
-///
-/// In v1's ClockParams model:
-///   branch_variance = variance_factor * edge_len + variance_offset        [all]
-///   branch_variance += variance_offset_leaf                               [leaves only]
-///
-/// Mapping:
-///   variance_factor = 1.0 / seq_len   (= om, the one_mutation value)
-///   variance_offset = 0.0
-///   variance_offset_leaf = tip_slack^2 / seq_len^2   (= tip_slack^2 * om^2)
-fn build_covariation_clock_params(
-  args: &TreetimeTimetreeArgs,
-  aln: Option<&[FastaRecord]>,
-) -> Result<Option<ClockParams>, Report> {
-  if !args.covariation {
-    return Ok(None);
-  }
-
-  let seq_len = if let Some(aln_data) = aln {
-    get_common_length(aln_data)? as f64
-  } else {
-    args
-      .sequence_length
-      .ok_or_else(|| make_report!("--sequence-length required for --covariation without alignment"))? as f64
-  };
-
-  // v0 default: OVER_DISPERSION = 10 (config.py:8), overridable via --tip-slack
-  let tip_slack = args.tip_slack.unwrap_or(10.0);
-
-  info!("Covariation-aware clock regression: seq_len={seq_len}, tip_slack={tip_slack}");
-
-  Ok(Some(ClockParams {
-    variance_factor: 1.0 / seq_len,
-    variance_offset: 0.0,
-    variance_offset_leaf: tip_slack * tip_slack / (seq_len * seq_len),
-  }))
-}
 
 /// Run one pass of ML branch-length optimization on timetree partitions.
 ///
@@ -599,21 +539,6 @@ mod tests {
   use pretty_assertions::assert_eq;
   use rstest::rstest;
 
-  fn args_with(
-    time_marginal: TimeMarginalMode,
-    confidence: bool,
-    covariation: bool,
-    clock_std_dev: Option<f64>,
-  ) -> TreetimeTimetreeArgs {
-    TreetimeTimetreeArgs {
-      clock_std_dev,
-      time_marginal,
-      confidence,
-      covariation,
-      ..TreetimeTimetreeArgs::default()
-    }
-  }
-
   #[rustfmt::skip]
   #[rstest]
   #[case::never_no_confidence(            (TimeMarginalMode::Never,     false, false, None),      TimeMarginalMode::Never)]
@@ -626,11 +551,10 @@ mod tests {
   #[case::only_final_no_confidence(       (TimeMarginalMode::OnlyFinal, false, false, None),      TimeMarginalMode::OnlyFinal)]
   #[case::only_final_confidence(          (TimeMarginalMode::OnlyFinal, true,  true,  None),      TimeMarginalMode::OnlyFinal)]
   #[trace]
-  fn test_compute_effective_time_marginal(
+  fn test_timetree_compute_effective_time_marginal(
     #[case] (mode, confidence, covariation, clock_std_dev): (TimeMarginalMode, bool, bool, Option<f64>),
     #[case] expected: TimeMarginalMode,
   ) {
-    let args = args_with(mode, confidence, covariation, clock_std_dev);
-    assert_eq!(expected, compute_effective_time_marginal(&args));
+    assert_eq!(expected, compute_effective_time_marginal(mode, confidence, clock_std_dev, covariation));
   }
 }

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -1,526 +1,125 @@
-use crate::ancestral::marginal::{initialize_marginal, update_marginal};
-use crate::clock::clock_filter::clock_filter_inplace;
-use crate::clock::clock_model::ClockModel;
-use crate::clock::clock_output::write_clock_model;
-use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
-use crate::clock::reroot::RerootParams;
-use crate::coalescent::optimize_tc::optimize_tc;
-use crate::coalescent::skyline::{SkylineParams, optimize_skyline};
 use crate::commands::timetree::args::TreetimeTimetreeArgs;
-use crate::commands::timetree::initialization::{InputData, initialize_partitions, load_input_data};
+use crate::commands::timetree::initialization::load_input_data;
 use crate::commands::timetree::output::augur_node_data::write_augur_node_data_json;
 use crate::commands::timetree::output::auspice::write_auspice_json;
 use crate::commands::timetree::result::TimetreeResult;
-use crate::timetree::params::{TimeMarginalMode, build_covariation_clock_params, compute_effective_time_marginal};
-use crate::timetree::refinement::{RefinementParams, run_refinement_iteration};
-use crate::optimize::dispatch::{run_optimize_mixed, run_optimize_mixed_inner};
-use crate::optimize::iteration::{apply_damping, save_branch_lengths};
-use crate::optimize::params::BranchLengthMode;
-use crate::optimize::params::BranchOptMethod;
-use crate::partition::timetree::GraphTimetree;
-use crate::partition::traits::{MutationCommentProvider, PartitionTimetreeAll};
-use crate::payload::timetree::EdgeTimetree;
-use crate::payload::timetree::NodeTimetree;
-use crate::timetree::confidence::{
-  NodeConfidenceInterval, compute_rate_susceptibility, determine_rate_std, extract_confidence_intervals,
-  write_confidence_intervals_file,
-};
-use crate::timetree::convergence::optimizer::{IterationContext, TimetreeOptimizer};
-use crate::timetree::inference::runner::run_timetree;
-use crate::timetree::optimization::clock_filter::{apply_outlier_bad_branches, report_bad_branches};
-use crate::timetree::optimization::reroot::reroot_tree;
-use crate::timetree::utils::initialize_clock_totals_from_time_distributions;
+use crate::clock::clock_output::write_clock_model;
+use crate::partition::traits::MutationCommentProvider;
+use crate::timetree::confidence::write_confidence_intervals_file;
+use crate::timetree::pipeline::{self, TimetreeInput, TimetreeParams};
 use crate::make_error;
 use eyre::{Report, WrapErr};
-use log::{debug, info, warn};
-use parking_lot::RwLock;
+use log::info;
 use std::path::PathBuf;
-use std::sync::Arc;
-use treetime_distribution::Distribution;
-use treetime_io::dates_csv::DatesMap;
 use treetime_io::graph::write_graph_files_with;
 use treetime_io::nwk::CommentProviders;
 use treetime_utils::io::file::create_file_or_stdout;
-
-/// v0 default damping for the timetree pre-step branch-length optimization (treeanc.py:1298).
-const TIMETREE_PRE_STEP_DAMPING: f64 = 0.75;
 
 pub fn run_timetree_estimation(
   args: &TreetimeTimetreeArgs,
   progress: &dyn crate::progress::ProgressSink,
 ) -> Result<TimetreeResult, Report> {
-  info!("# TreeTime Timetree Estimation");
-  debug!(
-    "Branch length mode: {:?}, Keep root: {}",
-    args.branch_length_mode, args.keep_root
-  );
-
-  // Compute effective time_marginal, accounting for --confidence flag.
-  //
-  // v0 (wrappers.py:453-469):
-  //   - --confidence with --covariation or --clock-std-dev: set time_marginal='confidence-only'
-  //     (equivalent to v1's OnlyFinal -- runs a final marginal pass for CI estimation)
-  //   - --confidence without prerequisites: warn and disable confidence
-  let time_marginal = compute_effective_time_marginal(args.time_marginal, args.confidence, args.clock_std_dev, args.covariation);
-
   progress.check_cancelled()?;
   progress.report("Loading input", 0.0, "");
-  info!("## Loading input data");
-  let InputData {
-    mut graph,
-    alphabet,
-    aln,
-    dates,
-  } = load_input_data(args)?;
-  info!(
-    "Input loaded: {} nodes, {} edges",
-    graph.get_nodes().len(),
-    graph.get_edges().len()
-  );
 
-  // Covariation-aware clock regression: weighted least squares with phylogenetic
-  // variance structure (Neher 2018, "Efficient estimation of evolutionary rates
-  // by covariance aware regression").
-  //
-  // v0 (clock_tree.py:277-285):
-  //   branch_variance = (max(0, clock_length) + tip_slack^2 * om) * om  [leaves]
-  //   branch_variance = max(0, clock_length) * om                       [internal]
-  // where om = one_mutation = 1/seq_len, tip_slack = OVER_DISPERSION = 10
-  //
-  // Without covariation (default): OLS with unit variance for leaves, zero for internal.
-  // This ignores phylogenetic correlation between tips, producing unreliable CIs.
-  //
-  // v0 uses default (non-covariation) params for the initial regression and clock
-  // filter, switching to covariation params only during iteration-loop reroots
-  // (treetime.py:488,491 vs 643-644). We follow the same pattern.
-  let covariation_clock_params = build_covariation_clock_params(args.covariation, args.sequence_length, args.tip_slack, aln.as_deref())?;
-  let branch_params = BranchPointOptimizationParams::default();
+  let input_data = load_input_data(args)?;
 
-  progress.check_cancelled()?;
-  progress.report("Clock regression", 0.1, "");
-  // Initial regression: always non-covariation (matching v0 treetime.py:488-491)
-  let reroot_params = RerootParams {
-    force_positive_rate: !args.allow_negative_rate,
-    ..RerootParams::default()
-  };
-  let mut clock_model = estimate_clock_model_with_reroot_policy(
-    &mut graph,
-    &ClockParams::default(),
-    args.clock_rate,
-    args.keep_root,
-    &branch_params,
-    &reroot_params,
-    None,
-  )
-  .wrap_err("Failed to infer clock model")?
-  .clock_model;
-
-  let partitions = match args.branch_length_mode {
-    BranchLengthMode::Input => {
-      info!("Branch length mode: Input - using tree branch lengths");
-      vec![]
-    },
-    BranchLengthMode::Marginal => {
-      info!("Branch length mode: Marginal - initializing partitions from alignment");
-      initialize_partitions(args, &graph, alphabet, aln.as_deref())?
-    },
-  };
-
-  // ML branch-length optimization pre-step (v0: optimize_tree(max_iter=1))
-  //
-  // v0 calls optimize_tree(infer_gtr=True, max_iter=1) before rerooting,
-  // then optimize_tree(max_iter=1) again after rerooting + clock filter.
-  // Both calls run marginal reconstruction followed by one round of per-edge
-  // Brent optimization, seeding time inference with ML-optimized branch
-  // lengths rather than raw input values.
-  if let Some(aln) = aln.as_deref() {
-    if args.branch_length_mode == BranchLengthMode::Marginal && !partitions.is_empty() {
-      info!("### ML branch-length optimization (pre-reroot)");
-      initialize_marginal(&graph, &partitions, aln)?;
-      optimize_branch_lengths_pre_step(&graph, &partitions, args.no_indels)
-        .wrap_err("ML branch-length optimization (pre-reroot) failed")?;
-    }
-  }
-
-  // First reroot: use non-covariation params (pre-filter, matching v0)
-  if !args.keep_root {
-    info!("First reroot (pre-ancestral)");
-    clock_model = reroot_tree(
-      &mut graph,
-      &partitions,
-      &ClockParams::default(),
-      args.clock_rate,
-      &branch_params,
-      !args.allow_negative_rate,
-    )
-    .wrap_err("Failed to reroot tree (pre-ancestral)")?;
-  }
-
-  if args.clock_filter > 0.0 {
-    let result = clock_filter_inplace(&graph, &clock_model, args.clock_filter);
-    report_bad_branches(&graph, &clock_model, result.iqd);
-    apply_outlier_bad_branches(&graph);
-  }
-
-  if let Some(aln) = aln.as_deref() {
-    match args.branch_length_mode {
-      BranchLengthMode::Input => {
-        info!("Using input branch lengths for timetree inference");
-      },
-      BranchLengthMode::Marginal => {
-        info!("### ML branch-length optimization (post-reroot)");
-        update_marginal(&graph, &partitions)?;
-        optimize_branch_lengths_pre_step(&graph, &partitions, args.no_indels)
-          .wrap_err("ML branch-length optimization (post-reroot) failed")?;
-      },
-    }
-  }
-
-  progress.check_cancelled()?;
-  progress.report("Initial timetree inference", 0.2, "");
-  info!("### TreeTime: initial round");
-  info!("### Initializing node times from date constraints");
-  initialize_clock_totals_from_time_distributions(&graph)?;
-
-  // Skyline coalescent parameters (constructed once, reused for initial and final optimization)
-  let skyline_params = SkylineParams {
-    n_points: args.n_skyline,
-    ..SkylineParams::default()
-  };
-
-  if args.n_branches_posterior.is_some() {
-    return make_error!("--n-branches-posterior is not yet implemented");
-  }
-
-  // First pass without coalescent: establish internal node time distributions via
-  // backward+forward pass. Coalescent contributions read node times that only exist
-  // after the backward pass writes them.
-  run_timetree(&mut graph, &partitions, &clock_model, None, args.no_indels)?;
-
-  // Build coalescent Tc using established node times.
-  // For skyline mode: use constant Tc during iterations, switch to skyline after convergence.
-  let mut coalescent_tc: Option<Distribution> = if args.coalescent_skyline {
-    // Starting point for Brent's method bounded search; insensitive to initial value
-    let initial_tc = 1.0;
-    info!("### Optimizing constant coalescent Tc (pre-loop, skyline deferred)");
-    match optimize_tc(&graph, initial_tc) {
-      Ok(result) if result.success => {
-        info!(
-          "Pre-loop Tc = {:.6e} (likelihood = {:.4})",
-          result.tc, result.likelihood
-        );
-        Some(Distribution::constant(result.tc))
-      },
-      Ok(_) => {
-        warn!("Pre-loop Tc optimization did not converge, using Tc = {initial_tc:.6e}");
-        Some(Distribution::constant(initial_tc))
-      },
-      Err(e) => {
-        warn!("Pre-loop Tc optimization failed: {e}, using Tc = {initial_tc:.6e}");
-        Some(Distribution::constant(initial_tc))
-      },
-    }
-  } else {
-    args.coalescent.map(Distribution::constant)
-  };
-
-  // Second pass with coalescent prior
-  if coalescent_tc.is_some() {
-    run_timetree(
-      &mut graph,
-      &partitions,
-      &clock_model,
-      coalescent_tc.as_ref(),
-      args.no_indels,
-    )?;
-  }
-
-  // Post-filter reroots: use covariation params when --covariation is enabled,
-  // matching v0's pattern where covariation kicks in from the iteration loop onward
-  // (treetime.py:643-644).
-  let default_clock_params = ClockParams::default();
-  let reroot_clock_params = covariation_clock_params.as_ref().unwrap_or(&default_clock_params);
-
-  if !args.keep_root {
-    info!("Reroot (post-ancestral)");
-    clock_model = reroot_tree(
-      &mut graph,
-      &partitions,
-      reroot_clock_params,
-      args.clock_rate,
-      &branch_params,
-      !args.allow_negative_rate,
-    )
-    .wrap_err("Failed to reroot tree (post-ancestral)")?;
-  }
-
-  progress.check_cancelled()?;
-  progress.report("Optimization", 0.3, "");
-  info!("### TreeTime: Optimisation rounds");
-  let mut optimizer = TimetreeOptimizer::new(args.max_iter, args.coalescent_skyline);
-  if let Some(path) = &args.tracelog {
-    let file = create_file_or_stdout(path)?;
-    optimizer = optimizer.with_tracelog(file)?;
-  }
-  let max_iter = args.max_iter;
-  while let Some(IterationContext { i }) = optimizer.next_iter() {
-    progress.check_cancelled()?;
-    let iter_fraction = 0.3 + 0.5 * (i as f64 / max_iter as f64);
-    progress.report(
-      "Optimization",
-      iter_fraction,
-      &format!("iteration {}/{max_iter}", i + 1),
-    );
-    // Re-optimize constant Tc each iteration. Skip i < 2 because v1 runs a pre-loop
-    // Tc optimization, making the first in-loop re-optimization redundant.
-    // In skyline mode, constant Tc is used during loop iterations; the full skyline
-    // fit is deferred to post-convergence.
-    if (args.coalescent_opt || args.coalescent_skyline) && i >= 2 {
-      // For constant distributions, max_value() returns the Tc amplitude
-      let initial_tc = coalescent_tc.as_ref().map_or(1.0, |d| d.max_value());
-      match optimize_tc(&graph, initial_tc) {
-        Ok(result) => {
-          if result.success {
-            coalescent_tc = Some(Distribution::constant(result.tc));
-            info!(
-              "Optimized Tc = {:.6e} (likelihood = {:.4})",
-              result.tc, result.likelihood
-            );
-          } else {
-            warn!("Tc optimization did not converge, keeping Tc = {initial_tc:.6e}");
-          }
-        },
-        Err(e) => {
-          warn!("Tc optimization failed: {e}, keeping Tc = {initial_tc:.6e}");
-        },
-      }
-    }
-
-    let refinement_params = RefinementParams {
-      relax: args.relax.clone(),
-      resolve_polytomies: args.resolve_polytomies,
-      clock_rate: args.clock_rate,
-      no_indels: args.no_indels,
-    };
-    let (n_diff, n_resolved) = run_refinement_iteration(
-      &refinement_params,
-      &mut graph,
-      &partitions,
-      &mut clock_model,
-      reroot_clock_params,
-      &branch_params,
-      coalescent_tc.as_ref(),
-    )
-    .wrap_err_with(|| format!("When running round {i}"))?;
-
-    optimizer
-      .record(n_diff, n_resolved, &graph, &partitions, coalescent_tc.as_ref())
-      .wrap_err("Failed to record convergence metrics")
-      .wrap_err_with(|| format!("When running round {i}"))?;
-  }
-
-  // Re-optimize skyline with stabilized node times (matching v0 behavior where skyline
-  // optimization happens only on the final iteration after times have converged)
-  if args.coalescent_skyline {
-    info!("### Re-optimizing skyline coalescent with stabilized node times");
-    let skyline_result =
-      optimize_skyline(&graph, &skyline_params).wrap_err("Failed to re-optimize skyline coalescent model")?;
-    info!(
-      "Skyline re-optimization completed: log_likelihood={:.4}",
-      skyline_result.log_likelihood
-    );
-    coalescent_tc = Some(skyline_result.tc_distribution);
-
-    // Run final timetree pass with optimized skyline. OnlyFinal defers this to the
-    // final marginal pass below; Always and Never take this path.
-    if time_marginal != TimeMarginalMode::OnlyFinal {
-      run_timetree(
-        &mut graph,
-        &partitions,
-        &clock_model,
-        coalescent_tc.as_ref(),
-        args.no_indels,
-      )
-      .wrap_err("Final timetree pass with optimized skyline failed")?;
-
-      if !partitions.is_empty() {
-        update_marginal(&graph, &partitions)?;
-      }
-    }
-  }
-
-  progress.check_cancelled()?;
-  progress.report("Postprocessing", 0.85, "");
-  info!("### TreeTime: postprocessing");
-
-  // Rate susceptibility analysis: re-run timetree at rate +/- rate_std.
-  // Runs BEFORE the final marginal pass (matching v0 treetime.py:380-388).
-  //
-  // v0 gating (wrappers.py:453-469): rate susceptibility requires --confidence
-  // AND either --clock-std-dev or --covariation. Without --confidence, rate
-  // susceptibility never runs even if rate_std is available.
-  //
-  // v1's run_timetree always produces marginal distributions. Rate susceptibility
-  // runs three passes (upper, lower, central rate); the central-rate pass restores
-  // the graph to its pre-call state.
-  let rate_std = if args.confidence {
-    determine_rate_std(args.clock_std_dev, args.covariation, &clock_model)?
+  let tracelog: Option<Box<dyn std::io::Write + Send>> = if let Some(path) = &args.tracelog {
+    Some(Box::new(create_file_or_stdout(path)?))
   } else {
     None
   };
 
-  if let Some(rate_std) = rate_std {
-    let current_rate = clock_model.clock_rate();
-    if current_rate <= 0.0 {
-      warn!("Clock rate is non-positive ({current_rate:.6e}), skipping rate susceptibility");
-    } else {
-      info!("### Rate susceptibility analysis (rate_std={rate_std:.6e})");
-      compute_rate_susceptibility(
-        &mut graph,
-        &partitions,
-        &clock_model,
-        coalescent_tc.as_ref(),
-        rate_std,
-        args.no_indels,
-      )
-      .wrap_err("Rate susceptibility analysis failed")?;
-    }
-  }
+  let params = TimetreeParams {
+    model: args.model_args.model,
+    alphabet_name: args.alphabet_args.alphabet.unwrap_or_default(),
+    dense: args.dense,
+    gap_fill: args.gap_fill_args.effective_gap_fill(),
+    branch_length_mode: args.branch_length_mode,
+    no_indels: args.no_indels,
+    sequence_length: args.sequence_length,
+    clock_rate: args.clock_rate,
+    clock_std_dev: args.clock_std_dev,
+    keep_root: args.keep_root,
+    allow_negative_rate: args.allow_negative_rate,
+    clock_filter: args.clock_filter,
+    covariation: args.covariation,
+    tip_slack: args.tip_slack,
+    max_iter: args.max_iter,
+    resolve_polytomies: args.resolve_polytomies,
+    keep_polytomies: args.keep_polytomies,
+    relax: args.relax.clone(),
+    coalescent: args.coalescent,
+    coalescent_opt: args.coalescent_opt,
+    coalescent_skyline: args.coalescent_skyline,
+    n_skyline: args.n_skyline,
+    n_branches_posterior: args.n_branches_posterior,
+    time_marginal: args.time_marginal,
+    confidence: args.confidence,
+    reconstruct_tip_states: args.reconstruct_tip_states,
+    report_ambiguous: args.report_ambiguous,
+    zero_based: args.zero_based,
+  };
 
-  // Final marginal pass for confidence interval estimation
-  if time_marginal == TimeMarginalMode::OnlyFinal {
-    info!("### Final round: marginal reconstruction for confidence intervals");
-    run_timetree(
-      &mut graph,
-      &partitions,
-      &clock_model,
-      coalescent_tc.as_ref(),
-      args.no_indels,
-    )
-    .wrap_err("Final timetree inference failed")?;
+  let input = TimetreeInput {
+    graph: input_data.graph,
+    alphabet: input_data.alphabet,
+    sequences: input_data.aln,
+    dates: input_data.dates,
+  };
 
-    if !partitions.is_empty() {
-      update_marginal(&graph, &partitions)?;
-    }
-  }
-
-  // Extract CI when any CI data is available.
-  //
-  // v0 behavior: marginal distributions provide mutation-stochasticity CIs via HPD
-  // regions. OnlyFinal and Always both produce these distributions (v1 always uses
-  // marginal inference, so both modes have HPD data). Rate susceptibility adds
-  // clock-rate-uncertainty CIs independently.
-  let confidence_intervals =
-    if matches!(time_marginal, TimeMarginalMode::OnlyFinal | TimeMarginalMode::Always) || rate_std.is_some() {
-      let intervals = extract_confidence_intervals(&graph);
-      let ci_path = args.output.outdir.join("confidence_intervals.tsv");
-      write_confidence_intervals_file(&intervals, &ci_path).wrap_err("Failed to write confidence intervals")?;
-      info!("Wrote confidence intervals to {ci_path}", ci_path = ci_path.display());
-      Some(intervals)
-    } else {
-      None
-    };
+  let output = pipeline::run(&params, input, tracelog, progress)?;
 
   progress.report("Writing output", 0.95, "");
   info!("### TreeTime: writing outputs");
-  write_outputs(
-    args,
-    &graph,
-    &partitions,
-    &clock_model,
-    confidence_intervals.as_deref(),
-    dates.as_ref(),
-  )?;
+
+  if let Some(intervals) = &output.confidence_intervals {
+    let ci_path = args.output.outdir.join("confidence_intervals.tsv");
+    write_confidence_intervals_file(intervals, &ci_path).wrap_err("Failed to write confidence intervals")?;
+    info!("Wrote confidence intervals to {ci_path}", ci_path = ci_path.display());
+  }
+
+  write_outputs(args, &output)?;
 
   progress.report("Done", 1.0, "");
   Ok(TimetreeResult {
-    graph,
-    clock_model,
-    confidence_intervals,
+    graph: output.graph,
+    clock_model: output.clock_model,
+    confidence_intervals: output.confidence_intervals,
   })
 }
 
-
-/// Run one pass of ML branch-length optimization on timetree partitions.
-///
-/// v0: `optimize_tree(max_iter=1)` calls `optimize_tree_marginal(max_iter=1,
-/// damping=0.75)`, which does per-edge Brent optimization in sqrt(t) space
-/// with damped updates followed by marginal reconstruction. At iteration 0
-/// with damping=0.75, the update blends 25% optimized + 75% old branch
-/// lengths (`damping_factor = 0.75^1 = 0.75`).
-///
-/// Requires marginal profiles to be populated (via `initialize_marginal` or
-/// `update_marginal`) before calling.
-fn optimize_branch_lengths_pre_step(
-  graph: &GraphTimetree,
-  partitions: &[Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>],
-  no_indels: bool,
-) -> Result<(), Report> {
-  let old_branch_lengths = save_branch_lengths(graph);
-
-  if no_indels {
-    run_optimize_mixed_inner(graph, partitions, BranchOptMethod::BrentSqrt, 0.0, true)
-  } else {
-    run_optimize_mixed(graph, partitions, BranchOptMethod::BrentSqrt)
-  }
-  .wrap_err("ML branch-length optimization pre-step failed")?;
-
-  // Blend optimized branch lengths with old values (iteration=0):
-  // bl = bl_optimized * (1 - 0.75^1) + bl_old * 0.75^1
-  //    = bl_optimized * 0.25 + bl_old * 0.75
-  apply_damping(graph, &old_branch_lengths, TIMETREE_PRE_STEP_DAMPING, 0);
-
-  // Re-run marginal reconstruction with damped branch lengths
-  update_marginal(graph, partitions)?;
-
-  Ok(())
-}
-
-fn write_outputs(
-  args: &TreetimeTimetreeArgs,
-  graph: &GraphTimetree,
-  partitions: &[Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>],
-  clock_model: &ClockModel,
-  confidence_intervals: Option<&[NodeConfidenceInterval]>,
-  dates: Option<&DatesMap>,
-) -> Result<(), Report> {
-  if !partitions.is_empty() {
-    let guard = partitions[0].read_arc();
-    let provider = MutationCommentProvider::new(&*guard, graph);
+fn write_outputs(args: &TreetimeTimetreeArgs, output: &pipeline::TimetreeOutput) -> Result<(), Report> {
+  if !output.partitions.is_empty() {
+    let guard = output.partitions[0].read_arc();
+    let provider = MutationCommentProvider::new(&*guard, &output.graph);
     let providers = CommentProviders::new().with(&provider);
-    write_graph_files_with(&args.output.outdir, "timetree", graph, &providers)
+    write_graph_files_with(&args.output.outdir, "timetree", &output.graph, &providers)
       .wrap_err("Failed to write tree output")?;
   } else {
-    write_graph_files_with(&args.output.outdir, "timetree", graph, &CommentProviders::new())
+    write_graph_files_with(&args.output.outdir, "timetree", &output.graph, &CommentProviders::new())
       .wrap_err("Failed to write tree output")?;
   }
 
-  write_clock_model(clock_model, &args.output.outdir.join("timetree"))?;
+  write_clock_model(&output.clock_model, &args.output.outdir.join("timetree"))?;
 
-  write_auspice_json(graph, confidence_intervals, &args.output.outdir)?;
+  write_auspice_json(&output.graph, output.confidence_intervals.as_deref(), &args.output.outdir)?;
 
-  // Augur-compatible node data JSON (treetime equivalent of `augur refine`).
-  // Branch lengths and dates come from the graph payloads and clock model; the
-  // parsed date constraints supply raw_date and date_inferred.
   let augur_node_data_path = args
     .output_augur_node_data
     .clone()
     .unwrap_or_else(|| args.output.outdir.join("timetree.augur-node-data.json"));
   let alignment = args.alignment.alignment.first().map(PathBuf::as_path);
   write_augur_node_data_json(
-    graph,
-    clock_model,
-    confidence_intervals,
-    dates,
+    &output.graph,
+    &output.clock_model,
+    output.confidence_intervals.as_deref(),
+    output.dates.as_ref(),
     alignment,
     args.tree.as_deref(),
     &augur_node_data_path,
   )?;
-  info!(
-    "Wrote augur node data JSON to {path}",
-    path = augur_node_data_path.display()
-  );
+  info!("Wrote augur node data JSON to {path}", path = augur_node_data_path.display());
 
   if args.plot_rtt.is_some() {
     return make_error!("--plot-rtt is not yet implemented");
@@ -531,30 +130,4 @@ fn write_outputs(
   }
 
   Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use pretty_assertions::assert_eq;
-  use rstest::rstest;
-
-  #[rustfmt::skip]
-  #[rstest]
-  #[case::never_no_confidence(            (TimeMarginalMode::Never,     false, false, None),      TimeMarginalMode::Never)]
-  #[case::never_confidence_covariation(   (TimeMarginalMode::Never,     true,  true,  None),      TimeMarginalMode::OnlyFinal)]
-  #[case::never_confidence_clock_std(     (TimeMarginalMode::Never,     true,  false, Some(0.1)), TimeMarginalMode::OnlyFinal)]
-  #[case::never_confidence_no_prereqs(    (TimeMarginalMode::Never,     true,  false, None),      TimeMarginalMode::Never)]
-  #[case::always_no_confidence(           (TimeMarginalMode::Always,    false, false, None),      TimeMarginalMode::Always)]
-  #[case::always_confidence_covariation(  (TimeMarginalMode::Always,    true,  true,  None),      TimeMarginalMode::Always)]
-  #[case::always_confidence_clock_std(    (TimeMarginalMode::Always,    true,  false, Some(0.1)), TimeMarginalMode::Always)]
-  #[case::only_final_no_confidence(       (TimeMarginalMode::OnlyFinal, false, false, None),      TimeMarginalMode::OnlyFinal)]
-  #[case::only_final_confidence(          (TimeMarginalMode::OnlyFinal, true,  true,  None),      TimeMarginalMode::OnlyFinal)]
-  #[trace]
-  fn test_timetree_compute_effective_time_marginal(
-    #[case] (mode, confidence, covariation, clock_std_dev): (TimeMarginalMode, bool, bool, Option<f64>),
-    #[case] expected: TimeMarginalMode,
-  ) {
-    assert_eq!(expected, compute_effective_time_marginal(mode, confidence, clock_std_dev, covariation));
-  }
 }

--- a/packages/treetime/src/mugration/mod.rs
+++ b/packages/treetime/src/mugration/mod.rs
@@ -1,2 +1,3 @@
 pub mod mugration;
+pub mod pipeline;
 pub mod result;

--- a/packages/treetime/src/mugration/pipeline.rs
+++ b/packages/treetime/src/mugration/pipeline.rs
@@ -1,0 +1,2 @@
+pub use crate::mugration::mugration::execute_mugration as run;
+pub use crate::mugration::result::MugrationResult;

--- a/packages/treetime/src/optimize/mod.rs
+++ b/packages/treetime/src/optimize/mod.rs
@@ -10,6 +10,7 @@ pub mod likelihood;
 pub(super) mod method_brent;
 pub(super) mod method_newton;
 pub mod params;
+pub mod pipeline;
 pub(super) mod run_loop;
 pub(super) mod sparse_eval;
 pub mod topology;

--- a/packages/treetime/src/optimize/pipeline.rs
+++ b/packages/treetime/src/optimize/pipeline.rs
@@ -1,0 +1,113 @@
+use crate::alphabet::alphabet::Alphabet;
+use crate::ancestral::marginal::{initialize_marginal, update_marginal};
+use crate::gtr::get_gtr::GtrModelName;
+use crate::gtr::gtr::GTR;
+use crate::optimize::params::{BranchOptMethod, InitialGuessMode};
+use crate::optimize::run_loop::{apply_initial_guess_mode, collect_optimize_partitions, normalize_partition_rates, run_optimize_loop};
+use crate::partition::create::{MarginalPartition, create_marginal_partition};
+use crate::partition::marginal_dense::PartitionMarginalDense;
+use crate::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::payload::ancestral::GraphAncestral;
+use crate::progress::ProgressSink;
+use eyre::Report;
+use log::info;
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::sync::Arc;
+use treetime_io::fasta::FastaRecord;
+use treetime_utils::make_error;
+
+pub struct OptimizeParams {
+  pub model: GtrModelName,
+  pub dense: Option<bool>,
+  pub max_iter: usize,
+  pub dp: f64,
+  pub damping: f64,
+  pub opt_method: BranchOptMethod,
+  pub initial_guess: InitialGuessMode,
+  pub no_indels: bool,
+}
+
+pub struct OptimizeInput {
+  pub graph: GraphAncestral,
+  pub alphabet: Alphabet,
+  pub sequences: Vec<FastaRecord>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OptimizeOutput {
+  #[serde(skip)]
+  pub graph: GraphAncestral,
+  #[serde(skip)]
+  pub gtr: GTR,
+  pub model_name: GtrModelName,
+  #[serde(skip)]
+  pub sparse_partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>>,
+  #[serde(skip)]
+  pub dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>>,
+}
+
+pub fn run(params: &OptimizeParams, mut input: OptimizeInput, progress: &dyn ProgressSink) -> Result<OptimizeOutput, Report> {
+  if !(0.0..1.0).contains(&params.damping) {
+    return make_error!("damping must be in [0.0, 1.0), got {}", params.damping);
+  }
+
+  let created = create_marginal_partition(&input.graph, 0, input.alphabet, &input.sequences, params.model, params.dense)?;
+  let model_name = created.model_name;
+  let gtr = created.gtr;
+
+  let sparse_partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>>;
+  let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>>;
+
+  match created.partition {
+    MarginalPartition::Sparse(p) => {
+      sparse_partitions = vec![Arc::new(RwLock::new(p))];
+      dense_partitions = vec![];
+    },
+    MarginalPartition::Dense(p) => {
+      sparse_partitions = vec![];
+      dense_partitions = vec![Arc::new(RwLock::new(p))];
+    },
+  }
+
+  update_marginal(&input.graph, &sparse_partitions)?;
+  if !dense_partitions.is_empty() {
+    initialize_marginal(&input.graph, &dense_partitions, &input.sequences)?;
+    update_marginal(&input.graph, &dense_partitions)?;
+  }
+
+  let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
+
+  if model_name == GtrModelName::Infer {
+    normalize_partition_rates(&input.graph, &sparse_partitions);
+    normalize_partition_rates(&input.graph, &dense_partitions);
+  }
+
+  apply_initial_guess_mode(&input.graph, &mixed_partitions, params.initial_guess, params.no_indels)?;
+
+  progress.check_cancelled()?;
+  progress.report("Optimizing branch lengths", 0.3, "");
+  run_optimize_loop(
+    &mut input.graph,
+    &sparse_partitions,
+    &dense_partitions,
+    &mixed_partitions,
+    params.max_iter,
+    params.dp,
+    params.damping,
+    params.opt_method,
+    params.no_indels,
+  )?;
+
+  info!("Re-running marginal to populate subs_ml after optimization loop");
+  update_marginal(&input.graph, &sparse_partitions)?;
+  update_marginal(&input.graph, &dense_partitions)?;
+
+  Ok(OptimizeOutput {
+    graph: input.graph,
+    gtr,
+    model_name,
+    sparse_partitions,
+    dense_partitions,
+  })
+}

--- a/packages/treetime/src/partition/create.rs
+++ b/packages/treetime/src/partition/create.rs
@@ -1,0 +1,79 @@
+use crate::alphabet::alphabet::Alphabet;
+use crate::ancestral::fitch::create_fitch_partition;
+use crate::ancestral::gtr_inference::infer_gtr_fitch;
+use crate::gtr::get_gtr::{GtrModelName, get_gtr_by_name, log_gtr};
+use crate::gtr::gtr::GTR;
+use crate::partition::algo::infer_dense::infer_dense;
+use crate::partition::marginal_dense::PartitionMarginalDense;
+use crate::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::seq::alignment::get_common_length;
+use eyre::Report;
+use treetime_graph::edge::{GraphEdge, HasBranchLength};
+use treetime_graph::graph::Graph;
+use treetime_graph::node::NodeAncestralOps;
+use treetime_io::fasta::FastaRecord;
+
+pub enum MarginalPartition {
+  Sparse(PartitionMarginalSparse),
+  Dense(PartitionMarginalDense),
+}
+
+pub struct PartitionCreated {
+  pub partition: MarginalPartition,
+  pub gtr: GTR,
+  pub model_name: GtrModelName,
+}
+
+/// Create a marginal partition from alignment data, consolidating the 3-way branch:
+/// sparse, dense+infer GTR, dense+named GTR.
+///
+/// No file I/O. GTR JSON writing is the caller's responsibility.
+pub fn create_marginal_partition<N, E>(
+  graph: &Graph<N, E, ()>,
+  index: usize,
+  alphabet: Alphabet,
+  sequences: &[FastaRecord],
+  model_name: GtrModelName,
+  dense: Option<bool>,
+) -> Result<PartitionCreated, Report>
+where
+  N: NodeAncestralOps,
+  E: GraphEdge + HasBranchLength,
+{
+  let dense = dense.unwrap_or_else(infer_dense);
+
+  if !dense {
+    let fitch = create_fitch_partition(graph, index, alphabet, sequences)?;
+    let gtr = match model_name {
+      GtrModelName::Infer => infer_gtr_fitch(&fitch, graph)?,
+      _ => get_gtr_by_name(model_name)?,
+    };
+    log_gtr(&gtr, model_name);
+    let partition = fitch.into_marginal_sparse(gtr.clone(), graph)?;
+    Ok(PartitionCreated {
+      partition: MarginalPartition::Sparse(partition),
+      gtr,
+      model_name,
+    })
+  } else if model_name == GtrModelName::Infer {
+    let fitch = create_fitch_partition(graph, index, alphabet, sequences)?;
+    let gtr = infer_gtr_fitch(&fitch, graph)?;
+    log_gtr(&gtr, model_name);
+    let partition = fitch.into_marginal_dense(gtr.clone());
+    Ok(PartitionCreated {
+      partition: MarginalPartition::Dense(partition),
+      gtr,
+      model_name,
+    })
+  } else {
+    let length = get_common_length(sequences)?;
+    let gtr = get_gtr_by_name(model_name)?;
+    log_gtr(&gtr, model_name);
+    let partition = PartitionMarginalDense::new(index, gtr.clone(), alphabet, length);
+    Ok(PartitionCreated {
+      partition: MarginalPartition::Dense(partition),
+      gtr,
+      model_name,
+    })
+  }
+}

--- a/packages/treetime/src/partition/mod.rs
+++ b/packages/treetime/src/partition/mod.rs
@@ -3,6 +3,7 @@ mod __tests__;
 
 pub mod algo;
 pub mod augur;
+pub mod create;
 pub mod dense;
 pub mod discrete_states;
 pub mod fitch;

--- a/packages/treetime/src/prune/mod.rs
+++ b/packages/treetime/src/prune/mod.rs
@@ -1,3 +1,4 @@
 #[cfg(test)]
 mod __tests__;
+pub mod pipeline;
 pub mod prune;

--- a/packages/treetime/src/prune/pipeline.rs
+++ b/packages/treetime/src/prune/pipeline.rs
@@ -1,0 +1,71 @@
+use crate::alphabet::alphabet::Alphabet;
+use crate::gtr::get_gtr::{GtrModelName, get_gtr_by_name, log_gtr};
+use crate::gtr::gtr::GTR;
+use crate::optimize::topology::merge_shared_mutations::merge_shared_mutation_branches;
+use crate::partition::create::{MarginalPartition, create_marginal_partition};
+use crate::partition::marginal_sparse::PartitionMarginalSparse;
+use crate::payload::ancestral::GraphAncestral;
+use crate::prune::prune::prune_nodes;
+use eyre::Report;
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use treetime_io::fasta::FastaRecord;
+
+pub struct PruneParams {
+  pub prune_short: Option<f64>,
+  pub prune_empty: bool,
+  pub merge_shared_mutations: bool,
+  pub node_names: BTreeSet<String>,
+}
+
+pub struct PruneInput {
+  pub graph: GraphAncestral,
+  pub alphabet: Alphabet,
+  pub sequences: Option<Vec<FastaRecord>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PruneOutput {
+  #[serde(skip)]
+  pub graph: GraphAncestral,
+  #[serde(skip)]
+  pub gtr: Option<GTR>,
+}
+
+pub fn run(params: &PruneParams, mut input: PruneInput) -> Result<PruneOutput, Report> {
+  let needs_sequences = params.prune_empty || params.merge_shared_mutations;
+  let partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>> = if needs_sequences {
+    let sequences = input.sequences.as_ref().ok_or_else(|| {
+      eyre::eyre!("Sequences required for --prune-empty or --merge-shared-mutations")
+    })?;
+    let created = create_marginal_partition(&input.graph, 0, input.alphabet.clone(), sequences, GtrModelName::JC69, None)?;
+    match created.partition {
+      MarginalPartition::Sparse(p) => vec![Arc::new(RwLock::new(p))],
+      MarginalPartition::Dense(_) => {
+        let gtr = get_gtr_by_name(GtrModelName::JC69)?;
+        log_gtr(&gtr, GtrModelName::JC69);
+        let fitch = crate::ancestral::fitch::create_fitch_partition(&input.graph, 0, input.alphabet.clone(), sequences)?;
+        let partition = fitch.into_marginal_sparse(gtr, &input.graph)?;
+        vec![Arc::new(RwLock::new(partition))]
+      },
+    }
+  } else {
+    vec![]
+  };
+
+  prune_nodes(&mut input.graph, &partitions, params.prune_short, params.prune_empty, &params.node_names)?;
+
+  if params.merge_shared_mutations {
+    merge_shared_mutation_branches(&mut input.graph, &partitions)?;
+    input.graph.build()?;
+  }
+
+  let gtr = (!partitions.is_empty()).then(|| partitions[0].read_arc().gtr.clone());
+
+  Ok(PruneOutput {
+    graph: input.graph,
+    gtr,
+  })
+}

--- a/packages/treetime/src/timetree/__tests__/mod.rs
+++ b/packages/treetime/src/timetree/__tests__/mod.rs
@@ -1,0 +1,1 @@
+mod test_params;

--- a/packages/treetime/src/timetree/__tests__/test_params.rs
+++ b/packages/treetime/src/timetree/__tests__/test_params.rs
@@ -1,0 +1,25 @@
+#[cfg(test)]
+mod tests {
+  use crate::timetree::params::{TimeMarginalMode, compute_effective_time_marginal};
+  use pretty_assertions::assert_eq;
+  use rstest::rstest;
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::never_no_confidence(            (TimeMarginalMode::Never,     false, false, None),      TimeMarginalMode::Never)]
+  #[case::never_confidence_covariation(   (TimeMarginalMode::Never,     true,  true,  None),      TimeMarginalMode::OnlyFinal)]
+  #[case::never_confidence_clock_std(     (TimeMarginalMode::Never,     true,  false, Some(0.1)), TimeMarginalMode::OnlyFinal)]
+  #[case::never_confidence_no_prereqs(    (TimeMarginalMode::Never,     true,  false, None),      TimeMarginalMode::Never)]
+  #[case::always_no_confidence(           (TimeMarginalMode::Always,    false, false, None),      TimeMarginalMode::Always)]
+  #[case::always_confidence_covariation(  (TimeMarginalMode::Always,    true,  true,  None),      TimeMarginalMode::Always)]
+  #[case::always_confidence_clock_std(    (TimeMarginalMode::Always,    true,  false, Some(0.1)), TimeMarginalMode::Always)]
+  #[case::only_final_no_confidence(       (TimeMarginalMode::OnlyFinal, false, false, None),      TimeMarginalMode::OnlyFinal)]
+  #[case::only_final_confidence(          (TimeMarginalMode::OnlyFinal, true,  true,  None),      TimeMarginalMode::OnlyFinal)]
+  #[trace]
+  fn test_timetree_compute_effective_time_marginal(
+    #[case] (mode, confidence, covariation, clock_std_dev): (TimeMarginalMode, bool, bool, Option<f64>),
+    #[case] expected: TimeMarginalMode,
+  ) {
+    assert_eq!(expected, compute_effective_time_marginal(mode, confidence, clock_std_dev, covariation));
+  }
+}

--- a/packages/treetime/src/timetree/mod.rs
+++ b/packages/treetime/src/timetree/mod.rs
@@ -4,5 +4,6 @@ pub mod inference;
 pub mod optimization;
 pub mod output;
 pub mod params;
+pub mod pipeline;
 pub mod refinement;
 pub mod utils;

--- a/packages/treetime/src/timetree/mod.rs
+++ b/packages/treetime/src/timetree/mod.rs
@@ -2,4 +2,6 @@ pub mod confidence;
 pub mod convergence;
 pub mod inference;
 pub mod optimization;
+pub mod params;
+pub mod refinement;
 pub mod utils;

--- a/packages/treetime/src/timetree/mod.rs
+++ b/packages/treetime/src/timetree/mod.rs
@@ -2,6 +2,7 @@ pub mod confidence;
 pub mod convergence;
 pub mod inference;
 pub mod optimization;
+pub mod output;
 pub mod params;
 pub mod refinement;
 pub mod utils;

--- a/packages/treetime/src/timetree/mod.rs
+++ b/packages/treetime/src/timetree/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod __tests__;
+
 pub mod confidence;
 pub mod convergence;
 pub mod inference;

--- a/packages/treetime/src/timetree/output/auspice.rs
+++ b/packages/treetime/src/timetree/output/auspice.rs
@@ -1,0 +1,157 @@
+use crate::payload::timetree::{EdgeTimetree, NodeTimetree};
+use crate::timetree::confidence::NodeConfidenceInterval;
+use eyre::Report;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use treetime_graph::graph::Graph;
+use treetime_graph::node::{GraphNodeKey, Named};
+use treetime_io::auspice::{AuspiceGraphContext, AuspiceWrite, auspice_from_graph_with};
+use treetime_io::auspice_types::{
+  AuspiceColoring, AuspiceDisplayDefaults, AuspiceNumDate, AuspiceTree, AuspiceTreeBranchAttrs, AuspiceTreeData,
+  AuspiceTreeMeta, AuspiceTreeNode, AuspiceTreeNodeAttr, AuspiceTreeNodeAttrs,
+};
+use treetime_utils::make_error;
+
+/// Build auspice v2 tree data from a timetree graph without file I/O.
+pub fn build_timetree_auspice(
+  graph: &Graph<NodeTimetree, EdgeTimetree, ()>,
+  confidence_intervals: Option<&[NodeConfidenceInterval]>,
+) -> Result<AuspiceTree, Report> {
+  let ci_map = confidence_intervals.map_or_else(BTreeMap::new, build_ci_map);
+  let mut writer = TimetreeAuspiceWriter { ci_map };
+  auspice_from_graph_with(&mut writer, graph)
+}
+
+struct TimetreeAuspiceWriter {
+  ci_map: BTreeMap<GraphNodeKey, ConfidenceBounds>,
+}
+
+impl AuspiceWrite<NodeTimetree, EdgeTimetree, ()> for TimetreeAuspiceWriter {
+  fn new(_graph: &Graph<NodeTimetree, EdgeTimetree, ()>) -> Result<Self, Report> {
+    make_error!(
+      "TimetreeAuspiceWriter must be constructed directly with a CI map. \
+       Use build_timetree_auspice() or auspice_from_graph_with() instead of auspice_from_graph()."
+    )
+  }
+
+  fn auspice_data_from_graph_data(
+    &self,
+    _graph: &Graph<NodeTimetree, EdgeTimetree, ()>,
+  ) -> Result<AuspiceTreeData, Report> {
+    let colorings = vec![
+      AuspiceColoring {
+        title: "Date".to_owned(),
+        type_: "continuous".to_owned(),
+        key: "num_date".to_owned(),
+        ..AuspiceColoring::default()
+      },
+      AuspiceColoring {
+        title: "Excluded".to_owned(),
+        type_: "categorical".to_owned(),
+        key: "bad_branch".to_owned(),
+        ..AuspiceColoring::default()
+      },
+    ];
+
+    Ok(AuspiceTreeData {
+      version: Some("v2".to_owned()),
+      meta: AuspiceTreeMeta {
+        title: Some("TreeTime timetree analysis".to_owned()),
+        updated: Some(chrono::Utc::now().format("%Y-%m-%d").to_string()),
+        panels: vec!["tree".to_owned()],
+        colorings,
+        display_defaults: AuspiceDisplayDefaults {
+          color_by: Some("bad_branch".to_owned()),
+          ..AuspiceDisplayDefaults::default()
+        },
+        filters: vec!["bad_branch".to_owned()],
+        ..AuspiceTreeMeta::default()
+      },
+      root_sequence: None,
+      other: Value::default(),
+    })
+  }
+
+  fn auspice_node_from_graph_components(
+    &mut self,
+    context: &AuspiceGraphContext<NodeTimetree, EdgeTimetree, ()>,
+  ) -> Result<AuspiceTreeNode, Report> {
+    let &AuspiceGraphContext { node_key, node, .. } = context;
+
+    let name = node
+      .name()
+      .map_or_else(|| format!("node_{}", node_key.as_usize()), |n| n.as_ref().to_owned());
+
+    if !node.div.is_finite() {
+      return make_error!("Node '{name}' has non-finite div={div}", div = node.div);
+    }
+    if let Some(t) = node.time {
+      if !t.is_finite() {
+        return make_error!("Node '{name}' has non-finite time={t}");
+      }
+    }
+
+    let num_date = node.time.map(|t| {
+      let confidence = self.ci_map.get(&node_key).map(|ci| {
+        if !ci.lower.is_finite() || !ci.upper.is_finite() {
+          log::warn!(
+            "Node '{name}' has non-finite CI bounds: [{lower}, {upper}]",
+            lower = ci.lower,
+            upper = ci.upper
+          );
+        }
+        debug_assert!(
+          ci.lower <= ci.upper,
+          "CI bounds inverted for node '{name}': [{lower}, {upper}]",
+          lower = ci.lower,
+          upper = ci.upper
+        );
+        [ci.lower, ci.upper]
+      });
+      AuspiceNumDate { value: t, confidence }
+    });
+
+    let bad_branch = Some(AuspiceTreeNodeAttr::new(if node.bad_branch { "Yes" } else { "No" }));
+
+    Ok(AuspiceTreeNode {
+      name,
+      branch_attrs: AuspiceTreeBranchAttrs {
+        mutations: BTreeMap::new(),
+        labels: None,
+        other: Value::default(),
+      },
+      node_attrs: AuspiceTreeNodeAttrs {
+        div: Some(node.div),
+        num_date,
+        bad_branch,
+        clade_membership: None,
+        region: None,
+        country: None,
+        division: None,
+        other: Value::default(),
+      },
+      children: vec![],
+      other: Value::default(),
+    })
+  }
+}
+
+struct ConfidenceBounds {
+  lower: f64,
+  upper: f64,
+}
+
+fn build_ci_map(intervals: &[NodeConfidenceInterval]) -> BTreeMap<GraphNodeKey, ConfidenceBounds> {
+  intervals
+    .iter()
+    .map(|ci| {
+      (
+        ci.key,
+        ConfidenceBounds {
+          lower: ci.lower,
+          upper: ci.upper,
+        },
+      )
+    })
+    .collect()
+}

--- a/packages/treetime/src/timetree/output/mod.rs
+++ b/packages/treetime/src/timetree/output/mod.rs
@@ -1,0 +1,1 @@
+pub mod auspice;

--- a/packages/treetime/src/timetree/params.rs
+++ b/packages/treetime/src/timetree/params.rs
@@ -1,0 +1,83 @@
+use crate::clock::clock_regression::ClockParams;
+use crate::make_report;
+use crate::seq::alignment::get_common_length;
+use eyre::Report;
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use smart_default::SmartDefault;
+use std::fmt::Debug;
+use treetime_io::fasta::FastaRecord;
+
+#[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, SmartDefault, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
+pub enum TimeMarginalMode {
+  #[default]
+  Never,
+  Always,
+  OnlyFinal,
+}
+
+/// Compute effective time_marginal mode, promoting Never to OnlyFinal when
+/// confidence is requested with rate uncertainty prerequisites.
+///
+/// v0 (wrappers.py:478):
+///   time_marginal = 'confidence-only' if (calc_confidence and time_marginal == 'never') else time_marginal
+pub fn compute_effective_time_marginal(
+  time_marginal: TimeMarginalMode,
+  confidence: bool,
+  clock_std_dev: Option<f64>,
+  covariation: bool,
+) -> TimeMarginalMode {
+  if confidence && time_marginal == TimeMarginalMode::Never {
+    if clock_std_dev.is_some() || covariation {
+      info!("--confidence: promoting time-marginal from never to only-final for CI estimation");
+      TimeMarginalMode::OnlyFinal
+    } else {
+      warn!(
+        "Cannot estimate confidence intervals without clock rate uncertainty. \
+         Specify --clock-std-dev or rerun with --covariation. \
+         Proceeding without confidence estimation."
+      );
+      TimeMarginalMode::Never
+    }
+  } else {
+    time_marginal
+  }
+}
+
+/// Build covariation-aware ClockParams when covariation is enabled.
+///
+/// v0 (clock_tree.py:277-285):
+///   branch_variance = (max(0, clock_length) + tip_slack^2 * om) * om   [leaves]
+///   branch_variance = max(0, clock_length) * om                         [internal]
+/// where om = 1/seq_len, tip_slack = OVER_DISPERSION = 10 (config.py:8)
+///
+/// Mapping to v1 ClockParams:
+///   variance_factor = 1/seq_len, variance_offset = 0, variance_offset_leaf = tip_slack^2/seq_len^2
+pub fn build_covariation_clock_params(
+  covariation: bool,
+  sequence_length: Option<usize>,
+  tip_slack: Option<f64>,
+  aln: Option<&[FastaRecord]>,
+) -> Result<Option<ClockParams>, Report> {
+  if !covariation {
+    return Ok(None);
+  }
+
+  let seq_len = if let Some(aln_data) = aln {
+    get_common_length(aln_data)? as f64
+  } else {
+    sequence_length.ok_or_else(|| make_report!("--sequence-length required for --covariation without alignment"))? as f64
+  };
+
+  let tip_slack = tip_slack.unwrap_or(10.0);
+
+  info!("Covariation-aware clock regression: seq_len={seq_len}, tip_slack={tip_slack}");
+
+  Ok(Some(ClockParams {
+    variance_factor: 1.0 / seq_len,
+    variance_offset: 0.0,
+    variance_offset_leaf: tip_slack * tip_slack / (seq_len * seq_len),
+  }))
+}

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -1,0 +1,418 @@
+use crate::alphabet::alphabet::Alphabet;
+use crate::ancestral::marginal::{initialize_marginal, update_marginal};
+use crate::clock::clock_filter::clock_filter_inplace;
+use crate::clock::clock_model::ClockModel;
+use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
+use crate::clock::date_constraints::load_date_constraints;
+use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::reroot::RerootParams;
+use crate::coalescent::optimize_tc::optimize_tc;
+use crate::coalescent::skyline::{SkylineParams, optimize_skyline};
+use crate::gtr::get_gtr::GtrModelName;
+use crate::make_error;
+use crate::optimize::dispatch::{run_optimize_mixed, run_optimize_mixed_inner};
+use crate::optimize::iteration::{apply_damping, save_branch_lengths};
+use crate::optimize::params::{BranchLengthMode, BranchOptMethod};
+use crate::partition::create::{MarginalPartition, create_marginal_partition};
+use crate::partition::timetree::{GraphTimetree, PartitionTimetreeAllVec};
+use crate::partition::traits::PartitionTimetreeAll;
+use crate::payload::timetree::{EdgeTimetree, NodeTimetree};
+use crate::progress::ProgressSink;
+use crate::seq::alignment::get_common_length;
+use crate::timetree::confidence::{
+  NodeConfidenceInterval, compute_rate_susceptibility, determine_rate_std, extract_confidence_intervals,
+};
+use crate::timetree::convergence::optimizer::{IterationContext, TimetreeOptimizer};
+use crate::timetree::inference::runner::run_timetree;
+use crate::timetree::optimization::clock_filter::{apply_outlier_bad_branches, report_bad_branches};
+use crate::timetree::optimization::reroot::reroot_tree;
+use crate::timetree::params::{TimeMarginalMode, build_covariation_clock_params, compute_effective_time_marginal};
+use crate::timetree::refinement::{RefinementParams, run_refinement_iteration};
+use crate::timetree::utils::{initialize_clock_totals_from_time_distributions, initialize_node_divergences};
+use eyre::{Report, WrapErr};
+use log::{debug, info, warn};
+use parking_lot::RwLock;
+use serde::Serialize;
+use std::io::Write;
+use std::sync::Arc;
+use treetime_distribution::Distribution;
+use treetime_io::dates_csv::DatesMap;
+use treetime_io::fasta::FastaRecord;
+use treetime_utils::make_report;
+
+const TIMETREE_PRE_STEP_DAMPING: f64 = 0.75;
+
+pub struct TimetreeParams {
+  pub model: GtrModelName,
+  pub alphabet_name: crate::alphabet::alphabet::AlphabetName,
+  pub dense: Option<bool>,
+  pub gap_fill: crate::seq::gap_fill::GapFill,
+  pub branch_length_mode: BranchLengthMode,
+  pub no_indels: bool,
+  pub sequence_length: Option<usize>,
+  pub clock_rate: Option<f64>,
+  pub clock_std_dev: Option<f64>,
+  pub keep_root: bool,
+  pub allow_negative_rate: bool,
+  pub clock_filter: f64,
+  pub covariation: bool,
+  pub tip_slack: Option<f64>,
+  pub max_iter: usize,
+  pub resolve_polytomies: bool,
+  pub keep_polytomies: bool,
+  pub relax: Vec<f64>,
+  pub coalescent: Option<f64>,
+  pub coalescent_opt: bool,
+  pub coalescent_skyline: bool,
+  pub n_skyline: usize,
+  pub n_branches_posterior: Option<usize>,
+  pub time_marginal: TimeMarginalMode,
+  pub confidence: bool,
+  pub reconstruct_tip_states: bool,
+  pub report_ambiguous: bool,
+  pub zero_based: bool,
+}
+
+pub struct TimetreeInput {
+  pub graph: GraphTimetree,
+  pub alphabet: Alphabet,
+  pub sequences: Option<Vec<FastaRecord>>,
+  pub dates: Option<DatesMap>,
+}
+
+#[derive(Serialize)]
+pub struct TimetreeOutput {
+  #[serde(skip)]
+  pub graph: GraphTimetree,
+  #[serde(skip)]
+  pub clock_model: ClockModel,
+  #[serde(skip)]
+  pub confidence_intervals: Option<Vec<NodeConfidenceInterval>>,
+  #[serde(skip)]
+  pub partitions: PartitionTimetreeAllVec,
+  #[serde(skip)]
+  pub dates: Option<DatesMap>,
+}
+
+pub fn run(
+  params: &TimetreeParams,
+  mut input: TimetreeInput,
+  tracelog: Option<Box<dyn Write + Send>>,
+  progress: &dyn ProgressSink,
+) -> Result<TimetreeOutput, Report> {
+  info!("# TreeTime Timetree Estimation");
+  debug!("Branch length mode: {:?}, Keep root: {}", params.branch_length_mode, params.keep_root);
+
+  let time_marginal = compute_effective_time_marginal(params.time_marginal, params.confidence, params.clock_std_dev, params.covariation);
+
+  let covariation_clock_params = build_covariation_clock_params(
+    params.covariation,
+    params.sequence_length,
+    params.tip_slack,
+    input.sequences.as_deref(),
+  )?;
+
+  if let Some(dates) = &input.dates {
+    load_date_constraints(dates, &input.graph).wrap_err("Failed to load date constraints")?;
+  }
+
+  initialize_node_divergences(&input.graph);
+
+  let branch_params = BranchPointOptimizationParams::default();
+
+  progress.check_cancelled()?;
+  progress.report("Clock regression", 0.1, "");
+  let reroot_params = RerootParams {
+    force_positive_rate: !params.allow_negative_rate,
+    ..RerootParams::default()
+  };
+  let mut clock_model = estimate_clock_model_with_reroot_policy(
+    &mut input.graph,
+    &ClockParams::default(),
+    params.clock_rate,
+    params.keep_root,
+    &branch_params,
+    &reroot_params,
+    None,
+  )
+  .wrap_err("Failed to infer clock model")?
+  .clock_model;
+
+  let partitions: PartitionTimetreeAllVec = match params.branch_length_mode {
+    BranchLengthMode::Input => {
+      info!("Branch length mode: Input - using tree branch lengths");
+      vec![]
+    },
+    BranchLengthMode::Marginal => {
+      info!("Branch length mode: Marginal - initializing partitions from alignment");
+      initialize_partitions_from_params(params, &input.graph, input.alphabet.clone(), input.sequences.as_deref())?
+    },
+  };
+
+  if let Some(aln) = input.sequences.as_deref() {
+    if params.branch_length_mode == BranchLengthMode::Marginal && !partitions.is_empty() {
+      info!("### ML branch-length optimization (pre-reroot)");
+      initialize_marginal(&input.graph, &partitions, aln)?;
+      optimize_branch_lengths_pre_step(&input.graph, &partitions, params.no_indels)
+        .wrap_err("ML branch-length optimization (pre-reroot) failed")?;
+    }
+  }
+
+  if !params.keep_root {
+    info!("First reroot (pre-ancestral)");
+    clock_model = reroot_tree(
+      &mut input.graph,
+      &partitions,
+      &ClockParams::default(),
+      params.clock_rate,
+      &branch_params,
+      !params.allow_negative_rate,
+    )
+    .wrap_err("Failed to reroot tree (pre-ancestral)")?;
+  }
+
+  if params.clock_filter > 0.0 {
+    let result = clock_filter_inplace(&input.graph, &clock_model, params.clock_filter);
+    report_bad_branches(&input.graph, &clock_model, result.iqd);
+    apply_outlier_bad_branches(&input.graph);
+  }
+
+  if let Some(aln) = input.sequences.as_deref() {
+    match params.branch_length_mode {
+      BranchLengthMode::Input => {
+        info!("Using input branch lengths for timetree inference");
+      },
+      BranchLengthMode::Marginal => {
+        info!("### ML branch-length optimization (post-reroot)");
+        update_marginal(&input.graph, &partitions)?;
+        optimize_branch_lengths_pre_step(&input.graph, &partitions, params.no_indels)
+          .wrap_err("ML branch-length optimization (post-reroot) failed")?;
+      },
+    }
+  }
+
+  progress.check_cancelled()?;
+  progress.report("Initial timetree inference", 0.2, "");
+  info!("### TreeTime: initial round");
+  info!("### Initializing node times from date constraints");
+  initialize_clock_totals_from_time_distributions(&input.graph)?;
+
+  let skyline_params = SkylineParams {
+    n_points: params.n_skyline,
+    ..SkylineParams::default()
+  };
+
+  if params.n_branches_posterior.is_some() {
+    return make_error!("--n-branches-posterior is not yet implemented");
+  }
+
+  run_timetree(&mut input.graph, &partitions, &clock_model, None, params.no_indels)?;
+
+  let mut coalescent_tc: Option<Distribution> = if params.coalescent_skyline {
+    let initial_tc = 1.0;
+    info!("### Optimizing constant coalescent Tc (pre-loop, skyline deferred)");
+    match optimize_tc(&input.graph, initial_tc) {
+      Ok(result) if result.success => {
+        info!("Pre-loop Tc = {:.6e} (likelihood = {:.4})", result.tc, result.likelihood);
+        Some(Distribution::constant(result.tc))
+      },
+      Ok(_) => {
+        warn!("Pre-loop Tc optimization did not converge, using Tc = {initial_tc:.6e}");
+        Some(Distribution::constant(initial_tc))
+      },
+      Err(e) => {
+        warn!("Pre-loop Tc optimization failed: {e}, using Tc = {initial_tc:.6e}");
+        Some(Distribution::constant(initial_tc))
+      },
+    }
+  } else {
+    params.coalescent.map(Distribution::constant)
+  };
+
+  if coalescent_tc.is_some() {
+    run_timetree(&mut input.graph, &partitions, &clock_model, coalescent_tc.as_ref(), params.no_indels)?;
+  }
+
+  let default_clock_params = ClockParams::default();
+  let reroot_clock_params = covariation_clock_params.as_ref().unwrap_or(&default_clock_params);
+
+  if !params.keep_root {
+    info!("Reroot (post-ancestral)");
+    clock_model = reroot_tree(
+      &mut input.graph,
+      &partitions,
+      reroot_clock_params,
+      params.clock_rate,
+      &branch_params,
+      !params.allow_negative_rate,
+    )
+    .wrap_err("Failed to reroot tree (post-ancestral)")?;
+  }
+
+  progress.check_cancelled()?;
+  progress.report("Optimization", 0.3, "");
+  info!("### TreeTime: Optimisation rounds");
+  let mut optimizer = TimetreeOptimizer::new(params.max_iter, params.coalescent_skyline);
+  if let Some(writer) = tracelog {
+    optimizer = optimizer.with_tracelog(writer)?;
+  }
+  let max_iter = params.max_iter;
+  while let Some(IterationContext { i }) = optimizer.next_iter() {
+    progress.check_cancelled()?;
+    let iter_fraction = 0.3 + 0.5 * (i as f64 / max_iter as f64);
+    progress.report("Optimization", iter_fraction, &format!("iteration {}/{max_iter}", i + 1));
+
+    if (params.coalescent_opt || params.coalescent_skyline) && i >= 2 {
+      let initial_tc = coalescent_tc.as_ref().map_or(1.0, |d| d.max_value());
+      match optimize_tc(&input.graph, initial_tc) {
+        Ok(result) => {
+          if result.success {
+            coalescent_tc = Some(Distribution::constant(result.tc));
+            info!("Optimized Tc = {:.6e} (likelihood = {:.4})", result.tc, result.likelihood);
+          } else {
+            warn!("Tc optimization did not converge, keeping Tc = {initial_tc:.6e}");
+          }
+        },
+        Err(e) => {
+          warn!("Tc optimization failed: {e}, keeping Tc = {initial_tc:.6e}");
+        },
+      }
+    }
+
+    let refinement_params = RefinementParams {
+      relax: params.relax.clone(),
+      resolve_polytomies: params.resolve_polytomies,
+      clock_rate: params.clock_rate,
+      no_indels: params.no_indels,
+    };
+    let (n_diff, n_resolved) = run_refinement_iteration(
+      &refinement_params,
+      &mut input.graph,
+      &partitions,
+      &mut clock_model,
+      reroot_clock_params,
+      &branch_params,
+      coalescent_tc.as_ref(),
+    )
+    .wrap_err_with(|| format!("When running round {i}"))?;
+
+    optimizer
+      .record(n_diff, n_resolved, &input.graph, &partitions, coalescent_tc.as_ref())
+      .wrap_err("Failed to record convergence metrics")
+      .wrap_err_with(|| format!("When running round {i}"))?;
+  }
+
+  if params.coalescent_skyline {
+    info!("### Re-optimizing skyline coalescent with stabilized node times");
+    let skyline_result =
+      optimize_skyline(&input.graph, &skyline_params).wrap_err("Failed to re-optimize skyline coalescent model")?;
+    info!("Skyline re-optimization completed: log_likelihood={:.4}", skyline_result.log_likelihood);
+    coalescent_tc = Some(skyline_result.tc_distribution);
+
+    if time_marginal != TimeMarginalMode::OnlyFinal {
+      run_timetree(&mut input.graph, &partitions, &clock_model, coalescent_tc.as_ref(), params.no_indels)
+        .wrap_err("Final timetree pass with optimized skyline failed")?;
+
+      if !partitions.is_empty() {
+        update_marginal(&input.graph, &partitions)?;
+      }
+    }
+  }
+
+  progress.check_cancelled()?;
+  progress.report("Postprocessing", 0.85, "");
+  info!("### TreeTime: postprocessing");
+
+  let rate_std = if params.confidence {
+    determine_rate_std(params.clock_std_dev, params.covariation, &clock_model)?
+  } else {
+    None
+  };
+
+  if let Some(rate_std) = rate_std {
+    let current_rate = clock_model.clock_rate();
+    if current_rate <= 0.0 {
+      warn!("Clock rate is non-positive ({current_rate:.6e}), skipping rate susceptibility");
+    } else {
+      info!("### Rate susceptibility analysis (rate_std={rate_std:.6e})");
+      compute_rate_susceptibility(
+        &mut input.graph,
+        &partitions,
+        &clock_model,
+        coalescent_tc.as_ref(),
+        rate_std,
+        params.no_indels,
+      )
+      .wrap_err("Rate susceptibility analysis failed")?;
+    }
+  }
+
+  if time_marginal == TimeMarginalMode::OnlyFinal {
+    info!("### Final round: marginal reconstruction for confidence intervals");
+    run_timetree(&mut input.graph, &partitions, &clock_model, coalescent_tc.as_ref(), params.no_indels)
+      .wrap_err("Final timetree inference failed")?;
+
+    if !partitions.is_empty() {
+      update_marginal(&input.graph, &partitions)?;
+    }
+  }
+
+  let confidence_intervals =
+    (matches!(time_marginal, TimeMarginalMode::OnlyFinal | TimeMarginalMode::Always) || rate_std.is_some())
+      .then(|| extract_confidence_intervals(&input.graph));
+
+  progress.report("Done", 1.0, "");
+  Ok(TimetreeOutput {
+    graph: input.graph,
+    clock_model,
+    confidence_intervals,
+    partitions,
+    dates: input.dates,
+  })
+}
+
+fn initialize_partitions_from_params(
+  params: &TimetreeParams,
+  graph: &GraphTimetree,
+  alphabet: Alphabet,
+  aln: Option<&[FastaRecord]>,
+) -> Result<PartitionTimetreeAllVec, Report> {
+  let model_name = params.model;
+  let length = if let Some(aln_data) = aln {
+    get_common_length(aln_data)?
+  } else {
+    params
+      .sequence_length
+      .ok_or_else(|| make_report!("sequence_length required when no alignment provided"))?
+  };
+
+  let aln_data = aln.ok_or_else(|| make_report!("Alignment required for marginal reconstruction"))?;
+  let created = create_marginal_partition(graph, 0, alphabet, aln_data, model_name, params.dense)?;
+
+  let partition: Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>> = match created.partition {
+    MarginalPartition::Sparse(p) => Arc::new(RwLock::new(p)),
+    MarginalPartition::Dense(p) => Arc::new(RwLock::new(p)),
+  };
+
+  Ok(vec![partition])
+}
+
+fn optimize_branch_lengths_pre_step(
+  graph: &GraphTimetree,
+  partitions: &[Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>],
+  no_indels: bool,
+) -> Result<(), Report> {
+  let old_branch_lengths = save_branch_lengths(graph);
+
+  if no_indels {
+    run_optimize_mixed_inner(graph, partitions, BranchOptMethod::BrentSqrt, 0.0, true)
+  } else {
+    run_optimize_mixed(graph, partitions, BranchOptMethod::BrentSqrt)
+  }
+  .wrap_err("ML branch-length optimization pre-step failed")?;
+
+  apply_damping(graph, &old_branch_lengths, TIMETREE_PRE_STEP_DAMPING, 0);
+  update_marginal(graph, partitions)?;
+
+  Ok(())
+}

--- a/packages/treetime/src/timetree/refinement.rs
+++ b/packages/treetime/src/timetree/refinement.rs
@@ -1,0 +1,105 @@
+use crate::ancestral::marginal::update_marginal;
+use crate::clock::clock_model::ClockModel;
+use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot};
+use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::partition::timetree::GraphTimetree;
+use crate::partition::traits::PartitionTimetreeAll;
+use crate::payload::timetree::EdgeTimetree;
+use crate::payload::timetree::NodeTimetree;
+use crate::timetree::convergence::sequence_changes::{capture_ancestral_states, count_sequence_changes};
+use crate::timetree::inference::runner::run_timetree;
+use crate::timetree::optimization::polytomy::{prepare_tree_after_topology_change, resolve_polytomies};
+use crate::timetree::optimization::relaxed_clock::apply_relaxed_clock;
+use eyre::{Report, WrapErr};
+use log::info;
+use parking_lot::RwLock;
+use std::sync::Arc;
+use treetime_distribution::Distribution;
+
+pub struct RefinementParams {
+  pub relax: Vec<f64>,
+  pub resolve_polytomies: bool,
+  pub clock_rate: Option<f64>,
+  pub no_indels: bool,
+}
+
+pub fn run_refinement_iteration(
+  params: &RefinementParams,
+  graph: &mut GraphTimetree,
+  partitions: &[Arc<RwLock<dyn PartitionTimetreeAll<NodeTimetree, EdgeTimetree>>>],
+  clock_model: &mut ClockModel,
+  clock_params: &ClockParams,
+  branch_params: &BranchPointOptimizationParams,
+  coalescent_tc: Option<&Distribution>,
+) -> Result<(usize, usize), Report> {
+  let total_length: usize = partitions.iter().map(|p| p.read_arc().get_sequence_length()).sum();
+
+  if !params.relax.is_empty() {
+    if total_length == 0 {
+      info!("Skipping relaxed clock: no sequence data (partitions empty or zero-length)");
+    } else {
+      let one_mutation = 1.0 / total_length as f64;
+      info!(
+        "Applying relaxed clock with slack={}, coupling={}",
+        params.relax.first().copied().unwrap_or(1.0),
+        params.relax.get(1).copied().unwrap_or(1.0)
+      );
+      apply_relaxed_clock(graph, &params.relax, one_mutation);
+    }
+  }
+
+  let prev_states = capture_ancestral_states(graph, partitions);
+
+  let n_resolved = if params.resolve_polytomies {
+    let zero_branch_slope = clock_model.clock_rate() * total_length as f64;
+    let n = resolve_polytomies(graph, partitions, zero_branch_slope, clock_model.clock_rate())
+      .wrap_err("Polytomy resolution failed")?;
+    if n > 0 {
+      info!("Resolved polytomies, introduced {n} new nodes");
+      prepare_tree_after_topology_change(graph).wrap_err("Failed to prepare tree after topology change")?;
+
+      for partition in partitions {
+        partition.write_arc().reconcile_topology(graph);
+      }
+    }
+    n
+  } else {
+    0
+  };
+
+  let is_tree_dirty = n_resolved > 0;
+
+  if is_tree_dirty {
+    info!("Tree structure changed - recomputing timetree then marginal");
+    run_timetree(graph, partitions, clock_model, coalescent_tc, params.no_indels)
+      .wrap_err("Timetree inference failed")?;
+
+    if !partitions.is_empty() {
+      update_marginal(graph, partitions)?;
+    }
+  } else {
+    if !partitions.is_empty() {
+      info!("Updating ancestral sequences via marginal reconstruction");
+      update_marginal(graph, partitions)?;
+    }
+
+    info!("Updating node times via timetree inference");
+    run_timetree(graph, partitions, clock_model, coalescent_tc, params.no_indels)
+      .wrap_err("Timetree inference failed")?;
+  }
+
+  let curr_states = capture_ancestral_states(graph, partitions);
+  let n_diff = count_sequence_changes(&prev_states, &curr_states);
+
+  *clock_model = estimate_clock_model_with_reroot(
+    graph,
+    clock_params,
+    params.clock_rate,
+    true,
+    branch_params,
+    Some(clock_model.clock_rate()),
+  )
+  .wrap_err("Failed to update clock model")?;
+
+  Ok((n_diff, n_resolved))
+}


### PR DESCRIPTION
- Related to: [kb/issues/H-core-multi-client-architecture-library-purity.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/issues/H-core-multi-client-architecture-library-purity.md)

The `treetime` library crate's `commands/` module mixes algorithm orchestration, CLI argument structs, and file I/O in every command's `run.rs`. Non-CLI consumers (`app-api`, `app-server`, `app-napi`) must import `treetime::commands::*` and construct clap-derived arg structs to call domain functions, inheriting file I/O side effects they cannot control.

Add a pipeline layer: each command gets `<module>/pipeline.rs` with `Params` (domain configuration, no file paths), `Input` (in-memory data), `Output` (computed results), and `pub fn run()`. The pipeline functions contain the full algorithmic logic previously embedded in `commands/*/run.rs`. The `run.rs` files become thin I/O wrappers that read files, construct pipeline types, call the pipeline, and write output files from the result. `app-api` re-exports all pipeline types via a `pipelines` module for in-memory consumers.

### Work items

- [x] Add `partition/create.rs` with `create_marginal_partition()` consolidating 3-way branch pattern
- [x] Extract `TimeMarginalMode`, `compute_effective_time_marginal`, `build_covariation_clock_params` to `timetree/params.rs`
- [x] Extract `run_refinement_iteration` to `timetree/refinement.rs` with `RefinementParams`
- [x] Split `write_auspice_json` into `build_timetree_auspice()` domain builder + file writer
- [x] Add pipeline functions for ancestral, clock, optimize, prune, mugration, timetree
- [x] Add `app-api::pipelines` module re-exporting pipeline types
- [x] Rewrite all 6 `commands/*/run.rs` as thin I/O wrappers delegating to pipelines
- [x] Add `compute_effective_time_marginal` parameterized test in `timetree/__tests__/`
- [x] Update `kb/issues/M-core-partition-init-orchestration-duplication.md` (partially resolved)
- [x] File `kb/tickets/architecture-migrate-command-tests-with-dissolution.md`
- [x] File `kb/tickets/architecture-clock-pipeline-params-naming.md`

### Possible improvements

- [ ] Move `commands/` (args + I/O handlers) from library to `app-api` ([kb/issues/H-core-multi-client-architecture-library-purity.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/issues/H-core-multi-client-architecture-library-purity.md))
- [ ] Migrate CLI/IO tests to consumer crates, domain tests to library modules ([kb/tickets/architecture-migrate-command-tests-with-dissolution.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/tickets/architecture-migrate-command-tests-with-dissolution.md))
- [ ] Rename `ClockParams_` to `ClockPipelineParams` ([kb/tickets/architecture-clock-pipeline-params-naming.md](https://github.com/neherlab/treetime/blob/4055e5ae95b75d1640ebbc07b6e4bd62df8b0454/kb/tickets/architecture-clock-pipeline-params-naming.md))
- [ ] Move 5 write functions from library domain modules to `app-api::output/` ([kb/issues/H-core-command-module-shared-ops-entanglement.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/issues/H-core-command-module-shared-ops-entanglement.md))