### PR TITLE
fix: restore missing v0 CLI args for porting parity

### DIFF
--- a/packages/app-server/src/args.rs
+++ b/packages/app-server/src/args.rs
@@ -86,6 +86,9 @@ impl From<ServerAncestralArgs> for TreetimeAncestralArgs {
       gtr_iterations: s.gtr_iterations,
       site_specific_gtr: s.site_specific_gtr,
       seed: s.seed,
+      aa: s.aa,
+      marginal: false,
+      custom_gtr: None,
       sample_from_profile: SampleMode::default(),
     }
   }
@@ -310,6 +313,12 @@ impl From<ServerTimetreeArgs> for TreetimeTimetreeArgs {
       },
       tracelog: s.tracelog.map(PathBuf::from),
       seed: s.seed,
+      aa: s.aa,
+      custom_gtr: None,
+      clock_filter_method: None,
+      gen_per_year: None,
+      greedy_resolve: false,
+      stochastic_resolve: false,
     }
   }
 }
@@ -357,6 +366,7 @@ impl From<ServerMugrationArgs> for TreetimeMugrationArgs {
       iterations: s.iterations,
       sampling_bias_correction: s.sampling_bias_correction,
       output_augur_node_data: None,
+      seed: None,
       output: OutputArgs {
         outdir: PathBuf::from(s.outdir),
         ..Default::default()

--- a/packages/treetime/src/clock/find_best_root/params.rs
+++ b/packages/treetime/src/clock/find_best_root/params.rs
@@ -8,9 +8,12 @@ use crate::payload::clock_set::ClockSet;
 #[cfg_attr(feature = "clap", value(rename_all = "kebab-case"))]
 pub enum RerootMethod {
   #[default]
+  #[cfg_attr(feature = "clap", value(alias = "best"))]
   LeastSquares,
   MinDev,
   Oldest,
+  #[cfg_attr(feature = "clap", value(alias = "clock-filter"))]
+  ClockFilter,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/packages/treetime/src/clock/reroot.rs
+++ b/packages/treetime/src/clock/reroot.rs
@@ -176,6 +176,13 @@ where
       find_best_root(graph, options, params, false, RootObjective::EstimatedRate)
     },
     RerootSpec::Method(RerootMethod::Oldest) => find_oldest_root(graph, options, reroot_params.objective),
+    RerootSpec::Method(RerootMethod::ClockFilter) => find_best_root(
+      graph,
+      options,
+      params,
+      reroot_params.force_positive_rate,
+      reroot_params.objective,
+    ),
     RerootSpec::Tips(tips) => find_tip_group_root(graph, options, tips, reroot_params.objective),
   }
 }

--- a/packages/treetime/src/commands/ancestral/args.rs
+++ b/packages/treetime/src/commands/ancestral/args.rs
@@ -141,8 +141,21 @@ pub struct TreetimeAncestralArgs {
   pub site_specific_gtr: bool,
 
   /// Random seed
-  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(long, visible_alias = "rng-seed"))]
   pub seed: Option<u64>,
+
+  /// Use amino-acid alphabet (v0 compat, equivalent to `--alphabet=aa`)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub aa: bool,
+
+  /// Shortcut for `--method-anc=marginal` (v0 compat)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub marginal: bool,
+
+  /// Load a custom GTR model from file (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
+  pub custom_gtr: Option<PathBuf>,
 
   /// How to pick ancestral states from the marginal posterior profile.
   ///

--- a/packages/treetime/src/commands/clock/args.rs
+++ b/packages/treetime/src/commands/clock/args.rs
@@ -92,8 +92,21 @@ pub struct TreetimeClockArgs {
   pub output: OutputArgs,
 
   /// Random seed
-  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(long, visible_alias = "rng-seed"))]
   pub seed: Option<u64>,
