### PR TITLE
refactor: rename clock pipeline params

### DIFF
--- a/kb/tickets/architecture-clock-pipeline-params-naming.md
+++ b/kb/tickets/architecture-clock-pipeline-params-naming.md
@@ -1,9 +1,0 @@
-# Rename ClockParams\_ to avoid underscore suffix
-
-## Description
-
-`packages/treetime/src/clock/pipeline.rs` defines `pub struct ClockParams_` with an underscore suffix to avoid collision with `ClockParams` from `clock/clock_regression.rs`. The underscore naming is a hack. Rename to `ClockPipelineParams` or restructure imports.
-
-## Related issues
-
-- Source: [H-core-command-module-shared-ops-entanglement.md](../issues/H-core-command-module-shared-ops-entanglement.md)

--- a/packages/app-api/src/pipelines.rs
+++ b/packages/app-api/src/pipelines.rs
@@ -5,7 +5,7 @@ pub mod ancestral {
 }
 
 pub mod clock {
-  pub use treetime::clock::pipeline::{ClockInput, ClockOutput, ClockParams_, run};
+  pub use treetime::clock::pipeline::{ClockInput, ClockOutput, ClockPipelineParams, run};
 }
 
 pub mod optimize {

--- a/packages/treetime/src/clock/mod.rs
+++ b/packages/treetime/src/clock/mod.rs
@@ -1,14 +1,14 @@
-#[cfg(test)]
-mod __tests__;
-
 pub mod assign_dates;
 pub mod clock_filter;
-pub mod pipeline;
 pub mod clock_graph;
 pub mod clock_model;
 pub mod clock_output;
 pub mod clock_regression;
 pub mod date_constraints;
 pub mod find_best_root;
+pub mod pipeline;
 pub mod reroot;
 pub mod rtt;
+
+#[cfg(test)]
+mod __tests__;

--- a/packages/treetime/src/clock/pipeline.rs
+++ b/packages/treetime/src/clock/pipeline.rs
@@ -12,7 +12,7 @@ use log::info;
 use serde::Serialize;
 use treetime_io::dates_csv::DatesMap;
 
-pub struct ClockParams_ {
+pub struct ClockPipelineParams {
   pub clock_params: ClockParams,
   pub clock_filter: f64,
   pub keep_root: bool,
@@ -33,7 +33,7 @@ pub struct ClockOutput {
   pub regression_results: Vec<ClockRegressionResult>,
 }
 
-pub fn run(params: &ClockParams_, mut input: ClockInput, progress: &dyn ProgressSink) -> Result<ClockOutput, Report> {
+pub fn run(params: &ClockPipelineParams, mut input: ClockInput, progress: &dyn ProgressSink) -> Result<ClockOutput, Report> {
   progress.check_cancelled()?;
   progress.report("Assigning dates", 0.1, "");
   assign_dates(&input.graph, &input.dates)?;

--- a/packages/treetime/src/commands/clock/run.rs
+++ b/packages/treetime/src/commands/clock/run.rs
@@ -1,7 +1,7 @@
 use crate::clock::clock_output::write_clock_model;
 use crate::clock::clock_graph::GraphClock;
 use crate::clock::clock_model::ClockModel;
-use crate::clock::pipeline::{self, ClockInput, ClockParams_};
+use crate::clock::pipeline::{self, ClockInput, ClockPipelineParams};
 use crate::clock::rtt::{ClockRegressionResult, write_clock_regression_result_csv};
 use crate::commands::clock::args::{BranchSplitArgs, TreetimeClockArgs};
 use crate::clock::clock_regression::ClockParams;
@@ -66,7 +66,7 @@ pub fn run_clock(
     clock_args.clock_regression.clock_params.clone()
   };
 
-  let params = ClockParams_ {
+  let params = ClockPipelineParams {
     clock_params,
     clock_filter: clock_args.clock_filter,
     keep_root: clock_args.keep_root,

--- a/packages/treetime/src/timetree/mod.rs
+++ b/packages/treetime/src/timetree/mod.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-mod __tests__;
-
 pub mod confidence;
 pub mod convergence;
 pub mod inference;
@@ -10,3 +7,6 @@ pub mod params;
 pub mod pipeline;
 pub mod refinement;
 pub mod utils;
+
+#[cfg(test)]
+mod __tests__;


### PR DESCRIPTION
- Resolves: [kb/tickets/architecture-clock-pipeline-params-naming.md](https://github.com/neherlab/treetime/blob/4055e5ae95b75d1640ebbc07b6e4bd62df8b0454/kb/tickets/architecture-clock-pipeline-params-naming.md)

The clock pipeline parameter type used a trailing underscore to avoid colliding with the legacy command argument type. That name is now part of the public in-memory API surface and should describe the pipeline role directly.

Rename the type to `ClockPipelineParams`, update the exported API, and keep module declarations ordered with test modules last.

### Work items

- [x] Rename `ClockParams_` to `ClockPipelineParams`
- [x] Update app API and command wrapper call sites
- [x] Move clock and timetree test module declarations to the end of their modules
- [x] Remove the resolved clock params naming ticket