### PR TITLE
refactor: eliminate O(N²) leaf_sets, add Divergence preset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,6 +4351,7 @@ dependencies = [
  "eyre",
  "getset",
  "itertools 0.14.0",
+ "ordered-float",
  "parking_lot",
  "pretty_assertions",
  "rayon",

--- a/kb/tests/supporting.md
+++ b/kb/tests/supporting.md
@@ -785,14 +785,22 @@ Unit and parameterized tests for all BitSet128 operations.
 
 **Impl:** [`packages/treetime-graph/src/topology_order.rs`](../../packages/treetime-graph/src/topology_order.rs)
 
-| Test                                                             | Purpose                                          |
-| ---------------------------------------------------------------- | ------------------------------------------------ |
-| `topology_order_descendant_count_sorts_children_ascending`       | Default ladderization sorts siblings by tip count |
+| Test                                                                | Purpose                                           |
+| ------------------------------------------------------------------- | ------------------------------------------------- |
+| `topology_order_descendant_count_sorts_children_ascending`          | Default ladderization sorts siblings by tip count |
 | `topology_order_descendant_count_reverse_sorts_children_descending` | Reverse ladderization sorts larger subtrees first |
-| `topology_order_keep_preserves_outbound_order`                   | Keep preset leaves existing child order intact   |
-| `topology_order_dag_counts_shared_descendant_once_per_child`     | DAG shared descendants are counted once per child |
-| `topology_order_target_order_uses_requested_tip_order`           | Target-order preset follows requested tip order  |
-| `topology_order_rejects_cycles`                                  | Cyclic directed graphs fail before output        |
+| `topology_order_keep_preserves_outbound_order`                      | Keep preset leaves existing child order intact    |
+| `topology_order_dag_counts_shared_descendant_once_per_child`        | DAG shared descendants are counted once per child |
+| `topology_order_target_order_uses_requested_tip_order`              | Target-order preset follows requested tip order   |
+| `topology_order_rejects_cycles`                                     | Cyclic directed graphs fail before output         |
+| `topology_order_height_sorts_by_subtree_depth`                      | Height preset sorts by max subtree depth          |
+| `topology_order_height_reverse_sorts_deepest_first`                 | HeightReverse puts deepest subtrees first         |
+| `topology_order_label_sorts_alphabetically`                         | Label preset sorts by min descendant label        |
+| `topology_order_label_reverse_sorts_descending`                     | LabelReverse sorts labels Z-to-A                  |
+| `topology_order_target_order_median_uses_median_position`           | Median aggregate uses median leaf position        |
+| `topology_order_propagates_through_nested_levels`                   | Ordering propagates recursively through tree      |
+| `topology_order_target_order_reverse_inverts_order`                 | TargetOrderReverse inverts target ordering        |
+| `topology_order_target_order_rejects_empty`                         | Empty target order rejected with error            |
 
 **Test:** [`packages/treetime/src/graph/__tests__/test_edge.rs`](../../packages/treetime/src/graph/__tests__/test_edge.rs)
 

--- a/packages/treetime-graph/Cargo.toml
+++ b/packages/treetime-graph/Cargo.toml
@@ -19,6 +19,7 @@ derive_more = { workspace = true }
 eyre = { workspace = true }
 getset = { workspace = true }
 itertools = { workspace = true }
+ordered-float = { workspace = true }
 parking_lot = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }

--- a/packages/treetime-graph/src/topology_order.rs
+++ b/packages/treetime-graph/src/topology_order.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::Arc;
 use treetime_utils::{make_error, make_report};
 
