### PR TITLE
fix: assign names to nodes created during topology modifications

### DIFF
--- a/packages/treetime/src/optimize/__tests__/test_topology_cleanup.rs
+++ b/packages/treetime/src/optimize/__tests__/test_topology_cleanup.rs
@@ -494,4 +494,67 @@ mod tests {
 
     Ok(())
   }
+
+  #[test]
+  fn test_optimize_prune_and_merge_names_new_nodes() -> Result<(), Report> {
+    // Collapse zero-length I, then merge A+B+C (shared sub A0T) under a new
+    // internal node. The new node must receive a NODE_NNNNNNN name.
+    let mut graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.1)I:0.0,C:0.1,D:0.1)root;")?;
+
+    let ri_key = find_edge_key(&graph, "root", "I").unwrap();
+
+    let mut partition = PartitionMarginalSparse {
+      index: 0,
+      gtr: jc69(JC69Params::default())?,
+      alphabet: Alphabet::new(AlphabetName::Nuc)?,
+      length: 100,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+      root_sequence: seq![],
+    };
+
+    populate_test_nodes(&mut partition, &graph);
+
+    partition.edges.insert(ri_key, SparseEdgePartition::default());
+
+    let ia_key = find_edge_key(&graph, "I", "A").unwrap();
+    let ib_key = find_edge_key(&graph, "I", "B").unwrap();
+    let rc_key = find_edge_key(&graph, "root", "C").unwrap();
+    let rd_key = find_edge_key(&graph, "root", "D").unwrap();
+
+    partition
+      .edges
+      .insert(ia_key, SparseEdgePartition::with_fitch_subs(vec![sub(b'A', 0, b'T')]));
+    partition
+      .edges
+      .insert(ib_key, SparseEdgePartition::with_fitch_subs(vec![sub(b'A', 0, b'T')]));
+    partition
+      .edges
+      .insert(rc_key, SparseEdgePartition::with_fitch_subs(vec![sub(b'A', 0, b'T')]));
+    partition
+      .edges
+      .insert(rd_key, SparseEdgePartition::with_fitch_subs(vec![sub(b'G', 5, b'C')]));
+
+    let sparse = vec![Arc::new(RwLock::new(partition))];
+    let dense: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
+
+    if let Some(edge) = graph.get_edge(ri_key) {
+      edge.write_arc().payload().write_arc().set_branch_length(Some(0.0));
+    }
+
+    let changed = prune_and_merge_in_loop(&mut graph, &sparse, &dense, &[ri_key])?;
+    assert!(changed);
+
+    let mut names: Vec<String> = graph
+      .get_nodes()
+      .iter()
+      .filter_map(|n| n.read_arc().payload().read_arc().name.clone())
+      .collect();
+    names.sort();
+
+    // I collapsed, A+B+C merged under a new NODE_0000000
+    assert_eq!(names, vec!["A", "B", "C", "D", "NODE_0000000", "root"]);
+
+    Ok(())
+  }
 }

--- a/packages/treetime/src/optimize/run_loop.rs
+++ b/packages/treetime/src/optimize/run_loop.rs
@@ -15,6 +15,7 @@ use itertools::{Itertools, chain};
 use log::debug;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use treetime_graph::assign_node_names::assign_node_names;
 use treetime_graph::edge::{GraphEdge, GraphEdgeKey, HasBranchLength};
 use treetime_graph::graph::Graph;
 use treetime_graph::node::GraphNode;
@@ -347,6 +348,7 @@ pub fn prune_and_merge_in_loop(
   }
 
   graph.build()?;
+  assign_node_names(graph)?;
   Ok(true)
 }
 

