### PR TITLE
refactor: lint

### DIFF
--- a/packages/app-napi/src/commands.rs
+++ b/packages/app-napi/src/commands.rs
@@ -1,7 +1,6 @@
 use crate::progress::{self, NapiProgressSink};
 use app_api::datasets::discover_datasets;
 use app_api::progress::{CancelledError, NoopProgress};
-use treetime_schema::version_info;
 use app_api::{
   TreetimeAncestralArgs, TreetimeClockArgs, TreetimeMugrationArgs, TreetimeOptimizeArgs, TreetimePruneArgs,
   TreetimeTimetreeArgs,
@@ -11,6 +10,7 @@ use napi::threadsafe_function::ThreadsafeFunction;
 use napi_derive::napi;
 use std::path::Path;
 use std::sync::Arc;
+use treetime_schema::version_info;
 
 #[napi]
 pub fn version() -> String {

--- a/packages/app-napi/src/progress.rs
+++ b/packages/app-napi/src/progress.rs
@@ -1,9 +1,9 @@
 use app_api::progress::{LogEvent, LogLevel, ProgressSink};
-use treetime_schema::ProgressEvent;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use serde::Serialize;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use treetime_schema::ProgressEvent;
 
 static CANCELLED: AtomicBool = AtomicBool::new(false);
 

--- a/packages/app-server/src/routes.rs
+++ b/packages/app-server/src/routes.rs
@@ -5,13 +5,13 @@ use crate::error::AppError;
 use crate::sse::handle_command;
 use crate::state::ServerConfig;
 use app_api::datasets::discover_datasets;
-use treetime_schema::version_info;
 use axum::extract::State;
 use axum::response::Response;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde_json::Value;
 use std::sync::Arc;
+use treetime_schema::version_info;
 
 pub fn api_routes(config: ServerConfig) -> Router {
   let state = Arc::new(config);

--- a/packages/treetime-validation/src/testing/metrics/distribution/histograms.rs
+++ b/packages/treetime-validation/src/testing/metrics/distribution/histograms.rs
@@ -216,7 +216,7 @@ mod tests {
   fn test_histograms_zero_bins_error() {
     let errors = array![1.0, 2.0];
     let result = compute_error_histogram(&errors, 0, HistogramMode::Signed);
-    let _ = result.unwrap_err();
+    drop(result.unwrap_err());
   }
 
   #[test]

--- a/packages/treetime/src/clock/clock_regression.rs
+++ b/packages/treetime/src/clock/clock_regression.rs
@@ -43,11 +43,10 @@ pub struct ClockParams {
 pub struct ClockRerootResult {
   regression: Option<ClockRegression>,
   clock_model: Option<ClockModel>,
-  pub reroot_result: Option<RerootResult>,
+  reroot_result: Option<RerootResult>,
 }
 
 impl ClockRerootResult {
-  /// Convert to a validated `ClockModel`, failing if the estimated rate is non-positive.
   pub fn into_clock_model(self) -> Result<ClockModel, Report> {
     if let Some(model) = self.clock_model {
       return Ok(model);
@@ -58,12 +57,15 @@ impl ClockRerootResult {
     ClockModel::from_regression(&regression)
   }
 
-  /// Access the raw regression result (rate can be any sign).
   pub fn regression(&self) -> &ClockRegression {
     self
       .regression
       .as_ref()
       .expect("regression() called on fixed-rate result")
+  }
+
+  pub fn reroot_result(&self) -> Option<&RerootResult> {
+    self.reroot_result.as_ref()
   }
 }
 
@@ -256,7 +258,7 @@ where
     .map_or_else(|| regression.as_ref().unwrap().intercept(), |m| m.intercept());
   info!("**Clock rate:** {rate:.6e}");
   info!("**Intercept:** {intercept:.4}");
-  if let Some(ref reg) = regression {
+  if let Some(reg) = &regression {
     info!("**R²:** {:.4}", reg.r_val() * reg.r_val());
     info!("**χ²:** {:.4}", reg.chisq());
     info!("**Hessian:**\n{}", reg.hessian());

--- a/packages/treetime/src/timetree/optimization/reroot.rs
+++ b/packages/treetime/src/timetree/optimization/reroot.rs
@@ -49,7 +49,7 @@ pub fn reroot_tree(
   )
   .wrap_err("Failed to estimate clock model with reroot")?;
 
-  if let Some(reroot_result) = &clock_reroot_result.reroot_result {
+  if let Some(reroot_result) = clock_reroot_result.reroot_result() {
     if !partitions.is_empty() {
       let changes = RerootChanges {
         edge_split: reroot_result.edge_split.clone(),


### PR DESCRIPTION
Clippy restriction and style lint warnings accumulated across the workspace.

### Work items

- [x] Replace `let _ =` with `drop()` for destructors (`let-underscore-drop`)
- [x] Replace `ref` patterns with `&` for clarity (`ref-patterns`)
- [x] Make `ClockRerootResult.reroot_result` private, add accessor (`partial-pub-fields`)
- [x] Fix import ordering

---