@@ -52,95 +52,31 @@ impl TopologyOrderSpec {
     E: GraphEdge,
     D: Sync + Send,
   {
-    let mut state = TopologyOrderState::new(graph, self)?;
-    let node_order = topological_order(graph)?;
-
-    for node_key in node_order.into_iter().rev() {
-      let node = graph
-        .get_node(node_key)
-        .ok_or_else(|| make_report!("When ordering topology: Node {node_key} not found"))?;
-      state.compute_node(graph, &node.read_arc())?;
-    }
-
-    Ok(TopologyOrderPlan {
-      roots: self.order_node_keys(&graph.roots, &state),
-      leaves: self.order_node_keys(&graph.leaves, &state),
-      outbound_edges: graph
-        .nodes
-        .iter()
-        .filter_map(Option::as_ref)
-        .map(|node| {
-          let node = node.read_arc();
-          (node.key(), self.order_edge_keys(graph, node.outbound(), &state))
-        })
-        .collect(),
-    })
-  }
-
-  fn order_edge_keys<N, E, D>(
-    &self,
-    graph: &Graph<N, E, D>,
-    edge_keys: &[GraphEdgeKey],
-    state: &TopologyOrderState,
-  ) -> Vec<GraphEdgeKey>
-  where
-    N: GraphNode,
-    E: GraphEdge,
-    D: Sync + Send,
-  {
     if self.preset == TopologyOrderPreset::Keep {
-      return edge_keys.to_vec();
+      return build_plan_unordered(graph);
     }
 
-    edge_keys
-      .iter()
-      .copied()
-      .enumerate()
-      .sorted_by(|(lhs_pos, lhs), (rhs_pos, rhs)| {
-        let lhs_target = graph.get_target_node_key(*lhs);
-        let rhs_target = graph.get_target_node_key(*rhs);
-        match (lhs_target, rhs_target) {
-          (Ok(lhs_target), Ok(rhs_target)) => self
-            .compare_nodes(lhs_target, rhs_target, state)
-            .then(lhs_pos.cmp(rhs_pos)),
-          _ => lhs_pos.cmp(rhs_pos),
-        }
-      })
-      .map(|(_, edge_key)| edge_key)
-      .collect_vec()
-  }
+    let postorder = postorder_keys(graph)?;
+    let reverse = self.preset.is_reverse();
 
-  fn order_node_keys(&self, node_keys: &[GraphNodeKey], state: &TopologyOrderState) -> Vec<GraphNodeKey> {
-    if self.preset == TopologyOrderPreset::Keep {
-      return node_keys.to_vec();
-    }
-
-    node_keys
-      .iter()
-      .copied()
-      .enumerate()
-      .sorted_by(|(lhs_pos, lhs), (rhs_pos, rhs)| self.compare_nodes(*lhs, *rhs, state).then(lhs_pos.cmp(rhs_pos)))
-      .map(|(_, node_key)| node_key)
-      .collect_vec()
-  }
-
-  fn compare_nodes(&self, lhs: GraphNodeKey, rhs: GraphNodeKey, state: &TopologyOrderState) -> Ordering {
-    let ordering = match self.preset {
-      TopologyOrderPreset::Keep => Ordering::Equal,
+    match self.preset {
+      TopologyOrderPreset::Keep => unreachable!(),
       TopologyOrderPreset::DescendantCount | TopologyOrderPreset::DescendantCountReverse => {
-        state.leaf_counts[&lhs].cmp(&state.leaf_counts[&rhs])
+        let keys = compute_descendant_counts(graph, &postorder);
+        build_plan(graph, &keys, reverse)
       },
-      TopologyOrderPreset::Height | TopologyOrderPreset::HeightReverse => state.heights[&lhs].cmp(&state.heights[&rhs]),
-      TopologyOrderPreset::Label | TopologyOrderPreset::LabelReverse => state.labels[&lhs].cmp(&state.labels[&rhs]),
+      TopologyOrderPreset::Height | TopologyOrderPreset::HeightReverse => {
+        let keys = compute_heights(graph, &postorder);
+        build_plan(graph, &keys, reverse)
+      },
+      TopologyOrderPreset::Label | TopologyOrderPreset::LabelReverse => {
+        let keys = compute_labels(graph, &postorder)?;
+        build_plan(graph, &keys, reverse)
+      },
       TopologyOrderPreset::TargetOrder | TopologyOrderPreset::TargetOrderReverse => {
-        state.target_scores[&lhs].cmp(&state.target_scores[&rhs])
+        let keys = compute_target_scores(graph, &postorder, &self.target_order, self.target_aggregate)?;
+        build_plan(graph, &keys, reverse)
       },
-    };
-
-    if self.preset.is_reverse() {
-      ordering.reverse()
-    } else {
-      ordering
     }
   }
 }
@@ -237,6 +173,84 @@ impl TopologyOrderPlan {
   }
 }
 
+fn build_plan_unordered<N, E, D>(graph: &Graph<N, E, D>) -> Result<TopologyOrderPlan, Report>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  Ok(TopologyOrderPlan {
+    roots: graph.roots.clone(),
+    leaves: graph.leaves.clone(),
+    outbound_edges: graph
+      .nodes
+      .iter()
+      .filter_map(Option::as_ref)
+      .map(|node| {
+        let node = node.read_arc();
+        (node.key(), node.outbound().to_vec())
+      })
+      .collect(),
+  })
+}
+
+fn build_plan<N, E, D, K: Ord>(
+  graph: &Graph<N, E, D>,
+  keys: &BTreeMap<GraphNodeKey, K>,
+  reverse: bool,
+) -> Result<TopologyOrderPlan, Report>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let compare = |a: &GraphNodeKey, b: &GraphNodeKey| -> Ordering {
+    let ord = keys[a].cmp(&keys[b]);
+    if reverse { ord.reverse() } else { ord }
+  };
+
+  let sort_node_keys = |node_keys: &[GraphNodeKey]| -> Vec<GraphNodeKey> {
+    node_keys
+      .iter()
+      .copied()
+      .enumerate()
+      .sorted_by(|(pos_a, a), (pos_b, b)| compare(a, b).then(pos_a.cmp(pos_b)))
+      .map(|(_, key)| key)
+      .collect_vec()
+  };
+
+  let sort_edge_keys = |edge_keys: &[GraphEdgeKey]| -> Vec<GraphEdgeKey> {
+    edge_keys
+      .iter()
+      .copied()
+      .enumerate()
+      .sorted_by(|(pos_a, a), (pos_b, b)| {
+        let target_a = graph.get_target_node_key(*a);
+        let target_b = graph.get_target_node_key(*b);
+        match (target_a, target_b) {
+          (Ok(ta), Ok(tb)) => compare(&ta, &tb).then(pos_a.cmp(pos_b)),
+          _ => pos_a.cmp(pos_b),
+        }
+      })
+      .map(|(_, key)| key)
+      .collect_vec()
+  };
+
+  Ok(TopologyOrderPlan {
+    roots: sort_node_keys(&graph.roots),
+    leaves: sort_node_keys(&graph.leaves),
+    outbound_edges: graph
+      .nodes
+      .iter()
+      .filter_map(Option::as_ref)
+      .map(|node| {
+        let node = node.read_arc();
+        (node.key(), sort_edge_keys(node.outbound()))
+      })
+      .collect(),
+  })
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TargetScore {
   numerator: usize,
@@ -256,162 +270,201 @@ impl PartialOrd for TargetScore {
   }
 }
 
