### PR TITLE
chore: migrate sccache backend from Redis to MinIO

### DIFF
--- a/dev/docker/run
+++ b/dev/docker/run
@@ -183,9 +183,14 @@ if [[ "${SCCACHE_ENABLED:-true}" == "true" ]]; then
     ["RUSTC_WRAPPER"]="sccache"
     ["SCCACHE_SERVER_UDS"]="/tmp/sccache.sock"
   )
-  sccache_redis_port="${SCCACHE_REDIS_PORT:-63793}"
-  if bash -c "echo > /dev/tcp/127.0.0.1/${sccache_redis_port}" 2>/dev/null; then
-    sccache_env["SCCACHE_REDIS"]="redis://127.0.0.1:${sccache_redis_port}"
+  sccache_minio_port="${SCCACHE_MINIO_PORT:-63900}"
+  if bash -c "echo > /dev/tcp/127.0.0.1/${sccache_minio_port}" 2>/dev/null; then
+    sccache_env["SCCACHE_BUCKET"]="sccache"
+    sccache_env["SCCACHE_ENDPOINT"]="http://127.0.0.1:${sccache_minio_port}"
+    sccache_env["SCCACHE_REGION"]="auto"
+    sccache_env["SCCACHE_S3_USE_SSL"]="false"
+    sccache_env["AWS_ACCESS_KEY_ID"]="sccache"
+    sccache_env["AWS_SECRET_ACCESS_KEY"]="sccache0"
   else
     volumes["${SCCACHE_DIR:-${cache_dir}/sccache}"]="/home/${USER}/.cache/sccache"
     sccache_env["SCCACHE_DIR"]="/home/${USER}/.cache/sccache"


### PR DESCRIPTION
- Follow-up to: `chore/sccache-redis-backend`

The dev container probes a shared sccache storage backend on a fixed port and falls back to the local disk cache when it is unreachable. The shared backend was a Redis instance configured through `SCCACHE_REDIS`.

Replace the Redis backend with a MinIO S3-compatible object store. The container probes MinIO on port 63900 (override via `SCCACHE_MINIO_PORT`) and configures sccache's S3 backend when MinIO is reachable. The local disk cache fallback is unchanged.

### Work items

- [x] Probe `SCCACHE_MINIO_PORT` (default 63900) instead of `SCCACHE_REDIS_PORT`
- [x] Configure sccache S3 backend (`SCCACHE_BUCKET`, `SCCACHE_ENDPOINT`, `SCCACHE_REGION`, S3 SSL flag, static credentials) when MinIO is reachable
- [x] Preserve the local disk cache fallback when MinIO is unavailable