### PR TITLE
refactor: convert augur node data tests to in-memory

### DIFF
--- a/kb/issues/N-test-filesystem-dependency.md
+++ b/kb/issues/N-test-filesystem-dependency.md
@@ -1,69 +1,17 @@
 # Tests with unnecessary filesystem dependency
 
-Several unit tests use `tempfile`/`tempdir` or read `data/` files when the underlying logic could be tested in-memory. This adds filesystem coupling, slows test execution, and makes tests fragile to working-directory or file-availability changes.
-
-12 test files across 3 categories have filesystem dependency. After excluding golden master tests (exempt), smoke/integration tests (inherently FS-dependent), and tests of filename logic, 25 individual tests across 7 files are convertible to in-memory.
-
-## Convertible: augur node data serialization (4 files, 17 tests)
-
-All four `test_augur_node_data.rs` files follow the same pattern: `NamedTempFile::new()` then `write_augur_node_data_json(..., tmp.path())` then `std::fs::read_to_string(tmp.path())`. The writers internally call a `build_*` function to produce a struct, then serialize via `json_write_file`. Tests only care about the JSON string.
-
-Conversion: call `build_*` directly, serialize with `json_write_str(&data, JsonPretty(true))`.
-
-- `commands/ancestral/__tests__/test_augur_node_data.rs` - 4 tests via `helpers::write_json`. `pub fn build_augur_node_data_json` already exists at `commands/ancestral/augur_node_data.rs:35:`.
-- `commands/mugration/__tests__/test_augur_node_data.rs` - 2 tests via `run_and_serialize`. Build logic is inlined in the writer body; extract a `build_augur_node_data_json` function from `commands/mugration/augur_node_data.rs`.
-- `commands/optimize/__tests__/test_augur_node_data.rs` - 5 unit tests via `helpers::write_and_read` / `helpers::write_json`. Extract a `build_augur_node_data_json` from `commands/optimize/augur_node_data.rs`.
-- `commands/timetree/output/__tests__/test_augur_node_data.rs` - 6 tests via `helpers::SampleCase::write_json`. The writer's core is `json_write(W: Write, ...)` so it already accepts a generic writer; tests could pass a `Vec<u8>` buffer. Or call the build function + `json_write_str`.
-
-## Convertible: auspice JSON (1 file, 8 tests)
-
-`commands/timetree/output/__tests__/test_auspice.rs` - 8 of 9 tests create `tempdir()`, write auspice JSON, read it back. `pub fn build_timetree_auspice` already exists at `timetree/output/auspice.rs:20:` and returns `Result<AuspiceTree>`. Tests can call it directly and assert on the struct. The two error-rejection tests (`test_auspice_rejects_nan_div`, `test_auspice_rejects_infinite_time`) already fail inside `build_timetree_auspice` before any file write.
-
-Exception: `test_auspice_output_file_is_valid_json` genuinely tests file creation and should keep the tempdir.
-
-## Convertible: data/ read-only (2 files, 3 tests, partial)
-
-- `ancestral/__tests__/test_python_parity.rs` - 1 test reads `data/flu/h3n2/20/{tree.nwk,aln.fasta.xz}`. The tree is 1.5 KB (one line) and the alignment is 20 short sequences. Both can be embedded as `const` string literals, parsed with `nwk_read_str` / `read_many_fasta_str`. The other 6 tests in the file already use inline constants.
-- `clock/__tests__/test_clock_dengue100.rs` - 2 tests read `data/dengue/100/{tree.nwk,metadata.tsv}`. The tree is 3.7 KB and the metadata is 101 lines (~2 KB). Embeddable as const, but the test's value is tied to this specific biological dataset (force_positive_rate behavior with all 198 root positions negative). Conversion changes character from "real dataset regression" to "inline fixture regression." Lower priority.
-
-## Not convertible (must remain FS-dependent)
-
-### Smoke/integration tests (3 files, 7 tests)
-
-Full command e2e tests that exercise the entire pipeline including file I/O. Inherently FS-dependent.
-
-- `commands/ancestral/__tests__/test_smoke_gtr_iterations.rs` - 2 tests: `run_ancestral_reconstruction` on `data/flu/h3n2/20/`, writes to `tmp/`, asserts output file existence and `result.gtr` properties.
-- `commands/ancestral/__tests__/test_smoke_sample_from_profile.rs` - 2 tests: sampling reproducibility via file content comparison, output file existence. (1 additional rejection test is already essentially in-memory.)
-- `commands/timetree/__tests__/test_pipeline.rs` - 1 test: full timetree pipeline, reads back tracelog CSV for convergence metrics, checks output file existence and size.
-
-### E2e tests embedded in augur_node_data files (2 files, 4 tests)
-
-- `commands/ancestral/__tests__/test_augur_node_data.rs` - 3 `reconstruct_json` tests: write synthetic tree+alignment to tempdir, run full `run_ancestral_reconstruction`, read back output JSON.
-- `commands/optimize/__tests__/test_augur_node_data.rs` - 1 `end_to_end` test: reads `data/flu/h3n2/20/`, runs full optimize command, reads back output JSON.
-
-### Filename logic tests (1 file, 2 tests)
-
-- `gtr/__tests__/test_write_gtr_json.rs` - 2 tests: verify filename construction (qualified vs unqualified, non-overwriting). Inherently path-based.
-
-### Large dataset convergence (1 file, 1 test)
-
-- `optimize/__tests__/test_convergence_sc2.rs` - `test_convergence_sc2_sparse_converges_on_sc2_2844`: reads 149 KB tree + ~85 MB alignment. Not embeddable. The convergence bug is triggered by specific dataset properties. (The second test in this file uses `data/flu/h3n2/20/` which is small enough to embed but shares the fixture with `test_python_parity`.)
-
-## Locations
+Four unit tests read `data/` files when the underlying logic could use inline fixtures. This adds filesystem coupling, slows test execution, and makes tests fragile to working-directory changes.
 
 All paths relative to `packages/treetime/src/`.
 