-struct TopologyOrderState {
-  leaf_sets: BTreeMap<GraphNodeKey, BTreeSet<GraphNodeKey>>,
-  leaf_counts: BTreeMap<GraphNodeKey, usize>,
-  heights: BTreeMap<GraphNodeKey, usize>,
-  labels: BTreeMap<GraphNodeKey, String>,
-  target_scores: BTreeMap<GraphNodeKey, TargetScore>,
-  target_order: BTreeMap<String, usize>,
-  target_aggregate: TopologyOrderTargetAggregate,
+fn compute_descendant_counts<N, E, D>(
+  graph: &Graph<N, E, D>,
+  postorder: &[GraphNodeKey],
+) -> BTreeMap<GraphNodeKey, usize>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let mut counts = BTreeMap::new();
+  for &node_key in postorder {
+    let node = graph.get_node(node_key).unwrap();
+    let child_keys = graph.child_keys_of(&node.read_arc());
+    let count = if child_keys.is_empty() {
+      1
+    } else {
+      child_keys.iter().map(|ck| counts[ck]).sum()
+    };
+    counts.insert(node_key, count);
+  }
+  counts
 }
 
-impl TopologyOrderState {
-  fn new<N, E, D>(graph: &Graph<N, E, D>, spec: &TopologyOrderSpec) -> Result<Self, Report>
-  where
-    N: GraphNode + Named,
-    E: GraphEdge,
-    D: Sync + Send,
-  {
-    let target_order = spec
-      .target_order
-      .iter()
-      .enumerate()
-      .map(|(index, label)| (label.clone(), index))
-      .collect();
-
-    if spec.preset.is_target_order() && spec.target_order.is_empty() {
-      return make_error!("When ordering topology: target-order mode requires a non-empty target order");
-    }
-
-    let state = Self {
-      leaf_sets: BTreeMap::new(),
-      leaf_counts: BTreeMap::new(),
-      heights: BTreeMap::new(),
-      labels: BTreeMap::new(),
-      target_scores: BTreeMap::new(),
-      target_order,
-      target_aggregate: spec.target_aggregate,
-    };
-
-    if spec.preset.is_target_order() {
-      validate_target_order(graph, &state.target_order)?;
-    }
-
-    Ok(state)
+fn compute_heights<N, E, D>(graph: &Graph<N, E, D>, postorder: &[GraphNodeKey]) -> BTreeMap<GraphNodeKey, usize>
+where
+  N: GraphNode,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let mut heights = BTreeMap::new();
+  for &node_key in postorder {
+    let node = graph.get_node(node_key).unwrap();
+    let child_keys = graph.child_keys_of(&node.read_arc());
+    let height = child_keys.iter().map(|ck| heights[ck] + 1).max().unwrap_or(0);
+    heights.insert(node_key, height);
   }
+  heights
+}
 
-  fn compute_node<N, E, D>(&mut self, graph: &Graph<N, E, D>, node: &Node<N>) -> Result<(), Report>
-  where
-    N: GraphNode + Named,
-    E: GraphEdge,
-    D: Sync + Send,
-  {
-    let child_keys = graph.child_keys_of(node);
-    let leaf_set = if child_keys.is_empty() {
-      BTreeSet::from([node.key()])
-    } else {
-      child_keys
-        .iter()
-        .flat_map(|child_key| self.leaf_sets[child_key].iter().copied())
-        .collect()
-    };
-
-    let height = child_keys
-      .iter()
-      .map(|child_key| self.heights[child_key] + 1)
-      .max()
-      .unwrap_or(0);
-
+fn compute_labels<N, E, D>(
+  graph: &Graph<N, E, D>,
+  postorder: &[GraphNodeKey],
+) -> Result<BTreeMap<GraphNodeKey, String>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let mut labels: BTreeMap<GraphNodeKey, String> = BTreeMap::new();
+  for &node_key in postorder {
+    let node = graph.get_node(node_key).unwrap();
+    let node = node.read_arc();
+    let child_keys = graph.child_keys_of(&node);
     let label = if child_keys.is_empty() {
       node
         .payload()
         .read_arc()
         .name()
         .map(|name| name.as_ref().to_owned())
-        .ok_or_else(|| make_report!("When ordering topology by labels: leaf node {} has no name", node.key()))?
+        .ok_or_else(|| make_report!("When ordering topology by labels: leaf node {} has no name", node_key))?
+    } else {
+      child_keys.iter().map(|ck| labels[ck].clone()).min().unwrap_or_default()
+    };
+    labels.insert(node_key, label);
+  }
+  Ok(labels)
+}
+
+fn compute_target_scores<N, E, D>(
+  graph: &Graph<N, E, D>,
+  postorder: &[GraphNodeKey],
+  target_order: &[String],
+  aggregate: TopologyOrderTargetAggregate,
+) -> Result<BTreeMap<GraphNodeKey, TargetScore>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  if target_order.is_empty() {
+    return make_error!("When ordering topology: target-order mode requires a non-empty target order");
+  }
+
+  let position_of: BTreeMap<&str, usize> = target_order
+    .iter()
+    .enumerate()
+    .map(|(i, label)| (label.as_str(), i))
+    .collect();
+
+  validate_target_order(graph, &position_of)?;
+
+  match aggregate {
+    TopologyOrderTargetAggregate::Mean => compute_target_scores_mean(graph, postorder, &position_of),
+    TopologyOrderTargetAggregate::Median => compute_target_scores_median(graph, postorder, &position_of),
+  }
+}
+
+fn compute_target_scores_mean<N, E, D>(
+  graph: &Graph<N, E, D>,
+  postorder: &[GraphNodeKey],
+  position_of: &BTreeMap<&str, usize>,
+) -> Result<BTreeMap<GraphNodeKey, TargetScore>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let mut scores: BTreeMap<GraphNodeKey, TargetScore> = BTreeMap::new();
+  for &node_key in postorder {
+    let node = graph.get_node(node_key).unwrap();
+    let node = node.read_arc();
+    let child_keys = graph.child_keys_of(&node);
+    let score = if child_keys.is_empty() {
+      let name = node
+        .payload()
+        .read_arc()
+        .name()
+        .map(|n| n.as_ref().to_owned())
+        .ok_or_else(|| make_report!("When ordering topology by target order: leaf node {node_key} has no name"))?;
+      let pos = *position_of.get(name.as_str()).ok_or_else(|| {
+        make_report!("When ordering topology by target order: leaf '{name}' is absent from target order")
+      })?;
+      TargetScore {
+        numerator: pos,
+        denominator: 1,
+      }
+    } else {
+      TargetScore {
+        numerator: child_keys.iter().map(|ck| scores[ck].numerator).sum(),
+        denominator: child_keys.iter().map(|ck| scores[ck].denominator).sum(),
+      }
+    };
+    scores.insert(node_key, score);
+  }
+  Ok(scores)
+}
+
+fn compute_target_scores_median<N, E, D>(
+  graph: &Graph<N, E, D>,
+  postorder: &[GraphNodeKey],
+  position_of: &BTreeMap<&str, usize>,
+) -> Result<BTreeMap<GraphNodeKey, TargetScore>, Report>
+where
+  N: GraphNode + Named,
+  E: GraphEdge,
+  D: Sync + Send,
+{
+  let mut positions: BTreeMap<GraphNodeKey, Vec<usize>> = BTreeMap::new();
+  let mut scores = BTreeMap::new();
+  for &node_key in postorder {
+    let node = graph.get_node(node_key).unwrap();
+    let node = node.read_arc();
+    let child_keys = graph.child_keys_of(&node);
+    let pos = if child_keys.is_empty() {
+      let name = node
+        .payload()
+        .read_arc()
+        .name()
+        .map(|n| n.as_ref().to_owned())
+        .ok_or_else(|| make_report!("When ordering topology by target order: leaf node {node_key} has no name"))?;
+      let p = *position_of.get(name.as_str()).ok_or_else(|| {
+        make_report!("When ordering topology by target order: leaf '{name}' is absent from target order")
+      })?;
+      vec![p]
     } else {
       child_keys
         .iter()
-        .map(|child_key| self.labels[child_key].clone())
-        .min()
-        .unwrap_or_default()
+        .flat_map(|ck| positions[ck].iter().copied())
+        .sorted_unstable()
+        .collect_vec()
     };
-
-    let target_score = self.target_score(graph, node, &leaf_set)?;
-
-    self.leaf_counts.insert(node.key(), leaf_set.len());
-    self.leaf_sets.insert(node.key(), leaf_set);
-    self.heights.insert(node.key(), height);
-    self.labels.insert(node.key(), label);
-    self.target_scores.insert(node.key(), target_score);
-
-    Ok(())
+    let score = median_score(&pos);
+    scores.insert(node_key, score);
+    positions.insert(node_key, pos);
   }
+  Ok(scores)
+}
 
