### PR TITLE
feat: add explicit reroot tip selection

### DIFF
--- a/kb/features/clock.md
+++ b/kb/features/clock.md
@@ -23,13 +23,12 @@
 - [x] Reroot rejects candidates with non-positive inferred clock rate
 - [x] `--keep-root` (disable rerooting)
 
-## Reroot Modes (5 modes)
+## Reroot Modes (4 modes)
 
 - [x] Least-squares (minimize RTT regression residuals)
 - [x] Min-dev (minimize RTT variance)
 - [x] Oldest (root at oldest node)
-- [x] Clock-filter mode
-- [x] MRCA mode
+- [x] Tip/MRCA mode (`--reroot-tips`)
 
 ## Edge Split Optimization (3 methods)
 
@@ -69,14 +68,13 @@
 - [x] `--clock-rate` (fixed rate bypasses estimation)
 - [x] `--allow-negative-rate` (for midpoint rooting)
 - [x] `--tip-slack` (terminal node excess variance)
+- [x] `--reroot` / `--reroot-tips`
 - [ ] `--aln` (parsed but not wired)
 - [ ] `--vcf-reference` (parsed but not wired)
 - [ ] `--gtr` (parsed but not wired)
 - [ ] `--gtr-params` (parsed but not wired)
 - [ ] `--branch-length-mode` (parsed but not wired)
 - [ ] `--method-anc` (parsed but not wired)
-- [ ] `--reroot` (parsed but not wired)
 - [ ] `--prune-short` (parsed but not wired)
-- [ ] `--plot-rtt` (parsed but not wired)
 - [ ] `--seed` (parsed but not wired)
 - [ ] Tree inference from alignment (help text mentions it, not implemented)

--- a/kb/features/timetree.md
+++ b/kb/features/timetree.md
@@ -113,6 +113,7 @@
 - [x] Rate susceptibility activated via `--confidence` with `--covariation` or `--clock-std-dev`
 - [x] `--confidence` promotion of `time_marginal` from `never` to `only-final`
 - [x] `--covariation` wired into timetree clock regression
+- [x] Reroot method and tip/MRCA selection passed into clock rerooting
 
 ## Output
 
@@ -133,13 +134,12 @@
 - [x] `--confidence` (time_marginal promotion, rate susceptibility)
 - [x] `--covariation` (GLS clock regression, rate susceptibility)
 - [x] `--tip-slack` (covariation variance computation)
+- [x] `--reroot` / `--reroot-tips`
 - [ ] `--n-iqd`
-- [ ] `--reroot`
 - [ ] `--tip-labels` / `--no-tip-labels`
 - [x] `--gtr` (model selection: named models and inference)
 - [ ] `--gtr-params` (parsed but not wired)
 - [ ] `--method-anc`
-- [ ] `--aa`
 - [ ] `--keep-overhangs` (gap handling not implemented)
 - [ ] `--zero-based`
 - [ ] `--reconstruct-tip-states`

--- a/kb/issues/H-core-command-module-shared-ops-entanglement.md
+++ b/kb/issues/H-core-command-module-shared-ops-entanglement.md
@@ -9,7 +9,7 @@ This initial sweep is not exhaustive. More investigation and more reorganization
 Five cross-command dependency edges exist in production code (excluding tests):
 
 - ~~`clock` -> `ancestral`: `MethodAncestral`~~ **Resolved**: extracted to `commands/shared/args`
-- ~~`clock` -> `timetree`: `BranchLengthMode`, `RerootMode`~~ **Resolved**: extracted to `commands/shared/args`
+- ~~`clock` -> `timetree`: `BranchLengthMode`, `RerootMethod`~~ **Resolved**: extracted to domain and shared command modules
 - ~~`timetree` -> `ancestral` (6 sites)~~ **Resolved**: ancestral algorithms extracted to top-level `src/ancestral/`; `get_common_length` moved to `src/seq/alignment`
 - ~~`timetree` -> `clock` (20 sites)~~ **Resolved**: clock model domain extracted to top-level `src/clock/`
 - ~~`timetree` -> `optimize` (8 sites)~~ **Resolved**: optimization machinery extracted to top-level `src/optimize/`; iteration helpers to `packages/treetime/src/optimize/iteration.rs`
