### PR TITLE
fix: restore timetree output regressions

### DIFF
--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -28,7 +28,8 @@ pub fn run_prune(
   let graph: GraphAncestral = nwk_read_file(&args.tree)?;
   let alphabet = Alphabet::new(args.alphabet_args.alphabet.unwrap_or_default())?;
 
-  let sequences = if !args.alignment.alignment.is_empty() {
+  let needs_sequences = args.prune_empty || args.merge_shared_mutations;
+  let sequences = if needs_sequences && !args.alignment.alignment.is_empty() {
     Some(read_many_fasta(&args.alignment.alignment, &alphabet)?)
   } else {
     None

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -1,13 +1,14 @@
+use crate::clock::clock_output::write_clock_model;
 use crate::commands::timetree::args::TreetimeTimetreeArgs;
 use crate::commands::timetree::initialization::load_input_data;
 use crate::commands::timetree::output::augur_node_data::write_augur_node_data_json;
 use crate::commands::timetree::output::auspice::write_auspice_json;
 use crate::commands::timetree::result::TimetreeResult;
-use crate::clock::clock_output::write_clock_model;
+use crate::gtr::get_gtr::write_gtr_json;
+use crate::make_error;
 use crate::partition::traits::MutationCommentProvider;
 use crate::timetree::confidence::write_confidence_intervals_file;
 use crate::timetree::pipeline::{self, TimetreeInput, TimetreeParams};
-use crate::make_error;
 use eyre::{Report, WrapErr};
 use log::info;
 use std::path::PathBuf;
@@ -102,6 +103,10 @@ fn write_outputs(args: &TreetimeTimetreeArgs, output: &pipeline::TimetreeOutput)
   }
 
   write_clock_model(&output.clock_model, &args.output.outdir.join("timetree"))?;
+
+  if let (Some(gtr), Some(model_name)) = (&output.gtr, output.model_name) {
+    write_gtr_json(gtr, model_name, &args.output.outdir, None)?;
+  }
 
   write_auspice_json(&output.graph, output.confidence_intervals.as_deref(), &args.output.outdir)?;
 

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -9,6 +9,7 @@ use crate::clock::reroot::RerootParams;
 use crate::coalescent::optimize_tc::optimize_tc;
 use crate::coalescent::skyline::{SkylineParams, optimize_skyline};
 use crate::gtr::get_gtr::GtrModelName;
+use crate::gtr::gtr::GTR;
 use crate::make_error;
 use crate::optimize::dispatch::{run_optimize_mixed, run_optimize_mixed_inner};
 use crate::optimize::iteration::{apply_damping, save_branch_lengths};
@@ -92,6 +93,10 @@ pub struct TimetreeOutput {
   pub partitions: PartitionTimetreeAllVec,
   #[serde(skip)]
   pub dates: Option<DatesMap>,
+  #[serde(skip)]
+  pub gtr: Option<GTR>,
+  #[serde(skip)]
+  pub model_name: Option<GtrModelName>,
 }
 
 pub fn run(
@@ -138,16 +143,18 @@ pub fn run(
   .wrap_err("Failed to infer clock model")?
   .clock_model;
 
-  let partitions: PartitionTimetreeAllVec = match params.branch_length_mode {
-    BranchLengthMode::Input => {
-      info!("Branch length mode: Input - using tree branch lengths");
-      vec![]
-    },
-    BranchLengthMode::Marginal => {
-      info!("Branch length mode: Marginal - initializing partitions from alignment");
-      initialize_partitions_from_params(params, &input.graph, input.alphabet.clone(), input.sequences.as_deref())?
-    },
-  };
+  let (partitions, partition_gtr, partition_model_name): (PartitionTimetreeAllVec, Option<GTR>, Option<GtrModelName>) =
+    match params.branch_length_mode {
+      BranchLengthMode::Input => {
+        info!("Branch length mode: Input - using tree branch lengths");
+        (vec![], None, None)
+      },
+      BranchLengthMode::Marginal => {
+        info!("Branch length mode: Marginal - initializing partitions from alignment");
+        let init = initialize_partitions_from_params(params, &input.graph, input.alphabet.clone(), input.sequences.as_deref())?;
+        (init.partitions, Some(init.gtr), Some(init.model_name))
+      },
+    };
 
   if let Some(aln) = input.sequences.as_deref() {
     if params.branch_length_mode == BranchLengthMode::Marginal && !partitions.is_empty() {
@@ -368,7 +375,15 @@ pub fn run(
     confidence_intervals,
     partitions,
     dates: input.dates,
+    gtr: partition_gtr,
+    model_name: partition_model_name,
   })
+}
+
+struct PartitionInitResult {
+  partitions: PartitionTimetreeAllVec,
+  gtr: GTR,
+  model_name: GtrModelName,
 }
 
 fn initialize_partitions_from_params(
@@ -376,15 +391,8 @@ fn initialize_partitions_from_params(
   graph: &GraphTimetree,
   alphabet: Alphabet,
   aln: Option<&[FastaRecord]>,
-) -> Result<PartitionTimetreeAllVec, Report> {
+) -> Result<PartitionInitResult, Report> {
   let model_name = params.model;
-  let length = if let Some(aln_data) = aln {
-    get_common_length(aln_data)?
-  } else {
-    params
-      .sequence_length
-      .ok_or_else(|| make_report!("sequence_length required when no alignment provided"))?
-  };
 
   let aln_data = aln.ok_or_else(|| make_report!("Alignment required for marginal reconstruction"))?;
   let created = create_marginal_partition(graph, 0, alphabet, aln_data, model_name, params.dense)?;
@@ -394,7 +402,11 @@ fn initialize_partitions_from_params(
     MarginalPartition::Dense(p) => Arc::new(RwLock::new(p)),
   };
 
-  Ok(vec![partition])
+  Ok(PartitionInitResult {
+    partitions: vec![partition],
+    gtr: created.gtr,
+    model_name: created.model_name,
+  })
 }
 
 fn optimize_branch_lengths_pre_step(


### PR DESCRIPTION
- Depends on: `refactor/separate-algo-args-io`

Pipeline extraction moved timetree orchestration out of command wrappers, but the wrapper still owns command-output files and prune still decides whether sequence input is required.

Restore the timetree command's General Time Reversible model JSON output and preserve the prune alignment guard so `--prune-empty`/`--prune-short` modes do not require alignment input when sequences are not needed.

### Work items

- [x] Propagate General Time Reversible model output through `TimetreeOutput`
- [x] Write `gtr.json` from the timetree command wrapper
- [x] Preserve prune sequence-loading behavior for options that operate on tree structure alone