-  fn target_score<N, E, D>(
-    &self,
-    graph: &Graph<N, E, D>,
-    node: &Node<N>,
-    leaf_set: &BTreeSet<GraphNodeKey>,
-  ) -> Result<TargetScore, Report>
-  where
-    N: GraphNode + Named,
-    E: GraphEdge,
-    D: Sync + Send,
-  {
-    if self.target_order.is_empty() {
-      return Ok(TargetScore {
-        numerator: 0,
-        denominator: 1,
-      });
+fn median_score(sorted_positions: &[usize]) -> TargetScore {
+  let n = sorted_positions.len();
+  let midpoint = n / 2;
+  if n.is_multiple_of(2) {
+    TargetScore {
+      numerator: sorted_positions[midpoint - 1] + sorted_positions[midpoint],
+      denominator: 2,
     }
-
-    let mut positions = leaf_set
-      .iter()
-      .map(|leaf_key| {
-        let leaf = graph
-          .get_node(*leaf_key)
-          .ok_or_else(|| make_report!("When ordering topology: leaf node {leaf_key} not found"))?;
-        let label = leaf
-          .read_arc()
-          .payload()
-          .read_arc()
-          .name()
-          .map(|name| name.as_ref().to_owned())
-          .ok_or_else(|| make_report!("When ordering topology by target order: leaf node {leaf_key} has no name"))?;
-        self.target_order.get(&label).copied().ok_or_else(|| {
-          make_report!("When ordering topology by target order: leaf '{label}' is absent from target order")
-        })
-      })
-      .collect::<Result<Vec<_>, _>>()?;
-
-    positions.sort_unstable();
-
-    match self.target_aggregate {
-      TopologyOrderTargetAggregate::Mean => Ok(TargetScore {
-        numerator: positions.iter().sum(),
-        denominator: positions.len(),
-      }),
-      TopologyOrderTargetAggregate::Median => {
-        let midpoint = positions.len() / 2;
-        if positions.len() % 2 == 0 {
-          Ok(TargetScore {
-            numerator: positions[midpoint - 1] + positions[midpoint],
-            denominator: 2,
-          })
-        } else {
-          Ok(TargetScore {
-            numerator: positions[midpoint],
-            denominator: 1,
-          })
-        }
-      },
+  } else {
+    TargetScore {
+      numerator: sorted_positions[midpoint],
+      denominator: 1,
     }
   }
 }
 
-fn validate_target_order<N, E, D>(graph: &Graph<N, E, D>, target_order: &BTreeMap<String, usize>) -> Result<(), Report>
+fn validate_target_order<N, E, D>(graph: &Graph<N, E, D>, position_of: &BTreeMap<&str, usize>) -> Result<(), Report>
 where
   N: GraphNode + Named,
   E: GraphEdge,
@@ -425,14 +478,14 @@ where
       .name()
       .map(|name| name.as_ref().to_owned())
       .ok_or_else(|| make_report!("When validating target order: leaf node {} has no name", leaf.key()))?;
-    if !target_order.contains_key(&label) {
+    if !position_of.contains_key(label.as_str()) {
       return make_error!("When validating target order: leaf '{label}' is absent from target order");
     }
   }
   Ok(())
 }
 
-fn topological_order<N, E, D>(graph: &Graph<N, E, D>) -> Result<Vec<GraphNodeKey>, Report>
+fn postorder_keys<N, E, D>(graph: &Graph<N, E, D>) -> Result<Vec<GraphNodeKey>, Report>
 where
   N: GraphNode,
   E: GraphEdge,
@@ -459,11 +512,11 @@ where
     ordered.push(node_key);
     let node = graph
       .get_node(node_key)
-      .ok_or_else(|| make_report!("When validating topology order: Node {node_key} not found"))?;
+      .ok_or_else(|| make_report!("When computing topology order: Node {node_key} not found"))?;
     for child_key in graph.child_keys_of(&node.read_arc()) {
       let count = remaining_inbound
         .get_mut(&child_key)
-        .ok_or_else(|| make_report!("When validating topology order: Node {child_key} not found"))?;
+        .ok_or_else(|| make_report!("When computing topology order: Node {child_key} not found"))?;
       *count -= 1;
       if *count == 0 {
         queue.push_back(child_key);
@@ -475,6 +528,7 @@ where
     return make_error!("When ordering topology: graph contains a directed cycle");
   }
 
+  ordered.reverse();
   Ok(ordered)
 }
 
@@ -587,6 +641,176 @@ mod tests {
     assert!(err.to_string().contains("directed cycle"));
 
     Ok(())
+  }
+
+  #[test]
+  fn topology_order_height_sorts_by_subtree_depth() -> Result<(), Report> {
+    let graph = fixture_deep_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::Height,
+      ..TopologyOrderSpec::default()
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    // A is leaf (height 0), shallow has height 1, deep has height 2
+    assert_eq!(vec!["A", "shallow", "deep"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_height_reverse_sorts_deepest_first() -> Result<(), Report> {
+    let graph = fixture_deep_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::HeightReverse,
+      ..TopologyOrderSpec::default()
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["deep", "shallow", "A"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_label_sorts_alphabetically() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::Label,
+      ..TopologyOrderSpec::default()
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    // A has label "A", BC has min label "B", DEF has min label "D"
+    assert_eq!(vec!["A", "BC", "DEF"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_label_reverse_sorts_descending() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::LabelReverse,
+      ..TopologyOrderSpec::default()
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["DEF", "BC", "A"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_target_order_median_uses_median_position() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    // Target order: D=0, E=1, F=2, B=3, C=4, A=5
+    // DEF median of [0,1,2] = 1, BC median of [3,4] = 3.5, A = 5
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::TargetOrder,
+      target_order: vec!["D", "E", "F", "B", "C", "A"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+      target_aggregate: TopologyOrderTargetAggregate::Median,
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["DEF", "BC", "A"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_propagates_through_nested_levels() -> Result<(), Report> {
+    let graph = fixture_deep_tree()?;
+    let plan = TopologyOrderSpec::default().plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let deep_children = child_names(&ordered, "deep")?;
+    // mid (2 leaves) vs D (1 leaf): D first
+    assert_eq!(vec!["D", "mid"], deep_children);
+
+    let mid_children = child_names(&ordered, "mid")?;
+    assert_eq!(vec!["E", "F"], mid_children);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_target_order_reverse_inverts_order() -> Result<(), Report> {
+    let graph = fixture_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::TargetOrderReverse,
+      target_order: vec!["D", "E", "F", "B", "C", "A"]
+        .into_iter()
+        .map(str::to_owned)
+        .collect(),
+      target_aggregate: TopologyOrderTargetAggregate::Mean,
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["A", "BC", "DEF"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_target_order_rejects_empty() {
+    let graph = fixture_tree().unwrap();
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::TargetOrder,
+      target_order: vec![],
+      target_aggregate: TopologyOrderTargetAggregate::Mean,
+    };
+    let err = spec.plan(&graph).unwrap_err();
+    assert!(err.to_string().contains("non-empty target order"));
+  }
+
+  /// root -> [deep -> [D, mid -> [E, F]], shallow -> [B, C], A]
+  fn fixture_deep_tree() -> Result<Graph<TestNode, TestEdge, ()>, Report> {
+    let mut graph = Graph::<TestNode, TestEdge, ()>::new();
+    let root = graph.add_node(TestNode::new("root"));
+    let deep = graph.add_node(TestNode::new("deep"));
+    let tip_a = graph.add_node(TestNode::new("A"));
+    let shallow = graph.add_node(TestNode::new("shallow"));
+    let mid = graph.add_node(TestNode::new("mid"));
+    let tip_d = graph.add_node(TestNode::new("D"));
+    let tip_e = graph.add_node(TestNode::new("E"));
+    let tip_f = graph.add_node(TestNode::new("F"));
+    let tip_b = graph.add_node(TestNode::new("B"));
+    let tip_c = graph.add_node(TestNode::new("C"));
+
+    graph.add_edge(root, deep, TestEdge)?;
+    graph.add_edge(root, tip_a, TestEdge)?;
+    graph.add_edge(root, shallow, TestEdge)?;
+    graph.add_edge(deep, tip_d, TestEdge)?;
+    graph.add_edge(deep, mid, TestEdge)?;
+    graph.add_edge(mid, tip_e, TestEdge)?;
+    graph.add_edge(mid, tip_f, TestEdge)?;
+    graph.add_edge(shallow, tip_b, TestEdge)?;
+    graph.add_edge(shallow, tip_c, TestEdge)?;
+    graph.build()?;
+
+    Ok(graph)
   }
 
   fn fixture_tree() -> Result<Graph<TestNode, TestEdge, ()>, Report> {

--- a/packages/treetime-graph/src/topology_order.rs
+++ b/packages/treetime-graph/src/topology_order.rs
@@ -1,8 +1,9 @@
-use crate::edge::{Edge, GraphEdge, GraphEdgeKey};
+use crate::edge::{Edge, GraphEdge, GraphEdgeKey, HasBranchLength};
 use crate::graph::Graph;
 use crate::node::{GraphNode, GraphNodeKey, Named, Node};
 use eyre::Report;
 use itertools::Itertools;
+use ordered_float::OrderedFloat;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -49,7 +50,7 @@ impl TopologyOrderSpec {
   pub fn plan<N, E, D>(&self, graph: &Graph<N, E, D>) -> Result<TopologyOrderPlan, Report>
   where
     N: GraphNode + Named,
-    E: GraphEdge,
+    E: GraphEdge + HasBranchLength,
     D: Sync + Send,
   {
     if self.preset == TopologyOrderPreset::Keep {
@@ -67,6 +68,10 @@ impl TopologyOrderSpec {
       },
       TopologyOrderPreset::Height | TopologyOrderPreset::HeightReverse => {
         let keys = compute_heights(graph, &postorder);
+        build_plan(graph, &keys, reverse)
+      },
+      TopologyOrderPreset::Divergence | TopologyOrderPreset::DivergenceReverse => {
+        let keys = compute_divergences(graph, &postorder);
         build_plan(graph, &keys, reverse)
       },
       TopologyOrderPreset::Label | TopologyOrderPreset::LabelReverse => {
@@ -89,6 +94,8 @@ pub enum TopologyOrderPreset {
   DescendantCountReverse,
   Height,
   HeightReverse,
+  Divergence,
+  DivergenceReverse,
   Label,
   LabelReverse,
   TargetOrder,
@@ -103,7 +110,11 @@ impl TopologyOrderPreset {
   fn is_reverse(self) -> bool {
     matches!(
       self,
-      Self::DescendantCountReverse | Self::HeightReverse | Self::LabelReverse | Self::TargetOrderReverse
+      Self::DescendantCountReverse
+        | Self::HeightReverse
+        | Self::DivergenceReverse
+        | Self::LabelReverse
+        | Self::TargetOrderReverse
     )
   }
 }
@@ -307,6 +318,34 @@ where
     heights.insert(node_key, height);
   }
   heights
+}
+
+fn compute_divergences<N, E, D>(
+  graph: &Graph<N, E, D>,
+  postorder: &[GraphNodeKey],
+) -> BTreeMap<GraphNodeKey, OrderedFloat<f64>>
+where
+  N: GraphNode,
+  E: GraphEdge + HasBranchLength,
+  D: Sync + Send,
+{
+  let mut divergences: BTreeMap<GraphNodeKey, OrderedFloat<f64>> = BTreeMap::new();
+  for &node_key in postorder {
+    let node = graph.get_node(node_key).unwrap();
+    let node = node.read_arc();
+    let divergence = graph
+      .children_of(&node)
+      .iter()
+      .map(|(child, edge)| {
+        let child_key = child.read_arc().key();
+        let edge_len = edge.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
+        divergences[&child_key].0 + edge_len
+      })
+      .reduce(f64::max)
+      .unwrap_or(0.0);
+    divergences.insert(node_key, OrderedFloat(divergence));
+  }
+  divergences
 }
 
 fn compute_labels<N, E, D>(
@@ -586,11 +625,11 @@ mod tests {
     let shared = graph.add_node(TestNode::new("shared"));
     let right_only = graph.add_node(TestNode::new("right_only"));
 
-    graph.add_edge(root, right, TestEdge)?;
-    graph.add_edge(root, left, TestEdge)?;
-    graph.add_edge(left, shared, TestEdge)?;
-    graph.add_edge(right, shared, TestEdge)?;
-    graph.add_edge(right, right_only, TestEdge)?;
+    graph.add_edge(root, right, TestEdge::new())?;
+    graph.add_edge(root, left, TestEdge::new())?;
+    graph.add_edge(left, shared, TestEdge::new())?;
+    graph.add_edge(right, shared, TestEdge::new())?;
+    graph.add_edge(right, right_only, TestEdge::new())?;
     graph.build()?;
 
     let plan = TopologyOrderSpec::default().plan(&graph)?;
@@ -631,9 +670,9 @@ mod tests {
     let b = graph.add_node(TestNode::new("B"));
     let c = graph.add_node(TestNode::new("C"));
 
-    graph.add_edge(a, b, TestEdge)?;
-    graph.add_edge(b, c, TestEdge)?;
-    graph.add_edge(c, a, TestEdge)?;
+    graph.add_edge(a, b, TestEdge::new())?;
+    graph.add_edge(b, c, TestEdge::new())?;
+    graph.add_edge(c, a, TestEdge::new())?;
     graph.build()?;
 
     let err = TopologyOrderSpec::default().plan(&graph).unwrap_err();
@@ -674,6 +713,44 @@ mod tests {
     let actual = child_names(&ordered, "root")?;
 
     assert_eq!(vec!["deep", "shallow", "A"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_divergence_sorts_by_total_branch_length() -> Result<(), Report> {
+    // root -> [short(0.1) -> [A(0.1), B(0.1)], long(0.5) -> [C(0.2)], D(0.3)]
+    // short: max divergence = 0.1 + 0.1 = 0.2
+    // long:  max divergence = 0.5 + 0.2 = 0.7
+    // D:     leaf, divergence = 0.0
+    let graph = fixture_branch_length_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::Divergence,
+      ..TopologyOrderSpec::default()
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["D", "short", "long"], actual);
+
+    Ok(())
+  }
+
+  #[test]
+  fn topology_order_divergence_reverse_sorts_longest_first() -> Result<(), Report> {
+    let graph = fixture_branch_length_tree()?;
+    let spec = TopologyOrderSpec {
+      preset: TopologyOrderPreset::DivergenceReverse,
+      ..TopologyOrderSpec::default()
+    };
+    let plan = spec.plan(&graph)?;
+    let ordered = plan.ordered_graph(&graph)?;
+
+    let actual = child_names(&ordered, "root")?;
+
+    assert_eq!(vec!["long", "short", "D"], actual);
 
     Ok(())
   }
@@ -799,15 +876,37 @@ mod tests {
     let tip_b = graph.add_node(TestNode::new("B"));
     let tip_c = graph.add_node(TestNode::new("C"));
 
-    graph.add_edge(root, deep, TestEdge)?;
-    graph.add_edge(root, tip_a, TestEdge)?;
-    graph.add_edge(root, shallow, TestEdge)?;
-    graph.add_edge(deep, tip_d, TestEdge)?;
-    graph.add_edge(deep, mid, TestEdge)?;
-    graph.add_edge(mid, tip_e, TestEdge)?;
-    graph.add_edge(mid, tip_f, TestEdge)?;
-    graph.add_edge(shallow, tip_b, TestEdge)?;
-    graph.add_edge(shallow, tip_c, TestEdge)?;
+    graph.add_edge(root, deep, TestEdge::new())?;
+    graph.add_edge(root, tip_a, TestEdge::new())?;
+    graph.add_edge(root, shallow, TestEdge::new())?;
+    graph.add_edge(deep, tip_d, TestEdge::new())?;
+    graph.add_edge(deep, mid, TestEdge::new())?;
+    graph.add_edge(mid, tip_e, TestEdge::new())?;
+    graph.add_edge(mid, tip_f, TestEdge::new())?;
+    graph.add_edge(shallow, tip_b, TestEdge::new())?;
+    graph.add_edge(shallow, tip_c, TestEdge::new())?;
+    graph.build()?;
+
+    Ok(graph)
+  }
+
+  /// root -> [short(0.1) -> [A(0.1), B(0.1)], long(0.5) -> [C(0.2)], D(0.3)]
+  fn fixture_branch_length_tree() -> Result<Graph<TestNode, TestEdge, ()>, Report> {
+    let mut graph = Graph::<TestNode, TestEdge, ()>::new();
+    let root = graph.add_node(TestNode::new("root"));
+    let short = graph.add_node(TestNode::new("short"));
+    let long = graph.add_node(TestNode::new("long"));
+    let tip_a = graph.add_node(TestNode::new("A"));
+    let tip_b = graph.add_node(TestNode::new("B"));
+    let tip_c = graph.add_node(TestNode::new("C"));
+    let tip_d = graph.add_node(TestNode::new("D"));
+
+    graph.add_edge(root, short, TestEdge::with_length(0.1))?;
+    graph.add_edge(root, long, TestEdge::with_length(0.5))?;
+    graph.add_edge(root, tip_d, TestEdge::with_length(0.3))?;
+    graph.add_edge(short, tip_a, TestEdge::with_length(0.1))?;
+    graph.add_edge(short, tip_b, TestEdge::with_length(0.1))?;
+    graph.add_edge(long, tip_c, TestEdge::with_length(0.2))?;
     graph.build()?;
 
     Ok(graph)
@@ -825,14 +924,14 @@ mod tests {
     let tip_b = graph.add_node(TestNode::new("B"));
     let tip_c = graph.add_node(TestNode::new("C"));
 
-    graph.add_edge(root, def, TestEdge)?;
-    graph.add_edge(root, tip_a, TestEdge)?;
-    graph.add_edge(root, bc, TestEdge)?;
-    graph.add_edge(def, tip_d, TestEdge)?;
-    graph.add_edge(def, tip_e, TestEdge)?;
-    graph.add_edge(def, tip_f, TestEdge)?;
-    graph.add_edge(bc, tip_b, TestEdge)?;
-    graph.add_edge(bc, tip_c, TestEdge)?;
+    graph.add_edge(root, def, TestEdge::new())?;
+    graph.add_edge(root, tip_a, TestEdge::new())?;
+    graph.add_edge(root, bc, TestEdge::new())?;
+    graph.add_edge(def, tip_d, TestEdge::new())?;
+    graph.add_edge(def, tip_e, TestEdge::new())?;
+    graph.add_edge(def, tip_f, TestEdge::new())?;
+    graph.add_edge(bc, tip_b, TestEdge::new())?;
+    graph.add_edge(bc, tip_c, TestEdge::new())?;
     graph.build()?;
 
     Ok(graph)
@@ -879,8 +978,32 @@ mod tests {
     }
   }
 
-  #[derive(Clone, Debug, Eq, PartialEq)]
-  struct TestEdge;
+  #[derive(Clone, Debug, PartialEq)]
+  struct TestEdge {
+    branch_length: Option<f64>,
+  }
+
+  impl TestEdge {
+    fn new() -> Self {
+      Self { branch_length: None }
+    }
+
+    fn with_length(len: f64) -> Self {
+      Self {
+        branch_length: Some(len),
+      }
+    }
+  }
 
   impl GraphEdge for TestEdge {}
+
+  impl HasBranchLength for TestEdge {
+    fn branch_length(&self) -> Option<f64> {
+      self.branch_length
+    }
+
+    fn set_branch_length(&mut self, branch_length: Option<f64>) {
+      self.branch_length = branch_length;
+    }
+  }
 }

--- a/packages/treetime-io/src/graph.rs
+++ b/packages/treetime-io/src/graph.rs
@@ -4,7 +4,7 @@ use crate::nwk::{CommentProviders, EdgeToNwk, NodeToNwk, NwkWriteOptions, nwk_wr
 use eyre::Report;
 use serde::Serialize;
 use std::path::Path;
-use treetime_graph::edge::GraphEdge;
+use treetime_graph::edge::{GraphEdge, HasBranchLength};
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
 use treetime_graph::topology_order::TopologyOrderSpec;
@@ -24,7 +24,7 @@ pub fn write_graph_files_with_options<N, E, D>(
 ) -> Result<(), Report>
 where
   N: GraphNode + Named + NodeToNwk + NodeToGraphviz + Serialize,
-  E: GraphEdge + EdgeToNwk + EdgeToGraphviz + Serialize,
+  E: GraphEdge + HasBranchLength + EdgeToNwk + EdgeToGraphviz + Serialize,
   D: Send + Sync + Default + Serialize,
 {
   let outdir = outdir.as_ref();

--- a/packages/treetime/src/commands/shared/output.rs
+++ b/packages/treetime/src/commands/shared/output.rs
@@ -237,6 +237,8 @@ pub enum TopologyOrderArg {
   DescendantCountReverse,
   Height,
   HeightReverse,
+  Divergence,
+  DivergenceReverse,
   Label,
   #[cfg_attr(feature = "clap", value(alias = "alphabetical-reverse"))]
   LabelReverse,
@@ -258,6 +260,8 @@ impl From<TopologyOrderArg> for TopologyOrderPreset {
       TopologyOrderArg::DescendantCountReverse => Self::DescendantCountReverse,
       TopologyOrderArg::Height => Self::Height,
       TopologyOrderArg::HeightReverse => Self::HeightReverse,
+      TopologyOrderArg::Divergence => Self::Divergence,
+      TopologyOrderArg::DivergenceReverse => Self::DivergenceReverse,
       TopologyOrderArg::Label => Self::Label,
       TopologyOrderArg::LabelReverse => Self::LabelReverse,
       TopologyOrderArg::TargetOrder => Self::TargetOrder,


### PR DESCRIPTION
`TopologyOrderState` unconditionally computed parallel maps for every node regardless of the active preset. The `leaf_sets` field accumulated set unions at every ancestor, storing O(N²) entries total, but only `TargetOrder` ever read them. The default ladderize path paid the full quadratic cost for data it never consumed.

Replace the monolithic state bag with per-preset key computation functions and a generic `build_plan<K: Ord>` that sorts children by a single key map. Each preset computes only its own sort key in one postorder pass, eliminating the unconditional O(N²) leaf-set construction.

Add a `Divergence` / `DivergenceReverse` preset that sorts by maximum root-to-leaf branch length sum, matching ete4's `ladderize(topological=False)`. Height counts edges; Divergence sums branch lengths. A survey of phylogenetic libraries confirmed no library builds leaf identity sets for ladderization.

### Work items

- [x] Delete `TopologyOrderState`, `compute_node`, `compare_nodes`, `order_edge_keys`, `order_node_keys`
- [x] Add `compute_descendant_counts` (leaf=1, internal=sum, O(N)), `compute_heights` (leaf=0, internal=max+1, O(N)), `compute_labels` (leaf=name, internal=min, O(N))
- [x] Add `compute_target_scores_mean` (composable from child scores, O(N)) and `compute_target_scores_median` (merged sorted position vectors, O(N log N))
- [x] Add generic `build_plan<K: Ord>` replacing preset dispatch in `compare_nodes`
- [x] Add `Divergence`/`DivergenceReverse` preset with `compute_divergences` using `OrderedFloat<f64>`, `HasBranchLength` bound on `plan()`, CLI args
- [x] Add tests for all previously untested presets (Height, Label, Divergence, TargetOrder+median, TargetOrderReverse) and deep tree propagation
- [x] Update `kb/tests/supporting.md` test inventory
