### PR TITLE
docs: file pipeline validation test tickets

### DIFF
--- a/kb/issues/H-core-command-module-shared-ops-entanglement.md
+++ b/kb/issues/H-core-command-module-shared-ops-entanglement.md
@@ -58,4 +58,4 @@ Traits and types moved to `partition/` and `payload/`: partition traits (`Partit
 
 - `homoplasy` -> `ancestral`: `TreetimeAncestralArgs` CLI struct embedding (minor)
 - Output helpers: `write_graph()` duplicated across `ancestral`, `optimize`, `prune` (tracked separately, not yet filed)
-- Pipeline layer added: all commands now have `<module>/pipeline.rs` with pure computation functions. `commands/*/run.rs` are thin I/O wrappers delegating to pipelines. Next step: move `commands/` (args + I/O handlers) from library to consumer crates (`app-api`, `app-cli`)
+- All commands delegate to `<module>/pipeline.rs` for pure computation. `commands/` (args + I/O handlers) remains in the library; planned move to consumer crates (`app-api`, `app-cli`) is not yet done

--- a/kb/issues/M-core-partition-init-orchestration-duplication.md
+++ b/kb/issues/M-core-partition-init-orchestration-duplication.md
@@ -1,6 +1,6 @@
 # Partition creation is hardcoded per-command instead of configured
 
-## Status: partially resolved
+## Current state
 
 `partition/create.rs` provides `create_marginal_partition()` consolidating the 3-way branch (sparse, dense+infer, dense+named) without `write_gtr_json` during init. All pipeline functions use it. The full `PartitionSpec`/config layer for multi-partition support is not yet implemented.
 

--- a/kb/issues/M-timetree-skyline-timing-v0-divergence.md
+++ b/kb/issues/M-timetree-skyline-timing-v0-divergence.md
@@ -1,0 +1,18 @@
+# Timetree skyline coalescent timing may diverge from v0
+
+v1 runs skyline coalescent optimization after the iteration loop exits, then re-runs timetree with the fitted skyline prior. v0 activates skyline on the last iteration within the loop, so the timetree inference runs once with the skyline prior during the loop itself.
+
+The v1 code at `packages/treetime/src/timetree/pipeline.rs` (skyline block after the optimizer loop) has a comment claiming "matching v0 behavior where skyline optimization happens only on the final iteration after times have converged." The v0 code (`packages/legacy/treetime/treetime/treetime.py` line 312) uses `if Tc == 'skyline' and niter < max_iter - 1: tmpTc = 'const'`, which means the last iteration (when `niter == max_iter - 1`) runs with `Tc = 'skyline'` inside the loop, not after it. The comment may be inaccurate.
+
+Both approaches produce self-consistent results. The difference is whether the final node times are conditioned on the skyline prior during the optimization iteration or via a separate post-loop pass. For datasets where the skyline shape deviates from constant Tc, final node time estimates may differ.
+
+## Investigation needed
+
+- Run v0 and v1 on a dataset with population size variation (e.g. `flu/h3n2/200` with `--coalescent-skyline`)
+- Compare node times to determine whether the difference is measurable
+- If measurable, decide whether v1's approach is an intentional improvement or should match v0
+
+## Related
+
+- `kb/issues/H-timetree-skyline-objective-mismatch.md`
+- `kb/issues/N-coalescent-skyline-robustness.md`

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -86,6 +86,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Timetree     | [--method-anc ignored in timetree](M-timetree-method-anc-ignored.md)                                                                                |
 | Medium     | Timetree     | [Positional likelihood metric differs from v0](M-timetree-positional-likelihood-metric.md)                                                          |
 | Medium     | Timetree     | [Skyline coalescent uses Nelder-Mead instead of SLSQP](M-timetree-skyline-nelder-mead-optimizer.md)                                                 |
+| Medium     | Timetree     | [Skyline coalescent timing may diverge from v0](M-timetree-skyline-timing-v0-divergence.md)                                                         |
 | Medium     | Timetree     | [Marginal dense golden master node key mismatch on ebola_20](M-timetree-dense-golden-master-node-mismatch.md)                                       |
 | Medium     | Timetree     | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)                                |
 | Medium     | Timetree     | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                                   |

--- a/kb/tickets/test-build-covariation-clock-params.md
+++ b/kb/tickets/test-build-covariation-clock-params.md
@@ -1,0 +1,23 @@
+# Test build_covariation_clock_params formula
+
+Add unit tests for `timetree::params::build_covariation_clock_params()` which maps covariation options and alignment/sequence length to `ClockParams`.
+
+The function encodes the v0 formula: `variance_factor = 1/seq_len`, `variance_offset_leaf = tip_slack^2 / seq_len^2`, with default `tip_slack = OVER_DISPERSION = 10` (v0 `config.py:8`).
+
+## Test cases
+
+- `covariation=false` returns `None`
+- `covariation=true, seq_len=Some(1000), tip_slack=None` -> verify `variance_factor=1e-3`, `variance_offset=0.0`, `variance_offset_leaf=1e-4` (default tip_slack=10)
+- `covariation=true, seq_len=Some(500), tip_slack=Some(5.0)` -> verify exact values
+- `covariation=true, aln=Some(records)` -> verify seq_len derived from alignment
+- `covariation=true, seq_len=None, aln=None` -> error
+
+Expected values from v0 `clock_tree.py:277-285` formula, not from running the SUT.
+
+## Location
+
+`packages/treetime/src/timetree/__tests__/test_params.rs`
+
+## Related issues
+
+Source: `kb/issues/N-test-coverage-gaps.md`

--- a/kb/tickets/test-create-marginal-partition.md
+++ b/kb/tickets/test-create-marginal-partition.md
@@ -1,0 +1,21 @@
+# Test create_marginal_partition 3-way branching
+
+Add unit tests for `partition::create::create_marginal_partition()` which consolidates sparse, dense+infer GTR, and dense+named GTR partition creation from 4 commands.
+
+## Test cases
+
+- `(dense=false, model=Infer)` -> Sparse partition, inferred GTR
+- `(dense=false, model=JC69)` -> Sparse partition, named GTR
+- `(dense=true, model=Infer)` -> Dense partition, inferred GTR
+- `(dense=true, model=JC69)` -> Dense partition, named GTR
+- `(dense=None)` -> auto-detect via `infer_dense()`
+
+Assert: partition variant, GTR alphabet, model name, root sequence consistency.
+
+## Location
+
+`packages/treetime/src/partition/__tests__/test_create.rs`
+
+## Related issues
+
+Source: `kb/issues/N-test-coverage-gaps.md`

--- a/kb/tickets/test-pipeline-error-paths.md
+++ b/kb/tickets/test-pipeline-error-paths.md
@@ -1,0 +1,28 @@
+# Test pipeline error paths
+
+Add unit tests for validation guards in pipeline functions that are currently uncovered.
+
+## Ancestral pipeline
+
+- `site_specific_gtr: true` returns error
+- `sample_from_profile != Argmax` with `method != Marginal` returns error
+- `method = Joint` returns error listing available methods
+
+Location: `packages/treetime/src/ancestral/pipeline.rs`
+
+## Optimize pipeline
+
+- `damping >= 1.0` returns error
+- `damping < 0.0` returns error
+
+Location: `packages/treetime/src/optimize/pipeline.rs`
+
+## Timetree pipeline
+
+- `n_branches_posterior: Some(n)` returns unimplemented error
+
+Location: `packages/treetime/src/timetree/pipeline.rs`
+
+## Related issues
+
+Source: `kb/issues/N-test-coverage-gaps.md`

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -1081,7 +1081,7 @@ mod tests {
     assert_eq!(vec_of_owned!["A1C", "A3G"], orig_root_cd_subs);
 
     // Merged AB->CD edge: inverted AB->root [T4G, C7A] chained with root->CD [A1C, A3G]
-    let mut merged_subs = merged_edge.fitch_subs().to_vec();
+    let mut merged_subs: Vec<String> = merged_edge.fitch_subs().iter().map(|s| s.to_string()).collect();
     merged_subs.sort();
     assert_eq!(vec_of_owned!["A1C", "A3G", "C7A", "T4G"], merged_subs);
 

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -1177,10 +1177,7 @@ mod tests {
         })
       })
       .collect();
-    assert!(
-      !root_edge_totals.is_empty(),
-      "new root should have outgoing edges"
-    );
+    assert!(!root_edge_totals.is_empty(), "new root should have outgoing edges");
     for (target, total) in &root_edge_totals {
       assert!(
         *total > 0,

--- a/packages/treetime/src/ancestral/pipeline.rs
+++ b/packages/treetime/src/ancestral/pipeline.rs
@@ -108,9 +108,12 @@ where
 
       compress_sequences(&input.graph, &partitions_parsimony, &input.sequences)?;
 
-      ancestral_reconstruction_fitch(&input.graph, params.reconstruct_tip_states, &partitions_parsimony, |node, seq| {
-        on_sequence(&node.payload, seq)
-      })?;
+      ancestral_reconstruction_fitch(
+        &input.graph,
+        params.reconstruct_tip_states,
+        &partitions_parsimony,
+        |node, seq| on_sequence(&node.payload, seq),
+      )?;
 
       progress.report("Done", 1.0, "");
       Ok(AncestralOutputFull {
@@ -127,7 +130,14 @@ where
       progress.check_cancelled()?;
       progress.report("Inferring GTR model", 0.2, "");
 
-      let created = create_marginal_partition(&input.graph, 0, input.alphabet, &input.sequences, params.model, params.dense)?;
+      let created = create_marginal_partition(
+        &input.graph,
+        0,
+        input.alphabet,
+        &input.sequences,
+        params.model,
+        params.dense,
+      )?;
 
       match created.partition {
         MarginalPartition::Sparse(partition) => {
@@ -138,7 +148,15 @@ where
           update_marginal(&input.graph, &partitions)?;
 
           if params.gtr_iterations > 0 && params.model == GtrModelName::Infer {
-            refine_gtr_iterative(&input.graph, &partitions[0], params.gtr_iterations, None, 1.0, None, false)?;
+            refine_gtr_iterative(
+              &input.graph,
+              &partitions[0],
+              params.gtr_iterations,
+              None,
+              1.0,
+              None,
+              false,
+            )?;
           }
 
           progress.check_cancelled()?;
@@ -161,7 +179,9 @@ where
               model_name: created.model_name,
               mask,
             },
-            partition: Some(AncestralPartition::Sparse(partitions.into_iter().next().expect("partition vec not empty"))),
+            partition: Some(AncestralPartition::Sparse(
+              partitions.into_iter().next().expect("partition vec not empty"),
+            )),
           })
         },
         MarginalPartition::Dense(partition) => {
@@ -173,7 +193,15 @@ where
           update_marginal(&input.graph, &partitions)?;
 
           if params.gtr_iterations > 0 && params.model == GtrModelName::Infer {
-            refine_gtr_iterative(&input.graph, &partitions[0], params.gtr_iterations, None, 1.0, None, false)?;
+            refine_gtr_iterative(
+              &input.graph,
+              &partitions[0],
+              params.gtr_iterations,
+              None,
+              1.0,
+              None,
+              false,
+            )?;
           }
 
           progress.check_cancelled()?;
@@ -196,7 +224,9 @@ where
               model_name: created.model_name,
               mask,
             },
-            partition: Some(AncestralPartition::Dense(partitions.into_iter().next().expect("partition vec not empty"))),
+            partition: Some(AncestralPartition::Dense(
+              partitions.into_iter().next().expect("partition vec not empty"),
+            )),
           })
         },
       }

--- a/packages/treetime/src/clock/pipeline.rs
+++ b/packages/treetime/src/clock/pipeline.rs
@@ -33,7 +33,11 @@ pub struct ClockOutput {
   pub regression_results: Vec<ClockRegressionResult>,
 }
 
-pub fn run(params: &ClockPipelineParams, mut input: ClockInput, progress: &dyn ProgressSink) -> Result<ClockOutput, Report> {
+pub fn run(
+  params: &ClockPipelineParams,
+  mut input: ClockInput,
+  progress: &dyn ProgressSink,
+) -> Result<ClockOutput, Report> {
   progress.check_cancelled()?;
   progress.report("Assigning dates", 0.1, "");
   assign_dates(&input.graph, &input.dates)?;

--- a/packages/treetime/src/commands/ancestral/__tests__/test_smoke_sample_from_profile.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_smoke_sample_from_profile.rs
@@ -70,19 +70,18 @@ mod tests {
     }
   }
 
-  /// Posterior sampling with a non-marginal method is rejected before any input is read. Nonexistent
-  /// input paths confirm the guard fails fast rather than via a file-read error.
+  /// Posterior sampling with a non-marginal method is rejected by the pipeline.
   #[test]
   fn test_sample_from_profile_rejected_for_parsimony() {
     let args = TreetimeAncestralArgs {
       alignment: AlignmentArgs {
-        alignment: vec![PathBuf::from("/nonexistent/aln.fasta")],
+        alignment: vec![PROJECT_ROOT.join("data/flu/h3n2/20/aln.fasta.xz")],
       },
-      tree: PathBuf::from("/nonexistent/tree.nwk"),
+      tree: PROJECT_ROOT.join("data/flu/h3n2/20/tree.nwk"),
       method_anc: MethodAncestral::Parsimony,
       sample_from_profile: SampleMode::Root,
       output: OutputArgs {
-        outdir: PathBuf::from("/nonexistent/out"),
+        outdir: PROJECT_ROOT.join("tmp/test-sample-parsimony-reject"),
       },
       ..TreetimeAncestralArgs::default()
     };

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -95,13 +95,23 @@ pub fn run_ancestral_reconstruction(
   match &result.partition {
     Some(AncestralPartition::Fitch(partition)) => {
       let guard = partition.read_arc();
-      write_augur_node_data_json(&result.output.graph, &*guard, &result.output.mask, &augur_node_data_path)?;
+      write_augur_node_data_json(
+        &result.output.graph,
+        &*guard,
+        &result.output.mask,
+        &augur_node_data_path,
+      )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
       write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &CommentProviders::new())?;
     },
     Some(AncestralPartition::Sparse(partition)) => {
       let guard = partition.read_arc();
-      write_augur_node_data_json(&result.output.graph, &*guard, &result.output.mask, &augur_node_data_path)?;
+      write_augur_node_data_json(
+        &result.output.graph,
+        &*guard,
+        &result.output.mask,
+        &augur_node_data_path,
+      )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
       let provider = MutationCommentProvider::new(&*guard, &result.output.graph);
       let providers = CommentProviders::new().with(&provider);
@@ -109,7 +119,12 @@ pub fn run_ancestral_reconstruction(
     },
     Some(AncestralPartition::Dense(partition)) => {
       let guard = partition.read_arc();
-      write_augur_node_data_json(&result.output.graph, &*guard, &result.output.mask, &augur_node_data_path)?;
+      write_augur_node_data_json(
+        &result.output.graph,
+        &*guard,
+        &result.output.mask,
+        &augur_node_data_path,
+      )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
       let provider = MutationCommentProvider::new(&*guard, &result.output.graph);
       let providers = CommentProviders::new().with(&provider);

--- a/packages/treetime/src/commands/clock/run.rs
+++ b/packages/treetime/src/commands/clock/run.rs
@@ -1,11 +1,11 @@
-use crate::clock::clock_output::write_clock_model;
 use crate::clock::clock_graph::GraphClock;
 use crate::clock::clock_model::ClockModel;
+use crate::clock::clock_output::write_clock_model;
+use crate::clock::clock_regression::ClockParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, OptimizationMethod};
 use crate::clock::pipeline::{self, ClockInput, ClockPipelineParams};
 use crate::clock::rtt::{ClockRegressionResult, write_clock_regression_result_csv};
 use crate::commands::clock::args::{BranchSplitArgs, TreetimeClockArgs};
-use crate::clock::clock_regression::ClockParams;
-use crate::clock::find_best_root::params::{BranchPointOptimizationParams, OptimizationMethod};
 use crate::make_error;
 use crate::make_report;
 use eyre::{Report, WrapErr};

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -70,8 +70,16 @@ pub fn run_optimize(
     .clone()
     .unwrap_or_else(|| outdir.join("optimize.augur-node-data.json"));
   let alignment = args.alignment.alignment.first().map(PathBuf::as_path);
-  write_augur_node_data_json(&output.graph, alignment, Some(args.tree.as_path()), &augur_node_data_path)?;
-  info!("Wrote augur node data JSON to {path}", path = augur_node_data_path.display());
+  write_augur_node_data_json(
+    &output.graph,
+    alignment,
+    Some(args.tree.as_path()),
+    &augur_node_data_path,
+  )?;
+  info!(
+    "Wrote augur node data JSON to {path}",
+    path = augur_node_data_path.display()
+  );
 
   progress.report("Done", 1.0, "");
   Ok(OptimizeResult { graph: output.graph })

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -108,7 +108,11 @@ fn write_outputs(args: &TreetimeTimetreeArgs, output: &pipeline::TimetreeOutput)
     write_gtr_json(gtr, model_name, &args.output.outdir, None)?;
   }
 
-  write_auspice_json(&output.graph, output.confidence_intervals.as_deref(), &args.output.outdir)?;
+  write_auspice_json(
+    &output.graph,
+    output.confidence_intervals.as_deref(),
+    &args.output.outdir,
+  )?;
 
   let augur_node_data_path = args
     .output_augur_node_data
@@ -124,7 +128,10 @@ fn write_outputs(args: &TreetimeTimetreeArgs, output: &pipeline::TimetreeOutput)
     args.tree.as_deref(),
     &augur_node_data_path,
   )?;
-  info!("Wrote augur node data JSON to {path}", path = augur_node_data_path.display());
+  info!(
+    "Wrote augur node data JSON to {path}",
+    path = augur_node_data_path.display()
+  );
 
   if args.plot_rtt.is_some() {
     return make_error!("--plot-rtt is not yet implemented");

--- a/packages/treetime/src/optimize/pipeline.rs
+++ b/packages/treetime/src/optimize/pipeline.rs
@@ -3,7 +3,9 @@ use crate::ancestral::marginal::{initialize_marginal, update_marginal};
 use crate::gtr::get_gtr::GtrModelName;
 use crate::gtr::gtr::GTR;
 use crate::optimize::params::{BranchOptMethod, InitialGuessMode};
-use crate::optimize::run_loop::{apply_initial_guess_mode, collect_optimize_partitions, normalize_partition_rates, run_optimize_loop};
+use crate::optimize::run_loop::{
+  apply_initial_guess_mode, collect_optimize_partitions, normalize_partition_rates, run_optimize_loop,
+};
 use crate::partition::create::{MarginalPartition, create_marginal_partition};
 use crate::partition::marginal_dense::PartitionMarginalDense;
 use crate::partition::marginal_sparse::PartitionMarginalSparse;
@@ -47,12 +49,23 @@ pub struct OptimizeOutput {
   pub dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>>,
 }
 
-pub fn run(params: &OptimizeParams, mut input: OptimizeInput, progress: &dyn ProgressSink) -> Result<OptimizeOutput, Report> {
+pub fn run(
+  params: &OptimizeParams,
+  mut input: OptimizeInput,
+  progress: &dyn ProgressSink,
+) -> Result<OptimizeOutput, Report> {
   if !(0.0..1.0).contains(&params.damping) {
     return make_error!("damping must be in [0.0, 1.0), got {}", params.damping);
   }
 
-  let created = create_marginal_partition(&input.graph, 0, input.alphabet, &input.sequences, params.model, params.dense)?;
+  let created = create_marginal_partition(
+    &input.graph,
+    0,
+    input.alphabet,
+    &input.sequences,
+    params.model,
+    params.dense,
+  )?;
   let model_name = created.model_name;
   let gtr = created.gtr;
 

--- a/packages/treetime/src/prune/pipeline.rs
+++ b/packages/treetime/src/prune/pipeline.rs
@@ -37,16 +37,25 @@ pub struct PruneOutput {
 pub fn run(params: &PruneParams, mut input: PruneInput) -> Result<PruneOutput, Report> {
   let needs_sequences = params.prune_empty || params.merge_shared_mutations;
   let partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>> = if needs_sequences {
-    let sequences = input.sequences.as_ref().ok_or_else(|| {
-      eyre::eyre!("Sequences required for --prune-empty or --merge-shared-mutations")
-    })?;
-    let created = create_marginal_partition(&input.graph, 0, input.alphabet.clone(), sequences, GtrModelName::JC69, None)?;
+    let sequences = input
+      .sequences
+      .as_ref()
+      .ok_or_else(|| eyre::eyre!("Sequences required for --prune-empty or --merge-shared-mutations"))?;
+    let created = create_marginal_partition(
+      &input.graph,
+      0,
+      input.alphabet.clone(),
+      sequences,
+      GtrModelName::JC69,
+      None,
+    )?;
     match created.partition {
       MarginalPartition::Sparse(p) => vec![Arc::new(RwLock::new(p))],
       MarginalPartition::Dense(_) => {
         let gtr = get_gtr_by_name(GtrModelName::JC69)?;
         log_gtr(&gtr, GtrModelName::JC69);
-        let fitch = crate::ancestral::fitch::create_fitch_partition(&input.graph, 0, input.alphabet.clone(), sequences)?;
+        let fitch =
+          crate::ancestral::fitch::create_fitch_partition(&input.graph, 0, input.alphabet.clone(), sequences)?;
         let partition = fitch.into_marginal_sparse(gtr, &input.graph)?;
         vec![Arc::new(RwLock::new(partition))]
       },
@@ -55,7 +64,13 @@ pub fn run(params: &PruneParams, mut input: PruneInput) -> Result<PruneOutput, R
     vec![]
   };
 
-  prune_nodes(&mut input.graph, &partitions, params.prune_short, params.prune_empty, &params.node_names)?;
+  prune_nodes(
+    &mut input.graph,
+    &partitions,
+    params.prune_short,
+    params.prune_empty,
+    &params.node_names,
+  )?;
 
   if params.merge_shared_mutations {
     merge_shared_mutation_branches(&mut input.graph, &partitions)?;

--- a/packages/treetime/src/timetree/params.rs
+++ b/packages/treetime/src/timetree/params.rs
@@ -68,7 +68,8 @@ pub fn build_covariation_clock_params(
   let seq_len = if let Some(aln_data) = aln {
     get_common_length(aln_data)? as f64
   } else {
-    sequence_length.ok_or_else(|| make_report!("--sequence-length required for --covariation without alignment"))? as f64
+    sequence_length.ok_or_else(|| make_report!("--sequence-length required for --covariation without alignment"))?
+      as f64
   };
 
   let tip_slack = tip_slack.unwrap_or(10.0);

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -105,9 +105,17 @@ pub fn run(
   progress: &dyn ProgressSink,
 ) -> Result<TimetreeOutput, Report> {
   info!("# TreeTime Timetree Estimation");
-  debug!("Branch length mode: {:?}, Keep root: {}", params.branch_length_mode, params.keep_root);
+  debug!(
+    "Branch length mode: {:?}, Keep root: {}",
+    params.branch_length_mode, params.keep_root
+  );
 
-  let time_marginal = compute_effective_time_marginal(params.time_marginal, params.confidence, params.clock_std_dev, params.covariation);
+  let time_marginal = compute_effective_time_marginal(
+    params.time_marginal,
+    params.confidence,
+    params.clock_std_dev,
+    params.covariation,
+  );
 
   let covariation_clock_params = build_covariation_clock_params(
     params.covariation,
@@ -150,7 +158,8 @@ pub fn run(
       },
       BranchLengthMode::Marginal => {
         info!("Branch length mode: Marginal - initializing partitions from alignment");
-        let init = initialize_partitions_from_params(params, &input.graph, input.alphabet.clone(), input.sequences.as_deref())?;
+        let init =
+          initialize_partitions_from_params(params, &input.graph, input.alphabet.clone(), input.sequences.as_deref())?;
         (init.partitions, Some(init.gtr), Some(init.model_name))
       },
     };
@@ -219,7 +228,10 @@ pub fn run(
     info!("### Optimizing constant coalescent Tc (pre-loop, skyline deferred)");
     match optimize_tc(&input.graph, initial_tc) {
       Ok(result) if result.success => {
-        info!("Pre-loop Tc = {:.6e} (likelihood = {:.4})", result.tc, result.likelihood);
+        info!(
+          "Pre-loop Tc = {:.6e} (likelihood = {:.4})",
+          result.tc, result.likelihood
+        );
         Some(Distribution::constant(result.tc))
       },
       Ok(_) => {
@@ -236,7 +248,13 @@ pub fn run(
   };
 
   if coalescent_tc.is_some() {
-    run_timetree(&mut input.graph, &partitions, &clock_model, coalescent_tc.as_ref(), params.no_indels)?;
+    run_timetree(
+      &mut input.graph,
+      &partitions,
+      &clock_model,
+      coalescent_tc.as_ref(),
+      params.no_indels,
+    )?;
   }
 
   let default_clock_params = ClockParams::default();
@@ -266,7 +284,11 @@ pub fn run(
   while let Some(IterationContext { i }) = optimizer.next_iter() {
     progress.check_cancelled()?;
     let iter_fraction = 0.3 + 0.5 * (i as f64 / max_iter as f64);
-    progress.report("Optimization", iter_fraction, &format!("iteration {}/{max_iter}", i + 1));
+    progress.report(
+      "Optimization",
+      iter_fraction,
+      &format!("iteration {}/{max_iter}", i + 1),
+    );
 
     if (params.coalescent_opt || params.coalescent_skyline) && i >= 2 {
       let initial_tc = coalescent_tc.as_ref().map_or(1.0, |d| d.max_value());
@@ -274,7 +296,10 @@ pub fn run(
         Ok(result) => {
           if result.success {
             coalescent_tc = Some(Distribution::constant(result.tc));
-            info!("Optimized Tc = {:.6e} (likelihood = {:.4})", result.tc, result.likelihood);
+            info!(
+              "Optimized Tc = {:.6e} (likelihood = {:.4})",
+              result.tc, result.likelihood
+            );
           } else {
             warn!("Tc optimization did not converge, keeping Tc = {initial_tc:.6e}");
           }
@@ -312,12 +337,21 @@ pub fn run(
     info!("### Re-optimizing skyline coalescent with stabilized node times");
     let skyline_result =
       optimize_skyline(&input.graph, &skyline_params).wrap_err("Failed to re-optimize skyline coalescent model")?;
-    info!("Skyline re-optimization completed: log_likelihood={:.4}", skyline_result.log_likelihood);
+    info!(
+      "Skyline re-optimization completed: log_likelihood={:.4}",
+      skyline_result.log_likelihood
+    );
     coalescent_tc = Some(skyline_result.tc_distribution);
 
     if time_marginal != TimeMarginalMode::OnlyFinal {
-      run_timetree(&mut input.graph, &partitions, &clock_model, coalescent_tc.as_ref(), params.no_indels)
-        .wrap_err("Final timetree pass with optimized skyline failed")?;
+      run_timetree(
+        &mut input.graph,
+        &partitions,
+        &clock_model,
+        coalescent_tc.as_ref(),
+        params.no_indels,
+      )
+      .wrap_err("Final timetree pass with optimized skyline failed")?;
 
       if !partitions.is_empty() {
         update_marginal(&input.graph, &partitions)?;
@@ -355,17 +389,23 @@ pub fn run(
 
   if time_marginal == TimeMarginalMode::OnlyFinal {
     info!("### Final round: marginal reconstruction for confidence intervals");
-    run_timetree(&mut input.graph, &partitions, &clock_model, coalescent_tc.as_ref(), params.no_indels)
-      .wrap_err("Final timetree inference failed")?;
+    run_timetree(
+      &mut input.graph,
+      &partitions,
+      &clock_model,
+      coalescent_tc.as_ref(),
+      params.no_indels,
+    )
+    .wrap_err("Final timetree inference failed")?;
 
     if !partitions.is_empty() {
       update_marginal(&input.graph, &partitions)?;
     }
   }
 
-  let confidence_intervals =
-    (matches!(time_marginal, TimeMarginalMode::OnlyFinal | TimeMarginalMode::Always) || rate_std.is_some())
-      .then(|| extract_confidence_intervals(&input.graph));
+  let confidence_intervals = (matches!(time_marginal, TimeMarginalMode::OnlyFinal | TimeMarginalMode::Always)
+    || rate_std.is_some())
+  .then(|| extract_confidence_intervals(&input.graph));
 
   progress.report("Done", 1.0, "");
   Ok(TimetreeOutput {

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -19,7 +19,6 @@ use crate::partition::timetree::{GraphTimetree, PartitionTimetreeAllVec};
 use crate::partition::traits::PartitionTimetreeAll;
 use crate::payload::timetree::{EdgeTimetree, NodeTimetree};
 use crate::progress::ProgressSink;
-use crate::seq::alignment::get_common_length;
 use crate::timetree::confidence::{
   NodeConfidenceInterval, compute_rate_susceptibility, determine_rate_std, extract_confidence_intervals,
 };


### PR DESCRIPTION
- Related to: [kb/issues/H-core-command-module-shared-ops-entanglement.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/issues/H-core-command-module-shared-ops-entanglement.md), [kb/issues/M-core-partition-init-orchestration-duplication.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/issues/M-core-partition-init-orchestration-duplication.md)

The pipeline extraction exposed several validation and formula paths that need direct domain tests. Existing KB issue text also contained session-history phrasing that should not appear in public tracking docs.

Rewrite the affected issue prose, file focused test tickets for the uncovered pipeline behaviors, and add the skyline timing question as a known issue pending reference verification.

### Work items

- [x] Rewrite session-history prose in architecture issue docs
- [x] File pipeline validation and marginal partition test tickets
- [x] File the timetree skyline timing known issue
- [x] Fix unused import and test type mismatch from validation changes
- [x] Update the ancestral sampling rejection smoke test to reach pipeline validation
- [x] Apply formatting after the validation and test changes

### Possible improvements

- [ ] Add direct tests for clock covariation formula construction ([kb/tickets/test-build-covariation-clock-params.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/tickets/test-build-covariation-clock-params.md))
- [ ] Add direct tests for marginal partition branch selection ([kb/tickets/test-create-marginal-partition.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/tickets/test-create-marginal-partition.md))
- [ ] Add direct tests for pipeline validation error paths ([kb/tickets/test-pipeline-error-paths.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/tickets/test-pipeline-error-paths.md))