--- a/packages/treetime/src/prune/pipeline.rs
+++ b/packages/treetime/src/prune/pipeline.rs
@@ -11,6 +11,7 @@ use parking_lot::RwLock;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use treetime_graph::assign_node_names::assign_node_names;
 use treetime_io::fasta::FastaRecord;
 
 pub struct PruneParams {
@@ -75,6 +76,7 @@ pub fn run(params: &PruneParams, mut input: PruneInput) -> Result<PruneOutput, R
   if params.merge_shared_mutations {
     merge_shared_mutation_branches(&mut input.graph, &partitions)?;
     input.graph.build()?;
+    assign_node_names(&input.graph)?;
   }
 
   let gtr = (!partitions.is_empty()).then(|| partitions[0].read_arc().gtr.clone());

--- a/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
+++ b/packages/treetime/src/timetree/optimization/__tests__/test_polytomy.rs
@@ -10,6 +10,7 @@ mod tests {
   use ndarray::Array1;
   use std::sync::Arc;
   use treetime_distribution::Distribution;
+  use treetime_graph::assign_node_names::assign_node_names;
   use treetime_graph::edge::HasBranchLength;
   use treetime_graph::node::Named;
   use treetime_io::nwk::nwk_read_str;
@@ -751,6 +752,29 @@ mod tests {
       .read_arc()
       .degree_out();
     assert_eq!(final_children, 2, "ABCD should have 2 children after resolution");
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_resolve_polytomies_assign_node_names_names_new_nodes() -> Result<(), Report> {
+    // Resolve a 3-way polytomy (ABC -> {A, B, C}), then assign names.
+    // The new internal node must receive a NODE_NNNNNNN name.
+    let mut graph = helpers::create_polytomy_tree()?;
+    let partitions = vec![];
+    let n_resolved = resolve_polytomies_with_options(&mut graph, &partitions, -1000.0, 10.0, TEST_CLOCK_RATE, false)?;
+    assert_eq!(n_resolved, 1);
+
+    assign_node_names(&graph)?;
+
+    let mut names: Vec<String> = graph
+      .get_nodes()
+      .iter()
+      .filter_map(|n| n.read_arc().payload().read_arc().name().map(|n| n.as_ref().to_owned()))
+      .collect();
+    names.sort();
+
+    assert_eq!(names, vec!["A", "ABC", "B", "C", "NODE_0000000", "root"]);
 
     Ok(())
   }

--- a/packages/treetime/src/timetree/refinement.rs
+++ b/packages/treetime/src/timetree/refinement.rs
@@ -15,6 +15,7 @@ use log::info;
 use parking_lot::RwLock;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
+use treetime_graph::assign_node_names::assign_node_names;
 
 pub struct RefinementParams {
   pub relax: Vec<f64>,
@@ -56,6 +57,7 @@ pub fn run_refinement_iteration(
       .wrap_err("Polytomy resolution failed")?;
     if n > 0 {
       info!("Resolved polytomies, introduced {n} new nodes");
+      assign_node_names(graph)?;
       prepare_tree_after_topology_change(graph).wrap_err("Failed to prepare tree after topology change")?;
 
       for partition in partitions {


### PR DESCRIPTION
`merge_shared_mutation_branches` and `resolve_polytomies` create new internal nodes during optimization, but `assign_node_names` was only called during Newick parsing. New nodes got `name: None`, producing bare `):<branch_length>` entries in output Newick and causing downstream augur errors about missing node names.

Call `assign_node_names` after topology modifications in the optimize loop, prune pipeline, and timetree refinement.

### Work items

- [x] Call `assign_node_names` after `merge_shared_mutation_branches` + `graph.build()` in `optimize/run_loop.rs`
- [x] Call `assign_node_names` after `merge_shared_mutation_branches` + `graph.build()` in `prune/pipeline.rs`
- [x] Call `assign_node_names` after `resolve_polytomies` in `timetree/refinement.rs`
- [x] Add `test_optimize_prune_and_merge_names_new_nodes` asserting exact node name set after collapse + merge
- [x] Add `test_resolve_polytomies_assign_node_names_names_new_nodes` asserting exact node name set after polytomy resolution