### PR TITLE
feat: add per-gene amino-acid ancestral node data output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,6 +4279,7 @@ dependencies = [
  "openblas-src",
  "ordered-float",
  "parking_lot",
+ "percent-encoding",
  "petgraph",
  "pretty_assertions",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ num = "=0.4.3"
 num-traits = "=0.2.19"
 ordered-float = { version = "=5.0.0", default-features = false }
 parking_lot = { version = "=0.12.4", features = ["arc_lock", "serde", "deadlock_detection", "hardware-lock-elision"] }
+percent-encoding = "=2.3.2"
 petgraph = { version = "=0.6.5", features = ["serde", "stable_graph"] }
 plotters = { version = "=0.3.7", default-features = false, features = ["all_series", "all_elements", "svg_backend"] }
 pretty_assertions = "=1.4.1"

--- a/packages/app-server/src/args.rs
+++ b/packages/app-server/src/args.rs
@@ -70,6 +70,10 @@ impl From<ServerAncestralArgs> for TreetimeAncestralArgs {
       reconstruct_tip_states: s.reconstruct_tip_states,
       report_ambiguous: s.report_ambiguous,
       output_augur_node_data: None,
+      translations: None,
+      genes: vec![],
+      annotation_gff: None,
+      aa_root_sequence: None,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
       },

--- a/packages/treetime/Cargo.toml
+++ b/packages/treetime/Cargo.toml
@@ -40,6 +40,7 @@ num = { workspace = true }
 num-traits = { workspace = true }
 ordered-float = { workspace = true }
 parking_lot = { workspace = true }
+percent-encoding = { workspace = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 regex = { workspace = true }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
@@ -152,11 +152,23 @@ mod tests {
     assert_eq!(helpers::expected_invariant_json(), actual.trim());
   }
 
+  #[test]
+  fn test_augur_node_data_ancestral_with_aa_reconstruction() {
+    let actual = helpers::build_json_with_aa();
+    let expected = helpers::expected_json_with_aa();
+
+    assert_eq!(
+      serde_json::to_value(expected).unwrap(),
+      serde_json::to_value(actual).unwrap()
+    );
+  }
+
   mod helpers {
     use crate::alphabet::alphabet::Alphabet;
     use crate::ancestral::params::MethodAncestral;
+    use crate::commands::ancestral::aa_node_data::{AaGeneNodeData, AaNodeData};
     use crate::commands::ancestral::args::TreetimeAncestralArgs;
-    use crate::commands::ancestral::augur_node_data::write_augur_node_data_json;
+    use crate::commands::ancestral::augur_node_data::{build_augur_node_data_json, write_augur_node_data_json};
     use crate::commands::ancestral::run::run_ancestral_reconstruction;
     use crate::commands::shared::alignment::AlignmentArgs;
     use crate::commands::shared::model::ModelArgs;
@@ -174,6 +186,10 @@ mod tests {
     use treetime_io::nwk::nwk_read_str;
     use treetime_primitives::{AsciiChar, Seq};
     use treetime_utils::o;
+    use util_augur_node_data_json::{
+      AugurNodeDataJsonAncestral, AugurNodeDataJsonAncestralMeta, AugurNodeDataJsonAncestralNode,
+      AugurNodeDataJsonAnnotationEntry, AugurNodeDataJsonAnnotations, AugurNodeDataJsonGeneratedBy,
+    };
 
     pub fn sub(reff: u8, pos: usize, qry: u8) -> Sub {
       Sub::new(
@@ -264,6 +280,102 @@ mod tests {
 
       run_ancestral_reconstruction(&args, &NoopProgress).unwrap();
       std::fs::read_to_string(dir.path().join("ancestral.augur-node-data.json")).unwrap()
+    }
+
+    pub fn build_json_with_aa() -> AugurNodeDataJsonAncestral {
+      let (graph, partition) = mutation_case();
+      let mut aa_node_data = AaNodeData::default();
+
+      aa_node_data.add_gene(
+        "S",
+        AaGeneNodeData {
+          reference: "AC".to_owned(),
+          root_sequence: "AC".to_owned(),
+          node_muts: btreemap! {
+            o!("A") => vec![o!("C2D")],
+            o!("B") => vec![],
+            o!("root") => vec![],
+          },
+        },
+        Some(AugurNodeDataJsonAnnotationEntry {
+          start: Some(1),
+          end: Some(6),
+          strand: Some("+".to_owned()),
+          entry_type: Some("CDS".to_owned()),
+          segments: None,
+          other: btreemap! {},
+        }),
+      );
+
+      build_augur_node_data_json(&graph, &partition, &[false, false, false, false], Some(&aa_node_data)).unwrap()
+    }
+
+    pub fn expected_json_with_aa() -> AugurNodeDataJsonAncestral {
+      AugurNodeDataJsonAncestral {
+        generated_by: Some(AugurNodeDataJsonGeneratedBy {
+          program: "treetime".to_owned(),
+          version: env!("CARGO_PKG_VERSION").to_owned(),
+        }),
+        metadata: AugurNodeDataJsonAncestralMeta {
+          annotations: Some(AugurNodeDataJsonAnnotations {
+            nuc: Some(AugurNodeDataJsonAnnotationEntry {
+              start: Some(1),
+              end: Some(4),
+              strand: Some("+".to_owned()),
+              entry_type: Some("source".to_owned()),
+              segments: None,
+              other: btreemap! {},
+            }),
+            other: btreemap! {
+              o!("S") => AugurNodeDataJsonAnnotationEntry {
+                start: Some(1),
+                end: Some(6),
+                strand: Some("+".to_owned()),
+                entry_type: Some("CDS".to_owned()),
+                segments: None,
+                other: btreemap! {},
+              },
+            },
+          }),
+          reference: Some(btreemap! {
+            o!("S") => o!("AC"),
+            o!("nuc") => o!("ACGT"),
+          }),
+          mask: Some("0000".to_owned()),
+          other: btreemap! {},
+        },
+        nodes: btreemap! {
+          o!("A") => AugurNodeDataJsonAncestralNode {
+            muts: vec![o!("T4A")],
+            sequence: Some(o!("ACGA")),
+            aa_muts: Some(btreemap! {
+              o!("S") => vec![o!("C2D")],
+            }),
+            aa_sequences: None,
+            other: btreemap! {},
+          },
+          o!("B") => AugurNodeDataJsonAncestralNode {
+            muts: vec![],
+            sequence: Some(o!("ACGT")),
+            aa_muts: Some(btreemap! {
+              o!("S") => vec![],
+            }),
+            aa_sequences: None,
+            other: btreemap! {},
+          },
+          o!("root") => AugurNodeDataJsonAncestralNode {
+            muts: vec![],
+            sequence: Some(o!("ACGT")),
+            aa_muts: Some(btreemap! {
+              o!("S") => vec![],
+            }),
+            aa_sequences: Some(btreemap! {
+              o!("S") => o!("AC"),
+            }),
+            other: btreemap! {},
+          },
+        },
+      }
     }
 
     /// Expected JSON when all leaves share the same sequence ACGT: every node

--- a/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
@@ -157,10 +157,7 @@ mod tests {
     let actual = helpers::build_json_with_aa();
     let expected = helpers::expected_json_with_aa();
 
-    assert_eq!(
-      serde_json::to_value(expected).unwrap(),
-      serde_json::to_value(actual).unwrap()
-    );
+    assert_eq!(expected, actual);
   }
 
   mod helpers {

--- a/packages/treetime/src/commands/ancestral/aa_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/aa_node_data.rs
@@ -4,17 +4,19 @@ use crate::partition::augur::AugurNodeDataJsonAncestralPartition;
 use crate::partition::traits::BranchTopology;
 use crate::payload::ancestral::GraphAncestral;
 use crate::seq::mutation::Sub;
-use eyre::Report;
+use eyre::{Report, WrapErr};
 use itertools::Itertools;
+use percent_encoding::percent_decode_str;
 use serde_json::json;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use treetime_graph::node::Named;
 use treetime_io::fasta::read_many_fasta;
-use treetime_primitives::Seq;
-use util_augur_node_data_json::AugurNodeDataJsonAnnotationEntry;
+use treetime_primitives::{AsciiChar, Seq};
+use treetime_utils::io::fs::read_file_to_string;
+use util_augur_node_data_json::{AugurNodeDataJsonAnnotationEntry, AugurNodeDataJsonAnnotationSegment};
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AaNodeData {
   pub annotations: BTreeMap<String, AugurNodeDataJsonAnnotationEntry>,
   pub reference: BTreeMap<String, String>,
@@ -44,7 +46,7 @@ impl AaNodeData {
   }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AaGeneNodeData {
   pub reference: String,
   pub root_sequence: String,
@@ -73,6 +75,9 @@ pub fn validate_aa_args(
     return make_error!("--genes must contain at least one gene when --translations is provided");
   }
 
+  validate_file_arg("--annotation-gff", annotation_gff.as_deref())?;
+  validate_file_arg("--aa-root-sequence", aa_root_sequence.as_deref())?;
+
   let mut seen = BTreeSet::new();
   for gene in genes {
     if gene.is_empty() {
@@ -86,6 +91,15 @@ pub fn validate_aa_args(
   Ok(())
 }
 
+fn validate_file_arg(arg_name: &str, path: Option<&Path>) -> Result<(), Report> {
+  if let Some(path) = path
+    && !path.is_file()
+  {
+    return make_error!("{arg_name} '{}' does not exist or is not a file", path.display());
+  }
+  Ok(())
+}
+
 pub fn translation_path(template: &str, gene: &str) -> PathBuf {
   PathBuf::from(template.replace("{cds}", gene))
 }
@@ -95,13 +109,23 @@ pub fn read_aa_root_sequences(path: Option<&Path>, genes: &[String]) -> Result<B
     return Ok(BTreeMap::new());
   };
 
-  let alphabet = Alphabet::new(AlphabetName::Aa)?;
+  let alphabet = Alphabet::new(AlphabetName::AaNoStop)?;
   let records = read_many_fasta(&[path], &alphabet)?;
   let mut by_gene = BTreeMap::new();
   for record in records {
     by_gene.insert(record.seq_name, record.seq);
   }
 
+  validate_aa_root_sequence_genes(path, &by_gene, genes)?;
+
+  Ok(by_gene)
+}
+
+fn validate_aa_root_sequence_genes(
+  path: &Path,
+  by_gene: &BTreeMap<String, Seq>,
+  genes: &[String],
+) -> Result<(), Report> {
   for gene in genes {
     if !by_gene.contains_key(gene) {
       return make_error!(
@@ -111,8 +135,7 @@ pub fn read_aa_root_sequences(path: Option<&Path>, genes: &[String]) -> Result<B
       );
     }
   }
-
-  Ok(by_gene)
+  Ok(())
 }
 
 pub fn read_gff3_annotations(
@@ -123,7 +146,15 @@ pub fn read_gff3_annotations(
     return Ok(BTreeMap::new());
   };
 
-  let contents = std::fs::read_to_string(path)?;
+  let contents = read_file_to_string(path)?;
+  parse_gff3_annotations(&contents, genes, path)
+}
+
+fn parse_gff3_annotations(
+  contents: &str,
+  genes: &[String],
+  path: &Path,
+) -> Result<BTreeMap<String, AugurNodeDataJsonAnnotationEntry>, Report> {
   let wanted: BTreeSet<&str> = genes.iter().map(String::as_str).collect();
   let mut features: BTreeMap<String, Vec<GffCdsRow>> = BTreeMap::new();
 
@@ -145,7 +176,13 @@ pub fn read_gff3_annotations(
       continue;
     }
 
-    let attrs = parse_gff_attributes(cols[8]);
+    let attrs = parse_gff_attributes(cols[8]).wrap_err_with(|| {
+      format!(
+        "Invalid GFF3 attributes on line {} in '{}'",
+        line_no + 1,
+        path.display()
+      )
+    })?;
     let Some(gene) = attrs
       .get("Name")
       .or_else(|| attrs.get("gene"))
@@ -227,7 +264,7 @@ pub fn read_gff3_annotations(
           segments: Some(
             rows
               .iter()
-              .map(|row| util_augur_node_data_json::AugurNodeDataJsonAnnotationSegment {
+              .map(|row| AugurNodeDataJsonAnnotationSegment {
                 start: row.start,
                 end: row.end,
                 other: BTreeMap::new(),
@@ -271,7 +308,7 @@ pub fn collect_aa_gene_node_data(
       .map_or_else(|| format!("node_{}", node_key.0), |n| n.as_ref().to_owned());
 
     let muts = if node_key == root_key {
-      diff_sequences(&reference, &inferred_root)?
+      diff_sequences(&reference, &inferred_root, partition.ambiguous_char())?
     } else {
       let (_parent_key, edge_key) = graph
         .node_parent(node_key)?
@@ -289,12 +326,12 @@ pub fn collect_aa_gene_node_data(
 
   Ok(AaGeneNodeData {
     reference: reference.as_str().to_owned(),
-    root_sequence: reference.as_str().to_owned(),
+    root_sequence: inferred_root.as_str().to_owned(),
     node_muts,
   })
 }
 
-fn diff_sequences(reference: &Seq, query: &Seq) -> Result<Vec<String>, Report> {
+fn diff_sequences(reference: &Seq, query: &Seq, unknown: AsciiChar) -> Result<Vec<String>, Report> {
   if reference.len() != query.len() {
     return make_error!(
       "Cannot diff sequences with lengths {} and {}",
@@ -308,18 +345,32 @@ fn diff_sequences(reference: &Seq, query: &Seq) -> Result<Vec<String>, Report> {
       .iter()
       .zip(query.iter())
       .enumerate()
-      .filter(|(_pos, (reff, qry))| reff != qry)
+      .filter(|(_pos, (reff, qry))| reff != qry && is_reportable_sub(**reff, **qry, unknown))
       .map(|(pos, (reff, qry))| format!("{}{}{}", char::from(*reff), pos + 1, char::from(*qry)))
       .collect(),
   )
 }
 
-fn parse_gff_attributes(raw: &str) -> BTreeMap<String, String> {
+fn is_reportable_sub(reff: AsciiChar, qry: AsciiChar, unknown: AsciiChar) -> bool {
+  let gap = AsciiChar::from_byte_unchecked(b'-');
+  reff != gap && qry != gap && reff != unknown && qry != unknown
+}
+
+fn parse_gff_attributes(raw: &str) -> Result<BTreeMap<String, String>, Report> {
   raw
     .split(';')
-    .filter_map(|attr| attr.split_once('='))
-    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .filter(|attr| !attr.is_empty())
+    .map(|attr| {
+      let Some((key, value)) = attr.split_once('=') else {
+        return make_error!("Invalid GFF3 attribute '{attr}': expected key=value");
+      };
+      Ok((decode_gff3_attribute(key)?, decode_gff3_attribute(value)?))
+    })
     .collect()
+}
+
+fn decode_gff3_attribute(raw: &str) -> Result<String, Report> {
+  Ok(percent_decode_str(raw).decode_utf8()?.into_owned())
 }
 
 #[derive(Clone, Debug)]
@@ -333,10 +384,169 @@ struct GffCdsRow {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::seq::mutation::Sub;
+  use maplit::btreemap;
+  use pretty_assertions::assert_eq;
+  use treetime_graph::edge::GraphEdgeKey;
+  use treetime_graph::node::GraphNodeKey;
+  use treetime_utils::o;
 
   #[test]
   fn test_validate_aa_args_requires_cds_placeholder() {
     let err = validate_aa_args(&Some("translations.fasta".to_owned()), &["S".to_owned()], &None, &None).unwrap_err();
     assert!(err.to_string().contains("{cds}"));
+  }
+
+  #[test]
+  fn test_validate_aa_root_sequence_genes_requires_every_gene() {
+    let by_gene = btreemap! {
+      o!("S") => Seq::try_from_str("AC").unwrap(),
+    };
+
+    let err = validate_aa_root_sequence_genes(Path::new("roots.fasta"), &by_gene, &[o!("S"), o!("M")]).unwrap_err();
+
+    assert!(err.to_string().contains("gene 'M'"));
+  }
+
+  #[test]
+  fn test_parse_gff3_annotations_returns_exact_annotations() {
+    let input = "\
+##gff-version 3
+MN908947.3\tNextclade\tCDS\t21563\t25384\t.\t+\t0\tID=cds-S;Name=S
+MN908947.3\tNextclade\tCDS\t266\t13468\t.\t+\t0\tID=cds-ORF1a;Name=ORF%31a
+MN908947.3\tNextclade\tCDS\t13468\t21555\t.\t+\t0\tID=cds-ORF1a-2;Name=ORF%31a
+MN908947.3\tNextclade\tgene\t100\t200\t.\t+\t.\tName=ignored
+";
+    let genes = vec![o!("S"), o!("ORF1a")];
+
+    let actual = parse_gff3_annotations(input, &genes, Path::new("annotations.gff3")).unwrap();
+
+    let expected = btreemap! {
+      o!("ORF1a") => AugurNodeDataJsonAnnotationEntry {
+        start: None,
+        end: None,
+        strand: Some(o!("+")),
+        entry_type: Some(o!("CDS")),
+        segments: Some(vec![
+          AugurNodeDataJsonAnnotationSegment {
+            start: 266,
+            end: 13468,
+            other: btreemap! {},
+          },
+          AugurNodeDataJsonAnnotationSegment {
+            start: 13468,
+            end: 21555,
+            other: btreemap! {},
+          },
+        ]),
+        other: btreemap! {
+          o!("seqid") => json!("MN908947.3"),
+        },
+      },
+      o!("S") => AugurNodeDataJsonAnnotationEntry {
+        start: Some(21563),
+        end: Some(25384),
+        strand: Some(o!("+")),
+        entry_type: Some(o!("CDS")),
+        segments: None,
+        other: btreemap! {
+          o!("seqid") => json!("MN908947.3"),
+        },
+      },
+    };
+    assert_eq!(expected, actual);
+  }
+
+  #[test]
+  fn test_diff_sequences_skips_gap_and_unknown_states() {
+    let reference = Seq::try_from_str("ACDX-").unwrap();
+    let query = Seq::try_from_str("ADQXF").unwrap();
+
+    let actual = diff_sequences(&reference, &query, AsciiChar::from_byte_unchecked(b'X')).unwrap();
+
+    let expected = vec![o!("C2D"), o!("D3Q")];
+    assert_eq!(expected, actual);
+  }
+
+  #[test]
+  fn test_collect_aa_gene_node_data_keeps_inferred_root_sequence() {
+    let graph = helpers::named_tree();
+    let partition = helpers::StubAugurPartition::new(
+      &graph,
+      &btreemap! {
+        o!("A") => o!("AD"),
+        o!("B") => o!("AC"),
+        o!("root") => o!("AC"),
+      },
+    );
+    let reference = Seq::try_from_str("AA").unwrap();
+
+    let actual = collect_aa_gene_node_data(&graph, &partition, "S", Some(&reference)).unwrap();
+
+    let expected = AaGeneNodeData {
+      reference: o!("AA"),
+      root_sequence: o!("AC"),
+      node_muts: btreemap! {
+        o!("A") => vec![],
+        o!("B") => vec![],
+        o!("root") => vec![o!("A2C")],
+      },
+    };
+    assert_eq!(expected, actual);
+  }
+
+  mod helpers {
+    use super::*;
+    use treetime_graph::node::Named;
+    use treetime_io::nwk::nwk_read_str;
+
+    pub fn named_tree() -> GraphAncestral {
+      nwk_read_str("(A:0.1,B:0.1)root;").unwrap()
+    }
+
+    pub struct StubAugurPartition {
+      sequences: BTreeMap<GraphNodeKey, Seq>,
+      unknown: AsciiChar,
+    }
+
+    impl StubAugurPartition {
+      pub fn new(graph: &GraphAncestral, sequences_by_name: &BTreeMap<String, String>) -> Self {
+        let sequences = graph
+          .get_nodes()
+          .into_iter()
+          .map(|node| {
+            let node = node.read_arc();
+            let payload = node.payload().read_arc();
+            let name = payload.name().unwrap();
+            (
+              node.key(),
+              Seq::try_from_str(&sequences_by_name[name.as_ref()]).unwrap(),
+            )
+          })
+          .collect();
+        Self {
+          sequences,
+          unknown: AsciiChar::from_byte_unchecked(b'X'),
+        }
+      }
+    }
+
+    impl AugurNodeDataJsonAncestralPartition for StubAugurPartition {
+      fn sequence_length(&self) -> usize {
+        self.sequences.values().next().unwrap().len()
+      }
+
+      fn node_sequence(&self, node_key: GraphNodeKey) -> Seq {
+        self.sequences[&node_key].clone()
+      }
+
+      fn edge_subs(&self, _graph: &dyn BranchTopology, _edge_key: GraphEdgeKey) -> Result<Vec<Sub>, Report> {
+        Ok(vec![])
+      }
+
+      fn ambiguous_char(&self) -> AsciiChar {
+        self.unknown
+      }
+    }
   }
 }

--- a/packages/treetime/src/commands/ancestral/aa_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/aa_node_data.rs
@@ -1,0 +1,342 @@
+use crate::alphabet::alphabet::{Alphabet, AlphabetName};
+use crate::make_error;
+use crate::partition::augur::AugurNodeDataJsonAncestralPartition;
+use crate::partition::traits::BranchTopology;
+use crate::payload::ancestral::GraphAncestral;
+use crate::seq::mutation::Sub;
+use eyre::Report;
+use itertools::Itertools;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use treetime_graph::node::Named;
+use treetime_io::fasta::read_many_fasta;
+use treetime_primitives::Seq;
+use util_augur_node_data_json::AugurNodeDataJsonAnnotationEntry;
+
+#[derive(Clone, Debug, Default)]
+pub struct AaNodeData {
+  pub annotations: BTreeMap<String, AugurNodeDataJsonAnnotationEntry>,
+  pub reference: BTreeMap<String, String>,
+  pub node_aa_muts: BTreeMap<String, BTreeMap<String, Vec<String>>>,
+  pub root_aa_sequences: BTreeMap<String, String>,
+}
+
+impl AaNodeData {
+  pub fn add_gene(
+    &mut self,
+    gene: &str,
+    gene_data: AaGeneNodeData,
+    annotation: Option<AugurNodeDataJsonAnnotationEntry>,
+  ) {
+    if let Some(annotation) = annotation {
+      self.annotations.insert(gene.to_owned(), annotation);
+    }
+    self.reference.insert(gene.to_owned(), gene_data.reference);
+    self.root_aa_sequences.insert(gene.to_owned(), gene_data.root_sequence);
+    for (node_name, muts) in gene_data.node_muts {
+      self
+        .node_aa_muts
+        .entry(node_name)
+        .or_default()
+        .insert(gene.to_owned(), muts);
+    }
+  }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AaGeneNodeData {
+  pub reference: String,
+  pub root_sequence: String,
+  pub node_muts: BTreeMap<String, Vec<String>>,
+}
+
+pub fn validate_aa_args(
+  translations: &Option<String>,
+  genes: &[String],
+  annotation_gff: &Option<PathBuf>,
+  aa_root_sequence: &Option<PathBuf>,
+) -> Result<(), Report> {
+  if translations.is_none() && genes.is_empty() && annotation_gff.is_none() && aa_root_sequence.is_none() {
+    return Ok(());
+  }
+
+  let Some(template) = translations else {
+    return make_error!("--translations is required when using --genes, --annotation-gff, or --aa-root-sequence");
+  };
+
+  if !template.contains("{cds}") {
+    return make_error!("--translations must contain the placeholder '{{cds}}'");
+  }
+
+  if genes.is_empty() {
+    return make_error!("--genes must contain at least one gene when --translations is provided");
+  }
+
+  let mut seen = BTreeSet::new();
+  for gene in genes {
+    if gene.is_empty() {
+      return make_error!("--genes must not contain an empty gene name");
+    }
+    if !seen.insert(gene) {
+      return make_error!("--genes contains duplicate gene '{gene}'");
+    }
+  }
+
+  Ok(())
+}
+
+pub fn translation_path(template: &str, gene: &str) -> PathBuf {
+  PathBuf::from(template.replace("{cds}", gene))
+}
+
+pub fn read_aa_root_sequences(path: Option<&Path>, genes: &[String]) -> Result<BTreeMap<String, Seq>, Report> {
+  let Some(path) = path else {
+    return Ok(BTreeMap::new());
+  };
+
+  let alphabet = Alphabet::new(AlphabetName::Aa)?;
+  let records = read_many_fasta(&[path], &alphabet)?;
+  let mut by_gene = BTreeMap::new();
+  for record in records {
+    by_gene.insert(record.seq_name, record.seq);
+  }
+
+  for gene in genes {
+    if !by_gene.contains_key(gene) {
+      return make_error!(
+        "--aa-root-sequence '{}' does not contain a FASTA record for gene '{}'",
+        path.display(),
+        gene
+      );
+    }
+  }
+
+  Ok(by_gene)
+}
+
+pub fn read_gff3_annotations(
+  path: Option<&Path>,
+  genes: &[String],
+) -> Result<BTreeMap<String, AugurNodeDataJsonAnnotationEntry>, Report> {
+  let Some(path) = path else {
+    return Ok(BTreeMap::new());
+  };
+
+  let contents = std::fs::read_to_string(path)?;
+  let wanted: BTreeSet<&str> = genes.iter().map(String::as_str).collect();
+  let mut features: BTreeMap<String, Vec<GffCdsRow>> = BTreeMap::new();
+
+  for (line_no, line) in contents.lines().enumerate() {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+      continue;
+    }
+
+    let cols = line.split('\t').collect_vec();
+    if cols.len() != 9 {
+      return make_error!(
+        "Invalid GFF3 line {} in '{}': expected 9 tab-separated columns",
+        line_no + 1,
+        path.display()
+      );
+    }
+    if cols[2] != "CDS" {
+      continue;
+    }
+
+    let attrs = parse_gff_attributes(cols[8]);
+    let Some(gene) = attrs
+      .get("Name")
+      .or_else(|| attrs.get("gene"))
+      .or_else(|| attrs.get("ID"))
+      .or_else(|| attrs.get("Parent"))
+      .cloned()
+    else {
+      continue;
+    };
+
+    if !wanted.contains(gene.as_str()) {
+      continue;
+    }
+
+    let start = cols[3].parse::<i64>()?;
+    let end = cols[4].parse::<i64>()?;
+    if start < 1 || end < start {
+      return make_error!("Invalid CDS coordinates for gene '{gene}' on GFF3 line {}", line_no + 1);
+    }
+
+    let strand = match cols[6] {
+      "+" | "-" => cols[6].to_owned(),
+      strand => {
+        return make_error!(
+          "Invalid CDS strand '{strand}' for gene '{gene}' on GFF3 line {}",
+          line_no + 1
+        );
+      },
+    };
+
+    features.entry(gene).or_default().push(GffCdsRow {
+      seqid: cols[0].to_owned(),
+      start,
+      end,
+      strand,
+    });
+  }
+
+  for gene in genes {
+    if !features.contains_key(gene) {
+      return make_error!(
+        "--annotation-gff '{}' does not contain a CDS feature for gene '{}'",
+        path.display(),
+        gene
+      );
+    }
+  }
+
+  features
+    .into_iter()
+    .map(|(gene, mut rows)| {
+      rows.sort_by_key(|row| (row.start, row.end));
+      let first = rows.first().expect("features are non-empty");
+      let strand = first.strand.clone();
+      let seqid = first.seqid.clone();
+
+      if rows.iter().any(|row| row.strand != strand) {
+        return make_error!("CDS feature rows for gene '{gene}' use multiple strands");
+      }
+
+      let mut other = BTreeMap::new();
+      other.insert("seqid".to_owned(), json!(seqid));
+
+      let annotation = if rows.len() == 1 {
+        AugurNodeDataJsonAnnotationEntry {
+          start: Some(first.start),
+          end: Some(first.end),
+          strand: Some(strand),
+          entry_type: Some("CDS".to_owned()),
+          segments: None,
+          other,
+        }
+      } else {
+        AugurNodeDataJsonAnnotationEntry {
+          start: None,
+          end: None,
+          strand: Some(strand),
+          entry_type: Some("CDS".to_owned()),
+          segments: Some(
+            rows
+              .iter()
+              .map(|row| util_augur_node_data_json::AugurNodeDataJsonAnnotationSegment {
+                start: row.start,
+                end: row.end,
+                other: BTreeMap::new(),
+              })
+              .collect(),
+          ),
+          other,
+        }
+      };
+
+      Ok((gene, annotation))
+    })
+    .collect()
+}
+
+pub fn collect_aa_gene_node_data(
+  graph: &GraphAncestral,
+  partition: &dyn AugurNodeDataJsonAncestralPartition,
+  gene: &str,
+  reference_override: Option<&Seq>,
+) -> Result<AaGeneNodeData, Report> {
+  let root_key = graph.root_key()?;
+  let inferred_root = partition.root_sequence(graph)?;
+  let reference = reference_override.cloned().unwrap_or_else(|| inferred_root.clone());
+
+  if reference.len() != inferred_root.len() {
+    return make_error!(
+      "AA root/reference sequence for gene '{gene}' has length {}, but inferred root has length {}",
+      reference.len(),
+      inferred_root.len()
+    );
+  }
+
+  let mut node_muts = BTreeMap::new();
+  for node in graph.get_nodes() {
+    let node_guard = node.read_arc();
+    let node_key = node_guard.key();
+    let payload = node_guard.payload().read_arc();
+    let node_name = payload
+      .name()
+      .map_or_else(|| format!("node_{}", node_key.0), |n| n.as_ref().to_owned());
+
+    let muts = if node_key == root_key {
+      diff_sequences(&reference, &inferred_root)?
+    } else {
+      let (_parent_key, edge_key) = graph
+        .node_parent(node_key)?
+        .ok_or_else(|| eyre::eyre!("Non-root node '{node_name}' has no parent while collecting AA node data"))?;
+      partition
+        .edge_subs(graph, edge_key)?
+        .into_iter()
+        .sorted_by_key(Sub::pos)
+        .map(|sub| sub.to_string())
+        .collect()
+    };
+
+    node_muts.insert(node_name, muts);
+  }
+
+  Ok(AaGeneNodeData {
+    reference: reference.as_str().to_owned(),
+    root_sequence: reference.as_str().to_owned(),
+    node_muts,
+  })
+}
+
+fn diff_sequences(reference: &Seq, query: &Seq) -> Result<Vec<String>, Report> {
+  if reference.len() != query.len() {
+    return make_error!(
+      "Cannot diff sequences with lengths {} and {}",
+      reference.len(),
+      query.len()
+    );
+  }
+
+  Ok(
+    reference
+      .iter()
+      .zip(query.iter())
+      .enumerate()
+      .filter(|(_pos, (reff, qry))| reff != qry)
+      .map(|(pos, (reff, qry))| format!("{}{}{}", char::from(*reff), pos + 1, char::from(*qry)))
+      .collect(),
+  )
+}
+
+fn parse_gff_attributes(raw: &str) -> BTreeMap<String, String> {
+  raw
+    .split(';')
+    .filter_map(|attr| attr.split_once('='))
+    .map(|(key, value)| (key.to_owned(), value.to_owned()))
+    .collect()
+}
+
+#[derive(Clone, Debug)]
+struct GffCdsRow {
+  seqid: String,
+  start: i64,
+  end: i64,
+  strand: String,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_validate_aa_args_requires_cds_placeholder() {
+    let err = validate_aa_args(&Some("translations.fasta".to_owned()), &["S".to_owned()], &None, &None).unwrap_err();
+    assert!(err.to_string().contains("{cds}"));
+  }
+}

--- a/packages/treetime/src/commands/ancestral/args.rs
+++ b/packages/treetime/src/commands/ancestral/args.rs
@@ -72,6 +72,28 @@ pub struct TreetimeAncestralArgs {
   #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
   pub output_augur_node_data: Option<PathBuf>,
 
+  /// Path template for per-gene amino-acid FASTA alignments.
+  ///
+  /// The template must contain `{cds}`, which is replaced with each value from
+  /// `--genes`. This matches Nextclade's `--output-translations` template.
+  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
+  pub translations: Option<String>,
+
+  /// Gene/CDS names to reconstruct from `--translations`.
+  #[cfg_attr(feature = "clap", clap(long = "genes", value_name = "GENE"))]
+  pub genes: Vec<String>,
+
+  /// GFF3 file with CDS coordinates for Augur node data annotations.
+  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
+  pub annotation_gff: Option<PathBuf>,
+
+  /// FASTA file with one amino-acid root/reference sequence per gene.
+  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
+  pub aa_root_sequence: Option<PathBuf>,
+
   #[cfg_attr(feature = "clap", clap(flatten))]
   pub output: OutputArgs,
 

--- a/packages/treetime/src/commands/ancestral/augur_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/augur_node_data.rs
@@ -1,4 +1,5 @@
 use crate::ancestral::mask::mask_to_string;
+use crate::commands::ancestral::aa_node_data::AaNodeData;
 use crate::partition::augur::AugurNodeDataJsonAncestralPartition;
 use crate::partition::traits::BranchTopology;
 use crate::payload::ancestral::GraphAncestral;
@@ -28,11 +29,20 @@ pub fn write_augur_node_data_json(
   mask: &[bool],
   path: &Path,
 ) -> Result<(), Report> {
+  write_augur_node_data_json_with_aa(graph, partition, mask, None, path)
+}
+
+pub fn build_augur_node_data_json(
+  graph: &GraphAncestral,
+  partition: &dyn AugurNodeDataJsonAncestralPartition,
+  mask: &[bool],
+  aa_node_data: Option<&AaNodeData>,
+) -> Result<AugurNodeDataJsonAncestral, Report> {
   let alignment_length = partition.sequence_length();
   let reference_seq = partition.root_sequence(graph)?;
   let ambiguous = partition.ambiguous_char();
 
-  let annotations = AugurNodeDataJsonAnnotations {
+  let mut annotations = AugurNodeDataJsonAnnotations {
     nuc: Some(AugurNodeDataJsonAnnotationEntry {
       start: Some(1),
       end: Some(i64::try_from(alignment_length)?),
@@ -43,8 +53,12 @@ pub fn write_augur_node_data_json(
     }),
     other: BTreeMap::new(),
   };
+  if let Some(aa_node_data) = aa_node_data {
+    annotations.other.extend(aa_node_data.annotations.clone());
+  }
 
   let mut nodes = BTreeMap::new();
+  let root_key = graph.root_key()?;
   for node in graph.get_nodes() {
     let node_guard = node.read_arc();
     let node_key = node_guard.key();
@@ -74,32 +88,53 @@ pub fn write_augur_node_data_json(
       }
     }
 
+    let aa_muts = aa_node_data.and_then(|aa| aa.node_aa_muts.get(&node_name).cloned());
     nodes.insert(
       node_name,
       AugurNodeDataJsonAncestralNode {
         muts,
         sequence: Some(sequence.as_str().to_owned()),
-        aa_muts: None,
-        aa_sequences: None,
+        aa_muts,
+        aa_sequences: if node_key == root_key {
+          aa_node_data
+            .map(|aa| aa.root_aa_sequences.clone())
+            .filter(|seqs| !seqs.is_empty())
+        } else {
+          None
+        },
         other: BTreeMap::new(),
       },
     );
   }
 
-  let data = AugurNodeDataJsonAncestral {
+  let mut reference = btreemap! { "nuc".to_owned() => reference_seq.as_str().to_owned() };
+  if let Some(aa_node_data) = aa_node_data {
+    reference.extend(aa_node_data.reference.clone());
+  }
+
+  Ok(AugurNodeDataJsonAncestral {
     generated_by: Some(AugurNodeDataJsonGeneratedBy {
       program: "treetime".to_owned(),
       version: env!("CARGO_PKG_VERSION").to_owned(),
     }),
     metadata: AugurNodeDataJsonAncestralMeta {
       annotations: Some(annotations),
-      reference: Some(btreemap! { "nuc".to_owned() => reference_seq.as_str().to_owned() }),
+      reference: Some(reference),
       mask: Some(mask_to_string(mask)),
       other: BTreeMap::new(),
     },
     nodes,
-  };
+  })
+}
 
+pub fn write_augur_node_data_json_with_aa(
+  graph: &GraphAncestral,
+  partition: &dyn AugurNodeDataJsonAncestralPartition,
+  mask: &[bool],
+  aa_node_data: Option<&AaNodeData>,
+  path: &Path,
+) -> Result<(), Report> {
+  let data = build_augur_node_data_json(graph, partition, mask, aa_node_data)?;
   json_write_file(path, &data, JsonPretty(true))?;
   Ok(())
 }

--- a/packages/treetime/src/commands/ancestral/mod.rs
+++ b/packages/treetime/src/commands/ancestral/mod.rs
@@ -1,3 +1,4 @@
+pub mod aa_node_data;
 pub mod args;
 pub mod augur_node_data;
 pub mod result;

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -1,8 +1,13 @@
-use crate::alphabet::alphabet::Alphabet;
+use crate::alphabet::alphabet::{Alphabet, AlphabetName};
 use crate::ancestral::pipeline::{self, AncestralInput, AncestralParams, AncestralPartition};
+use crate::commands::ancestral::aa_node_data::{
+  AaNodeData, collect_aa_gene_node_data, read_aa_root_sequences, read_gff3_annotations, translation_path,
+  validate_aa_args,
+};
 use crate::commands::ancestral::args::TreetimeAncestralArgs;
-use crate::commands::ancestral::augur_node_data::write_augur_node_data_json;
+use crate::commands::ancestral::augur_node_data::write_augur_node_data_json_with_aa;
 use crate::commands::ancestral::result::AncestralResult;
+use crate::gtr::get_gtr::GtrModelName;
 use crate::gtr::get_gtr::write_gtr_json;
 use crate::partition::traits::MutationCommentProvider;
 use crate::progress::ProgressSink;
@@ -22,6 +27,13 @@ pub fn run_ancestral_reconstruction(
   let outdir = &ancestral_args.output.outdir;
   let gap_fill_mode = ancestral_args.gap_fill_args.effective_gap_fill();
   let alphabet = Alphabet::new(ancestral_args.alphabet_args.alphabet.unwrap_or_default())?;
+
+  validate_aa_args(
+    &ancestral_args.translations,
+    &ancestral_args.genes,
+    &ancestral_args.annotation_gff,
+    &ancestral_args.aa_root_sequence,
+  )?;
 
   progress.check_cancelled()?;
   progress.report("Reading input", 0.0, "");
@@ -82,6 +94,12 @@ pub fn run_ancestral_reconstruction(
     progress,
   )?;
 
+  let aa_node_data = if let Some(translations) = &ancestral_args.translations {
+    Some(run_aa_reconstructions(ancestral_args, translations, progress)?)
+  } else {
+    None
+  };
+
   progress.report("Writing output", 0.9, "");
   let augur_node_data_path = ancestral_args
     .output_augur_node_data
@@ -95,10 +113,11 @@ pub fn run_ancestral_reconstruction(
   match &result.partition {
     Some(AncestralPartition::Fitch(partition)) => {
       let guard = partition.read_arc();
-      write_augur_node_data_json(
+      write_augur_node_data_json_with_aa(
         &result.output.graph,
         &*guard,
         &result.output.mask,
+        aa_node_data.as_ref(),
         &augur_node_data_path,
       )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
@@ -106,10 +125,11 @@ pub fn run_ancestral_reconstruction(
     },
     Some(AncestralPartition::Sparse(partition)) => {
       let guard = partition.read_arc();
-      write_augur_node_data_json(
+      write_augur_node_data_json_with_aa(
         &result.output.graph,
         &*guard,
         &result.output.mask,
+        aa_node_data.as_ref(),
         &augur_node_data_path,
       )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
@@ -119,10 +139,11 @@ pub fn run_ancestral_reconstruction(
     },
     Some(AncestralPartition::Dense(partition)) => {
       let guard = partition.read_arc();
-      write_augur_node_data_json(
+      write_augur_node_data_json_with_aa(
         &result.output.graph,
         &*guard,
         &result.output.mask,
+        aa_node_data.as_ref(),
         &augur_node_data_path,
       )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
@@ -141,4 +162,69 @@ pub fn run_ancestral_reconstruction(
     gtr: result.output.gtr,
     model_name: result.output.model_name,
   })
+}
+
+fn run_aa_reconstructions(
+  ancestral_args: &TreetimeAncestralArgs,
+  translations: &str,
+  progress: &dyn ProgressSink,
+) -> Result<AaNodeData, Report> {
+  let aa_alphabet = Alphabet::new(AlphabetName::AaNoStop)?;
+  let mut aa_node_data = AaNodeData::default();
+  let annotations = read_gff3_annotations(ancestral_args.annotation_gff.as_deref(), &ancestral_args.genes)?;
+  let aa_root_sequences = read_aa_root_sequences(ancestral_args.aa_root_sequence.as_deref(), &ancestral_args.genes)?;
+
+  for (index, gene) in ancestral_args.genes.iter().enumerate() {
+    progress.check_cancelled()?;
+    progress.report(
+      "AA ancestral reconstruction",
+      0.75,
+      &format!("{} ({}/{})", gene, index + 1, ancestral_args.genes.len()),
+    );
+
+    let path = translation_path(translations, gene);
+    let mut sequences = read_many_fasta(&[&path], &aa_alphabet)?;
+    let gap_fill_mode = ancestral_args.gap_fill_args.effective_gap_fill();
+    for record in &mut sequences {
+      apply_gap_fill(&mut record.seq, gap_fill_mode, aa_alphabet.gap(), aa_alphabet.unknown());
+    }
+
+    let graph = nwk_read_file(&ancestral_args.tree)?;
+    let input = AncestralInput {
+      graph,
+      alphabet: aa_alphabet.clone(),
+      sequences,
+    };
+    let params = AncestralParams {
+      method: ancestral_args.method_anc,
+      model: GtrModelName::Jtt92,
+      dense: ancestral_args.dense,
+      reconstruct_tip_states: ancestral_args.reconstruct_tip_states,
+      gtr_iterations: 0,
+      site_specific_gtr: false,
+      seed: ancestral_args.seed,
+      sample_from_profile: ancestral_args.sample_from_profile,
+    };
+
+    let result = pipeline::run(&params, input, |_node, _seq| Ok(()), progress)?;
+    let reference_override = aa_root_sequences.get(gene);
+    let gene_data = match &result.partition {
+      Some(AncestralPartition::Fitch(partition)) => {
+        let guard = partition.read_arc();
+        collect_aa_gene_node_data(&result.output.graph, &*guard, gene, reference_override)?
+      },
+      Some(AncestralPartition::Sparse(partition)) => {
+        let guard = partition.read_arc();
+        collect_aa_gene_node_data(&result.output.graph, &*guard, gene, reference_override)?
+      },
+      Some(AncestralPartition::Dense(partition)) => {
+        let guard = partition.read_arc();
+        collect_aa_gene_node_data(&result.output.graph, &*guard, gene, reference_override)?
+      },
+      None => continue,
+    };
+    aa_node_data.add_gene(gene, gene_data, annotations.get(gene).cloned());
+  }
+
+  Ok(aa_node_data)
 }

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -7,8 +7,7 @@ use crate::commands::ancestral::aa_node_data::{
 use crate::commands::ancestral::args::TreetimeAncestralArgs;
 use crate::commands::ancestral::augur_node_data::write_augur_node_data_json_with_aa;
 use crate::commands::ancestral::result::AncestralResult;
-use crate::gtr::get_gtr::GtrModelName;
-use crate::gtr::get_gtr::write_gtr_json;
+use crate::gtr::get_gtr::{GtrModelName, write_gtr_json};
 use crate::partition::traits::MutationCommentProvider;
 use crate::progress::ProgressSink;
 use crate::seq::gap_fill::apply_gap_fill;
@@ -17,8 +16,9 @@ use log::info;
 use treetime_io::fasta::{FastaReader, FastaRecord, FastaWriter, read_many_fasta};
 use treetime_io::graph::write_graph_files_with;
 use treetime_io::nwk::CommentProviders;
-use treetime_io::nwk::nwk_read_file;
+use treetime_io::nwk::{nwk_read_file, nwk_read_str};
 use treetime_utils::io::file::{create_file_or_stdout, open_stdin};
+use treetime_utils::io::fs::read_file_to_string;
 
 pub fn run_ancestral_reconstruction(
   ancestral_args: &TreetimeAncestralArgs,
@@ -173,6 +173,7 @@ fn run_aa_reconstructions(
   let mut aa_node_data = AaNodeData::default();
   let annotations = read_gff3_annotations(ancestral_args.annotation_gff.as_deref(), &ancestral_args.genes)?;
   let aa_root_sequences = read_aa_root_sequences(ancestral_args.aa_root_sequence.as_deref(), &ancestral_args.genes)?;
+  let tree = read_file_to_string(&ancestral_args.tree)?;
 
   for (index, gene) in ancestral_args.genes.iter().enumerate() {
     progress.check_cancelled()?;
@@ -189,7 +190,7 @@ fn run_aa_reconstructions(
       apply_gap_fill(&mut record.seq, gap_fill_mode, aa_alphabet.gap(), aa_alphabet.unknown());
     }
 
-    let graph = nwk_read_file(&ancestral_args.tree)?;
+    let graph = nwk_read_str(&tree)?;
     let input = AncestralInput {
       graph,
       alphabet: aa_alphabet.clone(),

--- a/packages/util-augur-node-data-json/src/ancestral.rs
+++ b/packages/util-augur-node-data-json/src/ancestral.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 
 pub type AugurNodeDataJsonAncestral = AugurNodeDataJson<AugurNodeDataJsonAncestralMeta, AugurNodeDataJsonAncestralNode>;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonAncestralMeta {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub annotations: Option<AugurNodeDataJsonAnnotations>,
@@ -20,7 +20,7 @@ pub struct AugurNodeDataJsonAncestralMeta {
   pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonAncestralNode {
   pub muts: Vec<String>,
 

--- a/packages/util-augur-node-data-json/src/annotations.rs
+++ b/packages/util-augur-node-data-json/src/annotations.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonAnnotations {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub nuc: Option<AugurNodeDataJsonAnnotationEntry>,
@@ -10,7 +10,7 @@ pub struct AugurNodeDataJsonAnnotations {
   pub other: BTreeMap<String, AugurNodeDataJsonAnnotationEntry>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonAnnotationEntry {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub start: Option<i64>,
@@ -32,7 +32,7 @@ pub struct AugurNodeDataJsonAnnotationEntry {
   pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonAnnotationSegment {
   pub start: i64,
   pub end: i64,

--- a/packages/util-augur-node-data-json/src/common.rs
+++ b/packages/util-augur-node-data-json/src/common.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJson<M, N> {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub generated_by: Option<AugurNodeDataJsonGeneratedBy>,
@@ -12,7 +12,7 @@ pub struct AugurNodeDataJson<M, N> {
   pub metadata: M,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonGeneratedBy {
   pub program: String,
   pub version: String,

--- a/packages/util-augur-node-data-json/src/refine.rs
+++ b/packages/util-augur-node-data-json/src/refine.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 pub type AugurNodeDataJsonRefine = AugurNodeDataJson<AugurNodeDataJsonRefineMeta, AugurNodeDataJsonRefineNode>;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonRefineMeta {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub alignment: Option<String>,
@@ -19,7 +19,7 @@ pub struct AugurNodeDataJsonRefineMeta {
   pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonClock {
   pub rate: f64,
   pub intercept: f64,
@@ -37,7 +37,7 @@ pub struct AugurNodeDataJsonClock {
   pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonRefineNode {
   pub branch_length: f64,
 

--- a/packages/util-augur-node-data-json/src/traits.rs
+++ b/packages/util-augur-node-data-json/src/traits.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 pub type AugurNodeDataJsonTraits = AugurNodeDataJson<AugurNodeDataJsonTraitsMeta, AugurNodeDataJsonTraitsNode>;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonTraitsMeta {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub models: Option<BTreeMap<String, AugurNodeDataJsonTraitModel>>,
@@ -13,7 +13,7 @@ pub struct AugurNodeDataJsonTraitsMeta {
   pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonTraitModel {
   pub rate: f64,
   pub alphabet: Vec<String>,
@@ -24,13 +24,13 @@ pub struct AugurNodeDataJsonTraitModel {
   pub other: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonTraitsNode {
   #[serde(flatten)]
   pub fields: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AugurNodeDataJsonTraitsBranches {
   #[serde(skip_serializing_if = "Option::is_none")]
   pub labels: Option<BTreeMap<String, String>>,


### PR DESCRIPTION
The ancestral command emitted Augur node data JSON for nucleotide mutations only. Nextstrain export workflows also need per-gene amino-acid node data built from translation alignments and genome annotations, and the command had no inputs for them.

Add `--translations`, `--genes`, `--annotation-gff`, and `--aa-root-sequence` so the ancestral command emits Augur-compatible amino-acid node data alongside the nucleotide output. The translation path is a template with a `{cds}` placeholder expanded per gene, matching Nextclade's `--output-translations` convention. The app-server argument mapping carries the same fields.

Amino-acid auxiliary inputs are validated before reconstruction so missing files or gene records fail before any partial output is written. GFF3 attributes are percent-decoded, and override root references stay separate from inferred root amino-acid sequences, so emitted node data matches the annotation and reconstruction contracts.

### Work items

- [x] Add `--translations`, `--genes`, `--annotation-gff`, `--aa-root-sequence` to ancestral args and the app-server mapping
- [x] Add the `aa_node_data` module emitting Augur amino-acid node data alongside nucleotide output
- [x] Validate amino-acid auxiliary inputs before reconstruction so failures precede partial output
- [x] Percent-decode GFF3 attributes and keep override references separate from inferred root sequences
- [x] Assert amino-acid node-data output in memory rather than via temporary files