-| File                                                             | Tests                             | Category        |
-| ---------------------------------------------------------------- | --------------------------------- | --------------- |
-| `commands/ancestral/__tests__/test_augur_node_data.rs`           | 4 convertible, 3 e2e              | augur node data |
-| `commands/mugration/__tests__/test_augur_node_data.rs`           | 2 convertible                     | augur node data |
-| `commands/optimize/__tests__/test_augur_node_data.rs`            | 5 convertible, 1 e2e              | augur node data |
-| `commands/timetree/output/__tests__/test_augur_node_data.rs`     | 6 convertible                     | augur node data |
-| `commands/timetree/output/__tests__/test_auspice.rs`             | 8 convertible, 1 keep             | auspice         |
-| `ancestral/__tests__/test_python_parity.rs`                      | 1 convertible                     | data/ read      |
-| `clock/__tests__/test_clock_dengue100.rs`                        | 2 convertible (lower priority)    | data/ read      |
-| `commands/ancestral/__tests__/test_smoke_gtr_iterations.rs`      | 2 keep                            | smoke           |
-| `commands/ancestral/__tests__/test_smoke_sample_from_profile.rs` | 2 keep                            | smoke           |
-| `commands/timetree/__tests__/test_pipeline.rs`                   | 1 keep                            | smoke           |
-| `gtr/__tests__/test_write_gtr_json.rs`                           | 2 keep                            | filename logic  |
-| `optimize/__tests__/test_convergence_sc2.rs`                     | 1 keep (sc2), 1 convertible (flu) | data/ read      |
+## `ancestral/__tests__/test_python_parity.rs` (1 test)
+
+`test_root_sequence_matches_python_h3n2_na_20` reads `data/flu/h3n2/20/{tree.nwk,aln.fasta.xz}`. The tree is 1.5 KB (one line). The alignment is 20 sequences totaling 28 KB uncompressed FASTA, too large for a const literal but embeddable via `include_str!` with a decompressed fixture file.
+
+## `clock/__tests__/test_clock_dengue100.rs` (2 tests)
+
+Both tests read `data/dengue/100/{tree.nwk,metadata.tsv}`. The tree is 3.7 KB and the metadata is 101 lines (~2 KB). Embeddable as const, but the test's value is tied to this specific biological dataset (force_positive_rate behavior with all 198 root positions negative).
+
+## `optimize/__tests__/test_convergence_sc2.rs` (1 test)
+
+`test_convergence_sc2_flu_h3n2_20_converges` reads `data/flu/h3n2/20/{tree.nwk,aln.fasta.xz}`. Same dataset as python parity; shares the conversion approach.

