### PR TITLE
refactor: extract TestCaseBase struct from validation test cases

### DIFF
--- a/packages/treetime-validation/src/testing/framework/test_case.rs
+++ b/packages/treetime-validation/src/testing/framework/test_case.rs
@@ -1,17 +1,66 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub trait TestCase: Clone + Send + Sync + Serialize {
-  fn name(&self) -> &str;
+  fn base(&self) -> &TestCaseBase;
 
-  fn description(&self) -> &str;
+  fn name(&self) -> &str {
+    self.base().name()
+  }
 
-  fn stress_type(&self) -> &str;
+  fn description(&self) -> &str {
+    self.base().description()
+  }
 
-  fn analytical_caution(&self) -> &str;
+  fn stress_type(&self) -> &str {
+    self.base().stress_type()
+  }
 
-  fn slowness(&self) -> f64;
+  fn analytical_caution(&self) -> &str {
+    self.base().analytical_caution()
+  }
+
+  fn slowness(&self) -> f64 {
+    self.base().slowness()
+  }
 
   fn input_grid_domain(&self) -> (f64, f64);
 
   fn input_grid_n_points(&self) -> usize;
+}
+
+/// Metadata fields shared by every test case across all test suites.
+///
+/// Embedded in each concrete test case with `#[serde(flatten)]` so the
+/// serialized form stays flat (fields are not nested under a `base` key). The
+/// accessors here are the single implementation forwarded to by the `TestCase`
+/// trait defaults.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestCaseBase {
+  pub name: String,
+  pub description: String,
+  pub stress_type: String,
+  pub analytical_caution: String,
+  pub slowness: f64,
+}
+
+impl TestCaseBase {
+  pub fn name(&self) -> &str {
+    &self.name
+  }
+
+  pub fn description(&self) -> &str {
+    &self.description
+  }
+
+  pub fn stress_type(&self) -> &str {
+    &self.stress_type
+  }
+
+  pub fn analytical_caution(&self) -> &str {
+    &self.analytical_caution
+  }
+
+  pub fn slowness(&self) -> f64 {
+    self.slowness
+  }
 }

--- a/packages/treetime-validation/src/testing/test_suites/exponential.rs
+++ b/packages/treetime-validation/src/testing/test_suites/exponential.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use crate::testing::framework::test_case::TestCase;
+use crate::testing::framework::test_case::{TestCase, TestCaseBase};
 use crate::testing::test_suites::test_suites::ConvolutionTestSuite;
 use eyre::Report;
 use ndarray::Array1;