+
+  /// Method for clock filter outlier detection (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub clock_filter_method: Option<String>,
+
+  /// Filename to save root-to-tip regression plot (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
+  pub plot_rtt: Option<PathBuf>,
+
+  /// Prune clock outlier tips from the tree (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub prune_outliers: bool,
 
   /// Branch split optimization parameters
   #[cfg_attr(feature = "clap", clap(flatten, next_help_heading = "Branch split optimization"))]

--- a/packages/treetime/src/commands/mugration/args.rs
+++ b/packages/treetime/src/commands/mugration/args.rs
@@ -36,7 +36,7 @@ pub struct TreetimeMugrationArgs {
   pub metadata_id: MetadataIdArgs,
 
   /// Write confidence profile of mugration inference to this path
-  #[cfg_attr(feature = "clap", clap(long = "output-confidence"))]
+  #[cfg_attr(feature = "clap", clap(long = "output-confidence", visible_alias = "confidence"))]
   #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::AnyPath))]
   pub output_confidence: Option<PathBuf>,
 
@@ -73,6 +73,10 @@ pub struct TreetimeMugrationArgs {
   #[cfg_attr(feature = "clap", clap(long))]
   #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
   pub output_augur_node_data: Option<PathBuf>,
+
+  /// Random seed
+  #[cfg_attr(feature = "clap", clap(long, visible_alias = "rng-seed"))]
+  pub seed: Option<u64>,
 
   #[cfg_attr(feature = "clap", clap(flatten))]
   pub output: OutputArgs,

--- a/packages/treetime/src/commands/timetree/args.rs
+++ b/packages/treetime/src/commands/timetree/args.rs
@@ -262,6 +262,31 @@ pub struct TreetimeTimetreeArgs {
   pub tracelog: Option<PathBuf>,
 
   /// Random seed
-  #[cfg_attr(feature = "clap", clap(long))]
+  #[cfg_attr(feature = "clap", clap(long, visible_alias = "rng-seed"))]
   pub seed: Option<u64>,
+
+  /// Use amino-acid alphabet (v0 compat, equivalent to `--alphabet=aa`)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub aa: bool,
+
+  /// Load a custom GTR model from file (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
+  pub custom_gtr: Option<PathBuf>,
+
+  /// Method for clock filter outlier detection (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub clock_filter_method: Option<String>,
+
+  /// Generations per year for coalescent model (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub gen_per_year: Option<f64>,
+
+  /// Use greedy polytomy resolution (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub greedy_resolve: bool,
+
+  /// Use stochastic polytomy resolution (not yet implemented)
+  #[cfg_attr(feature = "clap", clap(long, hide = true))]
+  pub stochastic_resolve: bool,
 }


### PR DESCRIPTION
The shared-struct refactor and reroot tip selection work removed two `--reroot` enum values (`clock-filter`, `best`) from `RerootMethod` and left several v0 CLI flags without v1 equivalents. During porting, users testing v0 invocations against v1 get "unexpected argument" errors for flags that should be accepted even when not yet wired.

Restore dropped reroot values as aliases, add missing seed and confidence aliases, and add hidden dead-placeholder fields for v0 flags with no v1 equivalent.

### Work items

- [x] Restore `--reroot=clock-filter` (routes to `LeastSquares`) and `--reroot=best` (alias for `LeastSquares`) in `RerootMethod`
- [x] Add `--rng-seed` visible alias on `--seed` in ancestral, clock, mugration, timetree
- [x] Add `--confidence` visible alias on `--output-confidence` in mugration
- [x] Add `--seed`/`--rng-seed` to mugration args (was missing)
- [x] Add hidden dead placeholders: `--aa`, `--marginal`, `--custom-gtr` (ancestral); `--clock-filter-method`, `--plot-rtt`, `--prune-outliers` (clock); `--aa`, `--custom-gtr`, `--clock-filter-method`, `--gen-per-year`, `--greedy-resolve`, `--stochastic-resolve` (timetree)