### PR TITLE
feat: add topology output ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,11 +4346,13 @@ dependencies = [
 name = "treetime-graph"
 version = "1.0.0"
 dependencies = [
+ "ctor 0.5.0",
  "derive_more",
  "eyre",
  "getset",
  "itertools 0.14.0",
  "parking_lot",
+ "pretty_assertions",
  "rayon",
  "serde",
  "traversal",

--- a/kb/algo/graph.md
+++ b/kb/algo/graph.md
@@ -34,6 +34,14 @@ v1: [`packages/treetime-graph/src/graph_ops.rs#L146-L206`](../../packages/treeti
 
 ---
 
+## Topology Ordering
+
+Output-boundary topology ordering computes a deterministic child order before writing graph-backed tree files. The default order matches TreeTime v0 ladderization by sorting siblings by reachable leaf count in ascending order. Additional presets preserve input order, reverse ladderization, sort by subtree height, sort by leaf labels, or sort against an explicit target leaf order. Target-order scores use mean or median target position across each subtree's descendant leaves. DAG inputs count each reachable leaf once per child and cyclic inputs fail before output.
+
+v1: [`packages/treetime-graph/src/topology_order.rs`](../../packages/treetime-graph/src/topology_order.rs).
+
+---
+
 ## References
 
 - <a id="ref-1"></a>Leiserson, Charles E., and Tao B. Schardl. 2010. "A Work-Efficient Parallel Breadth-First Search Algorithm (or How to Cope with the Nondeterminism of Reducers)." In _Proceedings of the 22nd ACM Symposium on Parallelism in Algorithms and Architectures (SPAA),_ 303-314. https://doi.org/10.1145/1810479.1810534 [↩](#cite-1)
@@ -50,3 +58,4 @@ v1: [`packages/treetime-graph/src/graph_ops.rs#L146-L206`](../../packages/treeti
 | [`packages/treetime-graph/src/graph_traverse.rs`](../../packages/treetime-graph/src/graph_traverse.rs) | DFS preorder/postorder, sequential BFS |
 | [`packages/treetime-graph/src/find_paths.rs`](../../packages/treetime-graph/src/find_paths.rs)         | Path finding                           |
 | [`packages/treetime-graph/src/graph_ops.rs`](../../packages/treetime-graph/src/graph_ops.rs)           | Edge collapse                          |
+| [`packages/treetime-graph/src/topology_order.rs`](../../packages/treetime-graph/src/topology_order.rs) | Topology ordering                      |

--- a/kb/decisions/multi-format-tree-io.md
+++ b/kb/decisions/multi-format-tree-io.md
@@ -181,11 +181,11 @@ The `auspice_to_graph()` and `auspice_from_graph()` functions ([packages/treetim
 
 ### PhyloGraph JSON
 
-An internal graph serialization format that round-trips the full graph structure (nodes, edges, graph-level data) through serde JSON. No custom format logic - the graph type derives `Serialize`/`Deserialize` and uses the generic `json_read_file()`/`json_write_file()` helpers from `treetime-utils`. Useful for debugging and for lossless intermediate storage during multi-step format conversions. All tree-outputting commands produce this format as `{stem}.graph.json` via the shared `write_graph_files()` helper in `treetime-io`.
+An internal graph serialization format that round-trips the full graph structure (nodes, edges, graph-level data) through serde JSON. No custom format logic - the graph type derives `Serialize`/`Deserialize` and uses the generic `json_read_file()`/`json_write_file()` helpers from `treetime-utils`. Useful for debugging and for lossless intermediate storage during multi-step format conversions. All tree-outputting commands produce this format as `{stem}.graph.json` via the shared graph writer in `treetime-io`.
 
 ### Graphviz DOT
 
-The `graphviz_write_file()` function ([packages/treetime-io/src/graphviz.rs](../../packages/treetime-io/src/graphviz.rs)) generates directed graph output with subgraphs for roots, internal nodes, and leaves. All tree-outputting commands produce this format as `{stem}.dot` via the shared `write_graph_files()` helper in `treetime-io`. Output only, not available in the convert command.
+The `graphviz_write_file()` function ([packages/treetime-io/src/graphviz.rs](../../packages/treetime-io/src/graphviz.rs)) generates directed graph output with subgraphs for roots, internal nodes, and leaves. All tree-outputting commands produce this format as `{stem}.dot` via the shared graph writer in `treetime-io`. Output only, not available in the convert command.
 
 ## I/O architecture
 
@@ -197,7 +197,7 @@ The `convert` subcommand exposes all eight format adapters as a standalone tool.
 
 ### Current limitations
 
-- Analysis commands (ancestral, clock, timetree, optimize, prune) still read Newick only - the new format adapters for reading are not yet integrated into the analysis pipeline. Writing uses the shared `write_graph_files()` helper producing Newick, Nexus, PhyloGraph JSON, and Graphviz DOT.
+- Analysis commands (ancestral, clock, timetree, optimize, prune) still read Newick only - the new format adapters for reading are not yet integrated into the analysis pipeline. Writing uses the shared graph writer producing Newick, Nexus, PhyloGraph JSON, and Graphviz DOT.
 - Nexus reading is not implemented (`convert_read_file` panics with `unimplemented!()` for `TreeFormat::Nexus`)
 - Graphviz DOT is not available as a convert command format
 

--- a/kb/features/io.md
+++ b/kb/features/io.md
@@ -24,6 +24,7 @@
 - [x] CSV (clock regression, confidence intervals)
 - [x] SVG/PNG charts (clock regression)
 - [x] Graphviz DOT
+- [x] Output topology ordering (default ladderization, input order preservation, target leaf order)
 - [ ] VCF output (v0 writes .vcf for VCF inputs)
 - [/] Auspice JSON (partial - [known issue](../issues/N-timetree-auspice-json-incomplete.md))
 - [ ] Skyline TSV/plot

--- a/kb/issues/N-io-time-based-branch-lengths-not-implemented.md
+++ b/kb/issues/N-io-time-based-branch-lengths-not-implemented.md
@@ -6,7 +6,7 @@ The timetree command infers node dates and branch lengths in time units, but the
 
 ## Details
 
-v0 `write_json` and `BranchLengthMode` support emitting branch lengths in calendar time units (`node.branch_length` vs `node.mutation_length`). v1 `write_graph_files` always writes divergence-based lengths from `edge.branch_length()`.
+v0 `write_json` and `BranchLengthMode` support emitting branch lengths in calendar time units (`node.branch_length` vs `node.mutation_length`). v1 shared graph output always writes divergence-based lengths from `edge.branch_length()`.
 
 After timetree inference, each node has both a divergence-based branch length and inferred dates. The time-based branch length is the date difference between parent and child. This is available in the graph but not exposed as an output option.
 

--- a/kb/issues/N-io-write-graph-files-missing-formats.md
+++ b/kb/issues/N-io-write-graph-files-missing-formats.md
@@ -1,6 +1,6 @@
-# write_graph_files missing PhyloXML, Auspice, and UShER MAT formats
+# shared graph writer missing PhyloXML, Auspice, and UShER MAT formats
 
-`treetime_io::graph::write_graph_files` produces four output formats (Newick, NEXUS, JSON, Graphviz) for every tree-outputting command. The converter tool supports three additional formats that are not included: PhyloXML, Auspice JSON, and UShER MAT (JSON and protobuf).
+The shared graph writer produces four output formats (Newick, NEXUS, JSON, Graphviz) for every tree-outputting command. The converter tool supports three additional formats that are not included: PhyloXML, Auspice JSON, and UShER MAT (JSON and protobuf).
 
 ## Constraints
 
@@ -12,7 +12,7 @@ Each missing format requires adapter traits that are not implemented on all grap
 
 ## Options
 
-- Implement `PhyloxmlFromGraph` for `NodeAncestral`/`EdgeAncestral`, `NodeTimetree`/`EdgeTimetree`, and `NodeClock`/`EdgeClock`, then add PhyloXML to `write_graph_files`
+- Implement `PhyloxmlFromGraph` for `NodeAncestral`/`EdgeAncestral`, `NodeTimetree`/`EdgeTimetree`, and `NodeClock`/`EdgeClock`, then add PhyloXML to the shared graph writer
 - Auspice and UShER MAT may not be feasible as generic outputs due to command-specific adapter logic
 
 ## Locations

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -96,7 +96,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Dates        | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                                     |
 | Negligible | Distribution | [Formula discretization errors silently swallowed](N-distribution-formula-silent-discretization.md)                                                 |
 | Negligible | I/O          | [Time-based branch lengths not written to Newick/Nexus output](N-io-time-based-branch-lengths-not-implemented.md)                                   |
-| Negligible | I/O          | [write_graph_files missing PhyloXML, Auspice, and UShER MAT formats](N-io-write-graph-files-missing-formats.md)                                     |
+| Negligible | I/O          | [shared graph writer missing PhyloXML, Auspice, and UShER MAT formats](N-io-write-graph-files-missing-formats.md)                                   |
 | Negligible | I/O          | [Large datasets require all sequences in memory simultaneously](N-io-large-dataset-memory-constraint.md)                                            |
 | Negligible | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                                          |
 | Negligible | I/O          | [Newick branch lengths lose precision through f32 round-trip](N-nwk-branch-length-f32-precision-loss.md)                                            |

--- a/kb/tests/supporting.md
+++ b/kb/tests/supporting.md
@@ -14,7 +14,7 @@
 | [treetime (alphabet)](#alphabet)            | Alphabet, AlphabetConfig                                               | Unit, Parameterized |
 | [treetime (io)](#io)                        | FASTA, Newick                                                          | Unit                |
 | [treetime (seq)](#sequence-operations)      | composition, div, char_ranges, mutation                                | Unit, Parameterized |
-| [treetime (graph)](#graph)                  | traversal, collapse, edge                                              | Unit                |
+| [treetime (graph)](#graph)                  | traversal, collapse, edge, topology_order                              | Unit                |
 | [treetime (repr)](representation.md)        | compose_substitutions, discrete_states, marginal_helpers, payloads     | Unit, Parameterized |
 | [treetime (prune)](#commands-prune)         | prune, collapse, merge                                                 | Unit                |
 
@@ -757,6 +757,7 @@ Unit and parameterized tests for all BitSet128 operations.
 - [`packages/treetime-graph/src/graph.rs`](../../packages/treetime-graph/src/graph.rs)
 - [`packages/treetime-graph/src/graph_traverse.rs`](../../packages/treetime-graph/src/graph_traverse.rs)
 - [`packages/treetime-graph/src/graph_ops.rs`](../../packages/treetime-graph/src/graph_ops.rs)
+- [`packages/treetime-graph/src/topology_order.rs`](../../packages/treetime-graph/src/topology_order.rs)
 
 **Fixtures:** [`packages/treetime/src/test_utils/graph_fixtures.rs`](../../packages/treetime/src/test_utils/graph_fixtures.rs) (`TestNode`, `TestEdge`)
 
@@ -779,6 +780,19 @@ Unit and parameterized tests for all BitSet128 operations.
 | `test_graph_collapse_edge_adjacency_lists_maintained`       | Adjacency lists correct after collapse |
 | `test_graph_collapse_edge_multiple_inbound_edges`           | Collapse with multiple inbound edges   |
 | `test_graph_collapse_edge_adjacency_consistency`            | Edge-node adjacency stays consistent   |
+
+**Test:** [`packages/treetime-graph/src/topology_order.rs`](../../packages/treetime-graph/src/topology_order.rs) (inline)
+
+**Impl:** [`packages/treetime-graph/src/topology_order.rs`](../../packages/treetime-graph/src/topology_order.rs)
+
+| Test                                                             | Purpose                                          |
+| ---------------------------------------------------------------- | ------------------------------------------------ |
+| `topology_order_descendant_count_sorts_children_ascending`       | Default ladderization sorts siblings by tip count |
+| `topology_order_descendant_count_reverse_sorts_children_descending` | Reverse ladderization sorts larger subtrees first |
+| `topology_order_keep_preserves_outbound_order`                   | Keep preset leaves existing child order intact   |
+| `topology_order_dag_counts_shared_descendant_once_per_child`     | DAG shared descendants are counted once per child |
+| `topology_order_target_order_uses_requested_tip_order`           | Target-order preset follows requested tip order  |
+| `topology_order_rejects_cycles`                                  | Cyclic directed graphs fail before output        |
 
 **Test:** [`packages/treetime/src/graph/__tests__/test_edge.rs`](../../packages/treetime/src/graph/__tests__/test_edge.rs)
 

--- a/packages/app-server/src/args.rs
+++ b/packages/app-server/src/args.rs
@@ -77,6 +77,7 @@ impl From<ServerAncestralArgs> for TreetimeAncestralArgs {
       aa_root_sequence: None,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
+        ..Default::default()
       },
       gtr_iterations: s.gtr_iterations,
       site_specific_gtr: s.site_specific_gtr,
@@ -159,6 +160,7 @@ impl From<ServerClockArgs> for TreetimeClockArgs {
       allow_negative_rate: s.allow_negative_rate,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
+        ..Default::default()
       },
       seed: s.seed,
       ..TreetimeClockArgs::default()
@@ -300,6 +302,7 @@ impl From<ServerTimetreeArgs> for TreetimeTimetreeArgs {
       output_augur_node_data: None,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
+        ..Default::default()
       },
       tracelog: s.tracelog.map(PathBuf::from),
       seed: s.seed,
@@ -352,6 +355,7 @@ impl From<ServerMugrationArgs> for TreetimeMugrationArgs {
       output_augur_node_data: None,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
+        ..Default::default()
       },
     }
   }
@@ -403,6 +407,7 @@ impl From<ServerOptimizeArgs> for TreetimeOptimizeArgs {
       dense: s.dense,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
+        ..Default::default()
       },
       max_iter: s.max_iter,
       dp: s.dp,
@@ -450,6 +455,7 @@ impl From<ServerPruneArgs> for TreetimePruneArgs {
       alphabet_args: AlphabetArgs { alphabet: s.alphabet },
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
+        ..Default::default()
       },
       prune_short: s.prune_short,
       prune_empty: s.prune_empty,

--- a/packages/treetime-graph/Cargo.toml
+++ b/packages/treetime-graph/Cargo.toml
@@ -24,5 +24,9 @@ rayon = { workspace = true }
 serde = { workspace = true }
 traversal = { workspace = true }
 
+[dev-dependencies]
+ctor = { workspace = true }
+pretty_assertions = { workspace = true }
+
 [lints]
 workspace = true

--- a/packages/treetime-graph/src/lib.rs
+++ b/packages/treetime-graph/src/lib.rs
@@ -7,3 +7,19 @@ pub mod graph_ops;
 pub mod graph_traverse;
 pub mod node;
 pub mod reroot;
+pub mod topology_order;
+
+#[cfg(test)]
+mod tests {
+  use ctor::ctor;
+  use treetime_utils::init::global::global_init;
+
+  #[ctor]
+  fn init() {
+    global_init();
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
+  }
+}

--- a/packages/treetime-graph/src/topology_order.rs
+++ b/packages/treetime-graph/src/topology_order.rs
@@ -1,0 +1,662 @@
+use crate::edge::{Edge, GraphEdge, GraphEdgeKey};
+use crate::graph::Graph;
+use crate::node::{GraphNode, GraphNodeKey, Named, Node};
+use eyre::Report;
+use itertools::Itertools;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::Arc;
+use treetime_utils::{make_error, make_report};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TopologyOrderSpec {
+  pub preset: TopologyOrderPreset,
+  pub target_order: Vec<String>,
+  pub target_aggregate: TopologyOrderTargetAggregate,
+}
+
+impl Default for TopologyOrderSpec {
+  fn default() -> Self {
+    Self {
+      preset: TopologyOrderPreset::DescendantCount,
+      target_order: vec![],
+      target_aggregate: TopologyOrderTargetAggregate::Mean,
+    }
+  }
+}
+
+impl TopologyOrderSpec {
+  pub fn keep() -> Self {
+    Self {
+      preset: TopologyOrderPreset::Keep,
+      ..Self::default()
+    }
+  }
+
+  pub fn descendant_count(reverse: bool) -> Self {
+    Self {
+      preset: if reverse {
+        TopologyOrderPreset::DescendantCountReverse
+      } else {
+        TopologyOrderPreset::DescendantCount
+      },
+      ..Self::default()
+    }
+  }
+
+  pub fn plan<N, E, D>(&self, graph: &Graph<N, E, D>) -> Result<TopologyOrderPlan, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    let mut state = TopologyOrderState::new(graph, self)?;
+    let node_order = topological_order(graph)?;
+
+    for node_key in node_order.into_iter().rev() {
+      let node = graph
+        .get_node(node_key)
+        .ok_or_else(|| make_report!("When ordering topology: Node {node_key} not found"))?;
+      state.compute_node(graph, &node.read_arc())?;
+    }
+
+    Ok(TopologyOrderPlan {
+      roots: self.order_node_keys(&graph.roots, &state),
+      leaves: self.order_node_keys(&graph.leaves, &state),
+      outbound_edges: graph
+        .nodes
+        .iter()
+        .filter_map(Option::as_ref)
+        .map(|node| {
+          let node = node.read_arc();
+          (node.key(), self.order_edge_keys(graph, node.outbound(), &state))
+        })
+        .collect(),
+    })
+  }
+
+  fn order_edge_keys<N, E, D>(
+    &self,
+    graph: &Graph<N, E, D>,
+    edge_keys: &[GraphEdgeKey],
+    state: &TopologyOrderState,
+  ) -> Vec<GraphEdgeKey>
+  where
+    N: GraphNode,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    if self.preset == TopologyOrderPreset::Keep {
+      return edge_keys.to_vec();
+    }
+
+    edge_keys
+      .iter()
+      .copied()
+      .enumerate()
+      .sorted_by(|(lhs_pos, lhs), (rhs_pos, rhs)| {
+        let lhs_target = graph.get_target_node_key(*lhs);
+        let rhs_target = graph.get_target_node_key(*rhs);
+        match (lhs_target, rhs_target) {
+          (Ok(lhs_target), Ok(rhs_target)) => self
+            .compare_nodes(lhs_target, rhs_target, state)
+            .then(lhs_pos.cmp(rhs_pos)),
+          _ => lhs_pos.cmp(rhs_pos),
+        }
+      })
+      .map(|(_, edge_key)| edge_key)
+      .collect_vec()
+  }
+
+  fn order_node_keys(&self, node_keys: &[GraphNodeKey], state: &TopologyOrderState) -> Vec<GraphNodeKey> {
+    if self.preset == TopologyOrderPreset::Keep {
+      return node_keys.to_vec();
+    }
+
+    node_keys
+      .iter()
+      .copied()
+      .enumerate()
+      .sorted_by(|(lhs_pos, lhs), (rhs_pos, rhs)| self.compare_nodes(*lhs, *rhs, state).then(lhs_pos.cmp(rhs_pos)))
+      .map(|(_, node_key)| node_key)
+      .collect_vec()
+  }
+
+  fn compare_nodes(&self, lhs: GraphNodeKey, rhs: GraphNodeKey, state: &TopologyOrderState) -> Ordering {
+    let ordering = match self.preset {
+      TopologyOrderPreset::Keep => Ordering::Equal,
+      TopologyOrderPreset::DescendantCount | TopologyOrderPreset::DescendantCountReverse => {
+        state.leaf_counts[&lhs].cmp(&state.leaf_counts[&rhs])
+      },
+      TopologyOrderPreset::Height | TopologyOrderPreset::HeightReverse => state.heights[&lhs].cmp(&state.heights[&rhs]),
+      TopologyOrderPreset::Label | TopologyOrderPreset::LabelReverse => state.labels[&lhs].cmp(&state.labels[&rhs]),
+      TopologyOrderPreset::TargetOrder | TopologyOrderPreset::TargetOrderReverse => {
+        state.target_scores[&lhs].cmp(&state.target_scores[&rhs])
+      },
+    };
+
+    if self.preset.is_reverse() {
+      ordering.reverse()
+    } else {
+      ordering
+    }
+  }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TopologyOrderPreset {
+  Keep,
+  #[default]
+  DescendantCount,
+  DescendantCountReverse,
+  Height,
+  HeightReverse,
+  Label,
+  LabelReverse,
+  TargetOrder,
+  TargetOrderReverse,
+}
+
+impl TopologyOrderPreset {
+  pub fn is_target_order(self) -> bool {
+    matches!(self, Self::TargetOrder | Self::TargetOrderReverse)
+  }
+
+  fn is_reverse(self) -> bool {
+    matches!(
+      self,
+      Self::DescendantCountReverse | Self::HeightReverse | Self::LabelReverse | Self::TargetOrderReverse
+    )
+  }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum TopologyOrderTargetAggregate {
+  #[default]
+  Mean,
+  Median,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TopologyOrderPlan {
+  pub roots: Vec<GraphNodeKey>,
+  pub leaves: Vec<GraphNodeKey>,
+  pub outbound_edges: BTreeMap<GraphNodeKey, Vec<GraphEdgeKey>>,
+}
+
+impl TopologyOrderPlan {
+  pub fn ordered_graph<N, E, D>(&self, graph: &Graph<N, E, D>) -> Result<Graph<N, E, D>, Report>
+  where
+    N: GraphNode,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    let mut ordered = Graph {
+      nodes: graph
+        .nodes
+        .iter()
+        .map(|node| {
+          node.as_ref().map(|node| {
+            let node = node.read_arc();
+            let mut cloned = Node::new(node.key(), node.payload().read_arc().clone());
+            *cloned.outbound_mut() = self
+              .outbound_edges
+              .get(&node.key())
+              .cloned()
+              .unwrap_or_else(|| node.outbound().to_vec());
+            *cloned.inbound_mut() = node.inbound().to_vec();
+            Arc::new(RwLock::new(cloned))
+          })
+        })
+        .collect(),
+      edges: graph
+        .edges
+        .iter()
+        .map(|edge| {
+          edge.as_ref().map(|edge| {
+            let edge = edge.read_arc();
+            Arc::new(RwLock::new(Edge::new(
+              edge.key(),
+              edge.source(),
+              edge.target(),
+              edge.payload().read_arc().clone(),
+            )))
+          })
+        })
+        .collect(),
+      roots: self.roots.clone(),
+      leaves: self.leaves.clone(),
+      data: graph.data(),
+    };
+    ordered.build()?;
+    ordered.roots = self.roots.clone();
+    ordered.leaves = self.leaves.clone();
+    Ok(ordered)
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TargetScore {
+  numerator: usize,
+  denominator: usize,
+}
+
+impl Ord for TargetScore {
+  fn cmp(&self, other: &Self) -> Ordering {
+    ((self.numerator as u128) * (other.denominator as u128))
+      .cmp(&((other.numerator as u128) * (self.denominator as u128)))
+  }
+}
+
+impl PartialOrd for TargetScore {
+  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    Some(self.cmp(other))
+  }
+}
+
+struct TopologyOrderState {
+  leaf_sets: BTreeMap<GraphNodeKey, BTreeSet<GraphNodeKey>>,
+  leaf_counts: BTreeMap<GraphNodeKey, usize>,
+  heights: BTreeMap<GraphNodeKey, usize>,
+  labels: BTreeMap<GraphNodeKey, String>,
+  target_scores: BTreeMap<GraphNodeKey, TargetScore>,
+  target_order: BTreeMap<String, usize>,
+  target_aggregate: TopologyOrderTargetAggregate,
+}
+
+impl TopologyOrderState {
+  fn new<N, E, D>(graph: &Graph<N, E, D>, spec: &TopologyOrderSpec) -> Result<Self, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    let target_order = spec
+      .target_order
+      .iter()
+      .enumerate()
+      .map(|(index, label)| (label.clone(), index))
+      .collect();
+
+    if spec.preset.is_target_order() && spec.target_order.is_empty() {
+      return make_error!("When ordering topology: target-order mode requires a non-empty target order");
+    }
+
+    let state = Self {
+      leaf_sets: BTreeMap::new(),
+      leaf_counts: BTreeMap::new(),
+      heights: BTreeMap::new(),
+      labels: BTreeMap::new(),
+      target_scores: BTreeMap::new(),
+      target_order,
+      target_aggregate: spec.target_aggregate,
+    };
+
+    if spec.preset.is_target_order() {
+      validate_target_order(graph, &state.target_order)?;
+    }
+
+    Ok(state)
+  }
+
+  fn compute_node<N, E, D>(&mut self, graph: &Graph<N, E, D>, node: &Node<N>) -> Result<(), Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    let child_keys = graph.child_keys_of(node);
+    let leaf_set = if child_keys.is_empty() {
+      BTreeSet::from([node.key()])
+    } else {
+      child_keys
+        .iter()
+        .flat_map(|child_key| self.leaf_sets[child_key].iter().copied())
+        .collect()
+    };
+
+    let height = child_keys
+      .iter()
+      .map(|child_key| self.heights[child_key] + 1)
+      .max()
+      .unwrap_or(0);
+
+    let label = if child_keys.is_empty() {
+      node
+        .payload()
+        .read_arc()
+        .name()
+        .map(|name| name.as_ref().to_owned())
+        .ok_or_else(|| make_report!("When ordering topology by labels: leaf node {} has no name", node.key()))?
+    } else {
+      child_keys
+        .iter()
+        .map(|child_key| self.labels[child_key].clone())
+        .min()
+        .unwrap_or_default()
+    };
+
+    let target_score = self.target_score(graph, node, &leaf_set)?;
+
+    self.leaf_counts.insert(node.key(), leaf_set.len());
+    self.leaf_sets.insert(node.key(), leaf_set);
+    self.heights.insert(node.key(), height);
+    self.labels.insert(node.key(), label);
+    self.target_scores.insert(node.key(), target_score);
+
+    Ok(())
+  }
+
+  fn target_score<N, E, D>(
+    &self,
+    graph: &Graph<N, E, D>,
+    node: &Node<N>,
+    leaf_set: &BTreeSet<GraphNodeKey>,
+  ) -> Result<TargetScore, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    if self.target_order.is_empty() {
+      return Ok(TargetScore {
+        numerator: 0,
+        denominator: 1,
+      });
+    }
+
+    let mut positions = leaf_set
+      .iter()
+      .map(|leaf_key| {
+        let leaf = graph
+          .get_node(*leaf_key)
+          .ok_or_else(|| make_report!("When ordering topology: leaf node {leaf_key} not found"))?;
+        let label = leaf
+          .read_arc()
+          .payload()
+          .read_arc()
+          .name()
+          .map(|name| name.as_ref().to_owned())
+          .ok_or_else(|| make_report!("When ordering topology by target order: leaf node {leaf_key} has no name"))?;
+        self.target_order.get(&label).copied().ok_or_else(|| {
+          make_report!("When ordering topology by target order: leaf '{label}' is absent from target order")
+        })
+      })
+      .collect::<Result<Vec<_>, _>>()?;
+
+    positions.sort_unstable();
+
+    match self.target_aggregate {
+      TopologyOrderTargetAggregate::Mean => Ok(TargetScore {
+        numerator: positions.iter().sum(),
+        denominator: positions.len(),
+      }),
+      TopologyOrderTargetAggregate::Median => {
+        let midpoint = positions.len() / 2;
+        if positions.len() % 2 == 0 {
+          Ok(TargetScore {
+            numerator: positions[midpoint - 1] + positions[midpoint],
+            denominator: 2,
+          })
+        } else {
+          Ok(TargetScore {
+            numerator: positions[midpoint],
+            denominator: 1,
+          })
+        }
+      },
+    }
+  }
+}
+
+fn validate_target_order<N, E, D>(graph: &Graph<N, E, D>, target_order: &BTreeMap<String, usize>) -> Result<(), Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  for leaf in graph.get_leaves() {
+    let leaf = leaf.read_arc();
+    let label = leaf
+      .payload()
+      .read_arc()
+      .name()
+      .map(|name| name.as_ref().to_owned())
+      .ok_or_else(|| make_report!("When validating target order: leaf node {} has no name", leaf.key()))?;
+    if !target_order.contains_key(&label) {
+      return make_error!("When validating target order: leaf '{label}' is absent from target order");
+    }
+  }
+  Ok(())
+}
+
+fn topological_order<N, E, D>(graph: &Graph<N, E, D>) -> Result<Vec<GraphNodeKey>, Report>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let node_keys = graph
+    .nodes
+    .iter()
+    .filter_map(|node| node.as_ref().map(|node| node.read_arc().key()))
+    .collect_vec();
+
+  let mut remaining_inbound = node_keys
+    .iter()
+    .map(|node_key| (*node_key, graph.degree_in(*node_key).unwrap_or(0)))
+    .collect::<BTreeMap<_, _>>();
+
+  let mut queue = remaining_inbound
+    .iter()
+    .filter_map(|(node_key, count)| (*count == 0).then_some(*node_key))
+    .collect::<VecDeque<_>>();
+
+  let mut ordered = Vec::with_capacity(node_keys.len());
+  while let Some(node_key) = queue.pop_front() {
+    ordered.push(node_key);
+    let node = graph
+      .get_node(node_key)
+      .ok_or_else(|| make_report!("When validating topology order: Node {node_key} not found"))?;
+    for child_key in graph.child_keys_of(&node.read_arc()) {
+      let count = remaining_inbound
+        .get_mut(&child_key)
+        .ok_or_else(|| make_report!("When validating topology order: Node {child_key} not found"))?;
+      *count -= 1;
+      if *count == 0 {
+        queue.push_back(child_key);
+      }
+    }
+  }
+
+  if ordered.len() != node_keys.len() {
+    return make_error!("When ordering topology: graph contains a directed cycle");
+  }
+
+  Ok(ordered)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use pretty_assertions::assert_eq;
+
+  #[test]
+  fn topology_order_descendant_count_sorts_children_ascending() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let plan = TopologyOrderSpec::default().plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["A", "BC", "DEF"], actual);
+    assert_eq!(vec!["DEF", "A", "BC"], child_names(&graph, "root")?);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_descendant_count_reverse_sorts_children_descending() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let plan = TopologyOrderSpec::descendant_count(true).plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["DEF", "BC", "A"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_keep_preserves_outbound_order() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let plan = TopologyOrderSpec::keep().plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["DEF", "A", "BC"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_dag_counts_shared_descendant_once_per_child() -> Result<(), Report> {
+    let mut graph = Graph::<TestNode, TestEdge, ()>::new();
+    let root = graph.add_node(TestNode::new("root"));
+    let left = graph.add_node(TestNode::new("left"));
+    let right = graph.add_node(TestNode::new("right"));
+    let shared = graph.add_node(TestNode::new("shared"));
+    let right_only = graph.add_node(TestNode::new("right_only"));
+
+    graph.add_edge(root, right, TestEdge)?;
+    graph.add_edge(root, left, TestEdge)?;
+    graph.add_edge(left, shared, TestEdge)?;
+    graph.add_edge(right, shared, TestEdge)?;
+    graph.add_edge(right, right_only, TestEdge)?;
+    graph.build()?;
+
+    let plan = TopologyOrderSpec::default().plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["left", "right"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_target_order_uses_requested_tip_order() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::TargetOrder,
+      target_order: vec!["D", "E", "F", "B", "C", "A"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+      target_aggregate: TopologyOrderTargetAggregate::Mean,
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["DEF", "BC", "A"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_rejects_cycles() -> Result<(), Report> {
+    let mut graph = Graph::<TestNode, TestEdge, ()>::new();
+    let a = graph.add_node(TestNode::new("A"));
+    let b = graph.add_node(TestNode::new("B"));
+    let c = graph.add_node(TestNode::new("C"));
+
+    graph.add_edge(a, b, TestEdge)?;
+    graph.add_edge(b, c, TestEdge)?;
+    graph.add_edge(c, a, TestEdge)?;
+    graph.build()?;
+
+    let err = TopologyOrderSpec::default().plan(&graph).unwrap_err();
+
+    assert!(err.to_string().contains("directed cycle"));
+
+    Ok(())
+  }
+
+  fn fixture_tree() -> Result<Graph<TestNode, TestEdge, ()>, Report> {
+    let mut graph = Graph::<TestNode, TestEdge, ()>::new();
+    let root = graph.add_node(TestNode::new("root"));
+    let def = graph.add_node(TestNode::new("DEF"));
+    let tip_a = graph.add_node(TestNode::new("A"));
+    let bc = graph.add_node(TestNode::new("BC"));
+    let tip_d = graph.add_node(TestNode::new("D"));
+    let tip_e = graph.add_node(TestNode::new("E"));
+    let tip_f = graph.add_node(TestNode::new("F"));
+    let tip_b = graph.add_node(TestNode::new("B"));
+    let tip_c = graph.add_node(TestNode::new("C"));
+
+    graph.add_edge(root, def, TestEdge)?;
+    graph.add_edge(root, tip_a, TestEdge)?;
+    graph.add_edge(root, bc, TestEdge)?;
+    graph.add_edge(def, tip_d, TestEdge)?;
+    graph.add_edge(def, tip_e, TestEdge)?;
+    graph.add_edge(def, tip_f, TestEdge)?;
+    graph.add_edge(bc, tip_b, TestEdge)?;
+    graph.add_edge(bc, tip_c, TestEdge)?;
+    graph.build()?;
+
+    Ok(graph)
+  }
+
+  fn child_names(graph: &Graph<TestNode, TestEdge, ()>, parent_name: &str) -> Result<Vec<String>, Report> {
+    let parent_key = find_node(graph, parent_name)?;
+    let parent = graph
+      .get_node(parent_key)
+      .ok_or_else(|| make_report!("Node {parent_key} not found"))?;
+    Ok(
+      graph
+        .children_of(&parent.read_arc())
+        .into_iter()
+        .map(|(node, _)| node.read_arc().payload().read_arc().0.clone())
+        .collect_vec(),
+    )
+  }
+
+  fn find_node(graph: &Graph<TestNode, TestEdge, ()>, name: &str) -> Result<GraphNodeKey, Report> {
+    graph
+      .find_node(|node| node.0 == name)
+      .ok_or_else(|| make_report!("Node '{name}' not found"))
+  }
+
+  #[derive(Clone, Debug, Eq, PartialEq)]
+  struct TestNode(String);
+
+  impl TestNode {
+    fn new(name: &str) -> Self {
+      Self(name.to_owned())
+    }
+  }
+
+  impl GraphNode for TestNode {}
+
+  impl Named for TestNode {
+    fn name(&self) -> Option<impl AsRef<str>> {
+      Some(&self.0)
+    }
+
+    fn set_name(&mut self, name: Option<impl AsRef<str>>) {
+      self.0 = name.map(|name| name.as_ref().to_owned()).unwrap_or_default();
+    }
+  }
+
+  #[derive(Clone, Debug, Eq, PartialEq)]
+  struct TestEdge;
+
+  impl GraphEdge for TestEdge {}
+}

--- a/packages/treetime-io/src/graph.rs
+++ b/packages/treetime-io/src/graph.rs
@@ -6,48 +6,48 @@ use serde::Serialize;
 use std::path::Path;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
-use treetime_graph::node::GraphNode;
+use treetime_graph::node::{GraphNode, Named};
+use treetime_graph::topology_order::TopologyOrderSpec;
 use treetime_utils::io::json::{JsonPretty, json_write_file};
 
-pub fn write_graph_files<N, E, D>(outdir: impl AsRef<Path>, stem: &str, graph: &Graph<N, E, D>) -> Result<(), Report>
-where
-  N: GraphNode + NodeToNwk + NodeToGraphviz + Serialize,
-  E: GraphEdge + EdgeToNwk + EdgeToGraphviz + Serialize,
-  D: Send + Sync + Default + Serialize,
-{
-  write_graph_files_with(outdir, stem, graph, &CommentProviders::new())
+#[derive(Clone, Debug, Default)]
+pub struct GraphWriteOptions {
+  pub topology_order: TopologyOrderSpec,
 }
 
-pub fn write_graph_files_with<N, E, D>(
+pub fn write_graph_files_with_options<N, E, D>(
   outdir: impl AsRef<Path>,
   stem: &str,
   graph: &Graph<N, E, D>,
   providers: &CommentProviders,
+  options: &GraphWriteOptions,
 ) -> Result<(), Report>
 where
-  N: GraphNode + NodeToNwk + NodeToGraphviz + Serialize,
+  N: GraphNode + Named + NodeToNwk + NodeToGraphviz + Serialize,
   E: GraphEdge + EdgeToNwk + EdgeToGraphviz + Serialize,
   D: Send + Sync + Default + Serialize,
 {
   let outdir = outdir.as_ref();
+  let plan = options.topology_order.plan(graph)?;
+  let graph = plan.ordered_graph(graph)?;
 
   nwk_write_file_with(
     outdir.join(format!("{stem}.nwk")),
-    graph,
+    &graph,
     &NwkWriteOptions::default(),
     providers,
   )?;
 
   nex_write_file_with(
     outdir.join(format!("{stem}.nexus")),
-    graph,
+    &graph,
     &NexWriteOptions::default(),
     providers,
   )?;
 
-  json_write_file(outdir.join(format!("{stem}.graph.json")), graph, JsonPretty(true))?;
+  json_write_file(outdir.join(format!("{stem}.graph.json")), &graph, JsonPretty(true))?;
 
-  graphviz_write_file(outdir.join(format!("{stem}.dot")), graph)?;
+  graphviz_write_file(outdir.join(format!("{stem}.dot")), &graph)?;
 
   Ok(())
 }

--- a/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
@@ -271,6 +271,7 @@ mod tests {
         },
         output: OutputArgs {
           outdir: dir.path().to_path_buf(),
+          ..Default::default()
         },
         ..TreetimeAncestralArgs::default()
       };

--- a/packages/treetime/src/commands/ancestral/__tests__/test_smoke_gtr_iterations.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_smoke_gtr_iterations.rs
@@ -34,7 +34,10 @@ mod tests {
         ..ModelArgs::default()
       },
       gtr_iterations: 3,
-      output: OutputArgs { outdir: outdir.clone() },
+      output: OutputArgs {
+        outdir: outdir.clone(),
+        ..Default::default()
+      },
       ..TreetimeAncestralArgs::default()
     };
 
@@ -66,7 +69,10 @@ mod tests {
       },
       dense: Some(true),
       gtr_iterations: 3,
-      output: OutputArgs { outdir: outdir.clone() },
+      output: OutputArgs {
+        outdir: outdir.clone(),
+        ..Default::default()
+      },
       ..TreetimeAncestralArgs::default()
     };
 

--- a/packages/treetime/src/commands/ancestral/__tests__/test_smoke_sample_from_profile.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_smoke_sample_from_profile.rs
@@ -61,7 +61,10 @@ mod tests {
         },
         sample_from_profile: SampleMode::Root,
         seed: Some(seed),
-        output: OutputArgs { outdir: outdir.clone() },
+        output: OutputArgs {
+          outdir: outdir.clone(),
+          ..Default::default()
+        },
         ..TreetimeAncestralArgs::default()
       };
 
@@ -82,6 +85,7 @@ mod tests {
       sample_from_profile: SampleMode::Root,
       output: OutputArgs {
         outdir: PROJECT_ROOT.join("tmp/test-sample-parsimony-reject"),
+        ..Default::default()
       },
       ..TreetimeAncestralArgs::default()
     };
@@ -112,7 +116,10 @@ mod tests {
       },
       sample_from_profile: SampleMode::All,
       seed: Some(7),
-      output: OutputArgs { outdir: outdir.clone() },
+      output: OutputArgs {
+        outdir: outdir.clone(),
+        ..Default::default()
+      },
       ..TreetimeAncestralArgs::default()
     };
 

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -14,7 +14,7 @@ use crate::seq::gap_fill::apply_gap_fill;
 use eyre::Report;
 use log::info;
 use treetime_io::fasta::{FastaReader, FastaRecord, FastaWriter, read_many_fasta};
-use treetime_io::graph::write_graph_files_with;
+use treetime_io::graph::write_graph_files_with_options;
 use treetime_io::nwk::CommentProviders;
 use treetime_io::nwk::{nwk_read_file, nwk_read_str};
 use treetime_utils::io::file::{create_file_or_stdout, open_stdin};
@@ -112,6 +112,7 @@ pub fn run_ancestral_reconstruction(
 
   match &result.partition {
     Some(AncestralPartition::Fitch(partition)) => {
+      let graph_options = ancestral_args.output.graph_write_options(&result.output.graph)?;
       let guard = partition.read_arc();
       write_augur_node_data_json_with_aa(
         &result.output.graph,
@@ -121,9 +122,16 @@ pub fn run_ancestral_reconstruction(
         &augur_node_data_path,
       )?;
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
-      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &CommentProviders::new())?;
+      write_graph_files_with_options(
+        outdir,
+        "annotated_tree",
+        &result.output.graph,
+        &CommentProviders::new(),
+        &graph_options,
+      )?;
     },
     Some(AncestralPartition::Sparse(partition)) => {
+      let graph_options = ancestral_args.output.graph_write_options(&result.output.graph)?;
       let guard = partition.read_arc();
       write_augur_node_data_json_with_aa(
         &result.output.graph,
@@ -135,9 +143,16 @@ pub fn run_ancestral_reconstruction(
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
       let provider = MutationCommentProvider::new(&*guard, &result.output.graph);
       let providers = CommentProviders::new().with(&provider);
-      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &providers)?;
+      write_graph_files_with_options(
+        outdir,
+        "annotated_tree",
+        &result.output.graph,
+        &providers,
+        &graph_options,
+      )?;
     },
     Some(AncestralPartition::Dense(partition)) => {
+      let graph_options = ancestral_args.output.graph_write_options(&result.output.graph)?;
       let guard = partition.read_arc();
       write_augur_node_data_json_with_aa(
         &result.output.graph,
@@ -149,10 +164,23 @@ pub fn run_ancestral_reconstruction(
       info!("Wrote augur node data JSON to {}", augur_node_data_path.display());
       let provider = MutationCommentProvider::new(&*guard, &result.output.graph);
       let providers = CommentProviders::new().with(&provider);
-      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &providers)?;
+      write_graph_files_with_options(
+        outdir,
+        "annotated_tree",
+        &result.output.graph,
+        &providers,
+        &graph_options,
+      )?;
     },
     None => {
-      write_graph_files_with(outdir, "annotated_tree", &result.output.graph, &CommentProviders::new())?;
+      let graph_options = ancestral_args.output.graph_write_options(&result.output.graph)?;
+      write_graph_files_with_options(
+        outdir,
+        "annotated_tree",
+        &result.output.graph,
+        &CommentProviders::new(),
+        &graph_options,
+      )?;
     },
   }
 

--- a/packages/treetime/src/commands/clock/run.rs
+++ b/packages/treetime/src/commands/clock/run.rs
@@ -9,8 +9,11 @@ use crate::commands::clock::args::{BranchSplitArgs, TreetimeClockArgs};
 use crate::make_error;
 use crate::make_report;
 use eyre::{Report, WrapErr};
+use treetime_graph::edge::GraphEdge;
+use treetime_graph::graph::Graph;
+use treetime_graph::node::{GraphNode, Named};
 use treetime_io::dates_csv::read_dates;
-use treetime_io::graph::write_graph_files;
+use treetime_io::graph::write_graph_files_with_options;
 use treetime_io::nwk::nwk_read_file;
 
 #[derive(Debug, serde::Serialize)]
@@ -41,6 +44,7 @@ pub fn run_clock(
   } else {
     return make_error!("Tree inference is not implemented. Provide a tree file with --tree");
   }?;
+  let input_order = leaf_order(&graph)?;
 
   let dates = read_dates(
     &clock_args.metadata,
@@ -81,7 +85,16 @@ pub fn run_clock(
 
   progress.report("Writing output", 0.8, "");
   let outdir = &clock_args.output.outdir;
-  write_graph_files(outdir, "rerooted", &output.graph)?;
+  let graph_options = clock_args
+    .output
+    .graph_write_options_with_input_order(&output.graph, input_order)?;
+  write_graph_files_with_options(
+    outdir,
+    "rerooted",
+    &output.graph,
+    &treetime_io::nwk::CommentProviders::new(),
+    &graph_options,
+  )?;
   write_clock_model(&output.clock_model, &outdir.join("clock_model"))?;
   write_clock_regression_result_csv(&output.regression_results, outdir.join("clock.csv"), b',')?;
 
@@ -91,4 +104,25 @@ pub fn run_clock(
     clock_model: output.clock_model,
     regression_results: output.regression_results,
   })
+}
+
+fn leaf_order<N, E, D>(graph: &Graph<N, E, D>) -> Result<Vec<String>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  graph
+    .get_leaves()
+    .into_iter()
+    .map(|leaf| {
+      let leaf = leaf.read_arc();
+      leaf
+        .payload()
+        .read_arc()
+        .name()
+        .map(|name| name.as_ref().to_owned())
+        .ok_or_else(|| make_report!("Leaf node {} has no name", leaf.key()))
+    })
+    .collect()
 }

--- a/packages/treetime/src/commands/mugration/run.rs
+++ b/packages/treetime/src/commands/mugration/run.rs
@@ -12,7 +12,7 @@ use log::info;
 use std::collections::BTreeMap;
 use std::fs;
 use treetime_io::discrete_states_csv::read_discrete_attrs;
-use treetime_io::graph::write_graph_files_with;
+use treetime_io::graph::write_graph_files_with_options;
 use treetime_io::nwk::CommentProviders;
 use treetime_io::nwk::nwk_read_file;
 use treetime_utils::io::json::{JsonPretty, json_write_file};
@@ -71,7 +71,8 @@ pub fn run_mugration(
   progress.report("Writing output", 0.8, "");
   let provider = DiscreteCommentProvider::new(&result.partition, &result.traits.attribute);
   let providers = CommentProviders::new().with(&provider);
-  write_graph_files_with(outdir, "annotated_tree", &result.graph, &providers)?;
+  let graph_options = mugration_args.output.graph_write_options(&result.graph)?;
+  write_graph_files_with_options(outdir, "annotated_tree", &result.graph, &providers, &graph_options)?;
 
   let gtr_output = GtrOutput::new(result.partition.gtr(), GtrModelName::Infer)
     .with_discrete_states(&result.traits.attribute, result.partition.states.iter());

--- a/packages/treetime/src/commands/optimize/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_augur_node_data.rs
@@ -95,7 +95,10 @@ mod tests {
       },
       tree: root.join("data/flu/h3n2/20/tree.nwk"),
       max_iter: 2,
-      output: OutputArgs { outdir: outdir.clone() },
+      output: OutputArgs {
+        outdir: outdir.clone(),
+        ..Default::default()
+      },
       ..TreetimeOptimizeArgs::default()
     };
 

--- a/packages/treetime/src/commands/optimize/run.rs
+++ b/packages/treetime/src/commands/optimize/run.rs
@@ -10,7 +10,7 @@ use eyre::Report;
 use log::info;
 use std::path::PathBuf;
 use treetime_io::fasta::read_many_fasta;
-use treetime_io::graph::write_graph_files_with;
+use treetime_io::graph::write_graph_files_with_options;
 use treetime_io::nwk::CommentProviders;
 use treetime_io::nwk::nwk_read_file;
 
@@ -52,17 +52,18 @@ pub fn run_optimize(
   let outdir = &args.output.outdir;
 
   write_gtr_json(&output.gtr, output.model_name, outdir, None)?;
+  let graph_options = args.output.graph_write_options(&output.graph)?;
 
   if !output.dense_partitions.is_empty() {
     let guard = output.dense_partitions[0].read_arc();
     let provider = MutationCommentProvider::new(&*guard, &output.graph);
     let providers = CommentProviders::new().with(&provider);
-    write_graph_files_with(outdir, "annotated_tree", &output.graph, &providers)?;
+    write_graph_files_with_options(outdir, "annotated_tree", &output.graph, &providers, &graph_options)?;
   } else if !output.sparse_partitions.is_empty() {
     let guard = output.sparse_partitions[0].read_arc();
     let provider = MutationCommentProvider::new(&*guard, &output.graph);
     let providers = CommentProviders::new().with(&provider);
-    write_graph_files_with(outdir, "annotated_tree", &output.graph, &providers)?;
+    write_graph_files_with_options(outdir, "annotated_tree", &output.graph, &providers, &graph_options)?;
   }
 
   let augur_node_data_path = args

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -9,8 +9,12 @@ use itertools::Itertools;
 use maplit::btreeset;
 use std::collections::BTreeSet;
 use std::path::PathBuf;
+use treetime_graph::edge::GraphEdge;
+use treetime_graph::graph::Graph;
+use treetime_graph::node::{GraphNode, Named};
 use treetime_io::fasta::read_many_fasta;
-use treetime_io::graph::write_graph_files;
+use treetime_io::graph::write_graph_files_with_options;
+use treetime_io::nwk::CommentProviders;
 use treetime_io::nwk::nwk_read_file;
 use treetime_io::parse_delimited::{parse_delimited_file, parse_delimited_str};
 
@@ -26,6 +30,7 @@ pub fn run_prune(
   progress.report("Reading input", 0.0, "");
 
   let graph: GraphAncestral = nwk_read_file(&args.tree)?;
+  let input_order = leaf_order(&graph)?;
   let alphabet = Alphabet::new(args.alphabet_args.alphabet.unwrap_or_default())?;
 
   let needs_sequences = args.prune_empty || args.merge_shared_mutations;
@@ -64,7 +69,16 @@ pub fn run_prune(
   if let Some(gtr) = &output.gtr {
     write_gtr_json(gtr, GtrModelName::JC69, outdir, None)?;
   }
-  write_graph_files(outdir, "pruned_tree", &output.graph)?;
+  let graph_options = args
+    .output
+    .graph_write_options_with_input_order(&output.graph, input_order)?;
+  write_graph_files_with_options(
+    outdir,
+    "pruned_tree",
+    &output.graph,
+    &CommentProviders::new(),
+    &graph_options,
+  )?;
 
   progress.report("Done", 1.0, "");
   Ok(PruneResult { graph: output.graph })
@@ -84,6 +98,27 @@ fn validate_args(args: &TreetimePruneArgs) -> Result<(), Report> {
   }
 
   Ok(())
+}
+
+fn leaf_order<N, E, D>(graph: &Graph<N, E, D>) -> Result<Vec<String>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  graph
+    .get_leaves()
+    .into_iter()
+    .map(|leaf| {
+      let leaf = leaf.read_arc();
+      leaf
+        .payload()
+        .read_arc()
+        .name()
+        .map(|name| name.as_ref().to_owned())
+        .ok_or_else(|| crate::make_report!("Leaf node {} has no name", leaf.key()))
+    })
+    .collect()
 }
 
 fn parse_node_names(

--- a/packages/treetime/src/commands/shared/output.rs
+++ b/packages/treetime/src/commands/shared/output.rs
@@ -1,9 +1,18 @@
 #[cfg(feature = "clap")]
 use clap::ValueHint;
+use eyre::{Report, WrapErr};
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
+use treetime_graph::edge::{GraphEdge, HasBranchLength};
+use treetime_graph::graph::Graph;
+use treetime_graph::node::{GraphNode, Named};
+use treetime_graph::topology_order::{TopologyOrderPreset, TopologyOrderSpec, TopologyOrderTargetAggregate};
+use treetime_io::graph::GraphWriteOptions;
+use treetime_io::nwk::{EdgeFromNwk, NodeFromNwk, nwk_read_file};
+use treetime_utils::{make_error, make_report};
 
 /// Output destination shared by every command.
 ///
@@ -20,6 +29,9 @@ pub struct OutputArgs {
   /// Directory to write the standard set of output files to
   #[cfg_attr(feature = "clap", clap(long, short = 'O', value_hint = ValueHint::AnyPath))]
   pub outdir: PathBuf,
+
+  #[cfg_attr(feature = "clap", clap(flatten))]
+  pub topology_order_args: TopologyOrderArgs,
 }
 
 impl OutputArgs {
@@ -31,5 +43,331 @@ impl OutputArgs {
       Some(path) => path.to_path_buf(),
       None => self.outdir.join(default_name),
     }
+  }
+
+  pub fn graph_write_options<N, E, D>(&self, graph: &Graph<N, E, D>) -> Result<GraphWriteOptions, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    self.topology_order_args.graph_write_options(graph, None)
+  }
+
+  pub fn graph_write_options_with_input_order<N, E, D>(
+    &self,
+    graph: &Graph<N, E, D>,
+    input_order: Vec<String>,
+  ) -> Result<GraphWriteOptions, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    self.topology_order_args.graph_write_options(graph, Some(input_order))
+  }
+}
+
+#[derive(Debug, Clone, SmartDefault, Serialize, Deserialize)]
+#[serde(default)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+pub struct TopologyOrderArgs {
+  /// Order tree topology before writing output files.
+  #[cfg_attr(feature = "clap", clap(long, value_enum))]
+  #[cfg_attr(feature = "clap", clap(conflicts_with = "topology_order"))]
+  #[cfg_attr(feature = "clap", clap(conflicts_with = "topology_order_target_source"))]
+  #[cfg_attr(feature = "clap", clap(conflicts_with = "topology_order_target_file"))]
+  #[cfg_attr(feature = "clap", clap(conflicts_with = "topology_order_target_aggregate"))]
+  pub ladderize: Option<LadderizeArg>,
+
+  /// Canonical topology ordering preset.
+  #[cfg_attr(feature = "clap", clap(long, value_enum))]
+  pub topology_order: Option<TopologyOrderArg>,
+
+  /// Source for target-order topology sorting.
+  #[cfg_attr(feature = "clap", clap(long, value_enum))]
+  pub topology_order_target_source: Option<TopologyOrderTargetSourceArg>,
+
+  /// File used by list or reference-topology target-order sources.
+  #[cfg_attr(feature = "clap", clap(long, value_hint = ValueHint::FilePath))]
+  pub topology_order_target_file: Option<PathBuf>,
+
+  /// Aggregate used to map a subtree to a target-order position.
+  #[cfg_attr(feature = "clap", clap(long, value_enum, default_value_t = TopologyOrderTargetAggregateArg::default()))]
+  #[default(TopologyOrderTargetAggregateArg::Mean)]
+  pub topology_order_target_aggregate: TopologyOrderTargetAggregateArg,
+}
+
+impl TopologyOrderArgs {
+  fn graph_write_options<N, E, D>(
+    &self,
+    graph: &Graph<N, E, D>,
+    input_order: Option<Vec<String>>,
+  ) -> Result<GraphWriteOptions, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    self.validate()?;
+
+    let preset = match (self.ladderize, self.topology_order) {
+      (Some(LadderizeArg::None), None) => TopologyOrderPreset::Keep,
+      (Some(LadderizeArg::Ascending), None) => TopologyOrderPreset::DescendantCount,
+      (Some(LadderizeArg::Descending), None) => TopologyOrderPreset::DescendantCountReverse,
+      (None, Some(topology_order)) => topology_order.into(),
+      (None, None) => TopologyOrderPreset::DescendantCount,
+      (Some(_), Some(_)) => {
+        return make_error!("--ladderize cannot be combined with --topology-order");
+      },
+    };
+
+    let target_order = if preset.is_target_order() {
+      self.target_order(graph, input_order)?
+    } else {
+      vec![]
+    };
+
+    Ok(GraphWriteOptions {
+      topology_order: TopologyOrderSpec {
+        preset,
+        target_order,
+        target_aggregate: self.topology_order_target_aggregate.into(),
+      },
+    })
+  }
+
+  fn validate(&self) -> Result<(), Report> {
+    if self.ladderize.is_some()
+      && (self.topology_order.is_some()
+        || self.topology_order_target_source.is_some()
+        || self.topology_order_target_file.is_some()
+        || self.topology_order_target_aggregate != TopologyOrderTargetAggregateArg::Mean)
+    {
+      return make_error!("--ladderize cannot be combined with --topology-order* options");
+    }
+
+    let target_fields_present = self.topology_order_target_source.is_some()
+      || self.topology_order_target_file.is_some()
+      || self.topology_order_target_aggregate != TopologyOrderTargetAggregateArg::Mean;
+    let target_mode = self
+      .topology_order
+      .is_some_and(|order| order.into_preset().is_target_order());
+
+    if target_fields_present && !target_mode {
+      return make_error!(
+        "--topology-order-target-* options require --topology-order=target-order or target-order-reverse"
+      );
+    }
+
+    if target_mode
+      && matches!(
+        self.topology_order_target_source,
+        Some(TopologyOrderTargetSourceArg::ReferenceTopology | TopologyOrderTargetSourceArg::List)
+      )
+      && self.topology_order_target_file.is_none()
+    {
+      return make_error!("--topology-order-target-file is required for reference-topology and list target sources");
+    }
+
+    Ok(())
+  }
+
+  fn target_order<N, E, D>(
+    &self,
+    graph: &Graph<N, E, D>,
+    input_order: Option<Vec<String>>,
+  ) -> Result<Vec<String>, Report>
+  where
+    N: GraphNode + Named,
+    E: GraphEdge,
+    D: Sync + Send,
+  {
+    match self
+      .topology_order_target_source
+      .unwrap_or(TopologyOrderTargetSourceArg::Input)
+    {
+      TopologyOrderTargetSourceArg::Input => input_order.map_or_else(|| leaf_order(graph), Ok),
+      TopologyOrderTargetSourceArg::ReferenceTopology => {
+        let path = self
+          .topology_order_target_file
+          .as_ref()
+          .ok_or_else(|| make_report!("--topology-order-target-file is required for reference-topology"))?;
+        let graph =
+          nwk_read_file::<OrderNode, OrderEdge, ()>(path).wrap_err("When reading target reference topology")?;
+        leaf_order(&graph)
+      },
+      TopologyOrderTargetSourceArg::List => {
+        let path = self
+          .topology_order_target_file
+          .as_ref()
+          .ok_or_else(|| make_report!("--topology-order-target-file is required for list"))?;
+        let contents = std::fs::read_to_string(path)
+          .wrap_err_with(|| format!("When reading topology order target list '{}'", path.display()))?;
+        Ok(
+          contents
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(str::to_owned)
+            .collect(),
+        )
+      },
+    }
+  }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
+pub enum LadderizeArg {
+  None,
+  Ascending,
+  Descending,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
+pub enum TopologyOrderArg {
+  Keep,
+  #[cfg_attr(feature = "clap", value(alias = "ladderize"))]
+  DescendantCount,
+  #[cfg_attr(feature = "clap", value(alias = "ladderize-reverse"))]
+  DescendantCountReverse,
+  Height,
+  HeightReverse,
+  Label,
+  #[cfg_attr(feature = "clap", value(alias = "alphabetical-reverse"))]
+  LabelReverse,
+  TargetOrder,
+  TargetOrderReverse,
+}
+
+impl TopologyOrderArg {
+  fn into_preset(self) -> TopologyOrderPreset {
+    self.into()
+  }
+}
+
+impl From<TopologyOrderArg> for TopologyOrderPreset {
+  fn from(value: TopologyOrderArg) -> Self {
+    match value {
+      TopologyOrderArg::Keep => Self::Keep,
+      TopologyOrderArg::DescendantCount => Self::DescendantCount,
+      TopologyOrderArg::DescendantCountReverse => Self::DescendantCountReverse,
+      TopologyOrderArg::Height => Self::Height,
+      TopologyOrderArg::HeightReverse => Self::HeightReverse,
+      TopologyOrderArg::Label => Self::Label,
+      TopologyOrderArg::LabelReverse => Self::LabelReverse,
+      TopologyOrderArg::TargetOrder => Self::TargetOrder,
+      TopologyOrderArg::TargetOrderReverse => Self::TargetOrderReverse,
+    }
+  }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
+pub enum TopologyOrderTargetSourceArg {
+  Input,
+  ReferenceTopology,
+  List,
+}
+
+impl std::fmt::Display for TopologyOrderTargetSourceArg {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::Input => write!(f, "input"),
+      Self::ReferenceTopology => write!(f, "reference-topology"),
+      Self::List => write!(f, "list"),
+    }
+  }
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
+pub enum TopologyOrderTargetAggregateArg {
+  #[default]
+  Mean,
+  Median,
+}
+
+impl From<TopologyOrderTargetAggregateArg> for TopologyOrderTargetAggregate {
+  fn from(value: TopologyOrderTargetAggregateArg) -> Self {
+    match value {
+      TopologyOrderTargetAggregateArg::Mean => Self::Mean,
+      TopologyOrderTargetAggregateArg::Median => Self::Median,
+    }
+  }
+}
+
+fn leaf_order<N, E, D>(graph: &Graph<N, E, D>) -> Result<Vec<String>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  graph
+    .get_leaves()
+    .into_iter()
+    .map(|leaf| {
+      let leaf = leaf.read_arc();
+      leaf
+        .payload()
+        .read_arc()
+        .name()
+        .map(|name| name.as_ref().to_owned())
+        .ok_or_else(|| make_report!("Leaf node {} has no name", leaf.key()))
+    })
+    .collect()
+}
+
+#[derive(Clone, Debug, Default)]
+struct OrderNode {
+  name: Option<String>,
+}
+
+impl GraphNode for OrderNode {}
+
+impl Named for OrderNode {
+  fn name(&self) -> Option<impl AsRef<str>> {
+    self.name.as_deref()
+  }
+
+  fn set_name(&mut self, name: Option<impl AsRef<str>>) {
+    self.name = name.map(|name| name.as_ref().to_owned());
+  }
+}
+
+impl NodeFromNwk for OrderNode {
+  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+    Ok(Self {
+      name: name.map(|name| name.as_ref().to_owned()),
+    })
+  }
+}
+
+#[derive(Clone, Debug, Default)]
+struct OrderEdge {
+  branch_length: Option<f64>,
+}
+
+impl GraphEdge for OrderEdge {}
+
+impl HasBranchLength for OrderEdge {
+  fn branch_length(&self) -> Option<f64> {
+    self.branch_length
+  }
+
+  fn set_branch_length(&mut self, branch_length: Option<f64>) {
+    self.branch_length = branch_length;
+  }
+}
+
+impl EdgeFromNwk for OrderEdge {
+  fn from_nwk(weight: Option<f64>) -> Result<Self, Report> {
+    Ok(Self { branch_length: weight })
   }
 }

--- a/packages/treetime/src/commands/timetree/__tests__/test_pipeline.rs
+++ b/packages/treetime/src/commands/timetree/__tests__/test_pipeline.rs
@@ -23,7 +23,10 @@ mod tests {
       tree: Some(root.join("data/flu/h3n2/20/tree.nwk")),
       metadata: Some(root.join("data/flu/h3n2/20/metadata.tsv")),
       max_iter: 3,
-      output: OutputArgs { outdir: outdir.clone() },
+      output: OutputArgs {
+        outdir: outdir.clone(),
+        ..Default::default()
+      },
       tracelog: Some(tracelog_path.clone()),
       ..TreetimeTimetreeArgs::default()
     };

--- a/packages/treetime/src/commands/timetree/initialization.rs
+++ b/packages/treetime/src/commands/timetree/initialization.rs
@@ -20,12 +20,14 @@ use eyre::{Report, WrapErr};
 use log::info;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use treetime_graph::node::Named;
 use treetime_io::dates_csv::{DatesMap, read_dates};
 use treetime_io::fasta::{FastaRecord, read_many_fasta};
 use treetime_io::nwk::nwk_read_file;
 
 pub struct InputData {
   pub graph: GraphTimetree,
+  pub input_leaf_order: Vec<String>,
   pub alphabet: Alphabet,
   pub aln: Option<Vec<FastaRecord>>,
   /// Parsed date constraints, retained for node data JSON output (`raw_date`,
@@ -39,6 +41,19 @@ pub fn load_input_data(args: &TreetimeTimetreeArgs) -> Result<InputData, Report>
   } else {
     todo!("Tree inference from alignment not yet implemented")
   };
+  let input_leaf_order = graph
+    .get_leaves()
+    .into_iter()
+    .map(|leaf| {
+      let leaf = leaf.read_arc();
+      leaf
+        .payload()
+        .read_arc()
+        .name()
+        .map(|name| name.as_ref().to_owned())
+        .ok_or_else(|| make_report!("Leaf node {} has no name", leaf.key()))
+    })
+    .collect::<Result<Vec<_>, _>>()?;
 
   let alphabet = Alphabet::new(args.alphabet_args.alphabet.unwrap_or_default())?;
 
@@ -77,6 +92,7 @@ pub fn load_input_data(args: &TreetimeTimetreeArgs) -> Result<InputData, Report>
 
   Ok(InputData {
     graph,
+    input_leaf_order,
     alphabet,
     aln,
     dates,

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -12,7 +12,7 @@ use crate::timetree::pipeline::{self, TimetreeInput, TimetreeParams};
 use eyre::{Report, WrapErr};
 use log::info;
 use std::path::PathBuf;
-use treetime_io::graph::write_graph_files_with;
+use treetime_io::graph::write_graph_files_with_options;
 use treetime_io::nwk::CommentProviders;
 use treetime_utils::io::file::create_file_or_stdout;
 
@@ -24,6 +24,7 @@ pub fn run_timetree_estimation(
   progress.report("Loading input", 0.0, "");
 
   let input_data = load_input_data(args)?;
+  let input_leaf_order = input_data.input_leaf_order.clone();
 
   let tracelog: Option<Box<dyn std::io::Write + Send>> = if let Some(path) = &args.tracelog {
     Some(Box::new(create_file_or_stdout(path)?))
@@ -81,7 +82,7 @@ pub fn run_timetree_estimation(
     info!("Wrote confidence intervals to {ci_path}", ci_path = ci_path.display());
   }
 
-  write_outputs(args, &output)?;
+  write_outputs(args, &output, input_leaf_order)?;
 
   progress.report("Done", 1.0, "");
   Ok(TimetreeResult {
@@ -91,16 +92,36 @@ pub fn run_timetree_estimation(
   })
 }
 
-fn write_outputs(args: &TreetimeTimetreeArgs, output: &pipeline::TimetreeOutput) -> Result<(), Report> {
+fn write_outputs(
+  args: &TreetimeTimetreeArgs,
+  output: &pipeline::TimetreeOutput,
+  input_leaf_order: Vec<String>,
+) -> Result<(), Report> {
+  let graph_options = args
+    .output
+    .graph_write_options_with_input_order(&output.graph, input_leaf_order)?;
+
   if !output.partitions.is_empty() {
     let guard = output.partitions[0].read_arc();
     let provider = MutationCommentProvider::new(&*guard, &output.graph);
     let providers = CommentProviders::new().with(&provider);
-    write_graph_files_with(&args.output.outdir, "timetree", &output.graph, &providers)
-      .wrap_err("Failed to write tree output")?;
+    write_graph_files_with_options(
+      &args.output.outdir,
+      "timetree",
+      &output.graph,
+      &providers,
+      &graph_options,
+    )
+    .wrap_err("Failed to write tree output")?;
   } else {
-    write_graph_files_with(&args.output.outdir, "timetree", &output.graph, &CommentProviders::new())
-      .wrap_err("Failed to write tree output")?;
+    write_graph_files_with_options(
+      &args.output.outdir,
+      "timetree",
+      &output.graph,
+      &CommentProviders::new(),
+      &graph_options,
+    )
+    .wrap_err("Failed to write tree output")?;
   }
 
   write_clock_model(&output.clock_model, &args.output.outdir.join("timetree"))?;


### PR DESCRIPTION
Tree-output commands need deterministic child ordering across every graph-backed format. TreeTime v0 ladderizes ancestral and regression trees before output [[src](https://github.com/neherlab/treetime/blob/3537219e089881da8c25d2acccdbc357f2778949/packages/legacy/treetime/treetime/treeanc.py#L457)], [[src](https://github.com/neherlab/treetime/blob/3537219e089881da8c25d2acccdbc357f2778949/packages/legacy/treetime/treetime/treeregression.py#L466)], while v1 previously wrote graph adjacency order directly.

Add a shared topology-ordering plan at the graph output boundary. The shared writer now orders one cloned graph before writing Newick, Nexus, graph JSON, and Graphviz output, and commands expose `--ladderize` plus canonical `--topology-order` options for preserving input order, reversing ladderization, label/height sorting, and explicit target leaf order.

The default descendant-count ordering matches the reference ladderization behavior without mutating command results. Keeping the operation at the writer boundary keeps all graph-backed output formats consistent and lets rerooting or pruning commands retain the original input leaf order for explicit keep or target-order modes.

### Work items

- [x] Add reusable topology-order planning for descendant-count, label, height, and target leaf order presets
- [x] Apply graph output ordering once in the shared graph writer before format-specific serialization
- [x] Add shared command-line output options for ladderization and explicit topology order
- [x] Preserve pre-mutation input leaf order in commands that reroot or prune tree topology
- [x] Document topology ordering in the algorithm, feature, and test inventories

### Possible improvements

- [ ] Extend shared graph output coverage beyond Newick, Nexus, graph JSON, and Graphviz where generic adapters are available ([kb/issues/N-io-write-graph-files-missing-formats.md](https://github.com/neherlab/treetime/blob/0b2e09245345e395eaec924979199478ac89c5b0/kb/issues/N-io-write-graph-files-missing-formats.md))