@@ -41,11 +41,8 @@ impl ConvolutionTestSuite for ExponentialTestSuite {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExponentialTestCase {
-  pub name: String,
-  pub description: String,
-  pub stress_type: String,
-  pub analytical_caution: String,
-  pub slowness: f64,
+  #[serde(flatten)]
+  pub base: TestCaseBase,
   pub a: f64,
   pub b: f64,
   pub input_grid_domain: (f64, f64),
@@ -55,11 +52,13 @@ pub struct ExponentialTestCase {
 impl From<&ExponentialConvolutionTestCase> for ExponentialTestCase {
   fn from(case: &ExponentialConvolutionTestCase) -> Self {
     Self {
-      name: case.name.to_owned(),
-      description: case.description.to_owned(),
-      stress_type: case.stress_type.to_owned(),
-      analytical_caution: case.analytical_caution.to_owned(),
-      slowness: case.slowness,
+      base: TestCaseBase {
+        name: case.name.to_owned(),
+        description: case.description.to_owned(),
+        stress_type: case.stress_type.to_owned(),
+        analytical_caution: case.analytical_caution.to_owned(),
+        slowness: case.slowness,
+      },
       a: case.a,
       b: case.b,
       input_grid_domain: case.input_grid_domain,
@@ -69,24 +68,8 @@ impl From<&ExponentialConvolutionTestCase> for ExponentialTestCase {
 }
 
 impl TestCase for ExponentialTestCase {
-  fn name(&self) -> &str {
-    &self.name
-  }
-
-  fn description(&self) -> &str {
-    &self.description
-  }
-
-  fn stress_type(&self) -> &str {
-    &self.stress_type
-  }
-
-  fn analytical_caution(&self) -> &str {
-    &self.analytical_caution
-  }
-
-  fn slowness(&self) -> f64 {
-    self.slowness
+  fn base(&self) -> &TestCaseBase {
+    &self.base
   }
 
   fn input_grid_domain(&self) -> (f64, f64) {

--- a/packages/treetime-validation/src/testing/test_suites/gaussian.rs
+++ b/packages/treetime-validation/src/testing/test_suites/gaussian.rs
@@ -83,3 +83,67 @@ impl TestCase for GaussianTestCase {
     self.input_grid_n_points
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use eyre::Report;
+  use treetime_utils::io::json::{JsonPretty, json_write_str};
+
+  fn sample() -> GaussianTestCase {
+    GaussianTestCase {
+      base: TestCaseBase {
+        name: "case-1".to_owned(),
+        description: "desc".to_owned(),
+        stress_type: "stress".to_owned(),
+        analytical_caution: "caution".to_owned(),
+        slowness: 1.5,
+      },
+      sigma_f: 1.0,
+      sigma_g: 2.0,
+      mu: 0.5,
+      input_grid_domain: (-5.0, 5.0),
+      input_grid_n_points: 100,
+    }
+  }
+
+  // The trait accessors are defaulted via `self.base()`; verify they forward
+  // the embedded `TestCaseBase` values rather than returning anything else.
+  #[test]
+  fn test_gaussian_test_case_accessors_forward_to_base() {
+    let case = sample();
+    assert_eq!("case-1", case.name());
+    assert_eq!("desc", case.description());
+    assert_eq!("stress", case.stress_type());
+    assert_eq!("caution", case.analytical_caution());
+    #[allow(clippy::float_cmp)] // 1.5 is exactly representable
+    {
+      assert_eq!(1.5, case.slowness());
+    }
+  }
+
+  // `#[serde(flatten)]` keeps the metadata fields at the top level. A
+  // regression that drops the attribute would nest them under a `base` key and
+  // change the JSON written to result files and the console.
+  #[test]
+  fn test_gaussian_test_case_serializes_flat() -> Result<(), Report> {
+    let actual = json_write_str(&sample(), JsonPretty(true))?;
+    let expected = r#"{
+  "name": "case-1",
+  "description": "desc",
+  "stress_type": "stress",
+  "analytical_caution": "caution",
+  "slowness": 1.5,
+  "sigma_f": 1.0,
+  "sigma_g": 2.0,
+  "mu": 0.5,
+  "input_grid_domain": [
+    -5.0,
+    5.0
+  ],
+  "input_grid_n_points": 100
+}"#;
+    assert_eq!(expected, actual);
+    Ok(())
+  }
+}

--- a/packages/treetime-validation/src/testing/test_suites/gaussian.rs
+++ b/packages/treetime-validation/src/testing/test_suites/gaussian.rs
@@ -1,4 +1,4 @@
-use crate::testing::framework::test_case::TestCase;
+use crate::testing::framework::test_case::{TestCase, TestCaseBase};
 use crate::testing::test_suites::test_suites::ConvolutionTestSuite;
 use eyre::Report;
 use ndarray::Array1;
@@ -42,11 +42,8 @@ impl ConvolutionTestSuite for GaussianTestSuite {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GaussianTestCase {
-  pub name: String,
-  pub description: String,
-  pub stress_type: String,
-  pub analytical_caution: String,
-  pub slowness: f64,
+  #[serde(flatten)]
+  pub base: TestCaseBase,
   pub sigma_f: f64,
   pub sigma_g: f64,
   pub mu: f64,
@@ -57,11 +54,13 @@ pub struct GaussianTestCase {
 impl From<&GaussianConvolutionTestCase> for GaussianTestCase {
   fn from(case: &GaussianConvolutionTestCase) -> Self {
     Self {
-      name: case.name.to_owned(),
-      description: case.description.to_owned(),
-      stress_type: case.stress_type.to_owned(),
-      analytical_caution: case.analytical_caution.to_owned(),
-      slowness: case.slowness,
+      base: TestCaseBase {
+        name: case.name.to_owned(),
+        description: case.description.to_owned(),
+        stress_type: case.stress_type.to_owned(),
+        analytical_caution: case.analytical_caution.to_owned(),
+        slowness: case.slowness,
+      },
       sigma_f: case.sigma_f,
       sigma_g: case.sigma_g,
       mu: case.mu,
@@ -72,24 +71,8 @@ impl From<&GaussianConvolutionTestCase> for GaussianTestCase {
 }
 
 impl TestCase for GaussianTestCase {
-  fn name(&self) -> &str {
-    &self.name
-  }
-
-  fn description(&self) -> &str {
-    &self.description
-  }
-
-  fn stress_type(&self) -> &str {
-    &self.stress_type
-  }
-
-  fn analytical_caution(&self) -> &str {
-    &self.analytical_caution
-  }
-
-  fn slowness(&self) -> f64 {
-    self.slowness
+  fn base(&self) -> &TestCaseBase {
+    &self.base
   }
 
   fn input_grid_domain(&self) -> (f64, f64) {

--- a/packages/treetime-validation/src/testing/test_suites/gaussian_chain_multiplication.rs
+++ b/packages/treetime-validation/src/testing/test_suites/gaussian_chain_multiplication.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use crate::testing::framework::test_case::TestCase;
+use crate::testing::framework::test_case::{TestCase, TestCaseBase};
 use crate::testing::test_suites::test_suites::ChainMultiplicationTestSuite;
 use eyre::Report;
 use ndarray::Array1;
@@ -47,11 +47,8 @@ impl ChainMultiplicationTestSuite for GaussianChainMultiplicationTestSuite {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GaussianChainTestCase {
-  pub name: String,
-  pub description: String,
-  pub stress_type: String,
-  pub analytical_caution: String,
-  pub slowness: f64,
+  #[serde(flatten)]
+  pub base: TestCaseBase,
   pub factors: Vec<GaussianParams>,
   pub input_grid_domain: (f64, f64),
   pub input_grid_n_points: usize,
@@ -60,11 +57,13 @@ pub struct GaussianChainTestCase {
 impl From<AnalyticalCase> for GaussianChainTestCase {
   fn from(case: AnalyticalCase) -> Self {
     Self {
-      name: case.name.to_owned(),
-      description: case.description.to_owned(),
-      stress_type: case.stress_type.to_owned(),
-      analytical_caution: case.analytical_caution.to_owned(),
-      slowness: case.slowness,
+      base: TestCaseBase {
+        name: case.name.to_owned(),
+        description: case.description.to_owned(),
+        stress_type: case.stress_type.to_owned(),
+        analytical_caution: case.analytical_caution.to_owned(),
+        slowness: case.slowness,
+      },
       factors: case.factors,
       input_grid_domain: case.input_grid_domain,
       input_grid_n_points: case.input_grid_n_points,
@@ -73,24 +72,8 @@ impl From<AnalyticalCase> for GaussianChainTestCase {
 }
 
 impl TestCase for GaussianChainTestCase {
-  fn name(&self) -> &str {
-    &self.name
-  }
-
-  fn description(&self) -> &str {
-    &self.description
-  }
-
-  fn stress_type(&self) -> &str {
-    &self.stress_type
-  }
-
-  fn analytical_caution(&self) -> &str {
-    &self.analytical_caution
-  }
-
-  fn slowness(&self) -> f64 {
-    self.slowness
+  fn base(&self) -> &TestCaseBase {
+    &self.base
   }
 
   fn input_grid_domain(&self) -> (f64, f64) {

--- a/packages/treetime-validation/src/testing/test_suites/gaussian_exponential.rs
+++ b/packages/treetime-validation/src/testing/test_suites/gaussian_exponential.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use crate::testing::framework::test_case::TestCase;
+use crate::testing::framework::test_case::{TestCase, TestCaseBase};
 use crate::testing::test_suites::test_suites::ConvolutionTestSuite;
 use eyre::Report;
 use ndarray::Array1;
@@ -42,11 +42,8 @@ impl ConvolutionTestSuite for GaussianExponentialTestSuite {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GaussianExponentialTestCase {
-  pub name: String,
-  pub description: String,
-  pub stress_type: String,
-  pub analytical_caution: String,
-  pub slowness: f64,
+  #[serde(flatten)]
+  pub base: TestCaseBase,
   pub a_f: f64,
   pub input_grid_domain: (f64, f64),
   pub input_grid_n_points: usize,
@@ -55,11 +52,13 @@ pub struct GaussianExponentialTestCase {
 impl From<&AnalyticalCase> for GaussianExponentialTestCase {
   fn from(case: &AnalyticalCase) -> Self {
     Self {
-      name: case.name.to_owned(),
-      description: case.description.to_owned(),
-      stress_type: case.stress_type.to_owned(),
-      analytical_caution: case.analytical_caution.to_owned(),
-      slowness: case.slowness,
+      base: TestCaseBase {
+        name: case.name.to_owned(),
+        description: case.description.to_owned(),
+        stress_type: case.stress_type.to_owned(),
+        analytical_caution: case.analytical_caution.to_owned(),
+        slowness: case.slowness,
+      },
       a_f: case.a_f,
       input_grid_domain: case.input_grid_domain,
       input_grid_n_points: case.input_grid_n_points,
@@ -68,24 +67,8 @@ impl From<&AnalyticalCase> for GaussianExponentialTestCase {
 }
 
 impl TestCase for GaussianExponentialTestCase {
-  fn name(&self) -> &str {
-    &self.name
-  }
-
-  fn description(&self) -> &str {
-    &self.description
-  }
-
-  fn stress_type(&self) -> &str {
-    &self.stress_type
-  }
-
-  fn analytical_caution(&self) -> &str {
-    &self.analytical_caution
-  }
-
-  fn slowness(&self) -> f64 {
-    self.slowness
+  fn base(&self) -> &TestCaseBase {
+    &self.base
   }
 
   fn input_grid_domain(&self) -> (f64, f64) {

--- a/packages/treetime-validation/src/testing/test_suites/gaussian_pairwise_multiplication.rs
+++ b/packages/treetime-validation/src/testing/test_suites/gaussian_pairwise_multiplication.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use crate::testing::framework::test_case::TestCase;
+use crate::testing::framework::test_case::{TestCase, TestCaseBase};
 use crate::testing::test_suites::test_suites::MultiplicationTestSuite;
 use eyre::Report;
 use ndarray::Array1;
@@ -61,11 +61,8 @@ impl MultiplicationTestSuite for GaussianPairwiseMultiplicationTestSuite {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GaussianPairwiseMultiplicationTestCase {
-  pub name: String,
-  pub description: String,
-  pub stress_type: String,
-  pub analytical_caution: String,
-  pub slowness: f64,
+  #[serde(flatten)]
+  pub base: TestCaseBase,
   pub mu_f: f64,
   pub sigma_f: f64,
   pub amplitude_f: f64,
@@ -79,11 +76,13 @@ pub struct GaussianPairwiseMultiplicationTestCase {
 impl From<&AnalyticalCase> for GaussianPairwiseMultiplicationTestCase {
   fn from(case: &AnalyticalCase) -> Self {
     Self {
-      name: case.name.to_owned(),
-      description: case.description.to_owned(),
-      stress_type: case.stress_type.to_owned(),
-      analytical_caution: case.analytical_caution.to_owned(),
-      slowness: case.slowness,
+      base: TestCaseBase {
+        name: case.name.to_owned(),
+        description: case.description.to_owned(),
+        stress_type: case.stress_type.to_owned(),
+        analytical_caution: case.analytical_caution.to_owned(),
+        slowness: case.slowness,
+      },
       mu_f: case.mu_f,
       sigma_f: case.sigma_f,
       amplitude_f: case.amplitude_f,
@@ -97,24 +96,8 @@ impl From<&AnalyticalCase> for GaussianPairwiseMultiplicationTestCase {
 }
 
 impl TestCase for GaussianPairwiseMultiplicationTestCase {
-  fn name(&self) -> &str {
-    &self.name
-  }
-
-  fn description(&self) -> &str {
-    &self.description
-  }
-
-  fn stress_type(&self) -> &str {
-    &self.stress_type
-  }
-
-  fn analytical_caution(&self) -> &str {
-    &self.analytical_caution
-  }
-
-  fn slowness(&self) -> f64 {
-    self.slowness
+  fn base(&self) -> &TestCaseBase {
+    &self.base
   }
 
   fn input_grid_domain(&self) -> (f64, f64) {


### PR DESCRIPTION
The five concrete `TestCase` implementors in `treetime-validation` each carried the same five metadata fields (`name`, `description`, `stress_type`, `analytical_caution`, `slowness`) with identical accessor bodies. Adding a sixth field or changing accessor logic required editing all five structs in lockstep.

Extract a `TestCaseBase` struct holding the shared metadata and add a `fn base()` method to the `TestCase` trait with default implementations for all five accessors. Each concrete type now embeds `TestCaseBase` with `#[serde(flatten)]` so serialized output stays flat, and forwards accessors through the trait defaults.

### Work items

- [x] Add `TestCaseBase` struct with shared metadata fields and accessors
- [x] Add `fn base()` to `TestCase` trait with default implementations for `name`, `description`, `stress_type`, `analytical_caution`, `slowness`
- [x] Embed `TestCaseBase` in all five test-case structs with `#[serde(flatten)]`
- [x] Add regression tests for flat serialization and accessor forwarding