### PR TITLE
docs: restore pipeline algorithm comments

### DIFF
--- a/packages/treetime/src/clock/pipeline.rs
+++ b/packages/treetime/src/clock/pipeline.rs
@@ -73,6 +73,9 @@ fn estimate_clock_model_with_prefilter(
 ) -> Result<(ClockModel, Option<i32>), Report> {
   let delta = (clock_filter_threshold > 0.0)
     .then(|| -> Result<i32, Report> {
+      // Allow negative rates during pre-filter root finding. Some datasets (e.g. dengue/100)
+      // have negative estimated rate at ALL root positions when outliers are included.
+      // The pre-filter clock model only needs to be good enough for IQD-based outlier detection.
       let reroot_params = RerootParams {
         force_positive_rate: false,
         ..RerootParams::default()
@@ -88,6 +91,9 @@ fn estimate_clock_model_with_prefilter(
       )?;
       let pre_clock_model = result.clock_model;
       if pre_clock_model.clock_rate() < 0.0 {
+        // IQD-based filtering uses |deviation| > IQD * threshold, so the absolute-value
+        // comparison is slope-sign-invariant: outliers are identified by distance from the
+        // fitted line regardless of slope direction.
         log::warn!(
           "Pre-filter clock rate is negative ({:.6e}). Outlier detection proceeds with this model.",
           pre_clock_model.clock_rate()

--- a/packages/treetime/src/timetree/output/auspice.rs
+++ b/packages/treetime/src/timetree/output/auspice.rs
@@ -12,7 +12,11 @@ use treetime_io::auspice_types::{
 };
 use treetime_utils::make_error;
 
-/// Build auspice v2 tree data from a timetree graph without file I/O.
+/// Build partial auspice v2 tree data from a timetree graph without file I/O.
+///
+/// Produces node dates (with optional confidence intervals), cumulative divergence,
+/// and bad-branch status. Branch mutations, branch-support confidence, and genome
+/// annotations are not yet included (see `kb/issues/N-timetree-auspice-json-incomplete.md`).
 pub fn build_timetree_auspice(
   graph: &Graph<NodeTimetree, EdgeTimetree, ()>,
   confidence_intervals: Option<&[NodeConfidenceInterval]>,
@@ -82,6 +86,7 @@ impl AuspiceWrite<NodeTimetree, EdgeTimetree, ()> for TimetreeAuspiceWriter {
       .name()
       .map_or_else(|| format!("node_{}", node_key.as_usize()), |n| n.as_ref().to_owned());
 
+    // JSON (RFC 8259) does not permit NaN or Infinity
     if !node.div.is_finite() {
       return make_error!("Node '{name}' has non-finite div={div}", div = node.div);
     }


### PR DESCRIPTION
Pipeline extraction moved algorithmic code across module boundaries. The rationale comments for clock prefiltering and timetree Auspice JSON handling remain part of the implementation contract.

Restore those comments at the new code locations so the extracted modules retain the scientific and serialization rationale.

### Work items

- [x] Restore clock prefilter and interquartile-distance slope comments
- [x] Restore timetree Auspice JSON scope and non-finite-number comments