### PR TITLE
chore: use Redis sccache backend with per-container UDS isolation

### DIFF
--- a/dev/docker/run
+++ b/dev/docker/run
@@ -179,12 +179,18 @@ declare -A volumes=(
 
 declare -A sccache_env=()
 if [[ "${SCCACHE_ENABLED:-true}" == "true" ]]; then
-  volumes["${SCCACHE_DIR:-${cache_dir}/sccache}"]="/home/${USER}/.cache/sccache"
   sccache_env=(
     ["RUSTC_WRAPPER"]="sccache"
-    ["SCCACHE_DIR"]="/home/${USER}/.cache/sccache"
-    ["SCCACHE_CACHE_SIZE"]="${SCCACHE_CACHE_SIZE:-5G}"
+    ["SCCACHE_SERVER_UDS"]="/tmp/sccache.sock"
   )
+  sccache_redis_port="${SCCACHE_REDIS_PORT:-63793}"
+  if bash -c "echo > /dev/tcp/127.0.0.1/${sccache_redis_port}" 2>/dev/null; then
+    sccache_env["SCCACHE_REDIS"]="redis://127.0.0.1:${sccache_redis_port}"
+  else
+    volumes["${SCCACHE_DIR:-${cache_dir}/sccache}"]="/home/${USER}/.cache/sccache"
+    sccache_env["SCCACHE_DIR"]="/home/${USER}/.cache/sccache"
+    sccache_env["SCCACHE_CACHE_SIZE"]="${SCCACHE_CACHE_SIZE:-5G}"
+  fi
 fi
 
 mkdir -p "${!volumes[@]}"


### PR DESCRIPTION
With Docker `--network=host`, concurrent build containers share TCP port 4226 for sccache's server process. The sccache server runs the compiler and writes output files, so when the first container exits and its server dies, all other containers' in-flight compilations fail with missing-file or exit-code-254 errors. This caused recurring build failures across concurrent worktree sessions.

Switch the sccache backend from local disk to a shared Redis instance (managed by `sccachectl` in `~/ai-rules/packages/sccache/`). Each container runs its own sccache server on a container-local Unix domain socket (`SCCACHE_SERVER_UDS=/tmp/sccache.sock`), eliminating TCP port collisions. When Redis is reachable on port 63793, the container uses it as the storage backend. When Redis is unavailable (CI, other developers), the container falls back to the original local disk cache. Cross-worktree cache sharing works automatically because all containers mount source at `/workdir`, producing identical sccache hash keys.

### Work items

- [x] Set `SCCACHE_SERVER_UDS=/tmp/sccache.sock` to isolate per-container sccache servers
- [x] Probe Redis on port 63793 and set `SCCACHE_REDIS` when reachable, fall back to `SCCACHE_DIR` when not
- [x] Create `~/ai-rules/packages/sccache/` with `docker-compose.yml` (Redis 7 alpine), `bin/sccachectl` (start/stop/status/logs/stats/reset), and README