### PR TITLE
fix: load_env_maybe uses parameter and respects CLI overrides

### DIFF
--- a/dev/cross/all
+++ b/dev/cross/all
@@ -21,8 +21,8 @@ set -euo pipefail
 trap "exit" INT
 # shellcheck source=./../lib/utils.sh
 source "${BASH_SOURCE%/*}/../lib/utils.sh"
-load_env "$(project_root)/.env.example"
 load_env_maybe "$(project_root)/.env"
+load_env "$(project_root)/.env.example"
 
 targets=(
   "x86_64-unknown-linux-gnu"

--- a/dev/docker/run
+++ b/dev/docker/run
@@ -4,8 +4,8 @@ trap "exit" INT
 # shellcheck source=./../lib/utils.sh
 source "${BASH_SOURCE%/*}/../lib/utils.sh"
 
-load_env "$(project_root)/.env.example"
 load_env_maybe "$(project_root)/.env"
+load_env "$(project_root)/.env.example"
 
 CROSS_COMPILE="${CROSS_COMPILE:-"native"}"
 PROJECT_DOCKER_REPO="${PROJECT_DOCKER_BUILDER_REPO:?}"

--- a/dev/lib/utils.sh
+++ b/dev/lib/utils.sh
@@ -172,14 +172,18 @@ export -f copy_bin_to_out
 
 function load_env_maybe() {
   local env_file="${1:-}"
-  # shellcheck disable=SC2046
-  [ -n "${env_file}" ] && export $(grep -v '^#' .env | xargs)
+  [[ -n "${env_file}" && -r "${env_file}" ]] || return 0
+  local line key
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    key="${line%%=*}"
+    [[ -z "${!key+x}" ]] && export "${line}"
+  done < <(grep -vE '^(#|$)' "${env_file}") || true
 }
 export -f load_env_maybe
 
 function load_env() {
   local env_file="${1:?}"
-  if ! [ -r "${env_file}" ]; then
+  if ! [[ -r "${env_file}" ]]; then
     err "unable to load env file: '${env_file}'" >&2
     exit 1
   fi


### PR DESCRIPTION
`load_env_maybe` in `dev/lib/utils.sh` hardcoded `grep -v '^#' .env` regardless of the `env_file` parameter, always reading `.env` even when called with `.env.example`. Both `load_env` and `load_env_maybe` used unconditional `export`, overriding any pre-existing environment variables. This made `SCCACHE_ENABLED=false ./dev/docker/run` ineffective because `.env`'s `SCCACHE_ENABLED=true` always won.

Replace the `export $(grep ...)` pattern with a `while read` loop that only sets variables not already present in the environment. Reverse the load order in `dev/docker/run` and `dev/cross/all` so `.env` (user overrides) loads before `.env.example` (defaults), giving precedence: CLI > `.env` > `.env.example`.

### Work items

- [x] Fix `load_env_maybe` to use `"${env_file}"` parameter instead of hardcoded `.env`
- [x] Replace unconditional `export` with set-if-not-set loop (`${!key+x}` guard, `|| true` for `set -e` EOF safety)
- [x] Reverse load order in `dev/docker/run` and `dev/cross/all`