### PR TITLE
fix: accept comma-separated --cdses values

### DIFF
--- a/packages/treetime/src/commands/ancestral/args.rs
+++ b/packages/treetime/src/commands/ancestral/args.rs
@@ -91,10 +91,13 @@ pub struct TreetimeAncestralArgs {
   #[cfg_attr(feature = "clap", clap(value_hint = ValueHint::FilePath))]
   pub translations: Option<String>,
 
-  /// CDS names to reconstruct from `--translations`.
+  /// Comma-separated CDS names to reconstruct from `--translations`.
   ///
   /// When omitted, the CDS set is derived from `--annotation`.
-  #[cfg_attr(feature = "clap", clap(long = "cdses", visible_alias = "genes", value_name = "CDS"))]
+  #[cfg_attr(
+    feature = "clap",
+    clap(long = "cdses", visible_alias = "genes", value_name = "CDS", value_delimiter = ',')
+  )]
   pub cdses: Vec<String>,
 
   /// GFF3 file with CDS coordinates for Augur node data annotations.


### PR DESCRIPTION
`--cdses=HA,NA` was silently treated as a single CDS name `"HA,NA"` because clap had no `value_delimiter` configured. The file lookup then failed with a confusing "file not found" error for a path containing the literal comma. `--reroot-tips` already had `value_delimiter = ','` for the same pattern.

Add `value_delimiter = ','` to the `--cdses` clap attribute so comma-separated lists are split into individual CDS names. Repeated `--cdses HA --cdses NA` continues to work.

### Work items

- [x] Add `value_delimiter = ','` to `--cdses` clap attribute in `commands/ancestral/args.rs`
- [x] Update doc comment to indicate comma-separated input
