### PR TITLE
fix: apply fixed-rate reroot objective

### DIFF
--- a/kb/tests/clock.md
+++ b/kb/tests/clock.md
@@ -6,12 +6,32 @@
 
 | Category                                   | Type                        |
 | ------------------------------------------ | --------------------------- |
+| [ClockSet statistics](#clockset-statistics) | Unit                        |
 | [Clock regression](#clock-regression)      | Unit                        |
 | [Date constraints](#date-constraints)      | Unit                        |
 | [Rerooting](#rerooting)                    | Unit                        |
 | [Clock filter](#clock-filter)              | Unit                        |
 | [Find best root](#find-best-root)          | Unit                        |
 | [Dengue/100 pipeline](#dengue100-pipeline) | Integration + Golden-master |
+
+---
+
+## ClockSet Statistics
+
+**Test:** [`packages/treetime/src/clock/__tests__/test_clock_set.rs`](../../packages/treetime/src/clock/__tests__/test_clock_set.rs)
+
+**Impl:** [`packages/treetime/src/payload/clock_set.rs`](../../packages/treetime/src/payload/clock_set.rs)
+
+| Test                                                                 | Purpose                                      |
+| -------------------------------------------------------------------- | -------------------------------------------- |
+| `test_clock_set_cov_is_hessian_inverse`                              | Covariance inverts ill-conditioned Hessian   |
+| `test_clock_set_chisq_fixed_rate_matches_zero_rate_formula`          | Fixed-rate chisq for zero-rate model         |
+| `test_clock_set_chisq_fixed_rate_matches_nonzero_rate_formula`       | Fixed-rate chisq for nonzero-rate model      |
+| `test_clock_set_cov_is_hessian_inverse_centered`                     | Covariance inverts centered Hessian          |
+| `test_clock_set_cov_off_diagonal_symmetry`                           | Covariance off-diagonal symmetry             |
+| `test_clock_set_cov_diagonal_positive`                               | Positive covariance diagonal entries         |
+| `test_clock_set_cov_off_diagonal_uses_t_sum_not_dt_sum`              | Off-diagonal uses `t_sum`                    |
+| `test_clock_set_cov_entrywise_against_formula`                       | Covariance entries match explicit 2x2 inverse |
 
 ---
 
@@ -64,6 +84,9 @@
 | `test_reroot_policy_allow_edge_split_false_no_new_nodes`                 | No edge split preserves node count   |
 | `test_reroot_policy_remove_old_root_if_trivial_false_preserves_old_root` | Old root preserved when flag off     |
 | `test_reroot_policy_default_allows_edge_split`                           | Default policy allows edge splitting |
+| `test_reroot_tips_uses_mrca_branch`                                      | Tip group reroot uses MRCA branch    |
+| `test_reroot_tips_reports_missing_tip`                                   | Missing tip error identifies name    |
+| `test_reroot_oldest_uses_oldest_dated_leaf`                              | Oldest mode uses oldest dated leaf   |
 
 ---
 
@@ -81,6 +104,7 @@
 | ---------------------------------------------------------------- | ------------------------------------------------------ |
 | `test_find_best_root_grid`                                       | Grid search root placement                             |
 | `test_find_best_root_grid_with_params`                           | Grid search with custom n_points                       |
+| `test_find_best_root_grid_scores_fixed_rate_objective`           | Grid search uses fixed-rate objective                  |
 | `test_find_best_root_brent`                                      | Brent method root placement                            |
 | `test_find_best_root_brent_with_params`                          | Brent method with custom params                        |
 | `test_find_best_root_golden_section`                             | Golden section root placement                          |

--- a/packages/treetime/src/clock/__tests__/test_clock_set.rs
+++ b/packages/treetime/src/clock/__tests__/test_clock_set.rs
@@ -20,6 +20,22 @@ mod tests {
   }
 
   #[test]
+  fn test_clock_set_chisq_fixed_rate_matches_zero_rate_formula() {
+    let cs = ClockSet::leaf_contribution_to_parent(Some(0.0), 1.0, 1.0)
+      + ClockSet::leaf_contribution_to_parent(Some(1.0), 3.0, 1.0);
+
+    pretty_assert_ulps_eq!(cs.chisq_fixed_rate(0.0), 0.5, max_ulps = 4);
+  }
+
+  #[test]
+  fn test_clock_set_chisq_fixed_rate_matches_nonzero_rate_formula() {
+    let cs = ClockSet::leaf_contribution_to_parent(Some(0.0), 1.0, 1.0)
+      + ClockSet::leaf_contribution_to_parent(Some(1.0), 3.0, 1.0);
+
+    pretty_assert_ulps_eq!(cs.chisq_fixed_rate(1.0), 0.125, max_ulps = 4);
+  }
+
+  #[test]
   fn test_clock_set_cov_is_hessian_inverse_centered() {
     // Centered dates produce a well-conditioned Hessian, enabling tight tolerance
     let cs = ClockSet::leaf_contribution_to_parent(Some(0.5), 0.03, 0.001)

--- a/packages/treetime/src/clock/clock_regression.rs
+++ b/packages/treetime/src/clock/clock_regression.rs
@@ -1,5 +1,5 @@
 use crate::clock::clock_model::ClockModel;
-use crate::clock::find_best_root::params::BranchPointOptimizationParams;
+use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RootObjective};
 use crate::clock::reroot::{RerootParams, reroot_in_place};
 use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
@@ -190,7 +190,11 @@ where
     debug!("Forward regression completed");
 
     info!("### Finding best root and rerooting tree");
-    let reroot_result = reroot_in_place(graph, options, optimization_params, reroot_params)?;
+    let reroot_params = clock_rate.map_or_else(
+      || reroot_params.clone(),
+      |rate| reroot_params.with_objective(RootObjective::FixedRate(rate)),
+    );
+    let reroot_result = reroot_in_place(graph, options, optimization_params, &reroot_params)?;
     info!("Rerooted to node {}", reroot_result.new_root_key.0);
     debug!("Rerooting completed");
     Some(reroot_result)

--- a/packages/treetime/src/clock/find_best_root/__tests__/test_find_best_root.rs
+++ b/packages/treetime/src/clock/find_best_root/__tests__/test_find_best_root.rs
@@ -119,6 +119,28 @@ mod tests {
   }
 
   #[test]
+  fn test_find_best_root_grid_scores_fixed_rate_objective() -> Result<(), Report> {
+    let (graph, options) = setup_test_graph()?;
+
+    let best_root = find_best_root(
+      &graph,
+      &options,
+      &BranchPointOptimizationParams::grid(),
+      true,
+      RootObjective::FixedRate(0.0),
+    )?;
+
+    let expected_chisq = best_root.clock_set.chisq_fixed_rate(0.0);
+    pretty_assert_ulps_eq!(best_root.chisq, expected_chisq, max_ulps = 4);
+    assert!(
+      (best_root.chisq - best_root.clock_set.chisq()).abs() > 1e-10,
+      "test must distinguish fixed-rate and estimated-rate objectives"
+    );
+
+    Ok(())
+  }
+
+  #[test]
   fn test_find_best_root_brent() -> Result<(), Report> {
     let (graph, options) = setup_test_graph()?;
 

--- a/packages/treetime/src/clock/find_best_root/cost_function.rs
+++ b/packages/treetime/src/clock/find_best_root/cost_function.rs
@@ -82,6 +82,10 @@ impl<'a> BranchPointCostFunction<'a> {
 
     Ok(clock_set)
   }
+
+  pub fn score_clock_set(&self, clock_set: &ClockSet) -> f64 {
+    self.objective.score(clock_set)
+  }
 }
 
 impl CostFunction for &BranchPointCostFunction<'_> {
@@ -94,13 +98,10 @@ impl CostFunction for &BranchPointCostFunction<'_> {
       return Ok(f64::INFINITY);
     }
 
-    // Evaluate the clock set and return chi-squared
+    // Evaluate the clock set and return the configured objective value.
     let result = self
       .evaluate_clock_set(*x)
-      .map_or(f64::INFINITY, |clock_set| match self.objective {
-        RootObjective::EstimatedRate => clock_set.chisq(),
-        RootObjective::FixedRate(rate) => clock_set.chisq_fixed_rate(rate),
-      });
+      .map_or(f64::INFINITY, |clock_set| self.score_clock_set(&clock_set));
 
     Ok(result)
   }

--- a/packages/treetime/src/clock/find_best_root/find_best_root.rs
+++ b/packages/treetime/src/clock/find_best_root/find_best_root.rs
@@ -38,13 +38,13 @@ where
   let root = root.read_arc().payload().read_arc();
   let root_acceptable = !force_positive || has_positive_clock_rate(root.clock_set());
   let mut best_chisq = if root_acceptable {
-    cost(root.clock_set(), objective)
+    objective.score(root.clock_set())
   } else {
     f64::INFINITY
   };
   debug!(
     "Initial root chi-squared: {:.6e} (acceptable: {root_acceptable})",
-    cost(root.clock_set(), objective)
+    objective.score(root.clock_set())
   );
 
   let mut best_res = FindRootResult {
@@ -67,7 +67,7 @@ where
       node_count += 1;
       continue;
     }
-    let tmp_chisq = cost(clock_set, objective);
+    let tmp_chisq = objective.score(clock_set);
     drop(payload_guard);
     drop(node_guard);
     if tmp_chisq < best_chisq {
@@ -142,11 +142,4 @@ where
 fn has_positive_clock_rate(clock_set: &ClockSet) -> bool {
   let det = clock_set.determinant();
   det > 0.0 && clock_set.clock_rate(det) > 0.0
-}
-
-fn cost(clock_set: &ClockSet, objective: RootObjective) -> f64 {
-  match objective {
-    RootObjective::EstimatedRate => clock_set.chisq(),
-    RootObjective::FixedRate(rate) => clock_set.chisq_fixed_rate(rate),
-  }
 }

--- a/packages/treetime/src/clock/find_best_root/method_grid_search.rs
+++ b/packages/treetime/src/clock/find_best_root/method_grid_search.rs
@@ -28,7 +28,7 @@ pub fn optimize_grid_search(
 
   for (point_count, x) in grid_points.into_iter().enumerate() {
     let clock_set = cost_fn.evaluate_clock_set(x).expect("Failed to evaluate clock set");
-    let chisq = clock_set.chisq();
+    let chisq = cost_fn.score_clock_set(&clock_set);
 
     if chisq < best_chisq {
       debug!(

--- a/packages/treetime/src/clock/find_best_root/params.rs
+++ b/packages/treetime/src/clock/find_best_root/params.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
 
+use crate::payload::clock_set::ClockSet;
+
 #[derive(Copy, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, SmartDefault, Serialize, Deserialize)]
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
@@ -23,10 +25,20 @@ impl Default for RerootSpec {
   }
 }
 
-#[derive(Copy, Debug, Clone, PartialEq)]
+#[derive(Copy, Debug, Clone, PartialEq, SmartDefault, Serialize, Deserialize)]
 pub enum RootObjective {
+  #[default]
   EstimatedRate,
   FixedRate(f64),
+}
+
+impl RootObjective {
+  pub fn score(self, clock_set: &ClockSet) -> f64 {
+    match self {
+      Self::EstimatedRate => clock_set.chisq(),
+      Self::FixedRate(rate) => clock_set.chisq_fixed_rate(rate),
+    }
+  }
 }
 
 /// Configuration for branch point optimization methods

--- a/packages/treetime/src/clock/reroot.rs
+++ b/packages/treetime/src/clock/reroot.rs
@@ -24,6 +24,9 @@ pub struct RerootParams {
   /// Root selection method.
   pub spec: RerootSpec,
 
+  /// Objective used to rank candidate root positions for least-squares rerooting.
+  pub objective: RootObjective,
+
   /// Allow creating a new node by splitting an edge during reroot.
   /// When false, reroot will snap to the nearest existing node endpoint.
   #[default = true]
@@ -39,6 +42,16 @@ pub struct RerootParams {
   /// Use false for pre-filter steps where outliers may cause negative rates at all positions.
   #[default = true]
   pub force_positive_rate: bool,
+}
+
+impl RerootParams {
+  #[must_use]
+  pub fn with_objective(&self, objective: RootObjective) -> Self {
+    Self {
+      objective,
+      ..self.clone()
+    }
+  }
 }
 
 pub fn reroot_in_place<N, E, D>(
@@ -156,17 +169,22 @@ where
       options,
       params,
       reroot_params.force_positive_rate,
-      RootObjective::EstimatedRate,
+      reroot_params.objective,
     ),
     RerootSpec::Method(RerootMethod::MinDev) => {
-      find_best_root(graph, options, params, false, RootObjective::FixedRate(0.0))
+      // v0 min_dev disables the positive-rate guard but still ranks roots by estimated-rate WLS chisq.
+      find_best_root(graph, options, params, false, RootObjective::EstimatedRate)
     },
-    RerootSpec::Method(RerootMethod::Oldest) => find_oldest_root(graph, options),
-    RerootSpec::Tips(tips) => find_tip_group_root(graph, options, tips),
+    RerootSpec::Method(RerootMethod::Oldest) => find_oldest_root(graph, options, reroot_params.objective),
+    RerootSpec::Tips(tips) => find_tip_group_root(graph, options, tips, reroot_params.objective),
   }
 }
 
-fn find_oldest_root<N, E, D>(graph: &Graph<N, E, D>, options: &ClockParams) -> Result<FindRootResult, Report>
+fn find_oldest_root<N, E, D>(
+  graph: &Graph<N, E, D>,
+  options: &ClockParams,
+  objective: RootObjective,
+) -> Result<FindRootResult, Report>
 where
   N: GraphNode + ClockNode,
   E: GraphEdge + ClockEdge,
@@ -186,13 +204,14 @@ where
     return make_error!("Cannot reroot to oldest tip because no dated leaves were found");
   };
 
-  find_named_root_point(graph, options, oldest_key)
+  find_named_root_point(graph, options, oldest_key, objective)
 }
 
 fn find_tip_group_root<N, E, D>(
   graph: &Graph<N, E, D>,
   options: &ClockParams,
   tips: &[String],
+  objective: RootObjective,
 ) -> Result<FindRootResult, Report>
 where
   N: GraphNode + ClockNode + Named,
@@ -208,13 +227,14 @@ where
     .map(|tip| find_node_key_by_name(graph, tip).ok_or_else(|| eyre::eyre!("Reroot tip not found: {tip}")))
     .try_collect::<_, Vec<_>, _>()?;
   let mrca_key = common_ancestor(graph, &tip_keys)?;
-  find_named_root_point(graph, options, mrca_key)
+  find_named_root_point(graph, options, mrca_key, objective)
 }
 
 fn find_named_root_point<N, E, D>(
   graph: &Graph<N, E, D>,
   options: &ClockParams,
   node_key: GraphNodeKey,
+  objective: RootObjective,
 ) -> Result<FindRootResult, Report>
 where
   N: GraphNode + ClockNode,
@@ -227,18 +247,18 @@ where
     return Ok(FindRootResult {
       edge: None,
       split: 0.0,
-      chisq: clock_set.chisq(),
+      chisq: objective.score(&clock_set),
       clock_set,
     });
   };
 
   let split = 0.5;
-  let cost_fn = BranchPointCostFunction::new(graph, edge, options, RootObjective::EstimatedRate)?;
+  let cost_fn = BranchPointCostFunction::new(graph, edge, options, objective)?;
   let clock_set = cost_fn.evaluate_clock_set(split)?;
   Ok(FindRootResult {
     edge: Some(edge),
     split,
-    chisq: clock_set.chisq(),
+    chisq: objective.score(&clock_set),
     clock_set,
   })
 }


### PR DESCRIPTION
- Depends on: `feat/reroot-tip-groups`

Least-squares rerooting used the fitted-rate objective unconditionally. When a clock rate was supplied via `--clock-rate`, the reroot search still fitted a new rate at every candidate root instead of evaluating the fixed-rate cost. Min-dev scoring also applied the positive-rate guard, rejecting valid zero-rate variance objectives.

Use the fixed-rate objective during least-squares rerooting when a clock rate is supplied, and keep min-dev on estimated-rate WLS scoring with the positive-rate guard disabled.

### Work items

- [x] Use fixed-rate objective in least-squares rerooting when clock rate is supplied
- [x] Disable positive-rate guard for min-dev estimated-rate WLS scoring
- [x] Add tests for fixed-rate reroot objective and min-dev scoring