@@ -52,7 +52,7 @@ Traits and types moved to `partition/` and `payload/`: partition traits (`Partit
 
 ### ~~CLI args shared across commands~~ **Resolved**
 
-`BranchLengthMode`, `RerootMode`, `MethodAncestral` extracted to `packages/treetime/src/commands/ancestral/args.rs`. `BranchOptMethod`, `InitialGuessMode` extracted to `optimize/args.rs`.
+`BranchLengthMode`, `RerootMethod`, `RerootSpec`, and `MethodAncestral` extracted to domain and shared command modules. `BranchOptMethod` and `InitialGuessMode` extracted to `optimize/args.rs`.
 
 ## Remaining items
 

--- a/kb/issues/N-timetree-dead-cli-flags.md
+++ b/kb/issues/N-timetree-dead-cli-flags.md
@@ -1,6 +1,6 @@
 # Dead CLI flags in timetree
 
-11 flags are parsed by clap but never read in the timetree pipeline:
+10 flags are parsed by clap but never read in the timetree pipeline:
 
 | Flag                       | Notes                                    |
 | -------------------------- | ---------------------------------------- |
@@ -14,9 +14,8 @@
 | `--report-ambiguous`       | Never read                               |
 | `--seed`                   | Never read                               |
 | `--model-params`           | Never read (renamed from `--gtr-params`) |
-| `--reroot`                 | Accepted but always uses least-squares   |
 
-Removed: `--aa` (redundant with `--alphabet`, dropped in CLI args unification).
+Removed: `--aa` (redundant with `--alphabet`, dropped in CLI args unification). Wired: `--reroot` and `--reroot-tips` now pass an explicit root selection spec into timetree rerooting.
 
 Flags that are already wired and not part of this issue:
 
@@ -25,8 +24,6 @@ Flags that are already wired and not part of this issue:
 - `--clock-std-dev` provides user-specified rate standard deviation for rate susceptibility
 - `--tip-slack` used in covariation variance computation
 - `--time-marginal=always` already triggers confidence-interval extraction, so it is intentionally excluded from the dead-flag list
-
-`--reroot` is accepted but `reroot_tree()` at [`packages/treetime/src/timetree/optimization/reroot.rs#L30`](../../packages/treetime/src/timetree/optimization/reroot.rs#L30) always uses `RerootParams::default()` (least-squares). The `--reroot=oldest`, `--reroot=min-dev` modes are never dispatched.
 
 ## Related issues
 

--- a/kb/tickets/architecture-restructure-packages-for-multi-client.md
+++ b/kb/tickets/architecture-restructure-packages-for-multi-client.md
@@ -24,7 +24,7 @@ Three extraction tickets, independent of each other:
 
 ### ~~3. Move shared domain enums~~ Done
 
-- ~~`architecture-move-shared-domain-enums-from-commands.md`~~ (resolved: `BranchLengthMode`, `RerootMode`, `MethodAncestral` moved to domain modules)
+- ~~`architecture-move-shared-domain-enums-from-commands.md`~~ (resolved: `BranchLengthMode`, `RerootMethod`, `RerootSpec`, and `MethodAncestral` moved to domain modules)
 
 ### 4. Move commands/ shell to CLI crate
 

--- a/kb/tickets/timetree-dead-cli-flags-12-parsed-never-read.md
+++ b/kb/tickets/timetree-dead-cli-flags-12-parsed-never-read.md
@@ -1,6 +1,6 @@
 # Dead CLI flags in timetree
 
-12 flags are parsed by clap but never read in the timetree pipeline:
+10 flags are parsed by clap but never read in the timetree pipeline:
 
 | Flag                       | Notes                                  |
 | -------------------------- | -------------------------------------- |
@@ -9,13 +9,13 @@
 | `--no-tip-labels`          | Never read                             |
 | `--n-iqd`                  | Never read                             |
 | `--vcf-reference`          | Never read                             |
-| `--aa`                     | Never read                             |
 | `--zero-based`             | Never read                             |
 | `--reconstruct-tip-states` | Never read                             |
 | `--report-ambiguous`       | Never read                             |
 | `--seed`                   | Never read                             |
 | `--gtr-params`             | Never read                             |
-| `--reroot`                 | Accepted but always uses least-squares |
+
+Resolved from this ticket: `--aa` was removed as redundant with `--alphabet`; `--reroot` and `--reroot-tips` now pass an explicit root selection spec into timetree rerooting.
 
 Flags that are already wired and not part of this issue:
 
@@ -24,8 +24,6 @@ Flags that are already wired and not part of this issue:
 - `--clock-std-dev` provides user-specified rate standard deviation for rate susceptibility
 - `--tip-slack` used in covariation variance computation
 - `--time-marginal=always` already triggers confidence-interval extraction, so it is intentionally excluded from the dead-flag list
-
-`--reroot` is accepted but `reroot_tree()` at [`packages/treetime/src/timetree/optimization/reroot.rs#L30`](../../packages/treetime/src/timetree/optimization/reroot.rs#L30) always uses `RerootParams::default()` (least-squares). The `--reroot=oldest`, `--reroot=min-dev` modes are never dispatched.
 
 ## Related issues
 

--- a/packages/app-server/src/args.rs
+++ b/packages/app-server/src/args.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use treetime::alphabet::alphabet::AlphabetName;
 use treetime::ancestral::params::MethodAncestral;
 use treetime::ancestral::sample::SampleMode;
-use treetime::clock::find_best_root::params::RerootMode;
+use treetime::clock::find_best_root::params::RerootMethod;
+use treetime::commands::shared::reroot::RerootArgs;
 use treetime::commands::timetree::args::TimeMarginalMode;
 use treetime::gtr::get_gtr::GtrModelName;
 use treetime::optimize::params::{BranchLengthMode, BranchOptMethod, InitialGuessMode};
@@ -104,8 +105,8 @@ pub struct ServerClockArgs {
   pub method_anc: MethodAncestral,
   #[default = 3.0]
   pub clock_filter: f64,
-  #[default(RerootMode::default())]
-  pub reroot: RerootMode,
+  pub reroot: Option<RerootMethod>,
+  pub reroot_tips: Vec<String>,
   pub keep_root: bool,
   pub prune_short: bool,
   pub tip_slack: Option<f64>,
@@ -147,7 +148,10 @@ impl From<ServerClockArgs> for TreetimeClockArgs {
       branch_length_mode: s.branch_length_mode,
       method_anc: s.method_anc,
       clock_filter: s.clock_filter,
-      reroot: s.reroot,
+      reroot: RerootArgs {
+        reroot: s.reroot,
+        reroot_tips: s.reroot_tips,
+      },
       keep_root: s.keep_root,
       prune_short: s.prune_short,
       tip_slack: s.tip_slack,
@@ -194,8 +198,8 @@ pub struct ServerTimetreeArgs {
   pub no_tip_labels: bool,
   pub clock_filter: f64,
   pub n_iqd: Option<f64>,
-  #[default(RerootMode::default())]
-  pub reroot: RerootMode,
+  pub reroot: Option<RerootMethod>,
+  pub reroot_tips: Vec<String>,
   pub keep_root: bool,
   pub allow_negative_rate: bool,
   pub tip_slack: Option<f64>,
@@ -268,7 +272,10 @@ impl From<ServerTimetreeArgs> for TreetimeTimetreeArgs {
       no_tip_labels: s.no_tip_labels,
       clock_filter: s.clock_filter,
       n_iqd: s.n_iqd,
-      reroot: s.reroot,
+      reroot: RerootArgs {
+        reroot: s.reroot,
+        reroot_tips: s.reroot_tips,
+      },
       keep_root: s.keep_root,
       allow_negative_rate: s.allow_negative_rate,
       tip_slack: s.tip_slack,

--- a/packages/treetime/src/clock/__tests__/test_reroot.rs
+++ b/packages/treetime/src/clock/__tests__/test_reroot.rs
@@ -2,7 +2,7 @@
 mod tests {
   use crate::clock::clock_graph::GraphClock;
   use crate::clock::clock_regression::{ClockParams, clock_regression_backward, clock_regression_forward};
-  use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+  use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RerootMethod, RerootSpec};
   use crate::clock::reroot::{RerootParams, reroot_in_place};
   use crate::o;
   use eyre::Report;
@@ -143,6 +143,118 @@ mod tests {
     assert!(
       node_count_after >= node_count_before - 1,
       "Node count should be reasonable after reroot with default policy"
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_reroot_tips_uses_mrca_branch() -> Result<(), Report> {
+    let (mut graph, options) = setup_reroot_test_graph()?;
+    let reroot_params = RerootParams {
+      spec: RerootSpec::Tips(vec![o!("A"), o!("B")]),
+      ..RerootParams::default()
+    };
+
+    let reroot_result = reroot_in_place(
+      &mut graph,
+      &options,
+      &BranchPointOptimizationParams::default(),
+      &reroot_params,
+    )?;
+
+    let root = graph
+      .get_node(reroot_result.new_root_key)
+      .expect("new root should exist");
+    let child_names = root
+      .read_arc()
+      .outbound()
+      .iter()
+      .map(|edge_key| {
+        let child_key = graph.get_target_node_key(*edge_key)?;
+        let child = graph.get_node(child_key).expect("child should exist");
+        Ok(
+          child
+            .read_arc()
+            .payload()
+            .read_arc()
+            .name()
+            .map(|name| name.as_ref().to_owned()),
+        )
+      })
+      .collect::<Result<Vec<_>, Report>>()?;
+
+    assert!(
+      child_names.contains(&Some(o!("AB"))),
+      "new root should split the branch leading to the AB MRCA"
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_reroot_tips_reports_missing_tip() -> Result<(), Report> {
+    let (mut graph, options) = setup_reroot_test_graph()?;
+    let reroot_params = RerootParams {
+      spec: RerootSpec::Tips(vec![o!("missing")]),
+      ..RerootParams::default()
+    };
+
+    let err = reroot_in_place(
+      &mut graph,
+      &options,
+      &BranchPointOptimizationParams::default(),
+      &reroot_params,
+    )
+    .unwrap_err();
+
+    assert!(
+      err.to_string().contains("Reroot tip not found: missing"),
+      "error should identify the missing tip"
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_reroot_oldest_uses_oldest_dated_leaf() -> Result<(), Report> {
+    let (mut graph, options) = setup_reroot_test_graph()?;
+    let reroot_params = RerootParams {
+      spec: RerootSpec::Method(RerootMethod::Oldest),
+      ..RerootParams::default()
+    };
+
+    let reroot_result = reroot_in_place(
+      &mut graph,
+      &options,
+      &BranchPointOptimizationParams::default(),
+      &reroot_params,
+    )?;
+
+    let root = graph
+      .get_node(reroot_result.new_root_key)
+      .expect("new root should exist");
+    let child_names = root
+      .read_arc()
+      .outbound()
+      .iter()
+      .map(|edge_key| {
+        let child_key = graph.get_target_node_key(*edge_key)?;
+        let child = graph.get_node(child_key).expect("child should exist");
+        Ok(
+          child
+            .read_arc()
+            .payload()
+            .read_arc()
+            .name()
+            .map(|name| name.as_ref().to_owned()),
+        )
+      })
+      .collect::<Result<Vec<_>, Report>>()?;
+
+    assert!(
+      child_names.contains(&Some(o!("D"))),
+      "new root should split the branch leading to the oldest dated leaf"
     );
 
     Ok(())

--- a/packages/treetime/src/clock/clock_regression.rs
+++ b/packages/treetime/src/clock/clock_regression.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 use treetime_graph::breadth_first::GraphTraversalContinuation;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
-use treetime_graph::node::GraphNode;
+use treetime_graph::node::{GraphNode, Named};
 use treetime_graph::reroot::RerootResult;
 use treetime_utils::io::json::{JsonPretty, json_write_str};
 
@@ -139,7 +139,7 @@ pub fn estimate_clock_model_with_reroot<N, E, D>(
   prev_clock_rate: Option<f64>,
 ) -> Result<ClockModel, Report>
 where
-  N: GraphNode + ClockNode + Default,
+  N: GraphNode + ClockNode + Named + Default,
   E: GraphEdge + ClockEdge + Default,
   D: Send + Sync,
 {
@@ -170,7 +170,7 @@ pub fn estimate_clock_model_with_reroot_policy<N, E, D>(
   prev_clock_rate: Option<f64>,
 ) -> Result<ClockRerootResult, Report>
 where
-  N: GraphNode + ClockNode + Default,
+  N: GraphNode + ClockNode + Named + Default,
   E: GraphEdge + ClockEdge + Default,
   D: Send + Sync,
 {

--- a/packages/treetime/src/clock/find_best_root/__tests__/test_find_best_root.rs
+++ b/packages/treetime/src/clock/find_best_root/__tests__/test_find_best_root.rs
@@ -5,7 +5,7 @@ mod tests {
   use crate::clock::find_best_root::find_best_root::find_best_root;
   use crate::clock::find_best_root::find_best_split::FindRootResult;
   use crate::clock::find_best_root::params::{
-    BranchPointOptimizationParams, BrentParams, GoldenSectionParams, GridSearchParams,
+    BranchPointOptimizationParams, BrentParams, GoldenSectionParams, GridSearchParams, RootObjective,
   };
   use crate::o;
   use crate::pretty_assert_ulps_eq;
@@ -64,7 +64,13 @@ mod tests {
   fn test_find_best_root_grid() -> Result<(), Report> {
     let (graph, options) = setup_test_graph()?;
 
-    let best_root = find_best_root(&graph, &options, &BranchPointOptimizationParams::grid(), true)?;
+    let best_root = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::grid(),
+      true,
+      RootObjective::EstimatedRate,
+    )?;
 
     // Verify chisq value
     pretty_assert_ulps_eq!(best_root.chisq, 0.0002610661988682317, max_ulps = 4);
@@ -92,6 +98,7 @@ mod tests {
       &options,
       &BranchPointOptimizationParams::grid_with(GridSearchParams { n_points: 51 }),
       true,
+      RootObjective::EstimatedRate,
     )?;
 
     // Verify chisq value
@@ -115,7 +122,13 @@ mod tests {
   fn test_find_best_root_brent() -> Result<(), Report> {
     let (graph, options) = setup_test_graph()?;
 
-    let best_root = find_best_root(&graph, &options, &BranchPointOptimizationParams::brent(), true)?;
+    let best_root = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::brent(),
+      true,
+      RootObjective::EstimatedRate,
+    )?;
 
     // Verify chisq value
     pretty_assert_ulps_eq!(best_root.chisq, 0.00025599996471448085, max_ulps = 4);
@@ -146,6 +159,7 @@ mod tests {
         brent_tolerance: 1e-8,
       }),
       true,
+      RootObjective::EstimatedRate,
     )?;
 
     // Verify chisq value
@@ -169,7 +183,13 @@ mod tests {
   fn test_find_best_root_golden_section() -> Result<(), Report> {
     let (graph, options) = setup_test_graph()?;
 
-    let best_root = find_best_root(&graph, &options, &BranchPointOptimizationParams::golden_section(), true)?;
+    let best_root = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::golden_section(),
+      true,
+      RootObjective::EstimatedRate,
+    )?;
 
     // Verify chisq value
     pretty_assert_ulps_eq!(best_root.chisq, 0.00025599996471244515, max_ulps = 4);
@@ -200,6 +220,7 @@ mod tests {
         golden_tolerance: 1e-8,
       }),
       true,
+      RootObjective::EstimatedRate,
     )?;
 
     // Verify chisq value
@@ -224,9 +245,27 @@ mod tests {
     let (graph, options) = setup_test_graph()?;
 
     // Run all three methods
-    let grid_result = find_best_root(&graph, &options, &BranchPointOptimizationParams::grid(), true)?;
-    let brent_result = find_best_root(&graph, &options, &BranchPointOptimizationParams::brent(), true)?;
-    let golden_result = find_best_root(&graph, &options, &BranchPointOptimizationParams::golden_section(), true)?;
+    let grid_result = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::grid(),
+      true,
+      RootObjective::EstimatedRate,
+    )?;
+    let brent_result = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::brent(),
+      true,
+      RootObjective::EstimatedRate,
+    )?;
+    let golden_result = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::golden_section(),
+      true,
+      RootObjective::EstimatedRate,
+    )?;
 
     // Brent and golden section should find better or equal chisq than default grid
     // (lower chisq is better)
@@ -272,7 +311,13 @@ mod tests {
   fn test_find_best_root_force_positive_true_rejects_negative_rate() -> Result<(), Report> {
     let (graph, options) = setup_negative_rate_graph()?;
 
-    let result = find_best_root(&graph, &options, &BranchPointOptimizationParams::grid(), true);
+    let result = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::grid(),
+      true,
+      RootObjective::EstimatedRate,
+    );
 
     assert!(
       result.is_err(),
@@ -291,7 +336,13 @@ mod tests {
   fn test_find_best_root_force_positive_false_accepts_negative_rate() -> Result<(), Report> {
     let (graph, options) = setup_negative_rate_graph()?;
 
-    let best_root = find_best_root(&graph, &options, &BranchPointOptimizationParams::grid(), false)?;
+    let best_root = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::grid(),
+      false,
+      RootObjective::EstimatedRate,
+    )?;
 
     // Confirm the fixture produces a negative-rate scenario
     let det = best_root.clock_set.determinant();

--- a/packages/treetime/src/clock/find_best_root/cost_function.rs
+++ b/packages/treetime/src/clock/find_best_root/cost_function.rs
@@ -1,4 +1,5 @@
 use crate::clock::clock_regression::ClockParams;
+use crate::clock::find_best_root::params::RootObjective;
 use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
 use argmin::core::{CostFunction, Error};
@@ -17,6 +18,7 @@ pub struct BranchPointCostFunction<'a> {
   pub is_leaf: bool,
   pub node_time: Option<f64>,
   pub options: &'a ClockParams,
+  pub objective: RootObjective,
 }
 
 impl<'a> BranchPointCostFunction<'a> {
@@ -24,6 +26,7 @@ impl<'a> BranchPointCostFunction<'a> {
     graph: &Graph<N, E, D>,
     edge: GraphEdgeKey,
     options: &'a ClockParams,
+    objective: RootObjective,
   ) -> Result<BranchPointCostFunction<'a>, Report>
   where
     N: GraphNode + ClockNode,
@@ -53,6 +56,7 @@ impl<'a> BranchPointCostFunction<'a> {
       is_leaf,
       node_time,
       options,
+      objective,
     })
   }
 
@@ -93,7 +97,10 @@ impl CostFunction for &BranchPointCostFunction<'_> {
     // Evaluate the clock set and return chi-squared
     let result = self
       .evaluate_clock_set(*x)
-      .map_or(f64::INFINITY, |clock_set| clock_set.chisq());
+      .map_or(f64::INFINITY, |clock_set| match self.objective {
+        RootObjective::EstimatedRate => clock_set.chisq(),
+        RootObjective::FixedRate(rate) => clock_set.chisq_fixed_rate(rate),
+      });
 
     Ok(result)
   }

--- a/packages/treetime/src/clock/find_best_root/find_best_root.rs
+++ b/packages/treetime/src/clock/find_best_root/find_best_root.rs
@@ -1,6 +1,6 @@
 use crate::clock::clock_regression::ClockParams;
 use crate::clock::find_best_root::find_best_split::{FindRootResult, find_best_split};
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RootObjective};
 use crate::make_error;
 use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
@@ -21,6 +21,7 @@ pub fn find_best_root<N, E, D>(
   options: &ClockParams,
   params: &BranchPointOptimizationParams,
   force_positive: bool,
+  objective: RootObjective,
 ) -> Result<FindRootResult, Report>
 where
   N: GraphNode + ClockNode,
@@ -37,13 +38,13 @@ where
   let root = root.read_arc().payload().read_arc();
   let root_acceptable = !force_positive || has_positive_clock_rate(root.clock_set());
   let mut best_chisq = if root_acceptable {
-    root.clock_set().chisq()
+    cost(root.clock_set(), objective)
   } else {
     f64::INFINITY
   };
   debug!(
     "Initial root chi-squared: {:.6e} (acceptable: {root_acceptable})",
-    root.clock_set().chisq()
+    cost(root.clock_set(), objective)
   );
 
   let mut best_res = FindRootResult {
@@ -66,7 +67,7 @@ where
       node_count += 1;
       continue;
     }
-    let tmp_chisq = clock_set.chisq();
+    let tmp_chisq = cost(clock_set, objective);
     drop(payload_guard);
     drop(node_guard);
     if tmp_chisq < best_chisq {
@@ -88,7 +89,7 @@ where
     debug!("Optimizing position on parent branch");
     let inbound = best_root_node.inbound();
     let edge = get_exactly_one(inbound).expect("Not implemented: multiple parent nodes");
-    let res = find_best_split(graph, *edge, options, params)?;
+    let res = find_best_split(graph, *edge, options, params, objective)?;
     debug!(
       "Parent branch optimization result: chi-squared = {:.6e}, split = {:.6}",
       res.chisq, res.split
@@ -107,7 +108,7 @@ where
   // Check if some place on a child branch is better
   for (child_branch_count, e) in best_root_node.outbound().iter().enumerate() {
     debug!("Optimizing position on child branch {child_branch_count}");
-    let res = find_best_split(graph, *e, options, params)?;
+    let res = find_best_split(graph, *e, options, params, objective)?;
     debug!(
       "Child branch {} optimization result: chi-squared = {:.6e}, split = {:.6}",
       child_branch_count, res.chisq, res.split
@@ -141,4 +142,11 @@ where
 fn has_positive_clock_rate(clock_set: &ClockSet) -> bool {
   let det = clock_set.determinant();
   det > 0.0 && clock_set.clock_rate(det) > 0.0
+}
+
+fn cost(clock_set: &ClockSet, objective: RootObjective) -> f64 {
+  match objective {
+    RootObjective::EstimatedRate => clock_set.chisq(),
+    RootObjective::FixedRate(rate) => clock_set.chisq_fixed_rate(rate),
+  }
 }

--- a/packages/treetime/src/clock/find_best_root/find_best_split.rs
+++ b/packages/treetime/src/clock/find_best_root/find_best_split.rs
@@ -1,6 +1,6 @@
 use crate::clock::clock_regression::ClockParams;
 use crate::clock::find_best_root::cost_function::BranchPointCostFunction;
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RootObjective};
 use crate::clock::find_best_root::{method_brent, method_golden_section, method_grid_search};
 use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
@@ -30,6 +30,7 @@ pub fn find_best_split<N, E, D>(
   edge: GraphEdgeKey,
   options: &ClockParams,
   params: &BranchPointOptimizationParams,
+  objective: RootObjective,
 ) -> Result<FindRootResult, Report>
 where
   N: GraphNode + ClockNode,
@@ -37,7 +38,7 @@ where
   D: Send + Sync,
 {
   // Create cost function once
-  let cost_fn = BranchPointCostFunction::new(graph, edge, options)?;
+  let cost_fn = BranchPointCostFunction::new(graph, edge, options, objective)?;
 
   match params {
     BranchPointOptimizationParams::Grid(params) => method_grid_search::optimize_grid_search(edge, &cost_fn, params),

--- a/packages/treetime/src/clock/find_best_root/params.rs
+++ b/packages/treetime/src/clock/find_best_root/params.rs
@@ -4,13 +4,29 @@ use smart_default::SmartDefault;
 #[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, SmartDefault, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
-pub enum RerootMode {
+pub enum RerootMethod {
   #[default]
   LeastSquares,
   MinDev,
   Oldest,
-  ClockFilter,
-  Mrca,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RerootSpec {
+  Method(RerootMethod),
+  Tips(Vec<String>),
+}
+
+impl Default for RerootSpec {
+  fn default() -> Self {
+    Self::Method(RerootMethod::default())
+  }
+}
+
+#[derive(Copy, Debug, Clone, PartialEq)]
+pub enum RootObjective {
+  EstimatedRate,
+  FixedRate(f64),
 }
 
 /// Configuration for branch point optimization methods

--- a/packages/treetime/src/clock/pipeline.rs
+++ b/packages/treetime/src/clock/pipeline.rs
@@ -3,7 +3,7 @@ use crate::clock::clock_filter::clock_filter_inplace;
 use crate::clock::clock_graph::GraphClock;
 use crate::clock::clock_model::ClockModel;
 use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RerootSpec};
 use crate::clock::reroot::RerootParams;
 use crate::clock::rtt::{ClockRegressionResult, gather_clock_regression_results};
 use crate::progress::ProgressSink;
@@ -18,6 +18,7 @@ pub struct ClockPipelineParams {
   pub keep_root: bool,
   pub allow_negative_rate: bool,
   pub branch_params: BranchPointOptimizationParams,
+  pub reroot_spec: RerootSpec,
 }
 
 pub struct ClockInput {
@@ -51,6 +52,7 @@ pub fn run(
     &params.branch_params,
     params.clock_filter,
     params.allow_negative_rate,
+    &params.reroot_spec,
   )?;
 
   if let Some(delta) = new_outliers {
@@ -74,6 +76,7 @@ fn estimate_clock_model_with_prefilter(
   branch_params: &BranchPointOptimizationParams,
   clock_filter_threshold: f64,
   allow_negative_rate: bool,
+  reroot_spec: &RerootSpec,
 ) -> Result<(ClockModel, Option<i32>), Report> {
   let delta = (clock_filter_threshold > 0.0)
     .then(|| -> Result<i32, Report> {
@@ -81,6 +84,7 @@ fn estimate_clock_model_with_prefilter(
       // have negative estimated rate at ALL root positions when outliers are included.
       // The pre-filter clock model only needs to be good enough for IQD-based outlier detection.
       let reroot_params = RerootParams {
+        spec: reroot_spec.clone(),
         force_positive_rate: false,
         ..RerootParams::default()
       };
@@ -108,6 +112,7 @@ fn estimate_clock_model_with_prefilter(
     .transpose()?;
 
   let reroot_params = RerootParams {
+    spec: reroot_spec.clone(),
     force_positive_rate: !allow_negative_rate,
     ..RerootParams::default()
   };

--- a/packages/treetime/src/clock/reroot.rs
+++ b/packages/treetime/src/clock/reroot.rs
@@ -1,16 +1,19 @@
 use crate::clock::clock_regression::ClockParams;
+use crate::clock::find_best_root::cost_function::BranchPointCostFunction;
 use crate::clock::find_best_root::find_best_root::find_best_root;
 use crate::clock::find_best_root::find_best_split::FindRootResult;
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RerootMethod, RerootSpec, RootObjective};
+use crate::make_error;
 use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
 use approx::ulps_eq;
 use eyre::Report;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
 use treetime_graph::edge::{GraphEdge, GraphEdgeKey};
 use treetime_graph::graph::Graph;
-use treetime_graph::node::{GraphNode, GraphNodeKey};
+use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_graph::reroot::{self as topology_reroot, remove_node_if_trivial, split_edge};
 
 use topology_reroot::{EdgeSplitInfo, RerootResult};
@@ -18,6 +21,9 @@ use topology_reroot::{EdgeSplitInfo, RerootResult};
 /// Controls reroot behavior for graph topology changes.
 #[derive(Clone, Debug, Serialize, Deserialize, SmartDefault)]
 pub struct RerootParams {
+  /// Root selection method.
+  pub spec: RerootSpec,
+
   /// Allow creating a new node by splitting an edge during reroot.
   /// When false, reroot will snap to the nearest existing node endpoint.
   #[default = true]
@@ -42,13 +48,13 @@ pub fn reroot_in_place<N, E, D>(
   reroot_params: &RerootParams,
 ) -> Result<RerootResult, Report>
 where
-  N: GraphNode + ClockNode + Default,
+  N: GraphNode + ClockNode + Named + Default,
   E: GraphEdge + ClockEdge + Default,
   D: Send + Sync,
 {
   let FindRootResult {
     edge, split, clock_set, ..
-  } = find_best_root(graph, options, params, reroot_params.force_positive_rate)?;
+  } = select_root(graph, options, params, reroot_params)?;
 
   let old_root_key = { graph.get_exactly_one_root()?.read_arc().key() };
   let Some(edge_key) = edge else {
@@ -131,6 +137,149 @@ where
   new_node.write_arc().payload().write_arc().set_clock_set(clock_set);
 
   Ok(split_info)
+}
+
+fn select_root<N, E, D>(
+  graph: &Graph<N, E, D>,
+  options: &ClockParams,
+  params: &BranchPointOptimizationParams,
+  reroot_params: &RerootParams,
+) -> Result<FindRootResult, Report>
+where
+  N: GraphNode + ClockNode + Named,
+  E: GraphEdge + ClockEdge,
+  D: Send + Sync,
+{
+  match &reroot_params.spec {
+    RerootSpec::Method(RerootMethod::LeastSquares) => find_best_root(
+      graph,
+      options,
+      params,
+      reroot_params.force_positive_rate,
+      RootObjective::EstimatedRate,
+    ),
+    RerootSpec::Method(RerootMethod::MinDev) => {
+      find_best_root(graph, options, params, false, RootObjective::FixedRate(0.0))
+    },
+    RerootSpec::Method(RerootMethod::Oldest) => find_oldest_root(graph, options),
+    RerootSpec::Tips(tips) => find_tip_group_root(graph, options, tips),
+  }
+}
+
+fn find_oldest_root<N, E, D>(graph: &Graph<N, E, D>, options: &ClockParams) -> Result<FindRootResult, Report>
+where
+  N: GraphNode + ClockNode,
+  E: GraphEdge + ClockEdge,
+  D: Send + Sync,
+{
+  let Some(oldest_key) = graph
+    .get_leaves()
+    .into_iter()
+    .filter_map(|node| {
+      let node = node.read_arc();
+      let time = node.payload().read_arc().likely_time()?;
+      Some((time, node.key()))
+    })
+    .min_by(|(lhs, _), (rhs, _)| lhs.total_cmp(rhs))
+    .map(|(_, key)| key)
+  else {
+    return make_error!("Cannot reroot to oldest tip because no dated leaves were found");
+  };
+
+  find_named_root_point(graph, options, oldest_key)
+}
+
+fn find_tip_group_root<N, E, D>(
+  graph: &Graph<N, E, D>,
+  options: &ClockParams,
+  tips: &[String],
+) -> Result<FindRootResult, Report>
+where
+  N: GraphNode + ClockNode + Named,
+  E: GraphEdge + ClockEdge,
+  D: Send + Sync,
+{
+  if tips.is_empty() {
+    return make_error!("--reroot-tips requires at least one tip name");
+  }
+
+  let tip_keys = tips
+    .iter()
+    .map(|tip| find_node_key_by_name(graph, tip).ok_or_else(|| eyre::eyre!("Reroot tip not found: {tip}")))
+    .try_collect::<_, Vec<_>, _>()?;
+  let mrca_key = common_ancestor(graph, &tip_keys)?;
+  find_named_root_point(graph, options, mrca_key)
+}
+
+fn find_named_root_point<N, E, D>(
+  graph: &Graph<N, E, D>,
+  options: &ClockParams,
+  node_key: GraphNodeKey,
+) -> Result<FindRootResult, Report>
+where
+  N: GraphNode + ClockNode,
+  E: GraphEdge + ClockEdge,
+  D: Send + Sync,
+{
+  let Some(edge) = graph.parent_inbound_edge(node_key)? else {
+    let root = graph.get_exactly_one_root()?;
+    let clock_set = root.read_arc().payload().read_arc().clock_set().clone();
+    return Ok(FindRootResult {
+      edge: None,
+      split: 0.0,
+      chisq: clock_set.chisq(),
+      clock_set,
+    });
+  };
+
+  let split = 0.5;
+  let cost_fn = BranchPointCostFunction::new(graph, edge, options, RootObjective::EstimatedRate)?;
+  let clock_set = cost_fn.evaluate_clock_set(split)?;
+  Ok(FindRootResult {
+    edge: Some(edge),
+    split,
+    chisq: clock_set.chisq(),
+    clock_set,
+  })
+}
+
+fn find_node_key_by_name<N, E, D>(graph: &Graph<N, E, D>, name: &str) -> Option<GraphNodeKey>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Send + Sync,
+{
+  graph.find_node(|node| node.name().is_some_and(|node_name| node_name.as_ref() == name))
+}
+
+fn common_ancestor<N, E, D>(graph: &Graph<N, E, D>, node_keys: &[GraphNodeKey]) -> Result<GraphNodeKey, Report>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Send + Sync,
+{
+  let paths = node_keys
+    .iter()
+    .map(|key| {
+      graph
+        .path_from_root_to_node(*key)
+        .map(|path| path.into_iter().map(|node| node.read_arc().key()).collect_vec())
+    })
+    .try_collect::<_, Vec<_>, _>()?;
+
+  let first_path = paths
+    .first()
+    .ok_or_else(|| eyre::eyre!("Cannot find MRCA of an empty node set"))?;
+  let mut ancestor = first_path[0];
+  for (index, candidate) in first_path.iter().copied().enumerate() {
+    if paths.iter().all(|path| path.get(index).copied() == Some(candidate)) {
+      ancestor = candidate;
+    } else {
+      break;
+    }
+  }
+
+  Ok(ancestor)
 }
 
 /// Modify graph topology to make the newly identified root the actual root,

--- a/packages/treetime/src/commands/clock/args.rs
+++ b/packages/treetime/src/commands/clock/args.rs
@@ -1,11 +1,11 @@
 use crate::ancestral::params::MethodAncestral;
 use crate::clock::clock_regression::ClockParams;
-use crate::clock::find_best_root::params::RerootMode;
 use crate::clock::find_best_root::params::{BrentParams, GoldenSectionParams, GridSearchParams, OptimizationMethod};
 use crate::commands::shared::alignment::AlignmentArgs;
 use crate::commands::shared::metadata::{DateColumnArgs, MetadataIdArgs};
 use crate::commands::shared::model::ModelArgs;
 use crate::commands::shared::output::OutputArgs;
+use crate::commands::shared::reroot::RerootArgs;
 use crate::optimize::params::BranchLengthMode;
 #[cfg(feature = "clap")]
 use clap::ValueHint;
@@ -64,19 +64,12 @@ pub struct TreetimeClockArgs {
   #[default = 3.0]
   pub clock_filter: f64,
 
-  /// Reroot the tree using root-to-tip regression. Valid choices are 'min_dev', 'least-squares',
-  /// and 'oldest'. 'least-squares' adjusts the root to minimize residuals of the root-to-tip vs
-  /// sampling time regression, 'min_dev' minimizes variance of root-to-tip distances. 'least-
-  /// squares' can be combined with --covariation to account for shared ancestry. Alternatively, you
-  /// can specify a node name or a list of node names to be used as outgroup or use 'oldest' to
-  /// reroot to the oldest node. By default, TreeTime will reroot using 'least-squares'. Use --keep-
-  /// root to keep the current root.
-  #[cfg_attr(feature = "clap", clap(long, value_enum, default_value_t = RerootMode::default()))]
-  pub reroot: RerootMode,
+  #[cfg_attr(feature = "clap", clap(flatten))]
+  pub reroot: RerootArgs,
 
   /// don't reroot the tree. Otherwise, reroot to minimize the residual of the regression of
   /// root-to-tip distance and sampling time
-  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(long, conflicts_with_all = ["reroot", "reroot_tips"]))]
   pub keep_root: bool,
 
   #[cfg_attr(feature = "clap", clap(long))]

--- a/packages/treetime/src/commands/clock/run.rs
+++ b/packages/treetime/src/commands/clock/run.rs
@@ -72,6 +72,7 @@ pub fn run_clock(
     keep_root: clock_args.keep_root,
     allow_negative_rate: clock_args.allow_negative_rate,
     branch_params: branch_split_to_params(&clock_args.branch_split),
+    reroot_spec: clock_args.reroot.spec(),
   };
 
   let input = ClockInput { graph, dates };

--- a/packages/treetime/src/commands/shared/mod.rs
+++ b/packages/treetime/src/commands/shared/mod.rs
@@ -4,3 +4,4 @@ pub mod gap_fill;
 pub mod metadata;
 pub mod model;
 pub mod output;
+pub mod reroot;

--- a/packages/treetime/src/commands/shared/reroot.rs
+++ b/packages/treetime/src/commands/shared/reroot.rs
@@ -1,0 +1,72 @@
+use crate::clock::find_best_root::params::{RerootMethod, RerootSpec};
+use serde::{Deserialize, Serialize};
+use smart_default::SmartDefault;
+
+#[derive(Debug, Clone, SmartDefault, Serialize, Deserialize)]
+#[serde(default)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+pub struct RerootArgs {
+  /// Reroot the tree by temporal-signal optimization.
+  ///
+  /// Defaults to least-squares when rerooting is enabled. Use --keep-root to keep the input root.
+  #[cfg_attr(feature = "clap", clap(long = "reroot", value_enum, conflicts_with = "reroot_tips"))]
+  pub reroot: Option<RerootMethod>,
+
+  /// Reroot on the branch leading to a tip or the MRCA of a comma-separated tip list.
+  #[cfg_attr(
+    feature = "clap",
+    clap(long = "reroot-tips", value_delimiter = ',', conflicts_with = "reroot")
+  )]
+  pub reroot_tips: Vec<String>,
+}
+
+impl RerootArgs {
+  pub fn spec(&self) -> RerootSpec {
+    if self.reroot_tips.is_empty() {
+      RerootSpec::Method(self.reroot.unwrap_or_default())
+    } else {
+      RerootSpec::Tips(self.reroot_tips.clone())
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::clock::find_best_root::params::{RerootMethod, RerootSpec};
+  use crate::commands::shared::reroot::RerootArgs;
+  use crate::o;
+  use pretty_assertions::assert_eq;
+
+  #[test]
+  fn test_reroot_args_default_spec_is_least_squares() {
+    let args = RerootArgs::default();
+
+    let actual = args.spec();
+
+    assert_eq!(RerootSpec::Method(RerootMethod::LeastSquares), actual);
+  }
+
+  #[test]
+  fn test_reroot_args_method_spec() {
+    let args = RerootArgs {
+      reroot: Some(RerootMethod::MinDev),
+      ..RerootArgs::default()
+    };
+
+    let actual = args.spec();
+
+    assert_eq!(RerootSpec::Method(RerootMethod::MinDev), actual);
+  }
+
+  #[test]
+  fn test_reroot_args_tips_spec() {
+    let args = RerootArgs {
+      reroot_tips: vec![o!("A"), o!("B")],
+      ..RerootArgs::default()
+    };
+
+    let actual = args.spec();
+
+    assert_eq!(RerootSpec::Tips(vec![o!("A"), o!("B")]), actual);
+  }
+}

--- a/packages/treetime/src/commands/timetree/args.rs
+++ b/packages/treetime/src/commands/timetree/args.rs
@@ -1,11 +1,11 @@
 use crate::ancestral::params::MethodAncestral;
-use crate::clock::find_best_root::params::RerootMode;
 use crate::commands::shared::alignment::AlignmentArgs;
 use crate::commands::shared::alphabet::AlphabetArgs;
 use crate::commands::shared::gap_fill::GapFillArgs;
 use crate::commands::shared::metadata::{DateColumnArgs, MetadataIdArgs};
 use crate::commands::shared::model::ModelArgs;
 use crate::commands::shared::output::OutputArgs;
+use crate::commands::shared::reroot::RerootArgs;
 use crate::optimize::params::BranchLengthMode;
 #[cfg(feature = "clap")]
 use clap::ValueHint;
@@ -183,19 +183,12 @@ pub struct TreetimeTimetreeArgs {
   #[cfg_attr(feature = "clap", clap(long))]
   pub n_iqd: Option<f64>,
 
-  /// Reroot the tree using root-to-tip regression. Valid choices are 'min_dev', 'least-squares',
-  /// and 'oldest'. 'least-squares' adjusts the root to minimize residuals of the root-to-tip vs
-  /// sampling time regression, 'min_dev' minimizes variance of root-to-tip distances. 'least-
-  /// squares' can be combined with --covariation to account for shared ancestry. Alternatively, you
-  /// can specify a node name or a list of node names to be used as outgroup or use 'oldest' to
-  /// reroot to the oldest node. By default, TreeTime will reroot using 'least-squares'. Use --keep-
-  /// root to keep the current root.
-  #[cfg_attr(feature = "clap", clap(long, value_enum, default_value_t = RerootMode::default()))]
-  pub reroot: RerootMode,
+  #[cfg_attr(feature = "clap", clap(flatten))]
+  pub reroot: RerootArgs,
 
   /// don't reroot the tree. Otherwise, reroot to minimize the residual of the regression of
   /// root-to-tip distance and sampling time
-  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(long, conflicts_with_all = ["reroot", "reroot_tips"]))]
   pub keep_root: bool,
 
   /// By default, rates are forced to be positive. For trees with little temporal signal it is advisable to remove this restriction to achieve essentially mid-point rooting.

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -42,6 +42,7 @@ pub fn run_timetree_estimation(
     clock_rate: args.clock_rate,
     clock_std_dev: args.clock_std_dev,
     keep_root: args.keep_root,
+    reroot_spec: args.reroot.spec(),
     allow_negative_rate: args.allow_negative_rate,
     clock_filter: args.clock_filter,
     covariation: args.covariation,

--- a/packages/treetime/src/payload/clock_set.rs
+++ b/packages/treetime/src/payload/clock_set.rs
@@ -124,6 +124,13 @@ impl ClockSet {
       / self.norm()
   }
 
+  pub fn chisq_fixed_rate(&self, rate: f64) -> f64 {
+    0.5
+      * (self.dsq_sum() - 2.0 * rate * self.dt_sum() + rate.powi(2) * self.tsq_sum()
+        - (self.d_sum() - rate * self.t_sum()).powi(2) / self.norm())
+      / self.norm()
+  }
+
   pub fn r_val(&self) -> f64 {
     (self.dt_sum * self.norm() - self.t_sum * self.d_sum)
       / ((self.dsq_sum * self.norm() - self.d_sum.powi(2)) * (self.tsq_sum * self.norm() - self.t_sum.powi(2))).sqrt()

--- a/packages/treetime/src/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/timetree/optimization/__tests__/test_reroot.rs
@@ -5,7 +5,7 @@ mod tests {
   use crate::ancestral::fitch::create_fitch_partition;
   use crate::ancestral::marginal::update_marginal;
   use crate::clock::clock_regression::{ClockParams, clock_regression_backward, clock_regression_forward};
-  use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+  use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RerootSpec};
   use crate::gtr::get_gtr::{JC69Params, jc69};
   use crate::o;
   use crate::partition::marginal_sparse::PartitionMarginalSparse;
@@ -108,6 +108,7 @@ mod tests {
       &clock_params,
       None,
       &BranchPointOptimizationParams::default(),
+      &RerootSpec::default(),
       true,
     )?;
 
@@ -505,6 +506,7 @@ mod tests {
       &clock_params,
       None,
       &BranchPointOptimizationParams::default(),
+      &RerootSpec::default(),
       true,
     )?;
 
@@ -525,6 +527,7 @@ mod tests {
       &clock_params,
       Some(clock_model_1.clock_rate()),
       &BranchPointOptimizationParams::default(),
+      &RerootSpec::default(),
       true,
     )?;
 

--- a/packages/treetime/src/timetree/optimization/reroot.rs
+++ b/packages/treetime/src/timetree/optimization/reroot.rs
@@ -1,7 +1,7 @@
 use crate::ancestral::marginal::update_marginal;
 use crate::clock::clock_model::ClockModel;
 use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RerootSpec};
 use crate::clock::reroot::RerootParams;
 use crate::partition::timetree::GraphTimetree;
 use crate::partition::traits::PartitionTimetreeAll;
@@ -23,9 +23,11 @@ pub fn reroot_tree(
   clock_params: &ClockParams,
   clock_rate: Option<f64>,
   branch_params: &BranchPointOptimizationParams,
+  reroot_spec: &RerootSpec,
   force_positive_rate: bool,
 ) -> Result<ClockModel, Report> {
   let reroot_params = RerootParams {
+    spec: reroot_spec.clone(),
     force_positive_rate,
     ..RerootParams::default()
   };

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -4,7 +4,7 @@ use crate::clock::clock_filter::clock_filter_inplace;
 use crate::clock::clock_model::ClockModel;
 use crate::clock::clock_regression::{ClockParams, estimate_clock_model_with_reroot_policy};
 use crate::clock::date_constraints::load_date_constraints;
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RerootSpec};
 use crate::clock::reroot::RerootParams;
 use crate::coalescent::optimize_tc::optimize_tc;
 use crate::coalescent::skyline::{SkylineParams, optimize_skyline};
@@ -53,6 +53,7 @@ pub struct TimetreeParams {
   pub clock_rate: Option<f64>,
   pub clock_std_dev: Option<f64>,
   pub keep_root: bool,
+  pub reroot_spec: RerootSpec,
   pub allow_negative_rate: bool,
   pub clock_filter: f64,
   pub covariation: bool,
@@ -135,6 +136,7 @@ pub fn run(
   progress.check_cancelled()?;
   progress.report("Clock regression", 0.1, "");
   let reroot_params = RerootParams {
+    spec: params.reroot_spec.clone(),
     force_positive_rate: !params.allow_negative_rate,
     ..RerootParams::default()
   };
@@ -181,6 +183,7 @@ pub fn run(
       &ClockParams::default(),
       params.clock_rate,
       &branch_params,
+      &params.reroot_spec,
       !params.allow_negative_rate,
     )
     .wrap_err("Failed to reroot tree (pre-ancestral)")?;
@@ -268,6 +271,7 @@ pub fn run(
       reroot_clock_params,
       params.clock_rate,
       &branch_params,
+      &params.reroot_spec,
       !params.allow_negative_rate,
     )
     .wrap_err("Failed to reroot tree (post-ancestral)")?;


### PR DESCRIPTION
TreeTime and Augur support rerooting on a named tip or on the most recent common ancestor of a tip group, but the v1 CLI only exposed `--reroot` as a method enum and the selected value was not passed through the clock and timetree pipelines. That made tip lists impossible to parse and left timetree reroot choices stuck on the default least-squares path.

Add a shared reroot argument group that keeps temporal optimization methods under `--reroot` and moves explicit tip/MRCA selection to `--reroot-tips`. The resulting `RerootSpec` is passed through clock, timetree, and app-server argument mappings so CLI and in-memory callers use the same root selection path.

The algorithm keeps least-squares on the existing fitted-rate objective, implements min-dev as a fixed zero-rate objective matching the root-to-tip variance criterion, and roots `oldest` and tip-group selections on the midpoint of the branch leading to the selected leaf or MRCA, matching the reference outgroup-rooting behavior.

### Work items

- [x] Split method rerooting from tip/MRCA rerooting in shared command args
- [x] Pass `RerootSpec` through clock and timetree pipeline params
- [x] Implement oldest, min-dev, and tip/MRCA root selection in clock rerooting
- [x] Cover reroot argument specs and direct tip/MRCA behavior with tests
- [x] Update reroot feature inventory and the timetree dead-flag ticket

### Possible improvements

- [ ] Finish wiring remaining timetree dead CLI flags ([kb/tickets/timetree-dead-cli-flags-12-parsed-never-read.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/tickets/timetree-dead-cli-flags-12-parsed-never-read.md))