--- a/kb/issues/N-test-filesystem-dependency.md
+++ b/kb/issues/N-test-filesystem-dependency.md
@@ -1,0 +1,69 @@
+# Tests with unnecessary filesystem dependency
+
+Several unit tests use `tempfile`/`tempdir` or read `data/` files when the underlying logic could be tested in-memory. This adds filesystem coupling, slows test execution, and makes tests fragile to working-directory or file-availability changes.
+
+12 test files across 3 categories have filesystem dependency. After excluding golden master tests (exempt), smoke/integration tests (inherently FS-dependent), and tests of filename logic, 25 individual tests across 7 files are convertible to in-memory.
+
+## Convertible: augur node data serialization (4 files, 17 tests)
+
+All four `test_augur_node_data.rs` files follow the same pattern: `NamedTempFile::new()` then `write_augur_node_data_json(..., tmp.path())` then `std::fs::read_to_string(tmp.path())`. The writers internally call a `build_*` function to produce a struct, then serialize via `json_write_file`. Tests only care about the JSON string.
+
+Conversion: call `build_*` directly, serialize with `json_write_str(&data, JsonPretty(true))`.
+
+- `commands/ancestral/__tests__/test_augur_node_data.rs` - 4 tests via `helpers::write_json`. `pub fn build_augur_node_data_json` already exists at `commands/ancestral/augur_node_data.rs:35:`.
+- `commands/mugration/__tests__/test_augur_node_data.rs` - 2 tests via `run_and_serialize`. Build logic is inlined in the writer body; extract a `build_augur_node_data_json` function from `commands/mugration/augur_node_data.rs`.
+- `commands/optimize/__tests__/test_augur_node_data.rs` - 5 unit tests via `helpers::write_and_read` / `helpers::write_json`. Extract a `build_augur_node_data_json` from `commands/optimize/augur_node_data.rs`.
+- `commands/timetree/output/__tests__/test_augur_node_data.rs` - 6 tests via `helpers::SampleCase::write_json`. The writer's core is `json_write(W: Write, ...)` so it already accepts a generic writer; tests could pass a `Vec<u8>` buffer. Or call the build function + `json_write_str`.
+
+## Convertible: auspice JSON (1 file, 8 tests)
+
+`commands/timetree/output/__tests__/test_auspice.rs` - 8 of 9 tests create `tempdir()`, write auspice JSON, read it back. `pub fn build_timetree_auspice` already exists at `timetree/output/auspice.rs:20:` and returns `Result<AuspiceTree>`. Tests can call it directly and assert on the struct. The two error-rejection tests (`test_auspice_rejects_nan_div`, `test_auspice_rejects_infinite_time`) already fail inside `build_timetree_auspice` before any file write.
+
+Exception: `test_auspice_output_file_is_valid_json` genuinely tests file creation and should keep the tempdir.
+
+## Convertible: data/ read-only (2 files, 3 tests, partial)
+
+- `ancestral/__tests__/test_python_parity.rs` - 1 test reads `data/flu/h3n2/20/{tree.nwk,aln.fasta.xz}`. The tree is 1.5 KB (one line) and the alignment is 20 short sequences. Both can be embedded as `const` string literals, parsed with `nwk_read_str` / `read_many_fasta_str`. The other 6 tests in the file already use inline constants.
+- `clock/__tests__/test_clock_dengue100.rs` - 2 tests read `data/dengue/100/{tree.nwk,metadata.tsv}`. The tree is 3.7 KB and the metadata is 101 lines (~2 KB). Embeddable as const, but the test's value is tied to this specific biological dataset (force_positive_rate behavior with all 198 root positions negative). Conversion changes character from "real dataset regression" to "inline fixture regression." Lower priority.
+
+## Not convertible (must remain FS-dependent)
+
+### Smoke/integration tests (3 files, 7 tests)
+
+Full command e2e tests that exercise the entire pipeline including file I/O. Inherently FS-dependent.
+
+- `commands/ancestral/__tests__/test_smoke_gtr_iterations.rs` - 2 tests: `run_ancestral_reconstruction` on `data/flu/h3n2/20/`, writes to `tmp/`, asserts output file existence and `result.gtr` properties.
+- `commands/ancestral/__tests__/test_smoke_sample_from_profile.rs` - 2 tests: sampling reproducibility via file content comparison, output file existence. (1 additional rejection test is already essentially in-memory.)
+- `commands/timetree/__tests__/test_pipeline.rs` - 1 test: full timetree pipeline, reads back tracelog CSV for convergence metrics, checks output file existence and size.
+
+### E2e tests embedded in augur_node_data files (2 files, 4 tests)
+
+- `commands/ancestral/__tests__/test_augur_node_data.rs` - 3 `reconstruct_json` tests: write synthetic tree+alignment to tempdir, run full `run_ancestral_reconstruction`, read back output JSON.
+- `commands/optimize/__tests__/test_augur_node_data.rs` - 1 `end_to_end` test: reads `data/flu/h3n2/20/`, runs full optimize command, reads back output JSON.
+
+### Filename logic tests (1 file, 2 tests)
+
+- `gtr/__tests__/test_write_gtr_json.rs` - 2 tests: verify filename construction (qualified vs unqualified, non-overwriting). Inherently path-based.
+
+### Large dataset convergence (1 file, 1 test)
+
+- `optimize/__tests__/test_convergence_sc2.rs` - `test_convergence_sc2_sparse_converges_on_sc2_2844`: reads 149 KB tree + ~85 MB alignment. Not embeddable. The convergence bug is triggered by specific dataset properties. (The second test in this file uses `data/flu/h3n2/20/` which is small enough to embed but shares the fixture with `test_python_parity`.)
+
+## Locations
+
+All paths relative to `packages/treetime/src/`.
+
+| File                                                             | Tests                             | Category        |
+| ---------------------------------------------------------------- | --------------------------------- | --------------- |
+| `commands/ancestral/__tests__/test_augur_node_data.rs`           | 4 convertible, 3 e2e              | augur node data |
+| `commands/mugration/__tests__/test_augur_node_data.rs`           | 2 convertible                     | augur node data |
+| `commands/optimize/__tests__/test_augur_node_data.rs`            | 5 convertible, 1 e2e              | augur node data |
+| `commands/timetree/output/__tests__/test_augur_node_data.rs`     | 6 convertible                     | augur node data |
+| `commands/timetree/output/__tests__/test_auspice.rs`             | 8 convertible, 1 keep             | auspice         |
+| `ancestral/__tests__/test_python_parity.rs`                      | 1 convertible                     | data/ read      |
+| `clock/__tests__/test_clock_dengue100.rs`                        | 2 convertible (lower priority)    | data/ read      |
+| `commands/ancestral/__tests__/test_smoke_gtr_iterations.rs`      | 2 keep                            | smoke           |
+| `commands/ancestral/__tests__/test_smoke_sample_from_profile.rs` | 2 keep                            | smoke           |
+| `commands/timetree/__tests__/test_pipeline.rs`                   | 1 keep                            | smoke           |
+| `gtr/__tests__/test_write_gtr_json.rs`                           | 2 keep                            | filename logic  |
+| `optimize/__tests__/test_convergence_sc2.rs`                     | 1 keep (sc2), 1 convertible (flu) | data/ read      |

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -168,6 +168,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Core         | [Production unwrap/expect/assert audit](N-production-unwrap-expect-audit.md)                                                                        |
 | Negligible | Test         | [Test coverage gaps across production functions](N-test-coverage-gaps.md)                                                                           |
 | Negligible | Test         | [Test quality deficiencies](N-test-quality-deficiencies.md)                                                                                         |
+| Negligible | Test         | [Tests with unnecessary filesystem dependency](N-test-filesystem-dependency.md)                                                                     |
 | Negligible | Test         | [Loose tolerances in test_gaussian_product.rs](N-test-gaussian-product-loose-tolerances.md)                                                         |
 | Negligible | GTR          | [GTR site-specific interpolation tolerance requires investigation](N-gtr-site-specific-interpolation-tolerance.md)                                  |
 | Negligible | Timetree     | [Coalescent integration test uses grossly loose tolerance](N-timetree-coalescent-integration-grossly-loose-tolerance.md)                            |

--- a/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_augur_node_data.rs
@@ -165,7 +165,7 @@ mod tests {
     use crate::ancestral::params::MethodAncestral;
     use crate::commands::ancestral::aa_node_data::{AaGeneNodeData, AaNodeData};
     use crate::commands::ancestral::args::TreetimeAncestralArgs;
-    use crate::commands::ancestral::augur_node_data::{build_augur_node_data_json, write_augur_node_data_json};
+    use crate::commands::ancestral::augur_node_data::build_augur_node_data_json;
     use crate::commands::ancestral::run::run_ancestral_reconstruction;
     use crate::commands::shared::alignment::AlignmentArgs;
     use crate::commands::shared::model::ModelArgs;
@@ -178,10 +178,11 @@ mod tests {
     use crate::seq::mutation::Sub;
     use maplit::btreemap;
     use std::collections::BTreeMap;
-    use tempfile::{NamedTempFile, tempdir};
+    use tempfile::tempdir;
     use treetime_graph::node::Named;
     use treetime_io::nwk::nwk_read_str;
     use treetime_primitives::{AsciiChar, Seq};
+    use treetime_utils::io::json::{JsonPretty, json_write_str};
     use treetime_utils::o;
     use util_augur_node_data_json::{
       AugurNodeDataJsonAncestral, AugurNodeDataJsonAncestralMeta, AugurNodeDataJsonAncestralNode,
@@ -246,9 +247,8 @@ mod tests {
     }
 
     pub fn write_json(graph: &GraphAncestral, partition: &PartitionFitch, mask: &[bool]) -> String {
-      let tmp = NamedTempFile::new().unwrap();
-      write_augur_node_data_json(graph, partition, mask, tmp.path()).unwrap();
-      std::fs::read_to_string(tmp.path()).unwrap()
+      let data = build_augur_node_data_json(graph, partition, mask, None).unwrap();
+      json_write_str(&data, JsonPretty(true)).unwrap()
     }
 
     pub fn reconstruct_json(method: MethodAncestral, dense: Option<bool>, model: GtrModelName) -> String {

--- a/packages/treetime/src/commands/mugration/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/mugration/__tests__/test_augur_node_data.rs
@@ -1,21 +1,19 @@
 #[cfg(test)]
 mod tests {
-  use crate::commands::mugration::augur_node_data::write_augur_node_data_json;
+  use crate::commands::mugration::augur_node_data::build_augur_node_data_json;
   use crate::mugration::mugration::execute_mugration;
   use maplit::btreemap;
   use pretty_assertions::assert_eq;
-  use tempfile::NamedTempFile;
   use treetime_io::nwk::nwk_read_str;
-  use treetime_utils::io::json::json_read_str;
+  use treetime_utils::io::json::{JsonPretty, json_read_str, json_write_str};
   use treetime_utils::o;
   use util_augur_node_data_json::AugurNodeDataJsonTraits;
 
   fn run_and_serialize(tree: &str, traits: &std::collections::BTreeMap<String, String>) -> String {
     let graph = nwk_read_str(tree).unwrap();
     let result = execute_mugration(graph, traits, "country", None, "?", None, 0.5, 5, None).unwrap();
-    let tmp = NamedTempFile::new().unwrap();
-    write_augur_node_data_json(&result, tmp.path()).unwrap();
-    std::fs::read_to_string(tmp.path()).unwrap()
+    let data = build_augur_node_data_json(&result).unwrap();
+    json_write_str(&data, JsonPretty(true)).unwrap()
   }
 
   #[test]

--- a/packages/treetime/src/commands/mugration/augur_node_data.rs
+++ b/packages/treetime/src/commands/mugration/augur_node_data.rs
@@ -13,7 +13,7 @@ use util_augur_node_data_json::{
   AugurNodeDataJsonTraitsMeta, AugurNodeDataJsonTraitsNode,
 };
 
-pub fn write_augur_node_data_json(result: &MugrationResult, path: &Path) -> Result<(), Report> {
+pub fn build_augur_node_data_json(result: &MugrationResult) -> Result<AugurNodeDataJsonTraits, Report> {
   let attribute = &result.traits.attribute;
   let partition = &result.partition;
   let graph = &result.graph;
@@ -22,7 +22,7 @@ pub fn write_augur_node_data_json(result: &MugrationResult, path: &Path) -> Resu
   let nodes = build_nodes(attribute, graph, partition);
   let branches = build_branches(attribute, graph, partition);
 
-  let data = AugurNodeDataJsonTraits {
+  Ok(AugurNodeDataJsonTraits {
     generated_by: Some(AugurNodeDataJsonGeneratedBy {
       program: "treetime".to_owned(),
       version: env!("CARGO_PKG_VERSION").to_owned(),
@@ -38,8 +38,11 @@ pub fn write_augur_node_data_json(result: &MugrationResult, path: &Path) -> Resu
       },
     },
     nodes,
-  };
+  })
+}
 
+pub fn write_augur_node_data_json(result: &MugrationResult, path: &Path) -> Result<(), Report> {
+  let data = build_augur_node_data_json(result)?;
   json_write_file(path, &data, JsonPretty(true))?;
   Ok(())
 }

--- a/packages/treetime/src/commands/optimize/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_augur_node_data.rs
@@ -118,25 +118,17 @@ mod tests {
   }
 
   mod helpers {
-    use crate::commands::optimize::augur_node_data::write_augur_node_data_json;
+    use crate::commands::optimize::augur_node_data::build_augur_node_data_json;
     use crate::payload::ancestral::GraphAncestral;
     use std::path::{Path, PathBuf};
-    use tempfile::NamedTempFile;
     use treetime_io::nwk::nwk_read_str;
-    use treetime_utils::io::json::json_read_str;
+    use treetime_utils::io::json::{JsonPretty, json_read_str, json_write_str};
     use util_augur_node_data_json::AugurNodeDataJsonRefine;
 
     pub fn write_json(nwk: &str) -> String {
       let graph: GraphAncestral = nwk_read_str(nwk).unwrap();
-      let tmp = NamedTempFile::new().unwrap();
-      write_augur_node_data_json(
-        &graph,
-        Some(Path::new("aln.fasta")),
-        Some(Path::new("tree.nwk")),
-        tmp.path(),
-      )
-      .unwrap();
-      std::fs::read_to_string(tmp.path()).unwrap()
+      let data = build_augur_node_data_json(&graph, Some(Path::new("aln.fasta")), Some(Path::new("tree.nwk"))).unwrap();
+      json_write_str(&data, JsonPretty(true)).unwrap()
     }
 
     pub fn write_and_read(nwk: &str) -> AugurNodeDataJsonRefine {

--- a/packages/treetime/src/commands/optimize/augur_node_data.rs
+++ b/packages/treetime/src/commands/optimize/augur_node_data.rs
@@ -37,12 +37,11 @@ use util_augur_node_data_json::{
 /// - `confidence` is omitted: v1's Newick reader does not parse input-tree branch
 ///   support values (shared gap with `timetree`, tracked in
 ///   `kb/issues/N-timetree-node-data-confidence-not-emitted.md`).
-pub fn write_augur_node_data_json(
+pub fn build_augur_node_data_json(
   graph: &GraphAncestral,
   alignment: Option<&Path>,
   input_tree: Option<&Path>,
-  path: &Path,
-) -> Result<(), Report> {
+) -> Result<AugurNodeDataJsonRefine, Report> {
   let mut nodes = BTreeMap::new();
   for node in graph.get_nodes() {
     let node_guard = node.read_arc();
@@ -83,7 +82,7 @@ pub fn write_augur_node_data_json(
     );
   }
 
-  let data = AugurNodeDataJsonRefine {
+  Ok(AugurNodeDataJsonRefine {
     generated_by: Some(AugurNodeDataJsonGeneratedBy {
       program: "treetime".to_owned(),
       version: env!("CARGO_PKG_VERSION").to_owned(),
@@ -96,8 +95,16 @@ pub fn write_augur_node_data_json(
       other: BTreeMap::new(),
     },
     nodes,
-  };
+  })
+}
 
+pub fn write_augur_node_data_json(
+  graph: &GraphAncestral,
+  alignment: Option<&Path>,
+  input_tree: Option<&Path>,
+  path: &Path,
+) -> Result<(), Report> {
+  let data = build_augur_node_data_json(graph, alignment, input_tree)?;
   json_write_file(path, &data, JsonPretty(true))?;
   Ok(())
 }

--- a/packages/treetime/src/commands/timetree/output/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/timetree/output/__tests__/test_augur_node_data.rs
@@ -123,16 +123,15 @@ mod tests {
 
   mod helpers {
     use crate::clock::clock_model::{ClockModel, ClockModelStats, RegressionStats};
-    use crate::commands::timetree::output::augur_node_data::write_augur_node_data_json;
+    use crate::commands::timetree::output::augur_node_data::build_augur_node_data_json;
     use crate::partition::timetree::GraphTimetree;
     use crate::payload::timetree::{EdgeTimetree, NodeTimetree};
     use crate::timetree::confidence::NodeConfidenceInterval;
     use ndarray::array;
     use std::path::Path;
-    use tempfile::NamedTempFile;
     use treetime_graph::node::Named;
     use treetime_io::dates_csv::{DateConstraint, DateRange, DateValue, DatesMap};
-    use treetime_utils::io::json::json_read_str;
+    use treetime_utils::io::json::{JsonPretty, json_read_str, json_write_str};
     use util_augur_node_data_json::AugurNodeDataJsonRefine;
 
     pub struct SampleCase {
@@ -144,18 +143,16 @@ mod tests {
 
     impl SampleCase {
       pub fn write_json(&self) -> String {
-        let tmp = NamedTempFile::new().unwrap();
-        write_augur_node_data_json(
+        let data = build_augur_node_data_json(
           &self.graph,
           &self.clock_model,
           Some(&self.intervals),
           Some(&self.dates),
           Some(Path::new("aln.fasta")),
           Some(Path::new("tree.nwk")),
-          tmp.path(),
         )
         .unwrap();
-        std::fs::read_to_string(tmp.path()).unwrap()
+        json_write_str(&data, JsonPretty(true)).unwrap()
       }
 
       pub fn write_and_read(&self) -> AugurNodeDataJsonRefine {

--- a/packages/treetime/src/commands/timetree/output/__tests__/test_auspice.rs
+++ b/packages/treetime/src/commands/timetree/output/__tests__/test_auspice.rs
@@ -4,20 +4,24 @@ mod tests {
   use crate::partition::timetree::GraphTimetree;
   use crate::payload::timetree::NodeTimetree;
   use crate::timetree::confidence::NodeConfidenceInterval;
+  use crate::timetree::output::auspice::build_timetree_auspice;
   use approx::assert_relative_eq;
   use pretty_assertions::assert_eq;
 
   use treetime_graph::node::{GraphNodeKey, Named};
   use treetime_io::auspice_types::{AuspiceColoring, AuspiceTree};
-  use treetime_utils::io::json::json_read_file;
+
+  fn build_and_roundtrip(graph: &GraphTimetree, ci: Option<&[NodeConfidenceInterval]>) -> AuspiceTree {
+    let tree = build_timetree_auspice(graph, ci).unwrap();
+    let json = serde_json::to_value(&tree).unwrap();
+    serde_json::from_value(json).unwrap()
+  }
 
   #[test]
   fn test_auspice_metadata_structure() {
     let graph = build_simple_tree();
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, None, dir.path()).unwrap();
+    let tree = build_and_roundtrip(&graph, None);
 
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
     assert_eq!(tree.data.version.as_deref(), Some("v2"));
     assert!(tree.data.meta.title.as_deref().is_some());
     assert!(tree.data.meta.updated.is_some());
@@ -53,10 +57,7 @@ mod tests {
   #[test]
   fn test_auspice_root_node_attributes() {
     let graph = build_simple_tree();
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, None, dir.path()).unwrap();
-
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
+    let tree = build_and_roundtrip(&graph, None);
 
     // Root has zero divergence (from NodeTimetree.div)
     assert_relative_eq!(tree.tree.node_attrs.div.unwrap(), 0.0);
@@ -73,10 +74,7 @@ mod tests {
   #[test]
   fn test_auspice_divergence_from_node_payload() {
     let graph = build_simple_tree();
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, None, dir.path()).unwrap();
-
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
+    let tree = build_and_roundtrip(&graph, None);
 
     // Root div = 0.0 (set in make_named_node)
     assert_relative_eq!(tree.tree.node_attrs.div.unwrap(), 0.0);
@@ -101,10 +99,7 @@ mod tests {
     graph.add_edge(root_key, bad_key, make_edge(0.003)).unwrap();
     graph.build().unwrap();
 
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, None, dir.path()).unwrap();
-
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
+    let tree = build_and_roundtrip(&graph, None);
     assert_eq!(tree.tree.node_attrs.bad_branch.as_ref().unwrap().value, "No");
     assert_eq!(
       tree.tree.children[0].node_attrs.bad_branch.as_ref().unwrap().value,
@@ -134,10 +129,7 @@ mod tests {
       },
     ];
 
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, Some(&intervals), dir.path()).unwrap();
-
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
+    let tree = build_and_roundtrip(&graph, Some(&intervals));
 
     // Root gets CI (looked up by key, not name)
     let root_ci = tree.tree.node_attrs.num_date.as_ref().unwrap().confidence.unwrap();
@@ -182,10 +174,7 @@ mod tests {
       upper: 2001.0,
     }];
 
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, Some(&intervals), dir.path()).unwrap();
-
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
+    let tree = build_and_roundtrip(&graph, Some(&intervals));
 
     // Unnamed node gets fallback name
     assert!(tree.tree.name.starts_with("node_"));
@@ -204,10 +193,7 @@ mod tests {
     graph.add_node(root);
     graph.build().unwrap();
 
-    let dir = tempfile::tempdir().unwrap();
-    write_auspice_json(&graph, None, dir.path()).unwrap();
-
-    let tree: AuspiceTree = json_read_file(dir.path().join("auspice_tree.json")).unwrap();
+    let tree = build_and_roundtrip(&graph, None);
     assert!(tree.tree.node_attrs.num_date.is_none());
   }
 
@@ -218,8 +204,7 @@ mod tests {
     graph.add_node(node);
     graph.build().unwrap();
 
-    let dir = tempfile::tempdir().unwrap();
-    let err = write_auspice_json(&graph, None, dir.path()).unwrap_err();
+    let err = build_timetree_auspice(&graph, None).unwrap_err();
     let msg = format!("{err}");
     assert!(msg.contains("non-finite div"), "expected div error, got: {msg}");
     assert!(msg.contains("bad"), "expected node name in error, got: {msg}");
@@ -234,8 +219,7 @@ mod tests {
     graph.add_node(node);
     graph.build().unwrap();
 
-    let dir = tempfile::tempdir().unwrap();
-    let err = write_auspice_json(&graph, None, dir.path()).unwrap_err();
+    let err = build_timetree_auspice(&graph, None).unwrap_err();
     let msg = format!("{err}");
     assert!(msg.contains("non-finite time"), "expected time error, got: {msg}");
     assert!(msg.contains("inf_node"), "expected node name in error, got: {msg}");
@@ -251,7 +235,7 @@ mod tests {
     assert!(path.exists());
 
     // Verify it parses as valid AuspiceTree
-    let tree: AuspiceTree = json_read_file(&path).unwrap();
+    let tree: AuspiceTree = treetime_utils::io::json::json_read_file(&path).unwrap();
     assert!(!tree.tree.name.is_empty());
   }
 

--- a/packages/treetime/src/commands/timetree/output/augur_node_data.rs
+++ b/packages/treetime/src/commands/timetree/output/augur_node_data.rs
@@ -45,15 +45,14 @@ use util_augur_node_data_json::{
 /// `dates` carries the parsed metadata date constraints used for `raw_date` (tips)
 /// and `date_inferred`; the inferred `date` string derives from each node's
 /// `numdate`.
-pub fn write_augur_node_data_json(
+pub fn build_augur_node_data_json(
   graph: &GraphTimetree,
   clock_model: &ClockModel,
   confidence_intervals: Option<&[NodeConfidenceInterval]>,
   dates: Option<&DatesMap>,
   alignment: Option<&Path>,
   input_tree: Option<&Path>,
-  path: &Path,
-) -> Result<(), Report> {
+) -> Result<AugurNodeDataJsonRefine, Report> {
   let ci_map = confidence_intervals.map(build_ci_map);
 
   let mut nodes = BTreeMap::new();
@@ -122,7 +121,7 @@ pub fn write_augur_node_data_json(
     );
   }
 
-  let data = AugurNodeDataJsonRefine {
+  Ok(AugurNodeDataJsonRefine {
     generated_by: Some(AugurNodeDataJsonGeneratedBy {
       program: "treetime".to_owned(),
       version: env!("CARGO_PKG_VERSION").to_owned(),
@@ -134,8 +133,19 @@ pub fn write_augur_node_data_json(
       other: BTreeMap::new(),
     },
     nodes,
-  };
+  })
+}
 
+pub fn write_augur_node_data_json(
+  graph: &GraphTimetree,
+  clock_model: &ClockModel,
+  confidence_intervals: Option<&[NodeConfidenceInterval]>,
+  dates: Option<&DatesMap>,
+  alignment: Option<&Path>,
+  input_tree: Option<&Path>,
+  path: &Path,
+) -> Result<(), Report> {
+  let data = build_augur_node_data_json(graph, clock_model, confidence_intervals, dates, alignment, input_tree)?;
   json_write_file(path, &data, JsonPretty(true))?;
   Ok(())
 }


### PR DESCRIPTION
- Follow-up to: `feat/topology-order-ladderize`

Several augur node data and auspice output tests wrote results to temporary files and read them back for assertion, coupling unit tests to the filesystem when the underlying logic operates on in-memory structs.

Extract `pub fn build_augur_node_data_json` from mugration, optimize, and timetree output writers, separating struct construction from file writing. Convert tests across ancestral, mugration, optimize, output, and timetree auspice modules from tempfile write-then-read-back to in-memory build with `json_write_str` or serde roundtrip.

### Work items

- [x] Extract `build_augur_node_data_json` from mugration, optimize, and timetree output writers
- [x] Convert augur node data tests to in-memory assertions across 5 modules
- [x] File known issue for remaining filesystem-dependent tests
- [x] Update known issue to reflect completed conversions