### PR TITLE
feat: add util-newick crate with pest-based parser and writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,20 +2735,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2756,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2769,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -4628,6 +4627,25 @@ dependencies = [
  "serde",
  "serde_json",
  "treetime-utils",
+]
+
+[[package]]
+name = "util-newick"
+version = "1.0.0"
+dependencies = [
+ "ctor 0.5.0",
+ "eyre",
+ "indoc",
+ "pest",
+ "pest_derive",
+ "pretty_assertions",
+ "pretty_dtoa",
+ "proptest",
+ "rayon",
+ "regex",
+ "rstest",
+ "serde",
+ "smart-default",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "packages/treetime-validation",
   "packages/util-augur-node-data-json",
   "packages/util-phyloxml",
+  "packages/util-newick",
   "packages/util-usher-mat",
 ]
 
@@ -111,6 +112,8 @@ num-traits = "=0.2.19"
 ordered-float = { version = "=5.0.0", default-features = false }
 parking_lot = { version = "=0.12.4", features = ["arc_lock", "serde", "deadlock_detection", "hardware-lock-elision"] }
 percent-encoding = "=2.3.2"
+pest = "=2.8.6"
+pest_derive = "=2.8.6"
 petgraph = { version = "=0.6.5", features = ["serde", "stable_graph"] }
 plotters = { version = "=0.3.7", default-features = false, features = ["all_series", "all_elements", "svg_backend"] }
 pretty_assertions = "=1.4.1"
@@ -157,6 +160,7 @@ treetime-primitives = { path = "packages/treetime-primitives" }
 treetime-schema = { path = "packages/treetime-schema" }
 treetime-utils = { path = "packages/treetime-utils" }
 util-augur-node-data-json = { path = "packages/util-augur-node-data-json" }
+util-newick = { path = "packages/util-newick" }
 util-phyloxml = { path = "packages/util-phyloxml" }
 util-usher-mat = { path = "packages/util-usher-mat" }
 

--- a/kb/issues/N-io-newick-root-branch-length-discarded.md
+++ b/kb/issues/N-io-newick-root-branch-length-discarded.md
@@ -1,0 +1,24 @@
+# Root branch length silently discarded during Newick parsing
+
+Severity: N (negligible)
+Category: I/O
+Crate: `util-newick`
+
+## Description
+
+The Newick parser accepts root-level branch lengths (`(A:0.1,B:0.2):0.5;`) but silently discards the root's `:0.5`. `NewickGraph` has no field to represent root branch lengths since the root node has no incoming edge.
+
+Round-trip of trees with root branch lengths loses data: `(A:0.1,B:0.2):0.5;` parses and writes back as `(A:0.1,B:0.2);`.
+
+## Impact
+
+Root branch lengths appear in some tool outputs (IQ-TREE, BEAST) and can carry evolutionary distance information (e.g., stem branch above displayed root). The loss is silent with no warning to callers.
+
+## Fix
+
+Add `root_branch_length: Option<f64>` to `NewickGraph`. Store the parsed root branch length there instead of discarding it. Update the writer to emit it after the root subtree.
+
+## Location
+
+- Parser: `packages/util-newick/src/parse.rs` `visit_root_branch()` line ~93
+- Data model: `packages/util-newick/src/types.rs` `NewickGraph`

--- a/kb/issues/N-io-nexus-parser-limited-subset.md
+++ b/kb/issues/N-io-nexus-parser-limited-subset.md
@@ -1,0 +1,27 @@
+# Nexus parser handles a limited subset
+
+The `util-newick` crate Nexus parser covers the TREES block subset needed for phylogenetic tree I/O. It does not implement a full Nexus grammar parser.
+
+## What is supported
+
+- `Begin Trees;` / `End;` block extraction (case-insensitive)
+- `Translate` integer-to-name tables with quote-aware comma splitting
+- `Tree name = [&R|U]? newick;` entries with quoted name handling
+- Multiple trees per TREES block
+- Unknown blocks silently skipped (FigTree, Data, Characters, etc.)
+
+## What is not supported
+
+- `Begin Characters;`, `Begin Data;`, `Begin Sets;`, `Begin Assumptions;` -- content ignored
+- Nexus comments `[...]` at the block level (only Newick-embedded comments are handled)
+- `UTREE`, `TREE * name =` syntax variants
+- Semicolons inside double-quoted labels in tree commands
+- Malformed blocks produce empty results rather than parse errors
+
+## Why this is acceptable
+
+Nexus is a 1997 format with no formal revision. The only tree-relevant content is inside TREES blocks. A full Nexus grammar covering CHARACTERS, ASSUMPTIONS, SETS, etc. would be a separate crate with no benefit for tree I/O.
+
+## What would change this
+
+If the project needs to read Nexus data matrices or other non-tree blocks, a formal Nexus parser (pest grammar or similar) should replace the string scanner in `nexus.rs`.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -175,6 +175,8 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Validation   | [ValidationRunner print methods duplicated across three runner implementations](N-validation-runner-print-method-boilerplate.md)                    |
 | Negligible | Validation   | [TestCase trait field accessors duplicated across five test suites](N-validation-test-case-accessor-boilerplate.md)                                 |
 | Negligible | Graph        | [Parallel traversal partition write locks serialize the frontier](N-graph-parallel-traversal-partition-lock-contention.md)                          |
+| Negligible | I/O          | [Nexus parser handles a limited subset](N-io-nexus-parser-limited-subset.md)                                                                        |
+| Negligible | I/O          | [Root branch length silently discarded](N-io-newick-root-branch-length-discarded.md)                                                                |
 
 ## Cross-references
 

--- a/kb/tickets/io-nwk-comment-dialect-parsing.md
+++ b/kb/tickets/io-nwk-comment-dialect-parsing.md
@@ -2,7 +2,23 @@
 
 Extend the pest grammar from ticket #2 with BEAST, NHX, and plain comment productions. Inline per-comment dialect detection. Populate `BTreeMap<String, String>` on `NodeFromNwk::from_nwk`.
 
-## Scope
+## Done (`util-newick` crate)
+
+The `util-newick` crate (`packages/util-newick/`) implements the standalone dialect parser:
+
+- Inline per-comment dialect detection: `&&NHX:` -> NHX, `&` -> BEAST, else -> plain (discarded or stored as raw comment)
+- BEAST value types: scalars, quoted strings, `{...}` arrays, booleans (case-insensitive), bare-key flags
+- Node vs branch annotation placement: BEAST2 canonical (before `:` = node, after `:` = branch), MrBayes (after length = branch)
+- NHX colon-separated key=value pairs
+- Typed `NewickValue` enum (`String`, `Number`, `Boolean`, `Array`) instead of flat `BTreeMap<String, String>`
+
+## Remaining (integration into `treetime-io`)
+
+- Wire `util-newick` parsed annotations into `treetime-io` node/edge `BTreeMap` population at `nwk.rs:73`
+- Map `NewickValue` variants to `treetime-io`'s string-valued `BTreeMap<String, String>`
+- Optional `--nwk-dialect` CLI override for malformed files
+
+## Original scope
 
 - Add comment productions to the pest grammar (~30 lines): Comment, CommentBody, BeastPairs, NhxPairs, Key, Value, Array, QuotedStr, Scalar, PlainText
 - Inline dialect detection per comment: first chars after `[` determine mode (`&&NHX:` -> NHX, `&` -> BEAST, else -> discard)

--- a/kb/tickets/io-nwk-writer-style-dispatch.md
+++ b/kb/tickets/io-nwk-writer-style-dispatch.md
@@ -2,7 +2,24 @@
 
 Add `NwkStyle` enum (Plain, Annotated, Nhx) and replace the hardcoded BEAST format string at `treetime-io/src/nwk.rs:255` with a dispatch on style. Default to Plain, fixing the round-trip bug where annotated output is rejected by the reader.
 
-## Scope
+## Done (`util-newick` crate)
+
+The `util-newick` crate (`packages/util-newick/`) implements the standalone writer:
+
+- `NwkStyle` enum: `Plain`, `Beast`, `Nhx` with configurable float precision
+- BEAST2 canonical annotation placement (node attrs before `:`, branch attrs after `:` before length)
+- BEAST key/value escaping (boolean/numeric lookalikes quoted, embedded quotes escaped)
+- NHX serialization with reserved-char rejection (fallible `newick_to_string` returning `Result`)
+- Nexus streaming writer with Taxa block, Translate table, multi-tree support
+
+## Remaining (integration into `treetime-io`)
+
+- Add `NwkStyle` parameter to `nwk_write_with`, `nwk_write_file_with`, `nex_write_with`, `nex_write_file_with`
+- Replace the format string at `nwk.rs:255` with dispatch to `util-newick` writer
+- Default: `Plain` -- suppresses all annotations, fixing the round-trip incompatibility
+- Update all call sites in command `run.rs` files to pass `NwkStyle::Plain`
+
+## Original scope
 
 - Define `NwkStyle` enum: `Plain` (no annotations), `Annotated` (BEAST `[&key="value"]`), `Nhx` (NHX `[&&NHX:key=value:...]`)
 - Add `NwkStyle` parameter to `nwk_write_with`, `nwk_write_file_with`, `nex_write_with`, `nex_write_file_with`

--- a/kb/tickets/io-replace-bio-parser-with-pest.md
+++ b/kb/tickets/io-replace-bio-parser-with-pest.md
@@ -2,7 +2,23 @@
 
 Replace `bio::io::newick::read` with a custom pest-based parser for base Newick (no comment parsing yet). Parse branch lengths as f64 directly. Remove the bio crate dependency.
 
-## Scope
+## Done (`util-newick` crate)
+
+The `util-newick` crate (`packages/util-newick/`) implements the standalone parser:
+
+- pest grammar for full Newick including comments, quoted names, scientific notation, eNewick hybrid markers
+- f64 branch lengths throughout
+- `[...]` content parsed with automatic BEAST/NHX/plain dialect detection (exceeds original "strip as plain" scope)
+- 85+ unit tests, 4 property-based round-trip tests, 8 doc tests
+
+## Remaining (integration into `treetime-io`)
+
+- Replace `bio::io::newick::read` in `treetime-io/src/nwk.rs` with `util_newick::newick_from_string`
+- Adapt `NodeFromNwk`/`EdgeFromNwk` traits to consume `util-newick`'s `NewickGraph`/`NewickNode`/`NewickEdge` types
+- Remove `bio` crate dependency (verify no other uses first)
+- Preserve existing `nwk_read`, `nwk_read_file`, `nwk_read_str` API signatures
+
+## Original scope
 
 - Write a pest grammar for base Newick (~20 lines): Tree, Subtree, Leaf, Internal, BranchSet, Branch, Name (quoted/unquoted), Length
 - Implement parser producing `Graph<N, E, D>` via existing `NodeFromNwk`/`EdgeFromNwk` traits

--- a/packages/util-newick/Cargo.toml
+++ b/packages/util-newick/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "util-newick"
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+eyre = { workspace = true }
+pest = { workspace = true }
+pest_derive = { workspace = true }
+pretty_dtoa = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+smart-default = { workspace = true }
+
+[dev-dependencies]
+ctor = { workspace = true }
+indoc = { workspace = true }
+pretty_assertions = { workspace = true }
+proptest = { workspace = true }
+rayon = { workspace = true }
+rstest = { workspace = true }
+
+[lints]
+workspace = true

--- a/packages/util-newick/README.md
+++ b/packages/util-newick/README.md
@@ -1,0 +1,334 @@
+# util-newick
+
+Newick and Nexus phylogenetic tree parser and writer. Reads all major annotation dialects (BEAST, NHX, plain comments), eNewick networks, and Nexus container files. Writes in configurable styles.
+
+## Data model
+
+The central type is `NewickGraph` -- a flat adjacency list representing a tree (or DAG for eNewick networks).
+
+```
+NewickGraph
+  nodes: Vec<NewickNodeData>    -- indexed by usize
+  edges: Vec<NewickEdgeEntry>   -- indexed by usize
+  root:  usize                  -- index into nodes
+  rooted: Option<bool>          -- [&R] / [&U] marker
+```
+
+Nodes and edges live in flat `Vec`s. Everything references them by index. A node's `children` field holds edge indices (not node indices). To get a child node, go through the edge:
+
+```rust
+let node = &graph.nodes[some_node_idx];
+for &edge_idx in &node.children {
+    let edge = &graph.edges[edge_idx];
+    let child_node = &graph.nodes[edge.child];
+    // edge.data has branch_length, branch_attrs, raw_comments
+    // child_node has name, node_attrs, raw_comments, hybrid, children
+}
+```
+
+### What's on nodes vs edges
+
+The split follows BEAST2's canonical grammar: annotations before `:` belong to the node, annotations after `:` belong to the edge.
+
+```
+    taxon[&node_stuff]:[&edge_stuff]0.05[&also_edge_stuff]
+          ^^^^^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          node_attrs           branch_attrs (merged)
+```
+
+**`NewickNodeData`** fields:
+
+| Field          | Type                            | Content                                                                        |
+| -------------- | ------------------------------- | ------------------------------------------------------------------------------ |
+| `name`         | `Option<String>`                | taxon or clade label. `None` for anonymous nodes                               |
+| `node_attrs`   | `BTreeMap<String, NewickValue>` | structured `[&k=v]` or `[&&NHX:k=v]` annotations before `:`                    |
+| `raw_comments` | `Vec<String>`                   | plain `[text]` comments (no `&` prefix), preserved verbatim including brackets |
+| `hybrid`       | `Option<NewickHybrid>`          | eNewick `#H1` / `##LGT2` marker, if present                                    |
+| `children`     | `Vec<usize>`                    | edge indices into `graph.edges`, in parse order                                |
+
+**`NewickEdgeData`** fields:
+
+| Field           | Type                            | Content                                  |
+| --------------- | ------------------------------- | ---------------------------------------- |
+| `branch_length` | `Option<f64>`                   | the number after `:`. `None` when absent |
+| `branch_attrs`  | `BTreeMap<String, NewickValue>` | structured annotations after `:`         |
+| `raw_comments`  | `Vec<String>`                   | plain comments on the branch             |
+
+### Annotation values
+
+`NewickValue` has four variants. Which you get depends on the dialect:
+
+**BEAST** `[&k=v]` -- typed parsing:
+
+| Input                                   | Variant                   |
+| --------------------------------------- | ------------------------- |
+| `TRUE`, `FALSE` (case-insensitive)      | `Boolean(bool)`           |
+| starts with digit or `-`, parses as f64 | `Number(f64)`             |
+| `{1.0,2.0,3.0}`                         | `Array(Vec<NewickValue>)` |
+| everything else                         | `String(String)`          |
+
+**NHX** `[&&NHX:k=v]` -- all values are `String`. No type inference.
+
+**Plain** `[text]` (no `&` prefix) -- not parsed into attrs, goes to `raw_comments` verbatim.
+
+Dialect is detected per-comment automatically. A single tree can mix dialects on different nodes.
+
+### Leaf vs internal
+
+There's no enum distinguishing leaves from internal nodes. A leaf has `children.is_empty() == true`. An internal node has children.
+
+### Finding nodes
+
+The graph is a flat `Vec`, so finding nodes by name is a linear scan:
+
+```rust
+let node = graph.nodes.iter().find(|n| n.name.as_deref() == Some("taxon_A"));
+```
+
+For index-based lookup (when you need the index for edge traversal):
+
+```rust
+let idx = graph.nodes.iter().position(|n| n.name.as_deref() == Some("taxon_A")).unwrap();
+```
+
+### Parent lookup
+
+Edges store both `parent` and `child` indices. To find a node's parent:
+
+```rust
+let parent_edge = graph.edges.iter().find(|e| e.child == node_idx);
+if let Some(edge) = parent_edge {
+    let parent_node = &graph.nodes[edge.parent];
+}
+```
+
+The root node has no incoming edge.
+
+## Parsing
+
+```rust
+use util_newick::{newick_from_string, newick_from_reader};
+
+// From string
+let graph = newick_from_string("(A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5)F;").unwrap();
+
+// From file
+let file = std::fs::File::open("tree.nwk").unwrap();
+let graph = newick_from_reader(std::io::BufReader::new(file)).unwrap();
+```
+
+Underscores in unquoted labels are preserved verbatim. The Felsenstein convention of converting underscores to spaces is not applied, as it breaks name matching against metadata.
+
+The parser accepts:
+
+- Standard Newick with optional names, branch lengths, quoted labels
+- BEAST annotations `[&prob=0.95,hpd={1.0,2.0}]`
+- NHX annotations `[&&NHX:S=human:B=90]`
+- Plain comments `[any text]`
+- Rooting markers `[&R]` / `[&U]` before the tree
+- Empty branches `(,)` -- produces anonymous leaf nodes
+- eNewick hybrid markers `#H1`, `##LGT2`
+
+### Accessing parsed data
+
+```rust
+let graph = newick_from_string("(A[&prob=0.95]:0.1,B:0.2)root;").unwrap();
+
+// Root
+let root = &graph.nodes[graph.root];
+assert_eq!(root.name.as_deref(), Some("root"));
+
+// Iterate children of root
+for &edge_idx in &root.children {
+    let edge = &graph.edges[edge_idx];
+    let child = &graph.nodes[edge.child];
+    println!("child={} length={:?}", child.name.as_deref().unwrap_or("?"), edge.data.branch_length);
+}
+
+// Read an annotation
+let a = graph.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+if let Some(util_newick::NewickValue::Number(prob)) = a.node_attrs.get("prob") {
+    println!("posterior probability: {prob}");
+}
+```
+
+## Writing
+
+```rust
+use util_newick::{newick_to_string, newick_to_writer, NewickWriteOptions, NwkStyle};
+
+let opts = NewickWriteOptions::default(); // Beast style, full precision
+
+// To string (returns Result for NHX reserved-char errors)
+let nwk = newick_to_string(&graph, &opts).unwrap();
+
+// To file
+let mut file = std::fs::File::create("out.nwk").unwrap();
+newick_to_writer(&mut file, &graph, &opts).unwrap();
+```
+
+### Output styles
+
+Plain -- maximum compatibility, strips all annotations and comments:
+
+```
+(A:0.1,B:0.2)root;
+```
+
+Beast (default) -- BEAST2 canonical placement, node attrs before `:`, branch attrs between `:` and length:
+
+```
+(A[&prob=0.95]:[&rate=1.5]0.1,B:0.2)root;
+```
+
+Nhx -- NHX colon-separated format, all values as strings:
+
+```
+(A[&&NHX:prob=0.95]:0.1[&&NHX:rate=1.5],B:0.2)root;
+```
+
+Raw comments are emitted after structured blocks in Beast and Nhx styles. Plain drops them.
+
+### Float precision
+
+```rust
+// Full precision (default)
+NewickWriteOptions { significant_digits: None, decimal_digits: None, ..Default::default() }
+
+// 3 significant digits
+NewickWriteOptions { significant_digits: Some(3), ..Default::default() }
+// -> 0.123
+
+// 5 decimal places
+NewickWriteOptions { decimal_digits: Some(5), significant_digits: None, ..Default::default() }
+// -> 0.12346
+```
+
+## Building trees programmatically
+
+```rust
+use util_newick::*;
+use std::collections::BTreeMap;
+
+let mut graph = NewickGraph::new();
+
+// Create nodes -- add_node returns the index
+let root = graph.add_node(NewickNodeData::new().with_name("root"));
+graph.root = root;
+
+let leaf_a = graph.add_node(NewickNodeData::new().with_name("A"));
+let leaf_b = graph.add_node(NewickNodeData::new().with_name("B"));
+
+// Create edges -- add_edge returns the edge index and updates parent.children
+graph.add_edge(root, leaf_a, NewickEdgeData::new().with_length(0.1));
+graph.add_edge(root, leaf_b, NewickEdgeData::new().with_length(0.2));
+
+// Add annotations
+graph.nodes[leaf_a].node_attrs.insert("prob".to_owned(), NewickValue::Number(0.95));
+
+// Rooting marker
+graph.rooted = Some(true);
+
+let nwk = newick_to_string(&graph, &NewickWriteOptions::default()).unwrap();
+// -> [&R](A[&prob=0.95]:0.1,B:0.2)root;
+```
+
+### Building edges with annotations
+
+```rust
+let mut branch_attrs = BTreeMap::new();
+branch_attrs.insert("rate".to_owned(), NewickValue::Number(1.5));
+
+graph.add_edge(root, leaf_a, NewickEdgeData {
+    branch_length: Some(0.1),
+    branch_attrs,
+    raw_comments: Vec::new(),
+    is_acceptor: false,
+});
+```
+
+## Nexus files
+
+Nexus is a container around Newick strings. The crate handles parsing the TREES block, TRANSLATE tables, and multi-tree files.
+
+```rust
+use util_newick::{nexus_from_string, nexus_to_string, NewickWriteOptions};
+
+let input = "#NEXUS\n\
+    Begin Trees;\n\
+      Translate\n\
+        1 Homo_sapiens,\n\
+        2 Pan_troglodytes\n\
+      ;\n\
+      Tree primates = [&R] (1:0.1,2:0.2);\n\
+    End;\n";
+
+let trees = nexus_from_string(input).unwrap();
+
+// Each tree has a name and a NewickGraph
+let tree = &trees[0];
+assert_eq!(tree.name, "primates");
+assert_eq!(tree.graph.rooted, Some(true));
+
+// TRANSLATE tokens are resolved -- names are full taxon names, not integers
+let names: Vec<_> = tree.graph.nodes.iter()
+    .filter_map(|n| n.name.as_deref())
+    .collect();
+assert!(names.contains(&"Homo_sapiens"));
+
+// Write back to Nexus
+let output = nexus_to_string(&trees, &NewickWriteOptions::default()).unwrap();
+```
+
+The Nexus parser:
+
+- Handles case-insensitive keywords (`begin`, `Begin`, `BEGIN`)
+- Resolves TRANSLATE integer-to-name mappings before Newick parsing
+- Ignores unknown blocks (FigTree display settings, Data blocks, etc.)
+- Supports multiple `Tree` entries per TREES block
+
+The Nexus writer emits a Taxa block (sorted, deduplicated leaf names) and a Trees block.
+
+## eNewick networks
+
+eNewick encodes phylogenetic networks (DAGs with hybrid/reticulate nodes) by duplicating hybrid nodes with `#` markers:
+
+```
+((A,(B)x#H1)c,(x#H1,C)d);
+```
+
+The parser detects `#TypeN` patterns in labels, creates a single graph node for each unique `(type, index)` pair, and connects multiple parent edges to it. The resulting graph is a DAG, not a tree.
+
+```rust
+let g = newick_from_string("((A,(B)x#H1)c,(x#H1,C)d);").unwrap();
+
+// x#H1 appears as one node with two parent edges
+let hybrid = g.nodes.iter().find(|n| n.hybrid.is_some()).unwrap();
+let h = hybrid.hybrid.as_ref().unwrap();
+assert_eq!(h.kind.as_deref(), Some("H"));  // H, LGT, R, or None
+assert_eq!(h.index, 1);
+```
+
+The writer reproduces hybrid markers: first visit writes the full subtree, subsequent visits write `name#TypeN` with branch length only.
+
+Reticulation types: `H` (hybridization), `LGT` (lateral gene transfer), `R` (recombination), or any custom string. `##` (double hash) marks the acceptor edge (main lineage).
+
+## Equality
+
+`PartialEq` on `NewickGraph` is **order-insensitive**: `(A,B)` equals `(B,A)`. Children are sorted by a canonical key `(name, child_count, branch_length)` before comparison. This is the right default for comparing trees parsed from different sources.
+
+For **order-sensitive** comparison (when child ordering matters, e.g. verifying exact serialization round-trips):
+
+```rust
+assert!(g1.eq_ordered(&g2));
+```
+
+Both comparisons check: topology, node names, branch lengths (bitwise f64 equality), structured annotations, raw comments, hybrid markers, and rooting.
+
+## Round-trip guarantees
+
+- `parse(write(g, Beast))` == `g` for any valid graph (order-insensitive)
+- `write(parse(write(g)))` == `write(g)` (string-level idempotence)
+- Plain style is lossy by design: annotations and raw comments are dropped
+- NHX converts typed values to strings: `Number(0.95)` becomes `String("0.95")`
+- Nexus TRANSLATE is transparent: parsed names are always resolved, never integer tokens

--- a/packages/util-newick/src/__tests__/mod.rs
+++ b/packages/util-newick/src/__tests__/mod.rs
@@ -1,0 +1,4 @@
+mod test_nexus;
+mod test_parse;
+mod test_prop_roundtrip;
+mod test_write;

--- a/packages/util-newick/src/__tests__/test_nexus.rs
+++ b/packages/util-newick/src/__tests__/test_nexus.rs
@@ -1,0 +1,250 @@
+#[cfg(test)]
+mod tests {
+  use crate::nexus::{nexus_from_string, nexus_to_string};
+  use crate::types::{NewickWriteOptions, NwkStyle};
+  use indoc::indoc;
+  use pretty_assertions::assert_eq;
+
+  fn opts(style: NwkStyle) -> NewickWriteOptions {
+    NewickWriteOptions {
+      style,
+      significant_digits: None,
+      decimal_digits: None,
+    }
+  }
+
+  #[test]
+  fn test_nexus_simple() {
+    let input = indoc! {"
+      #NEXUS
+
+      Begin Trees;
+        Tree tree1 = (A:0.1,B:0.2);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(1, trees.len());
+    assert_eq!("tree1", trees[0].name);
+    assert_eq!(3, trees[0].graph.nodes.len());
+  }
+
+  #[test]
+  fn test_nexus_multiple_trees() {
+    let input = indoc! {"
+      #NEXUS
+
+      Begin Trees;
+        Tree t1 = (A,B);
+        Tree t2 = (C,D);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(2, trees.len());
+    assert_eq!("t1", trees[0].name);
+    assert_eq!("t2", trees[1].name);
+  }
+
+  #[test]
+  fn test_nexus_translate() {
+    let input = indoc! {"
+      #NEXUS
+
+      Begin Trees;
+        Translate
+          1 Homo_sapiens,
+          2 Pan_troglodytes,
+          3 Gorilla_gorilla
+        ;
+        Tree tree1 = (1:0.1,2:0.2,3:0.3);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(1, trees.len());
+    let names: Vec<_> = trees[0].graph.nodes.iter().filter_map(|n| n.name.as_deref()).collect();
+    assert!(names.contains(&"Homo_sapiens"));
+    assert!(names.contains(&"Pan_troglodytes"));
+    assert!(names.contains(&"Gorilla_gorilla"));
+    assert!(!names.contains(&"1"));
+  }
+
+  #[test]
+  fn test_nexus_rooted_marker() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Tree tree1 = [&R] (A,B);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(Some(true), trees[0].graph.rooted);
+  }
+
+  #[test]
+  fn test_nexus_with_annotations() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Tree tree1 = (A[&prob=0.9]:0.1,B:0.2);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    let a_idx = trees[0]
+      .graph
+      .nodes
+      .iter()
+      .position(|n| n.name.as_deref() == Some("A"))
+      .unwrap();
+    assert!(trees[0].graph.nodes[a_idx].node_attrs.contains_key("prob"));
+  }
+
+  #[test]
+  fn test_nexus_unknown_blocks_ignored() {
+    let input = indoc! {"
+      #NEXUS
+
+      Begin Data;
+        something irrelevant;
+      End;
+
+      Begin Trees;
+        Tree tree1 = (A,B);
+      End;
+
+      Begin figtree;
+        display settings;
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(1, trees.len());
+    assert_eq!("tree1", trees[0].name);
+  }
+
+  #[test]
+  fn test_nexus_case_insensitive_header() {
+    let input = indoc! {"
+      #nexus
+      begin trees;
+        tree t1 = (A,B);
+      end;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(1, trees.len());
+  }
+
+  #[test]
+  fn test_nexus_missing_header_error() {
+    let input = indoc! {"
+      Begin Trees;
+        Tree t1 = (A,B);
+      End;
+    "};
+    let err = format!("{}", nexus_from_string(input).unwrap_err());
+    assert!(err.contains("#NEXUS"), "unexpected error: {err}");
+  }
+
+  #[test]
+  fn test_nexus_roundtrip() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Tree tree1 = (A:0.1,B:0.2);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    let output = nexus_to_string(&trees, &opts(NwkStyle::Plain)).unwrap();
+    let trees2 = nexus_from_string(&output).unwrap();
+
+    assert_eq!(trees.len(), trees2.len());
+    assert_eq!(trees[0].name, trees2[0].name);
+    assert_eq!(trees[0].graph, trees2[0].graph);
+  }
+
+  #[test]
+  fn test_nexus_translate_quoted_names() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Translate
+          1 'Homo sapiens',
+          2 'Pan troglodytes'
+        ;
+        Tree tree1 = (1:0.1,2:0.2);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    let names: Vec<_> = trees[0].graph.nodes.iter().filter_map(|n| n.name.as_deref()).collect();
+    assert!(names.contains(&"Homo sapiens"));
+    assert!(names.contains(&"Pan troglodytes"));
+  }
+
+  #[test]
+  fn test_nexus_translate_comma_in_quoted_name() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Translate
+          1 'A,B',
+          2 C
+        ;
+        Tree tree1 = (1:0.1,2:0.2);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    let names: Vec<_> = trees[0].graph.nodes.iter().filter_map(|n| n.name.as_deref()).collect();
+    assert!(names.contains(&"A,B"), "Expected 'A,B' in {names:?}");
+    assert!(names.contains(&"C"));
+  }
+
+  #[test]
+  fn test_nexus_writer_taxa_block() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Tree tree1 = (A:0.1,B:0.2);
+      End;
+    "};
+
+    let trees = nexus_from_string(input).unwrap();
+    let output = nexus_to_string(&trees, &opts(NwkStyle::Plain)).unwrap();
+
+    assert!(output.contains("Begin Taxa;"));
+    assert!(output.contains("ntax=2"));
+    assert!(output.contains('A'));
+    assert!(output.contains('B'));
+  }
+
+  #[test]
+  fn test_nexus_mixed_case_header() {
+    let input = indoc! {"
+      #Nexus
+      Begin Trees;
+        Tree t1 = (A,B);
+      End;
+    "};
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(1, trees.len());
+  }
+
+  #[test]
+  fn test_nexus_semicolon_inside_comment() {
+    let input = indoc! {"
+      #NEXUS
+      Begin Trees;
+        Tree t1 = (A[comment;still]:0.1,B:0.2);
+      End;
+    "};
+    let trees = nexus_from_string(input).unwrap();
+    assert_eq!(1, trees.len());
+    assert_eq!(3, trees[0].graph.nodes.len());
+  }
+}

--- a/packages/util-newick/src/__tests__/test_parse.rs
+++ b/packages/util-newick/src/__tests__/test_parse.rs
@@ -1,0 +1,473 @@
+#[cfg(test)]
+mod tests {
+  use crate::parse::newick_from_string;
+  use crate::types::NewickValue;
+  use indoc::indoc;
+  use pretty_assertions::assert_eq;
+
+  #[test]
+  fn test_parse_single_leaf() {
+    let g = newick_from_string("A;").unwrap();
+    assert_eq!(g.nodes.len(), 1);
+    assert_eq!(g.nodes[0].name.as_deref(), Some("A"));
+    assert!(g.nodes[0].children.is_empty());
+  }
+
+  #[test]
+  fn test_parse_two_leaves() {
+    let g = newick_from_string("(A,B);").unwrap();
+    assert_eq!(g.nodes.len(), 3);
+    let root = &g.nodes[g.root];
+    assert_eq!(root.children.len(), 2);
+  }
+
+  #[test]
+  fn test_parse_named_internal() {
+    let g = newick_from_string("(A,B)root;").unwrap();
+    assert_eq!(g.nodes[g.root].name.as_deref(), Some("root"));
+  }
+
+  #[test]
+  fn test_parse_branch_lengths() {
+    let g = newick_from_string("(A:0.1,B:0.2):0.0;").unwrap();
+    assert_eq!(g.edges.len(), 2);
+    let lengths: Vec<f64> = g.edges.iter().filter_map(|e| e.data.branch_length).collect();
+    assert!(lengths.contains(&0.1));
+    assert!(lengths.contains(&0.2));
+  }
+
+  #[test]
+  fn test_parse_scientific_notation() {
+    let g = newick_from_string("(A:1.5e-3,B:2E4);").unwrap();
+    let lengths: Vec<f64> = g.edges.iter().filter_map(|e| e.data.branch_length).collect();
+    assert!(lengths.contains(&1.5e-3));
+    assert!(lengths.contains(&2e4));
+  }
+
+  #[test]
+  fn test_parse_negative_branch_length() {
+    let g = newick_from_string("(A:-0.01,B:0.2);").unwrap();
+    assert!(
+      g.edges
+        .iter()
+        .filter_map(|e| e.data.branch_length)
+        .any(|x| (x - (-0.01)).abs() < 1e-15)
+    );
+  }
+
+  #[test]
+  fn test_parse_quoted_label() {
+    let g = newick_from_string("'node with spaces';").unwrap();
+    assert_eq!(g.nodes[0].name.as_deref(), Some("node with spaces"));
+  }
+
+  #[test]
+  fn test_parse_quoted_label_escaped_quote() {
+    let g = newick_from_string("'it''s a name';").unwrap();
+    assert_eq!(g.nodes[0].name.as_deref(), Some("it's a name"));
+  }
+
+  #[test]
+  fn test_parse_empty_branches() {
+    let g = newick_from_string("(,);").unwrap();
+    assert_eq!(g.nodes.len(), 3);
+    let root = &g.nodes[g.root];
+    assert_eq!(root.children.len(), 2);
+    // Anonymous children
+    for &ei in &root.children {
+      let child_idx = g.edges[ei].child;
+      assert_eq!(g.nodes[child_idx].name, None);
+    }
+  }
+
+  #[test]
+  fn test_parse_empty_branches_three() {
+    let g = newick_from_string("(A,,B);").unwrap();
+    assert_eq!(g.nodes.len(), 4); // root + A + anonymous + B
+    let root = &g.nodes[g.root];
+    assert_eq!(root.children.len(), 3);
+  }
+
+  #[test]
+  fn test_parse_rooted_marker() {
+    let g = newick_from_string("[&R](A,B);").unwrap();
+    assert_eq!(g.rooted, Some(true));
+  }
+
+  #[test]
+  fn test_parse_unrooted_marker() {
+    let g = newick_from_string("[&U](A,B);").unwrap();
+    assert_eq!(g.rooted, Some(false));
+  }
+
+  #[test]
+  fn test_parse_rooted_case_insensitive() {
+    let g = newick_from_string("[&r](A,B);").unwrap();
+    assert_eq!(g.rooted, Some(true));
+  }
+
+  #[test]
+  fn test_parse_no_rooting_marker() {
+    let g = newick_from_string("(A,B);").unwrap();
+    assert_eq!(g.rooted, None);
+  }
+
+  // BEAST dialect tests
+  #[test]
+  fn test_parse_beast_node_attrs() {
+    let g = newick_from_string("(A[&prob=0.95,rate=1.2],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    let attrs = &g.nodes[a_idx].node_attrs;
+    assert_eq!(attrs.get("prob"), Some(&NewickValue::Number(0.95)));
+    assert_eq!(attrs.get("rate"), Some(&NewickValue::Number(1.2)));
+  }
+
+  #[test]
+  fn test_parse_beast_boolean_values() {
+    let g = newick_from_string("(A[&fixed=TRUE,active=FALSE],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    let attrs = &g.nodes[a_idx].node_attrs;
+    assert_eq!(attrs.get("fixed"), Some(&NewickValue::Boolean(true)));
+    assert_eq!(attrs.get("active"), Some(&NewickValue::Boolean(false)));
+  }
+
+  #[test]
+  fn test_parse_beast_boolean_case_insensitive() {
+    let g = newick_from_string("(A[&x=true,y=False],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    let attrs = &g.nodes[a_idx].node_attrs;
+    assert_eq!(attrs.get("x"), Some(&NewickValue::Boolean(true)));
+    assert_eq!(attrs.get("y"), Some(&NewickValue::Boolean(false)));
+  }
+
+  #[test]
+  fn test_parse_beast_array_values() {
+    let g = newick_from_string("(A[&hpd={1.0,2.0,3.0}],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    let hpd = &g.nodes[a_idx].node_attrs["hpd"];
+    match hpd {
+      NewickValue::Array(arr) => {
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0], NewickValue::Number(1.0));
+        assert_eq!(arr[1], NewickValue::Number(2.0));
+        assert_eq!(arr[2], NewickValue::Number(3.0));
+      },
+      _ => panic!("Expected Array"),
+    }
+  }
+
+  #[test]
+  fn test_parse_beast_string_value() {
+    let g = newick_from_string("(A[&country=USA],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(
+      g.nodes[a_idx].node_attrs.get("country"),
+      Some(&NewickValue::String("USA".to_owned()))
+    );
+  }
+
+  #[test]
+  fn test_parse_beast_quoted_string_value() {
+    let g = newick_from_string("(A[&label=\"hello, world\"],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(
+      g.nodes[a_idx].node_attrs.get("label"),
+      Some(&NewickValue::String("hello, world".to_owned()))
+    );
+  }
+
+  #[test]
+  fn test_parse_beast_bare_key_boolean() {
+    let g = newick_from_string("(A[&flagged],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(
+      g.nodes[a_idx].node_attrs.get("flagged"),
+      Some(&NewickValue::Boolean(true))
+    );
+  }
+
+  // BEAST2 canonical branch attr placement
+  #[test]
+  fn test_parse_beast2_branch_attrs() {
+    let g = newick_from_string("(A:[&rate=1.5]0.1,B:0.2);").unwrap();
+    let a_edge = g
+      .edges
+      .iter()
+      .find(|e| g.nodes[e.child].name.as_deref() == Some("A"))
+      .unwrap();
+    assert_eq!(a_edge.data.branch_attrs.get("rate"), Some(&NewickValue::Number(1.5)));
+    assert_eq!(a_edge.data.branch_length, Some(0.1));
+  }
+
+  // MrBayes-style: branch attrs after length
+  #[test]
+  fn test_parse_mrbayes_branch_attrs() {
+    let g = newick_from_string("(A:0.1[&prob=0.99],B:0.2);").unwrap();
+    let a_edge = g
+      .edges
+      .iter()
+      .find(|e| g.nodes[e.child].name.as_deref() == Some("A"))
+      .unwrap();
+    assert_eq!(a_edge.data.branch_attrs.get("prob"), Some(&NewickValue::Number(0.99)));
+  }
+
+  // NHX dialect tests
+  #[test]
+  fn test_parse_nhx_attrs() {
+    let g = newick_from_string("(A[&&NHX:S=human:B=90],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    let attrs = &g.nodes[a_idx].node_attrs;
+    assert_eq!(attrs.get("S"), Some(&NewickValue::String("human".to_owned())));
+    assert_eq!(attrs.get("B"), Some(&NewickValue::String("90".to_owned())));
+  }
+
+  // Raw comments
+  #[test]
+  fn test_parse_raw_comment() {
+    let g = newick_from_string("(A[some comment],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(g.nodes[a_idx].raw_comments, vec!["[some comment]"]);
+    assert!(g.nodes[a_idx].node_attrs.is_empty());
+  }
+
+  #[test]
+  fn test_parse_nested_bracket_comment() {
+    let g = newick_from_string("(A[outer[inner]],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(g.nodes[a_idx].raw_comments, vec!["[outer[inner]]"]);
+  }
+
+  // Malformed annotation falls back to raw
+  #[test]
+  fn test_parse_malformed_beast_fallback() {
+    let g = newick_from_string("(A[&broken=],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    // Even malformed, the BEAST parser attempts to parse it
+    // [&broken=] has key "broken" with empty value -> String("")
+    assert!(g.nodes[a_idx].node_attrs.contains_key("broken"));
+  }
+
+  // eNewick hybrid tests
+  #[test]
+  fn test_parse_enewick_hybrid() {
+    let g = newick_from_string("(A,B,((C,(Y)x#H1)c,(x#H1,D)d)e)f;").unwrap();
+    // x#H1 should appear as a single node with two parents
+    let hybrid_nodes: Vec<_> = g.nodes.iter().filter(|n| n.hybrid.is_some()).collect();
+    assert_eq!(hybrid_nodes.len(), 1);
+    let h = hybrid_nodes[0].hybrid.as_ref().unwrap();
+    assert_eq!(h.kind.as_deref(), Some("H"));
+    assert_eq!(h.index, 1);
+    // Node x should have name "x"
+    assert_eq!(hybrid_nodes[0].name.as_deref(), Some("x"));
+  }
+
+  #[test]
+  fn test_parse_enewick_acceptor() {
+    let g = newick_from_string("((A)x##LGT1,(x#LGT1,B));").unwrap();
+    let hybrid_nodes: Vec<_> = g.nodes.iter().filter(|n| n.hybrid.is_some()).collect();
+    assert_eq!(1, hybrid_nodes.len());
+    let h = hybrid_nodes[0].hybrid.as_ref().unwrap();
+    assert_eq!(Some("LGT"), h.kind.as_deref());
+    assert_eq!(1, h.index);
+
+    // Acceptor is edge-specific: exactly one of the two parent edges should be acceptor
+    let hybrid_idx = g.nodes.iter().position(|n| n.hybrid.is_some()).unwrap();
+    let parent_edges: Vec<_> = g.edges.iter().filter(|e| e.child == hybrid_idx).collect();
+    assert_eq!(2, parent_edges.len());
+    let acceptor_count = parent_edges.iter().filter(|e| e.data.is_acceptor).count();
+    assert_eq!(1, acceptor_count, "exactly one parent edge should be the acceptor");
+  }
+
+  #[test]
+  fn test_parse_enewick_no_name() {
+    let g = newick_from_string("((A)#H1,(#H1,B));").unwrap();
+    let hybrid_nodes: Vec<_> = g.nodes.iter().filter(|n| n.hybrid.is_some()).collect();
+    assert_eq!(hybrid_nodes.len(), 1);
+    assert_eq!(hybrid_nodes[0].name, None);
+  }
+
+  #[test]
+  fn test_parse_hash_no_match_is_plain_name() {
+    let g = newick_from_string("node#;").unwrap();
+    assert_eq!(g.nodes[0].name.as_deref(), Some("node#"));
+    assert!(g.nodes[0].hybrid.is_none());
+  }
+
+  #[test]
+  fn test_parse_spec_no_names() {
+    let g = newick_from_string("(,,(,));").unwrap();
+    assert_eq!(6, g.nodes.len());
+    assert_eq!(3, g.nodes[g.root].children.len());
+  }
+
+  #[test]
+  fn test_parse_spec_leaf_names() {
+    let g = newick_from_string("(A,B,(C,D));").unwrap();
+    assert_eq!(6, g.nodes.len());
+    let leaf_names: Vec<_> = g
+      .nodes
+      .iter()
+      .filter(|n| n.children.is_empty())
+      .filter_map(|n| n.name.as_deref())
+      .collect();
+    assert!(leaf_names.contains(&"A"));
+    assert!(leaf_names.contains(&"B"));
+    assert!(leaf_names.contains(&"C"));
+    assert!(leaf_names.contains(&"D"));
+  }
+
+  #[test]
+  fn test_parse_spec_all_names() {
+    let g = newick_from_string("(A,B,(C,D)E)F;").unwrap();
+    assert_eq!(6, g.nodes.len());
+    assert_eq!(Some("F"), g.nodes[g.root].name.as_deref());
+    assert_eq!(3, g.nodes[g.root].children.len());
+  }
+
+  #[test]
+  fn test_parse_spec_distances_and_leaf_names() {
+    let g = newick_from_string("(A:0.1,B:0.2,(C:0.3,D:0.4):0.5);").unwrap();
+    assert_eq!(6, g.nodes.len());
+    let a_edge = g
+      .edges
+      .iter()
+      .find(|e| g.nodes[e.child].name.as_deref() == Some("A"))
+      .unwrap();
+    assert_eq!(Some(0.1), a_edge.data.branch_length);
+  }
+
+  #[test]
+  fn test_parse_spec_distances_and_all_names() {
+    let g = newick_from_string("(A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5)F;").unwrap();
+    assert_eq!(6, g.nodes.len());
+    assert_eq!(Some("F"), g.nodes[g.root].name.as_deref());
+    let e_edge = g
+      .edges
+      .iter()
+      .find(|e| g.nodes[e.child].name.as_deref() == Some("E"))
+      .unwrap();
+    assert_eq!(Some(0.5), e_edge.data.branch_length);
+  }
+
+  #[test]
+  fn test_parse_missing_semicolon() {
+    let err = format!("{}", newick_from_string("(A,B)").unwrap_err());
+    assert!(err.contains("Failed to parse Newick string"), "unexpected error: {err}");
+  }
+
+  #[test]
+  fn test_parse_unmatched_paren() {
+    let err = format!("{}", newick_from_string("(A,B;").unwrap_err());
+    assert!(err.contains("Failed to parse Newick string"), "unexpected error: {err}");
+  }
+
+  #[test]
+  fn test_parse_empty_string() {
+    let err = format!("{}", newick_from_string("").unwrap_err());
+    assert!(err.contains("Failed to parse Newick string"), "unexpected error: {err}");
+  }
+
+  // PartialEq tests
+  #[test]
+  fn test_eq_order_insensitive() {
+    let g1 = newick_from_string("(A,B,C);").unwrap();
+    let g2 = newick_from_string("(C,A,B);").unwrap();
+    assert_eq!(g1, g2);
+  }
+
+  #[test]
+  fn test_eq_ordered_sensitive() {
+    let g1 = newick_from_string("(A,B,C);").unwrap();
+    let g2 = newick_from_string("(C,A,B);").unwrap();
+    assert!(!g1.eq_ordered(&g2));
+  }
+
+  #[test]
+  fn test_eq_ordered_same() {
+    let g1 = newick_from_string("(A,B,C);").unwrap();
+    let g2 = newick_from_string("(A,B,C);").unwrap();
+    assert!(g1.eq_ordered(&g2));
+  }
+
+  #[test]
+  fn test_eq_with_branch_lengths() {
+    let g1 = newick_from_string("(A:0.1,B:0.2);").unwrap();
+    let g2 = newick_from_string("(B:0.2,A:0.1);").unwrap();
+    assert_eq!(g1, g2);
+  }
+
+  #[test]
+  fn test_eq_unnamed_internal_reorder() {
+    let g1 = newick_from_string("((A,B),(C,D));").unwrap();
+    let g2 = newick_from_string("((C,D),(A,B));").unwrap();
+    assert_eq!(g1, g2);
+  }
+
+  #[test]
+  fn test_neq_different_topology() {
+    let g1 = newick_from_string("((A,B),C);").unwrap();
+    let g2 = newick_from_string("(A,(B,C));").unwrap();
+    assert_ne!(g1, g2);
+  }
+
+  #[test]
+  fn test_eq_rooting_matters() {
+    let g1 = newick_from_string("[&R](A,B);").unwrap();
+    let g2 = newick_from_string("[&U](A,B);").unwrap();
+    assert_ne!(g1, g2);
+  }
+
+  // Whitespace handling
+  #[test]
+  fn test_parse_whitespace() {
+    let g = newick_from_string("  ( A : 0.1 , B : 0.2 ) ; ").unwrap();
+    assert_eq!(g.nodes.len(), 3);
+  }
+
+  #[test]
+  fn test_parse_newlines() {
+    let g = newick_from_string(indoc! {"
+      (
+        A:0.1,
+        B:0.2
+      );
+    "})
+    .unwrap();
+    assert_eq!(g.nodes.len(), 3);
+  }
+
+  // Single-child internal node
+  #[test]
+  fn test_parse_single_child_internal() {
+    let g = newick_from_string("((A));").unwrap();
+    assert_eq!(g.nodes.len(), 3);
+  }
+
+  // Deep nesting
+  #[test]
+  fn test_parse_deep_nesting() {
+    let g = newick_from_string("((((A,B),C),D),E);").unwrap();
+    assert_eq!(g.nodes.len(), 9);
+  }
+
+  // Comment on edge with no length
+  #[test]
+  fn test_parse_comment_no_length() {
+    let g = newick_from_string("(A[&note=yes],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(
+      g.nodes[a_idx].node_attrs.get("note"),
+      Some(&NewickValue::String("yes".to_owned()))
+    );
+  }
+
+  #[test]
+  fn test_parse_beast_infinity_as_string() {
+    let g = newick_from_string("(A[&score=-infinity],B);").unwrap();
+    let a_idx = g.nodes.iter().position(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert!(
+      matches!(g.nodes[a_idx].node_attrs.get("score"), Some(NewickValue::String(_))),
+      "Non-finite value should parse as String, not Number"
+    );
+  }
+}

--- a/packages/util-newick/src/__tests__/test_prop_roundtrip.rs
+++ b/packages/util-newick/src/__tests__/test_prop_roundtrip.rs
@@ -1,0 +1,131 @@
+#[cfg(test)]
+mod tests {
+  use crate::parse::newick_from_string;
+  use crate::types::{NewickEdgeData, NewickGraph, NewickNodeData, NewickValue, NewickWriteOptions, NwkStyle};
+  use crate::write::newick_to_string;
+  use proptest::prelude::*;
+  use std::collections::BTreeMap;
+
+  fn arb_branch_length() -> impl Strategy<Value = Option<f64>> {
+    prop_oneof![Just(None), (0.0001_f64..100.0).prop_map(Some),]
+  }
+
+  fn arb_value() -> impl Strategy<Value = NewickValue> {
+    prop_oneof![
+      any::<bool>().prop_map(NewickValue::Boolean),
+      (0.001_f64..1000.0).prop_map(NewickValue::Number),
+      "[A-Za-z]{1,6}".prop_map(NewickValue::String),
+    ]
+  }
+
+  fn arb_attrs() -> impl Strategy<Value = BTreeMap<String, NewickValue>> {
+    proptest::collection::btree_map("[a-z]{1,4}", arb_value(), 0..3)
+  }
+
+  fn arb_leaf() -> impl Strategy<Value = (NewickNodeData, NewickEdgeData)> {
+    // Branch attrs require a branch length for unambiguous round-trip
+    // (without `:`, attrs written after the subtree are parsed as node attrs)
+    (arb_branch_length(), arb_attrs()).prop_flat_map(|(bl, branch_attrs)| {
+      let branch_attrs = if bl.is_some() { branch_attrs } else { BTreeMap::new() };
+      let name_strat = "[A-Za-z][A-Za-z0-9_]{0,8}".prop_map(Some);
+      (name_strat, Just(bl), Just(branch_attrs), arb_attrs()).prop_map(|(name, bl, branch_attrs, node_attrs)| {
+        (
+          NewickNodeData {
+            name,
+            node_attrs,
+            raw_comments: Vec::new(),
+            hybrid: None,
+            children: Vec::new(),
+          },
+          NewickEdgeData {
+            branch_length: bl,
+            branch_attrs,
+            raw_comments: Vec::new(),
+            is_acceptor: false,
+          },
+        )
+      })
+    })
+  }
+
+  fn arb_tree() -> impl Strategy<Value = NewickGraph> {
+    proptest::collection::vec(arb_leaf(), 2..7).prop_map(|leaves| {
+      let mut g = NewickGraph::new();
+      let root = g.add_node(NewickNodeData::new());
+      g.root = root;
+      for (i, (mut node_data, edge_data)) in leaves.into_iter().enumerate() {
+        // Ensure unique names for deterministic order-insensitive comparison
+        node_data.name = Some(format!("T{i}_{}", node_data.name.unwrap_or_default()));
+        let child = g.add_node(node_data);
+        g.add_edge(root, child, edge_data);
+      }
+      g
+    })
+  }
+
+  proptest! {
+    #[test]
+    fn test_prop_roundtrip_beast(g in arb_tree()) {
+      let opts = NewickWriteOptions {
+        style: NwkStyle::Beast,
+        significant_digits: None,
+        decimal_digits: None,
+      };
+      let written = newick_to_string(&g, &opts).unwrap();
+      let parsed = newick_from_string(&written).unwrap();
+      prop_assert_eq!(&g, &parsed, "Round-trip failed.\nWritten: {}", written);
+    }
+
+    #[test]
+    fn test_prop_roundtrip_nhx(g in arb_tree()) {
+      // NHX converts typed values to strings, so we verify topology and branch lengths only
+      let opts = NewickWriteOptions {
+        style: NwkStyle::Nhx,
+        significant_digits: None,
+        decimal_digits: None,
+      };
+      let written = newick_to_string(&g, &opts).unwrap();
+      let parsed = newick_from_string(&written).unwrap();
+      // NHX round-trip: topology, names, branch lengths match.
+      // Attrs may differ in type (Number -> String) so we only check topology.
+      prop_assert_eq!(g.nodes.len(), parsed.nodes.len());
+      prop_assert_eq!(g.edges.len(), parsed.edges.len());
+      for (e1, e2) in g.edges.iter().zip(parsed.edges.iter()) {
+        match (e1.data.branch_length, e2.data.branch_length) {
+          (Some(a), Some(b)) => {
+            prop_assert!((a - b).abs() < 1e-10,
+              "Branch length mismatch: {a} vs {b}");
+          }
+          (None, None) => {}
+          _ => prop_assert!(false, "Branch length presence mismatch"),
+        }
+      }
+    }
+
+    #[test]
+    fn test_prop_idempotent_write_beast(g in arb_tree()) {
+      let opts = NewickWriteOptions {
+        style: NwkStyle::Beast,
+        significant_digits: None,
+        decimal_digits: None,
+      };
+      let w1 = newick_to_string(&g, &opts).unwrap();
+      let parsed = newick_from_string(&w1).unwrap();
+      let w2 = newick_to_string(&parsed, &opts).unwrap();
+      prop_assert_eq!(w1, w2, "Write not idempotent");
+    }
+
+    #[test]
+    fn test_prop_idempotent_write_plain(g in arb_tree()) {
+      let opts = NewickWriteOptions {
+        style: NwkStyle::Plain,
+        significant_digits: None,
+        decimal_digits: None,
+      };
+      let w1 = newick_to_string(&g, &opts).unwrap();
+      let parsed = newick_from_string(&w1).unwrap();
+      let w2 = newick_to_string(&parsed, &opts).unwrap();
+      prop_assert_eq!(w1, w2, "Write not idempotent");
+    }
+  }
+}

--- a/packages/util-newick/src/__tests__/test_write.rs
+++ b/packages/util-newick/src/__tests__/test_write.rs
@@ -1,0 +1,419 @@
+#[cfg(test)]
+mod tests {
+  use crate::parse::newick_from_string;
+  use crate::types::{NewickEdgeData, NewickGraph, NewickNodeData, NewickValue, NewickWriteOptions, NwkStyle};
+  use crate::write::newick_to_string;
+  use pretty_assertions::assert_eq;
+  use std::collections::BTreeMap;
+
+  fn opts(style: NwkStyle) -> NewickWriteOptions {
+    NewickWriteOptions {
+      style,
+      significant_digits: None,
+      decimal_digits: None,
+    }
+  }
+
+  // Plain style
+  #[test]
+  fn test_write_plain_simple() {
+    let g = newick_from_string("(A:0.1,B:0.2)root;").unwrap();
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("(A:0.1,B:0.2)root;", s);
+  }
+
+  #[test]
+  fn test_write_plain_strips_annotations() {
+    let g = newick_from_string("(A[&prob=0.95]:0.1,B:0.2);").unwrap();
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("(A:0.1,B:0.2);", s);
+  }
+
+  #[test]
+  fn test_write_plain_strips_raw_comments() {
+    let g = newick_from_string("(A[some comment]:0.1,B:0.2);").unwrap();
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("(A:0.1,B:0.2);", s);
+  }
+
+  // Beast style
+  #[test]
+  fn test_write_beast_node_attrs() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("prob".to_owned(), NewickValue::Number(0.95));
+    let root = g.add_node(NewickNodeData {
+      name: None,
+      node_attrs: BTreeMap::new(),
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    let a = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    let b = g.add_node(NewickNodeData::new().with_name("B"));
+    g.add_edge(root, a, NewickEdgeData::new().with_length(0.1));
+    g.add_edge(root, b, NewickEdgeData::new().with_length(0.2));
+    g.root = root;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    assert_eq!("(A[&prob=0.95]:0.1,B:0.2);", s);
+  }
+
+  #[test]
+  fn test_write_beast_branch_attrs() {
+    let mut g = NewickGraph::new();
+    let root = g.add_node(NewickNodeData::new());
+    let a = g.add_node(NewickNodeData::new().with_name("A"));
+    let mut branch_attrs = BTreeMap::new();
+    branch_attrs.insert("rate".to_owned(), NewickValue::Number(1.5));
+    g.add_edge(
+      root,
+      a,
+      NewickEdgeData {
+        branch_length: Some(0.1),
+        branch_attrs,
+        raw_comments: Vec::new(),
+        is_acceptor: false,
+      },
+    );
+    g.root = root;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    assert_eq!("(A:[&rate=1.5]0.1);", s);
+  }
+
+  #[test]
+  fn test_write_beast_boolean_values() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("active".to_owned(), NewickValue::Boolean(true));
+    attrs.insert("fixed".to_owned(), NewickValue::Boolean(false));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    assert_eq!("A[&active=TRUE,fixed=FALSE];", s);
+  }
+
+  #[test]
+  fn test_write_beast_array_values() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert(
+      "hpd".to_owned(),
+      NewickValue::Array(vec![NewickValue::Number(1.0), NewickValue::Number(2.0)]),
+    );
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    assert_eq!("A[&hpd={1,2}];", s);
+  }
+
+  #[test]
+  fn test_write_beast_quoted_string() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("label".to_owned(), NewickValue::String("hello, world".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    assert_eq!("A[&label=\"hello, world\"];", s);
+  }
+
+  #[test]
+  fn test_write_beast_raw_comments() {
+    let mut g = NewickGraph::new();
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: BTreeMap::new(),
+      raw_comments: vec!["[some note]".to_owned()],
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    assert_eq!("A[some note];", s);
+  }
+
+  // NHX style
+  #[test]
+  fn test_write_nhx_node_attrs() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("S".to_owned(), NewickValue::String("human".to_owned()));
+    attrs.insert("T".to_owned(), NewickValue::String("9606".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let s = newick_to_string(&g, &opts(NwkStyle::Nhx)).unwrap();
+    assert_eq!("A[&&NHX:S=human:T=9606];", s);
+  }
+
+  // Name quoting
+  #[test]
+  fn test_write_name_quoting_special_chars() {
+    let mut g = NewickGraph::new();
+    let node = g.add_node(NewickNodeData::new().with_name("node (1)"));
+    g.root = node;
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("'node (1)';", s);
+  }
+
+  #[test]
+  fn test_write_name_quoting_single_quote() {
+    let mut g = NewickGraph::new();
+    let node = g.add_node(NewickNodeData::new().with_name("it's"));
+    g.root = node;
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("'it''s';", s);
+  }
+
+  #[test]
+  fn test_write_name_no_quoting_needed() {
+    let mut g = NewickGraph::new();
+    let node = g.add_node(NewickNodeData::new().with_name("simple_name"));
+    g.root = node;
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("simple_name;", s);
+  }
+
+  // Rooting prefix
+  #[test]
+  fn test_write_rooted_prefix() {
+    let mut g = newick_from_string("(A,B);").unwrap();
+    g.rooted = Some(true);
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("[&R](A,B);", s);
+  }
+
+  #[test]
+  fn test_write_unrooted_prefix() {
+    let mut g = newick_from_string("(A,B);").unwrap();
+    g.rooted = Some(false);
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("[&U](A,B);", s);
+  }
+
+  // Float formatting
+  #[test]
+  fn test_write_significant_digits() {
+    let g = newick_from_string("(A:0.123456789,B:0.2);").unwrap();
+
+    // Full precision by default
+    let full = newick_to_string(&g, &NewickWriteOptions::default()).unwrap();
+    assert_eq!("(A:0.123456789,B:0.2);", full);
+
+    // Explicit 3 significant digits
+    let o = NewickWriteOptions {
+      style: NwkStyle::Plain,
+      significant_digits: Some(3),
+      decimal_digits: None,
+    };
+    let s = newick_to_string(&g, &o).unwrap();
+    assert_eq!("(A:0.123,B:0.2);", s);
+  }
+
+  // Empty branches
+  #[test]
+  fn test_write_empty_branches() {
+    let g = newick_from_string("(,);").unwrap();
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("(,);", s);
+  }
+
+  // No branch length
+  #[test]
+  fn test_write_no_branch_length() {
+    let g = newick_from_string("(A,B);").unwrap();
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    assert_eq!("(A,B);", s);
+  }
+
+  // eNewick writer
+  #[test]
+  fn test_write_enewick_hybrid() {
+    let g = newick_from_string("(A,B,((C,(Y)x#H1)c,(x#H1,D)d)e)f;").unwrap();
+    let s = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    // Should contain x#H1 marker twice but subtree only once
+    let count = s.matches("x#H1").count();
+    assert_eq!(count, 2, "hybrid marker should appear twice: {s}");
+  }
+
+  // BEAST string that looks like boolean/number must round-trip via quoting
+  #[test]
+  fn test_write_beast_string_true_roundtrip() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("val".to_owned(), NewickValue::String("TRUE".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let written = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    let parsed = newick_from_string(&written).unwrap();
+    let a = parsed.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(Some(&NewickValue::String("TRUE".to_owned())), a.node_attrs.get("val"));
+  }
+
+  #[test]
+  fn test_write_beast_string_numeric_roundtrip() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("id".to_owned(), NewickValue::String("123".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let written = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    let parsed = newick_from_string(&written).unwrap();
+    let a = parsed.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(Some(&NewickValue::String("123".to_owned())), a.node_attrs.get("id"));
+  }
+
+  // Embedded double quotes in BEAST strings are escaped by doubling
+  #[test]
+  fn test_write_beast_string_embedded_quote_roundtrip() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("note".to_owned(), NewickValue::String("say \"hello\"".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let written = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    let parsed = newick_from_string(&written).unwrap();
+    let a = parsed.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+    assert_eq!(
+      Some(&NewickValue::String("say \"hello\"".to_owned())),
+      a.node_attrs.get("note")
+    );
+  }
+
+  // NHX rejects values containing reserved characters
+  #[test]
+  fn test_write_nhx_rejects_colon_in_value() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("key".to_owned(), NewickValue::String("a:b".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+
+    let mut buf = Vec::new();
+    let result = crate::write::newick_to_writer(
+      &mut buf,
+      &g,
+      &NewickWriteOptions {
+        style: NwkStyle::Nhx,
+        ..Default::default()
+      },
+    );
+    assert!(result.is_err(), "NHX writer should reject values containing ':'");
+  }
+
+  // All three styles produce different output for same annotated graph
+  #[test]
+  fn test_write_all_styles_differ() {
+    let g = newick_from_string("(A[&prob=0.9]:0.1,B:0.2);").unwrap();
+    let plain = newick_to_string(&g, &opts(NwkStyle::Plain)).unwrap();
+    let beast = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    let nhx = newick_to_string(&g, &opts(NwkStyle::Nhx)).unwrap();
+    assert_ne!(plain, beast);
+    assert_ne!(beast, nhx);
+    assert_ne!(plain, nhx);
+  }
+
+  #[test]
+  fn test_write_beast_key_escaping() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("posterior prob".to_owned(), NewickValue::Number(0.95));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+    let s = newick_to_string(&g, &opts(NwkStyle::Beast)).unwrap();
+    let parsed = newick_from_string(&s).unwrap();
+    assert_eq!(
+      Some(&NewickValue::Number(0.95)),
+      parsed.nodes[0].node_attrs.get("posterior prob")
+    );
+  }
+
+  #[test]
+  fn test_write_newick_to_string_nhx_error() {
+    let mut g = NewickGraph::new();
+    let mut attrs = BTreeMap::new();
+    attrs.insert("k".to_owned(), NewickValue::String("a:b".to_owned()));
+    let node = g.add_node(NewickNodeData {
+      name: Some("A".to_owned()),
+      node_attrs: attrs,
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    });
+    g.root = node;
+    let result = newick_to_string(&g, &opts(NwkStyle::Nhx));
+    assert!(
+      result.is_err(),
+      "newick_to_string should return Err for NHX reserved chars"
+    );
+  }
+}

--- a/packages/util-newick/src/lib.rs
+++ b/packages/util-newick/src/lib.rs
@@ -1,0 +1,203 @@
+//! Newick and Nexus phylogenetic tree parser and writer.
+//!
+//! Reads and writes Newick trees with automatic dialect detection (BEAST `[&k=v]`,
+//! NHX `[&&NHX:k=v]`, plain comments), eNewick network markers (`#H1`, `##LGT2`),
+//! and Nexus container files (TRANSLATE tables, multi-tree blocks).
+//!
+//! # Parse a Newick string
+//!
+//! ```
+//! use util_newick::newick_from_string;
+//!
+//! let graph = newick_from_string("(A:0.1,B:0.2,(C:0.3,D:0.4)E:0.5)F;").unwrap();
+//!
+//! // Traverse nodes
+//! let root = &graph.nodes[graph.root];
+//! assert_eq!(root.name.as_deref(), Some("F"));
+//! assert_eq!(root.children.len(), 3);
+//!
+//! // Read branch lengths from edges
+//! for &edge_idx in &root.children {
+//!   let edge = &graph.edges[edge_idx];
+//!   let child = &graph.nodes[edge.child];
+//!   println!("{}: {:?}", child.name.as_deref().unwrap_or(""), edge.data.branch_length);
+//! }
+//! ```
+//!
+//! # Write a tree
+//!
+//! ```
+//! use util_newick::{newick_from_string, newick_to_string, NewickWriteOptions, NwkStyle};
+//!
+//! let graph = newick_from_string("(A[&prob=0.95]:0.1,B:0.2);").unwrap();
+//!
+//! // Plain: strips all annotations
+//! let plain = newick_to_string(&graph, &NewickWriteOptions { style: NwkStyle::Plain, ..Default::default() }).unwrap();
+//! assert_eq!(plain, "(A:0.1,B:0.2);");
+//!
+//! // BEAST: preserves annotations in [&k=v] format
+//! let beast = newick_to_string(&graph, &NewickWriteOptions::default()).unwrap();
+//! assert!(beast.contains("[&prob="));
+//! ```
+//!
+//! # Read annotations
+//!
+//! The parser auto-detects annotation dialect per comment:
+//!
+//! ```
+//! use util_newick::{newick_from_string, NewickValue};
+//!
+//! // BEAST-style: [&key=value] -- typed values
+//! let g = newick_from_string("(A[&prob=0.95,fixed=TRUE,hpd={1.0,2.0}],B);").unwrap();
+//! let a = g.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+//! assert!(matches!(a.node_attrs["prob"], NewickValue::Number(_)));
+//! assert!(matches!(a.node_attrs["fixed"], NewickValue::Boolean(true)));
+//! assert!(matches!(a.node_attrs["hpd"], NewickValue::Array(_)));
+//!
+//! // NHX-style: [&&NHX:key=value] -- all values are strings
+//! let g = newick_from_string("(A[&&NHX:S=human:B=90],B);").unwrap();
+//! let a = g.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+//! assert!(matches!(&a.node_attrs["S"], NewickValue::String(s) if s == "human"));
+//!
+//! // Plain comments [text] without & prefix go to raw_comments
+//! let g = newick_from_string("(A[a note],B);").unwrap();
+//! let a = g.nodes.iter().find(|n| n.name.as_deref() == Some("A")).unwrap();
+//! assert_eq!(a.raw_comments, vec!["[a note]"]);
+//! ```
+//!
+//! # Build a tree programmatically
+//!
+//! ```
+//! use util_newick::*;
+//! use std::collections::BTreeMap;
+//!
+//! let mut graph = NewickGraph::new();
+//!
+//! let root = graph.add_node(NewickNodeData::new().with_name("root"));
+//! graph.root = root;
+//!
+//! let leaf_a = graph.add_node(NewickNodeData::new().with_name("A"));
+//! let leaf_b = graph.add_node(NewickNodeData::new().with_name("B"));
+//!
+//! graph.add_edge(root, leaf_a, NewickEdgeData::new().with_length(0.1));
+//! graph.add_edge(root, leaf_b, NewickEdgeData::new().with_length(0.2));
+//!
+//! let nwk = newick_to_string(&graph, &NewickWriteOptions::default()).unwrap();
+//! assert_eq!(nwk, "(A:0.1,B:0.2)root;");
+//! ```
+//!
+//! # Nexus files
+//!
+//! ```
+//! use util_newick::{nexus_from_string, nexus_to_string, NewickWriteOptions};
+//!
+//! let nexus = "#NEXUS\n\
+//!   Begin Trees;\n\
+//!     Translate\n\
+//!       1 Homo_sapiens,\n\
+//!       2 Pan_troglodytes\n\
+//!     ;\n\
+//!     Tree primates = (1:0.1,2:0.2);\n\
+//!   End;\n";
+//!
+//! let trees = nexus_from_string(nexus).unwrap();
+//! assert_eq!(trees.len(), 1);
+//! assert_eq!(trees[0].name, "primates");
+//!
+//! // TRANSLATE tokens are resolved -- node names are full taxon names
+//! let names: Vec<_> = trees[0].graph.nodes.iter()
+//!   .filter_map(|n| n.name.as_deref())
+//!   .collect();
+//! assert!(names.contains(&"Homo_sapiens"));
+//!
+//! // Round-trip back to Nexus
+//! let output = nexus_to_string(&trees, &NewickWriteOptions::default()).unwrap();
+//! assert!(output.starts_with("#NEXUS"));
+//! ```
+//!
+//! # eNewick networks
+//!
+//! Hybrid nodes (`#H1`, `#LGT2`, `##R3` acceptor) are detected in labels and
+//! merged into a single graph node with multiple parent edges:
+//!
+//! ```
+//! use util_newick::newick_from_string;
+//!
+//! let g = newick_from_string("((A,(B)x#H1)c,(x#H1,C)d);").unwrap();
+//! let hybrid = g.nodes.iter().find(|n| n.hybrid.is_some()).unwrap();
+//! assert_eq!(hybrid.name.as_deref(), Some("x"));
+//! let h = hybrid.hybrid.as_ref().unwrap();
+//! assert_eq!(h.kind.as_deref(), Some("H"));
+//! assert_eq!(h.index, 1);
+//!
+//! // The hybrid node has two parent edges (from c and d)
+//! let parent_edges: Vec<_> = g.edges.iter().filter(|e| e.child == g.nodes.iter().position(|n| n.hybrid.is_some()).unwrap()).collect();
+//! assert_eq!(parent_edges.len(), 2);
+//! ```
+//!
+//! # Equality
+//!
+//! `PartialEq` compares trees order-insensitively -- `(A,B)` equals `(B,A)`.
+//! Use `eq_ordered` when child order matters:
+//!
+//! ```
+//! use util_newick::newick_from_string;
+//!
+//! let g1 = newick_from_string("(A,B,C);").unwrap();
+//! let g2 = newick_from_string("(C,A,B);").unwrap();
+//! assert_eq!(g1, g2);           // order-insensitive
+//! assert!(!g1.eq_ordered(&g2)); // order-sensitive
+//! ```
+//!
+//! # Write styles
+//!
+//! | Style | Output | Compatible with |
+//! |-------|--------|-----------------|
+//! | `Plain` | name:length only | all tools |
+//! | `Beast` (default) | `[&k=v]` annotations | BEAST, FigTree, MrBayes, IQ-TREE, DendroPy |
+//! | `Nhx` | `[&&NHX:k=v]` annotations | Forester, ETE, DendroPy |
+//!
+//! # I/O with files
+//!
+//! ```no_run
+//! use util_newick::{newick_from_reader, newick_to_writer, NewickWriteOptions};
+//! use std::fs::File;
+//! use std::io::BufReader;
+//!
+//! // Read
+//! let file = File::open("tree.nwk").unwrap();
+//! let graph = newick_from_reader(BufReader::new(file)).unwrap();
+//!
+//! // Write
+//! let mut out = File::create("output.nwk").unwrap();
+//! newick_to_writer(&mut out, &graph, &NewickWriteOptions::default()).unwrap();
+//! ```
+
+pub mod nexus;
+pub mod parse;
+pub mod types;
+pub mod write;
+
+pub use crate::nexus::{nexus_from_reader, nexus_from_string, nexus_to_string, nexus_to_writer};
+pub use crate::parse::{newick_from_reader, newick_from_string};
+pub use crate::types::{
+  NewickEdgeData, NewickEdgeEntry, NewickGraph, NewickHybrid, NewickNodeData, NewickValue, NewickWriteOptions,
+  NexusTree, NwkStyle,
+};
+pub use crate::write::{newick_to_string, newick_to_writer};
+
+#[cfg(test)]
+mod __tests__;
+
+#[cfg(test)]
+mod tests {
+  use ctor::ctor;
+
+  #[ctor]
+  fn init() {
+    rayon::ThreadPoolBuilder::new()
+      .num_threads(1)
+      .build_global()
+      .expect("rayon global thread pool initialization failed");
+  }
+}

--- a/packages/util-newick/src/nexus.rs
+++ b/packages/util-newick/src/nexus.rs
@@ -1,0 +1,323 @@
+//! Nexus container format reader and writer.
+
+use crate::parse::newick_from_string;
+use crate::types::{NewickGraph, NewickWriteOptions, NexusTree};
+use crate::write::newick_to_writer;
+use eyre::{Report, WrapErr};
+use std::collections::BTreeMap;
+use std::io::{Read, Write};
+
+/// Parse a Nexus string, returning all trees from TREES blocks.
+pub fn nexus_from_string(input: &str) -> Result<Vec<NexusTree>, Report> {
+  let input = input.trim();
+  let header_end = input.find(|c: char| c.is_ascii_whitespace()).unwrap_or(input.len());
+  if !input[..header_end].eq_ignore_ascii_case("#nexus") {
+    return Err(eyre::eyre!("Input does not start with #NEXUS header"));
+  }
+
+  let blocks = parse_nexus_blocks(input);
+  let translate_table = extract_translate_table(&blocks);
+  extract_trees(&blocks, &translate_table)
+}
+
+/// Parse Nexus from an `impl Read` source.
+pub fn nexus_from_reader(mut reader: impl Read) -> Result<Vec<NexusTree>, Report> {
+  let mut input = String::new();
+  reader.read_to_string(&mut input)?;
+  nexus_from_string(&input)
+}
+
+/// Write trees as a Nexus string with Taxa and Trees blocks.
+pub fn nexus_to_string(trees: &[NexusTree], options: &NewickWriteOptions) -> Result<String, Report> {
+  let mut buf = Vec::new();
+  nexus_to_writer(&mut buf, trees, options)?;
+  Ok(String::from_utf8(buf).expect("Nexus output should be valid UTF-8"))
+}
+
+/// Write trees in Nexus format to an `impl Write` destination.
+pub fn nexus_to_writer(
+  writer: &mut impl Write,
+  trees: &[NexusTree],
+  options: &NewickWriteOptions,
+) -> Result<(), Report> {
+  writeln!(writer, "#NEXUS")?;
+  writeln!(writer)?;
+
+  // Collect all leaf names across all trees
+  let mut taxa: Vec<String> = Vec::new();
+  for tree in trees {
+    collect_leaf_names(&tree.graph, &mut taxa);
+  }
+  taxa.sort();
+  taxa.dedup();
+
+  // Taxa block
+  writeln!(writer, "Begin Taxa;")?;
+  writeln!(writer, "  Dimensions ntax={};", taxa.len())?;
+  writeln!(writer, "  TaxLabels")?;
+  for name in &taxa {
+    if needs_nexus_quoting(name) {
+      writeln!(writer, "    '{}'", name.replace('\'', "''"))?;
+    } else {
+      writeln!(writer, "    {name}")?;
+    }
+  }
+  writeln!(writer, "  ;")?;
+  writeln!(writer, "End;")?;
+  writeln!(writer)?;
+
+  // Trees block
+  writeln!(writer, "Begin Trees;")?;
+  for tree in trees {
+    let name = &tree.name;
+    if needs_nexus_quoting(name) {
+      write!(writer, "  Tree '{}' = ", name.replace('\'', "''"))?;
+    } else {
+      write!(writer, "  Tree {name} = ")?;
+    }
+    newick_to_writer(writer, &tree.graph, options)?;
+    writeln!(writer)?;
+  }
+  writeln!(writer, "End;")?;
+
+  Ok(())
+}
+
+fn collect_leaf_names(graph: &NewickGraph, taxa: &mut Vec<String>) {
+  for node in &graph.nodes {
+    if node.children.is_empty() {
+      if let Some(name) = &node.name {
+        taxa.push(name.clone());
+      }
+    }
+  }
+}
+
+fn needs_nexus_quoting(s: &str) -> bool {
+  s.contains(|c: char| matches!(c, '(' | ')' | '[' | ']' | ',' | ';' | ':' | '\'') || c.is_whitespace())
+}
+
+struct NexusBlock {
+  name: String,
+  content: String,
+}
+
+#[allow(clippy::string_slice)]
+fn parse_nexus_blocks(input: &str) -> Vec<NexusBlock> {
+  let mut blocks = Vec::new();
+  let lower = input.to_ascii_lowercase();
+  let mut pos = 0;
+
+  while pos < input.len() {
+    // Find "begin <name>;"
+    let Some(begin_pos) = lower[pos..].find("begin ") else {
+      break;
+    };
+    let begin_start = pos + begin_pos + 6; // after "begin "
+
+    let Some(semi_pos) = input[begin_start..].find(';') else {
+      break;
+    };
+    let block_name = input[begin_start..begin_start + semi_pos].trim().to_ascii_lowercase();
+    let content_start = begin_start + semi_pos + 1;
+
+    // Find "end;"
+    let Some(end_pos) = lower[content_start..].find("end;") else {
+      break;
+    };
+    let content = input[content_start..content_start + end_pos].to_owned();
+
+    blocks.push(NexusBlock {
+      name: block_name,
+      content,
+    });
+
+    pos = content_start + end_pos + 4;
+  }
+
+  blocks
+}
+
+#[allow(clippy::string_slice)]
+fn extract_translate_table(blocks: &[NexusBlock]) -> BTreeMap<String, String> {
+  let mut table = BTreeMap::new();
+
+  for block in blocks {
+    if block.name != "trees" {
+      continue;
+    }
+
+    let lower = block.content.to_ascii_lowercase();
+    let Some(translate_pos) = lower.find("translate") else {
+      continue;
+    };
+
+    let after_translate = &block.content[translate_pos + 9..];
+    let Some(semi_pos) = after_translate.find(';') else {
+      continue;
+    };
+    let translate_body = &after_translate[..semi_pos];
+
+    for entry in split_translate_entries(translate_body) {
+      let entry = entry.trim();
+      if entry.is_empty() {
+        continue;
+      }
+      let mut parts = entry.splitn(2, char::is_whitespace);
+      let Some(key) = parts.next() else { continue };
+      let Some(value) = parts.next() else { continue };
+      let key = key.trim().to_owned();
+      let value = value.trim().to_owned();
+      let value = strip_nexus_quotes(&value);
+      table.insert(key, value);
+    }
+  }
+
+  table
+}
+
+fn split_translate_entries(body: &str) -> Vec<String> {
+  let mut entries = Vec::new();
+  let mut current = String::new();
+  let mut in_single_quote = false;
+
+  for ch in body.chars() {
+    match ch {
+      '\'' => {
+        in_single_quote = !in_single_quote;
+        current.push(ch);
+      },
+      ',' if !in_single_quote => {
+        entries.push(std::mem::take(&mut current));
+      },
+      _ => {
+        current.push(ch);
+      },
+    }
+  }
+  if !current.is_empty() {
+    entries.push(current);
+  }
+  entries
+}
+
+fn strip_nexus_quotes(s: &str) -> String {
+  if let Some(inner) = s.strip_prefix('\'').and_then(|i| i.strip_suffix('\'')) {
+    return inner.replace("''", "'");
+  }
+  if let Some(inner) = s.strip_prefix('"').and_then(|i| i.strip_suffix('"')) {
+    return inner.replace("\"\"", "\"");
+  }
+  s.to_owned()
+}
+
+#[allow(clippy::string_slice)]
+fn extract_trees(blocks: &[NexusBlock], translate_table: &BTreeMap<String, String>) -> Result<Vec<NexusTree>, Report> {
+  let mut trees = Vec::new();
+
+  for block in blocks {
+    if block.name != "trees" {
+      continue;
+    }
+
+    // Find all "tree <name> = <newick>;" entries
+    let lower = block.content.to_ascii_lowercase();
+    let mut search_pos = 0;
+
+    while search_pos < block.content.len() {
+      // Skip past translate block if present
+      let remaining_lower = &lower[search_pos..];
+      let Some(tree_pos) = find_tree_command(remaining_lower) else {
+        break;
+      };
+
+      let abs_pos = search_pos + tree_pos + 4; // after "tree"
+      let after_tree = &block.content[abs_pos..];
+
+      // Find "=" separating name from newick
+      let Some(eq_pos) = after_tree.find('=') else {
+        break;
+      };
+      let tree_name = after_tree[..eq_pos].trim();
+      let tree_name = strip_nexus_quotes(tree_name);
+
+      // Find ";" terminating the newick string
+      let after_eq = &after_tree[eq_pos + 1..];
+      let Some(semi_pos) = find_newick_semicolon(after_eq) else {
+        break;
+      };
+      let nwk_str = after_eq[..=semi_pos].trim();
+
+      let graph = parse_newick_with_translate(nwk_str, translate_table)
+        .wrap_err_with(|| format!("In Nexus tree '{tree_name}'"))?;
+
+      trees.push(NexusTree { name: tree_name, graph });
+
+      search_pos = abs_pos + eq_pos + 1 + semi_pos + 1;
+    }
+  }
+
+  Ok(trees)
+}
+
+#[allow(clippy::string_slice)]
+fn find_tree_command(lower: &str) -> Option<usize> {
+  let mut pos = 0;
+  while pos < lower.len() {
+    let found = lower[pos..].find("tree")?;
+    let abs = pos + found;
+
+    // Must be preceded by whitespace or start of string
+    let before_ok = abs == 0 || lower.as_bytes()[abs - 1].is_ascii_whitespace() || lower.as_bytes()[abs - 1] == b';';
+    // Must be followed by whitespace
+    let after_ok = abs + 4 < lower.len() && lower.as_bytes()[abs + 4].is_ascii_whitespace();
+
+    // Must not be inside "translate" keyword
+    if before_ok && after_ok {
+      let prefix = &lower[..abs].trim_end();
+      if !prefix.ends_with("translat") {
+        return Some(found + pos);
+      }
+    }
+
+    pos = abs + 4;
+  }
+  None
+}
+
+fn find_newick_semicolon(s: &str) -> Option<usize> {
+  let mut in_single_quote = false;
+  let mut bracket_depth = 0u32;
+  for (i, c) in s.char_indices() {
+    match c {
+      '\'' if bracket_depth == 0 => in_single_quote = !in_single_quote,
+      '[' if !in_single_quote => bracket_depth += 1,
+      ']' if !in_single_quote && bracket_depth > 0 => bracket_depth -= 1,
+      ';' if !in_single_quote && bracket_depth == 0 => return Some(i),
+      _ => {},
+    }
+  }
+  None
+}
+
+fn parse_newick_with_translate(
+  nwk_str: &str,
+  translate_table: &BTreeMap<String, String>,
+) -> Result<NewickGraph, Report> {
+  let mut graph = newick_from_string(nwk_str)?;
+
+  if translate_table.is_empty() {
+    return Ok(graph);
+  }
+
+  // Replace integer tokens with full taxon names
+  for node in &mut graph.nodes {
+    if let Some(name) = &node.name {
+      if let Some(translated) = translate_table.get(name) {
+        node.name = Some(translated.clone());
+      }
+    }
+  }
+
+  Ok(graph)
+}

--- a/packages/util-newick/src/parse.rs
+++ b/packages/util-newick/src/parse.rs
@@ -1,0 +1,471 @@
+//! Newick parser with automatic annotation dialect detection.
+
+use crate::types::{NewickEdgeData, NewickGraph, NewickHybrid, NewickNodeData, NewickValue};
+use eyre::{Report, WrapErr};
+use pest::Parser;
+use pest_derive::Parser;
+use regex::Regex;
+use std::collections::{BTreeMap, HashMap};
+use std::io::Read;
+use std::sync::LazyLock;
+
+#[derive(Parser)]
+#[grammar_inline = r#"
+tree        = _{ SOI ~ rooting? ~ root_branch ~ ";" ~ EOI }
+root_branch =  { subtree ~ comment* ~ (":" ~ comment* ~ number)? ~ comment* }
+subtree     =  { leaf | internal }
+internal =  { "(" ~ branch_list ~ ")" ~ label? ~ comment* }
+leaf     =  { label ~ comment* }
+
+branch_list = { branch ~ ("," ~ branch)* }
+branch      = { subtree? ~ comment* ~ (":" ~ comment* ~ number)? ~ comment* }
+
+rooting        = { "[&" ~ rooting_value ~ "]" }
+rooting_value  = @{ ^"r" | ^"u" }
+
+label          = { quoted_label | unquoted_label }
+quoted_label   = @{ "'" ~ (!"'" ~ ANY | "''")* ~ "'" }
+unquoted_label = @{ safe_char+ }
+safe_char      = _{ !("(" | ")" | "[" | "]" | "," | ";" | ":" | WHITESPACE) ~ ANY }
+number  = @{ "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)? }
+
+comment       = @{ "[" ~ comment_inner ~ "]" }
+comment_inner = _{ (!"[" ~ !"]" ~ ANY | "[" ~ comment_inner ~ "]")* }
+
+WHITESPACE = _{ " " | "\t" | NEWLINE }
+"#]
+struct NewickParser;
+
+static HYBRID_RE: LazyLock<Regex> =
+  LazyLock::new(|| Regex::new(r"^(.*?)(##|#)([A-Za-z]*)(\d+)$").expect("hybrid regex"));
+
+/// Parse a Newick string into a [`NewickGraph`], auto-detecting BEAST, NHX, and plain comment dialects.
+pub fn newick_from_string(input: &str) -> Result<NewickGraph, Report> {
+  let pairs = NewickParser::parse(Rule::tree, input).wrap_err("Failed to parse Newick string")?;
+
+  let mut graph = NewickGraph::new();
+  let mut hybrid_map: HashMap<(Option<String>, u32), usize> = HashMap::new();
+
+  let mut rooted = None;
+  let mut root = None;
+
+  for pair in pairs {
+    match pair.as_rule() {
+      Rule::rooting => {
+        let inner = pair.into_inner().next().expect("rooting_value");
+        rooted = Some(inner.as_str().eq_ignore_ascii_case("r"));
+      },
+      Rule::root_branch => {
+        root = Some(visit_root_branch(pair, &mut graph, &mut hybrid_map)?);
+      },
+      _ => {},
+    }
+  }
+
+  graph.root = root.expect("tree must have a root subtree");
+  graph.rooted = rooted;
+
+  Ok(graph)
+}
+
+/// Parse Newick from an `impl Read` source.
+pub fn newick_from_reader(mut reader: impl Read) -> Result<NewickGraph, Report> {
+  let mut input = String::new();
+  reader.read_to_string(&mut input)?;
+  newick_from_string(&input)
+}
+
+fn visit_root_branch(
+  pair: pest::iterators::Pair<Rule>,
+  graph: &mut NewickGraph,
+  hybrid_map: &mut HashMap<(Option<String>, u32), usize>,
+) -> Result<usize, Report> {
+  let mut root_idx = None;
+  let mut root_attrs = BTreeMap::new();
+  let mut root_raw = Vec::new();
+
+  for inner in pair.into_inner() {
+    match inner.as_rule() {
+      Rule::subtree => {
+        let (idx, _acceptor) = visit_subtree(inner, graph, hybrid_map)?;
+        root_idx = Some(idx);
+      },
+      Rule::number => {
+        // Root branch length discarded (no parent edge to attach it to)
+      },
+      Rule::comment => {
+        classify_comment(inner.as_str(), &mut root_attrs, &mut root_raw);
+      },
+      _ => {},
+    }
+  }
+
+  let idx = root_idx.expect("root_branch must contain a subtree");
+  let root_node = &mut graph.nodes[idx];
+  root_node.node_attrs.extend(root_attrs);
+  root_node.raw_comments.extend(root_raw);
+  Ok(idx)
+}
+
+fn visit_subtree(
+  pair: pest::iterators::Pair<Rule>,
+  graph: &mut NewickGraph,
+  hybrid_map: &mut HashMap<(Option<String>, u32), usize>,
+) -> Result<(usize, bool), Report> {
+  let inner = pair.into_inner().next().expect("subtree must have leaf or internal");
+  match inner.as_rule() {
+    Rule::leaf => visit_leaf(inner, graph, hybrid_map),
+    Rule::internal => visit_internal(inner, graph, hybrid_map),
+    _ => unreachable!(),
+  }
+}
+
+fn visit_leaf(
+  pair: pest::iterators::Pair<Rule>,
+  graph: &mut NewickGraph,
+  hybrid_map: &mut HashMap<(Option<String>, u32), usize>,
+) -> Result<(usize, bool), Report> {
+  let mut name = None;
+  let mut raw_comments = Vec::new();
+  let mut node_attrs = BTreeMap::new();
+
+  for inner in pair.into_inner() {
+    match inner.as_rule() {
+      Rule::label => {
+        name = Some(parse_label(inner));
+      },
+      Rule::comment => {
+        classify_comment(inner.as_str(), &mut node_attrs, &mut raw_comments);
+      },
+      _ => {},
+    }
+  }
+
+  let extraction = extract_hybrid(name);
+  let node_data = NewickNodeData {
+    name: extraction.clean_name,
+    node_attrs,
+    raw_comments,
+    hybrid: extraction.hybrid.clone(),
+    children: Vec::new(),
+  };
+
+  let idx = resolve_hybrid_node(node_data, extraction.hybrid.as_ref(), graph, hybrid_map);
+  Ok((idx, extraction.is_acceptor))
+}
+
+fn visit_internal(
+  pair: pest::iterators::Pair<Rule>,
+  graph: &mut NewickGraph,
+  hybrid_map: &mut HashMap<(Option<String>, u32), usize>,
+) -> Result<(usize, bool), Report> {
+  let mut name = None;
+  let mut raw_comments = Vec::new();
+  let mut node_attrs = BTreeMap::new();
+  let mut branch_children = Vec::new();
+
+  for inner in pair.into_inner() {
+    match inner.as_rule() {
+      Rule::branch_list => {
+        for branch in inner.into_inner() {
+          if branch.as_rule() == Rule::branch {
+            branch_children.push(visit_branch(branch, graph, hybrid_map)?);
+          }
+        }
+      },
+      Rule::label => {
+        name = Some(parse_label(inner));
+      },
+      Rule::comment => {
+        classify_comment(inner.as_str(), &mut node_attrs, &mut raw_comments);
+      },
+      _ => {},
+    }
+  }
+
+  let extraction = extract_hybrid(name);
+  let node_data = NewickNodeData {
+    name: extraction.clean_name,
+    node_attrs,
+    raw_comments,
+    hybrid: extraction.hybrid.clone(),
+    children: Vec::new(),
+  };
+
+  let node_idx = resolve_hybrid_node(node_data, extraction.hybrid.as_ref(), graph, hybrid_map);
+
+  for (child_idx, edge_data) in branch_children {
+    graph.add_edge(node_idx, child_idx, edge_data);
+  }
+
+  Ok((node_idx, extraction.is_acceptor))
+}
+
+fn visit_branch(
+  pair: pest::iterators::Pair<Rule>,
+  graph: &mut NewickGraph,
+  hybrid_map: &mut HashMap<(Option<String>, u32), usize>,
+) -> Result<(usize, NewickEdgeData), Report> {
+  let mut child_idx = None;
+  let mut branch_length = None;
+  let mut seen_number = false;
+
+  let mut is_acceptor = false;
+  let mut raw_comments: Vec<String> = Vec::new();
+  let mut pre_colon_attrs = BTreeMap::new();
+  let mut post_colon_attrs = BTreeMap::new();
+
+  for inner in pair.into_inner() {
+    match inner.as_rule() {
+      Rule::subtree => {
+        let (idx, acceptor) = visit_subtree(inner, graph, hybrid_map)?;
+        child_idx = Some(idx);
+        is_acceptor = acceptor;
+      },
+      Rule::number => {
+        branch_length = Some(
+          inner
+            .as_str()
+            .parse::<f64>()
+            .wrap_err_with(|| format!("Invalid branch length: '{}'", inner.as_str()))?,
+        );
+        seen_number = true;
+      },
+      Rule::comment => {
+        if seen_number {
+          classify_comment(inner.as_str(), &mut post_colon_attrs, &mut raw_comments);
+        } else {
+          classify_comment(inner.as_str(), &mut pre_colon_attrs, &mut raw_comments);
+        }
+      },
+      _ => {},
+    }
+  }
+
+  // If no subtree was present, create an anonymous leaf node
+  let child_idx = child_idx.unwrap_or_else(|| graph.add_node(NewickNodeData::new()));
+
+  let mut branch_attrs = pre_colon_attrs;
+  branch_attrs.extend(post_colon_attrs);
+
+  let edge_data = NewickEdgeData {
+    branch_length,
+    branch_attrs,
+    raw_comments,
+    is_acceptor,
+  };
+
+  Ok((child_idx, edge_data))
+}
+
+fn parse_label(pair: pest::iterators::Pair<Rule>) -> String {
+  let inner = pair.into_inner().next().expect("label must have content");
+  match inner.as_rule() {
+    Rule::quoted_label => {
+      let raw = inner.as_str();
+      raw
+        .strip_prefix('\'')
+        .and_then(|s| s.strip_suffix('\''))
+        .unwrap_or(raw)
+        .replace("''", "'")
+    },
+    Rule::unquoted_label => inner.as_str().to_owned(),
+    _ => unreachable!(),
+  }
+}
+
+struct HybridExtraction {
+  clean_name: Option<String>,
+  hybrid: Option<NewickHybrid>,
+  is_acceptor: bool,
+}
+
+fn extract_hybrid(name: Option<String>) -> HybridExtraction {
+  let Some(name) = name else {
+    return HybridExtraction {
+      clean_name: None,
+      hybrid: None,
+      is_acceptor: false,
+    };
+  };
+
+  let Some(caps) = HYBRID_RE.captures(&name) else {
+    return HybridExtraction {
+      clean_name: Some(name),
+      hybrid: None,
+      is_acceptor: false,
+    };
+  };
+
+  let prefix = caps.get(1).map_or("", |m| m.as_str());
+  let hash_marker = caps.get(2).map_or("", |m| m.as_str());
+  let kind_str = caps.get(3).map_or("", |m| m.as_str());
+  let index_str = caps.get(4).map_or("0", |m| m.as_str());
+
+  let clean_name = if prefix.is_empty() {
+    None
+  } else {
+    Some(prefix.to_owned())
+  };
+  let kind = if kind_str.is_empty() {
+    None
+  } else {
+    Some(kind_str.to_owned())
+  };
+  let index = index_str.parse::<u32>().unwrap_or(0);
+  let is_acceptor = hash_marker == "##";
+
+  HybridExtraction {
+    clean_name,
+    hybrid: Some(NewickHybrid { kind, index }),
+    is_acceptor,
+  }
+}
+
+fn resolve_hybrid_node(
+  node_data: NewickNodeData,
+  hybrid: Option<&NewickHybrid>,
+  graph: &mut NewickGraph,
+  hybrid_map: &mut HashMap<(Option<String>, u32), usize>,
+) -> usize {
+  let Some(h) = hybrid else {
+    return graph.add_node(node_data);
+  };
+
+  let key = (h.kind.clone(), h.index);
+  if let Some(&existing_idx) = hybrid_map.get(&key) {
+    let existing = &mut graph.nodes[existing_idx];
+    existing.node_attrs.extend(node_data.node_attrs);
+    existing.raw_comments.extend(node_data.raw_comments);
+    existing_idx
+  } else {
+    let idx = graph.add_node(node_data);
+    hybrid_map.insert(key, idx);
+    idx
+  }
+}
+
+fn classify_comment(comment_text: &str, attrs: &mut BTreeMap<String, NewickValue>, raw: &mut Vec<String>) {
+  let inner = comment_text
+    .strip_prefix('[')
+    .and_then(|s| s.strip_suffix(']'))
+    .unwrap_or(comment_text);
+
+  if let Some(nhx_body) = inner.strip_prefix("&&NHX") {
+    parse_nhx_attrs(nhx_body, attrs);
+  } else if let Some(beast_body) = inner.strip_prefix('&') {
+    parse_beast_attrs(beast_body, attrs);
+  } else {
+    raw.push(comment_text.to_owned());
+  }
+}
+
+fn parse_nhx_attrs(body: &str, attrs: &mut BTreeMap<String, NewickValue>) {
+  // NHX format: :key=value:key=value...
+  // Leading colon before first tag
+  for tag in body.split(':') {
+    let tag = tag.trim();
+    if tag.is_empty() {
+      continue;
+    }
+    if let Some((key, value)) = tag.split_once('=') {
+      attrs.insert(key.to_owned(), NewickValue::String(value.to_owned()));
+    }
+  }
+}
+
+fn parse_beast_attrs(body: &str, attrs: &mut BTreeMap<String, NewickValue>) {
+  // BEAST format: key=value,key=value,...
+  // Need to handle {array} values and "quoted strings"
+  let pairs = split_beast_pairs(body);
+  for pair_str in pairs {
+    let pair_str = pair_str.trim();
+    if pair_str.is_empty() {
+      continue;
+    }
+    if let Some((key, value_str)) = pair_str.split_once('=') {
+      let key = strip_beast_quotes(key.trim());
+      let value_str = value_str.trim();
+      attrs.insert(key, parse_beast_value(value_str));
+    } else {
+      // Bare key = boolean TRUE
+      attrs.insert(strip_beast_quotes(pair_str), NewickValue::Boolean(true));
+    }
+  }
+}
+
+fn split_beast_pairs(body: &str) -> Vec<String> {
+  let mut pairs = Vec::new();
+  let mut current = String::new();
+  let mut brace_depth = 0_u32;
+  let mut in_quote = false;
+
+  for ch in body.chars() {
+    match ch {
+      '"' if brace_depth == 0 => {
+        in_quote = !in_quote;
+        current.push(ch);
+      },
+      '{' if !in_quote => {
+        brace_depth += 1;
+        current.push(ch);
+      },
+      '}' if !in_quote => {
+        brace_depth = brace_depth.saturating_sub(1);
+        current.push(ch);
+      },
+      ',' if brace_depth == 0 && !in_quote => {
+        pairs.push(std::mem::take(&mut current));
+      },
+      _ => {
+        current.push(ch);
+      },
+    }
+  }
+  if !current.is_empty() {
+    pairs.push(current);
+  }
+  pairs
+}
+
+fn strip_beast_quotes(s: &str) -> String {
+  if let Some(inner) = s.strip_prefix('"').and_then(|i| i.strip_suffix('"')) {
+    return inner.replace("\"\"", "\"");
+  }
+  if let Some(inner) = s.strip_prefix('\'').and_then(|i| i.strip_suffix('\'')) {
+    return inner.replace("''", "'");
+  }
+  s.to_owned()
+}
+
+fn parse_beast_value(s: &str) -> NewickValue {
+  let s = s.trim();
+
+  if let Some(inner) = s.strip_prefix('{').and_then(|s| s.strip_suffix('}')) {
+    let elements: Vec<NewickValue> = split_beast_pairs(inner)
+      .iter()
+      .map(|e| parse_beast_value(e.trim()))
+      .collect();
+    return NewickValue::Array(elements);
+  }
+
+  // Boolean: TRUE/FALSE (case-insensitive)
+  if s.eq_ignore_ascii_case("true") {
+    return NewickValue::Boolean(true);
+  }
+  if s.eq_ignore_ascii_case("false") {
+    return NewickValue::Boolean(false);
+  }
+
+  // Number: starts with digit or '-', must be finite
+  if s.starts_with(|c: char| c.is_ascii_digit() || c == '-') {
+    if let Ok(n) = s.parse::<f64>() {
+      if n.is_finite() {
+        return NewickValue::Number(n);
+      }
+    }
+  }
+
+  // String (strip quotes if present)
+  NewickValue::String(strip_beast_quotes(s))
+}

--- a/packages/util-newick/src/types.rs
+++ b/packages/util-newick/src/types.rs
@@ -1,0 +1,335 @@
+use serde::{Deserialize, Serialize};
+use smart_default::SmartDefault;
+use std::collections::BTreeMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+/// Adjacency-list representation of a Newick tree or eNewick network.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewickGraph {
+  pub nodes: Vec<NewickNodeData>,
+  pub edges: Vec<NewickEdgeEntry>,
+  /// Node index of the tree root.
+  pub root: usize,
+  /// `[&R]` -> `Some(true)`, `[&U]` -> `Some(false)`, absent -> `None`.
+  pub rooted: Option<bool>,
+}
+
+/// Edge in the adjacency list, connecting parent to child by node index.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewickEdgeEntry {
+  pub parent: usize,
+  pub child: usize,
+  pub data: NewickEdgeData,
+}
+
+/// Per-node data: name, structured annotations, raw comments, eNewick hybrid info.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewickNodeData {
+  pub name: Option<String>,
+  /// Structured annotations from `[&...]` or `[&&NHX:...]` before `:`.
+  pub node_attrs: BTreeMap<String, NewickValue>,
+  /// Plain `[text]` comments without `&` prefix, preserved verbatim.
+  pub raw_comments: Vec<String>,
+  pub hybrid: Option<NewickHybrid>,
+  /// Edge indices into `NewickGraph.edges`, in insertion (parse) order.
+  pub children: Vec<usize>,
+}
+
+/// Per-edge data: branch length, structured annotations, raw comments.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NewickEdgeData {
+  pub branch_length: Option<f64>,
+  /// Structured annotations from after `:` (BEAST2 canonical or MrBayes position).
+  pub branch_attrs: BTreeMap<String, NewickValue>,
+  /// Plain `[text]` comments on the branch.
+  pub raw_comments: Vec<String>,
+  /// eNewick `##` (double-hash) marking this edge as the acceptor/main lineage.
+  pub is_acceptor: bool,
+}
+
+/// eNewick hybrid marker parsed from `#TypeN` or `##TypeN` in node labels.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NewickHybrid {
+  /// Reticulation type: `H`, `LGT`, `R`, or custom. `None` when untyped (`#1`).
+  pub kind: Option<String>,
+  pub index: u32,
+}
+
+/// Annotation value from BEAST `[&k=v]` or NHX `[&&NHX:k=v]` comments.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum NewickValue {
+  /// BEAST `TRUE`/`FALSE` (case-insensitive).
+  Boolean(bool),
+  /// Bare numeric value, parsed as f64.
+  Number(f64),
+  /// Unquoted or quoted string value. NHX values are always String.
+  String(String),
+  /// BEAST `{v1,v2,v3}` array.
+  Array(Vec<NewickValue>),
+}
+
+/// Output annotation style.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, SmartDefault, Serialize, Deserialize)]
+pub enum NwkStyle {
+  /// Name and branch length only, no annotations.
+  Plain,
+  /// BEAST2 `[&k=v,k2=v2]` format (default).
+  #[default]
+  Beast,
+  /// NHX `[&&NHX:k=v:k2=v2]` format.
+  Nhx,
+}
+
+/// Controls output format and float precision.
+#[derive(Clone, Debug, SmartDefault, Serialize, Deserialize)]
+pub struct NewickWriteOptions {
+  pub style: NwkStyle,
+  /// Max significant digits for branch lengths. Default: None (full precision).
+  pub significant_digits: Option<u8>,
+  /// Max decimal places for branch lengths. Default: None (unlimited).
+  pub decimal_digits: Option<i8>,
+}
+
+/// Named tree from a Nexus TREES block.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NexusTree {
+  pub name: String,
+  pub graph: NewickGraph,
+}
+
+impl NewickGraph {
+  /// Create an empty graph.
+  pub fn new() -> Self {
+    Self {
+      nodes: Vec::new(),
+      edges: Vec::new(),
+      root: 0,
+      rooted: None,
+    }
+  }
+
+  /// Add a node, return its index.
+  pub fn add_node(&mut self, data: NewickNodeData) -> usize {
+    let idx = self.nodes.len();
+    self.nodes.push(data);
+    idx
+  }
+
+  /// Add an edge from parent to child, return its index.
+  pub fn add_edge(&mut self, parent: usize, child: usize, data: NewickEdgeData) -> usize {
+    let idx = self.edges.len();
+    self.edges.push(NewickEdgeEntry { parent, child, data });
+    self.nodes[parent].children.push(idx);
+    idx
+  }
+
+  /// Compare two graphs with child-order sensitivity (unlike `PartialEq` which is order-insensitive).
+  pub fn eq_ordered(&self, other: &NewickGraph) -> bool {
+    if self.rooted != other.rooted {
+      return false;
+    }
+    eq_subtree_ordered(self, self.root, other, other.root)
+  }
+}
+
+impl Default for NewickGraph {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl PartialEq for NewickGraph {
+  fn eq(&self, other: &Self) -> bool {
+    if self.rooted != other.rooted {
+      return false;
+    }
+    eq_subtree_unordered(self, self.root, other, other.root)
+  }
+}
+
+impl Eq for NewickGraph {}
+
+impl PartialEq for NewickValue {
+  fn eq(&self, other: &Self) -> bool {
+    match (self, other) {
+      (Self::Boolean(a), Self::Boolean(b)) => a == b,
+      (Self::Number(a), Self::Number(b)) => a.to_bits() == b.to_bits(),
+      (Self::String(a), Self::String(b)) => a == b,
+      (Self::Array(a), Self::Array(b)) => a == b,
+      _ => false,
+    }
+  }
+}
+
+impl Eq for NewickValue {}
+
+impl Hash for NewickValue {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    std::mem::discriminant(self).hash(state);
+    match self {
+      Self::Boolean(b) => b.hash(state),
+      Self::Number(n) => n.to_bits().hash(state),
+      Self::String(s) => s.hash(state),
+      Self::Array(a) => a.hash(state),
+    }
+  }
+}
+
+impl NewickNodeData {
+  /// Create a node with no name, no annotations, no children.
+  pub fn new() -> Self {
+    Self {
+      name: None,
+      node_attrs: BTreeMap::new(),
+      raw_comments: Vec::new(),
+      hybrid: None,
+      children: Vec::new(),
+    }
+  }
+
+  /// Set the node name (builder pattern).
+  #[must_use]
+  pub fn with_name(mut self, name: impl Into<String>) -> Self {
+    self.name = Some(name.into());
+    self
+  }
+}
+
+impl Default for NewickNodeData {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl NewickEdgeData {
+  /// Create an edge with no branch length and no annotations.
+  pub fn new() -> Self {
+    Self {
+      branch_length: None,
+      branch_attrs: BTreeMap::new(),
+      raw_comments: Vec::new(),
+      is_acceptor: false,
+    }
+  }
+
+  /// Set the branch length (builder pattern).
+  #[must_use]
+  pub fn with_length(mut self, length: f64) -> Self {
+    self.branch_length = Some(length);
+    self
+  }
+}
+
+impl Default for NewickEdgeData {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+fn subtree_hash(graph: &NewickGraph, node_idx: usize) -> u64 {
+  let mut hasher = DefaultHasher::new();
+  let node = &graph.nodes[node_idx];
+  node.name.hash(&mut hasher);
+  node.node_attrs.hash(&mut hasher);
+  node.raw_comments.hash(&mut hasher);
+  node.hybrid.hash(&mut hasher);
+
+  let mut child_hashes: Vec<(u64, u64)> = node
+    .children
+    .iter()
+    .map(|&ei| {
+      let edge = &graph.edges[ei];
+      let child_h = subtree_hash(graph, edge.child);
+      let mut edge_hasher = DefaultHasher::new();
+      edge.data.branch_length.map(f64::to_bits).hash(&mut edge_hasher);
+      edge.data.branch_attrs.hash(&mut edge_hasher);
+      edge.data.raw_comments.hash(&mut edge_hasher);
+      edge.data.is_acceptor.hash(&mut edge_hasher);
+      (child_h, edge_hasher.finish())
+    })
+    .collect();
+  child_hashes.sort();
+  child_hashes.hash(&mut hasher);
+  hasher.finish()
+}
+
+fn eq_subtree_unordered(g1: &NewickGraph, n1: usize, g2: &NewickGraph, n2: usize) -> bool {
+  let nd1 = &g1.nodes[n1];
+  let nd2 = &g2.nodes[n2];
+
+  if nd1.name != nd2.name
+    || nd1.node_attrs != nd2.node_attrs
+    || nd1.raw_comments != nd2.raw_comments
+    || nd1.hybrid != nd2.hybrid
+    || nd1.children.len() != nd2.children.len()
+  {
+    return false;
+  }
+
+  if nd1.children.is_empty() {
+    return true;
+  }
+
+  // Compute (subtree_hash, edge_hash) for each child, sort, compare
+  let mut hashes1: Vec<(u64, u64)> = nd1
+    .children
+    .iter()
+    .map(|&ei| {
+      let edge = &g1.edges[ei];
+      let child_h = subtree_hash(g1, edge.child);
+      let mut eh = DefaultHasher::new();
+      edge.data.branch_length.map(f64::to_bits).hash(&mut eh);
+      edge.data.branch_attrs.hash(&mut eh);
+      edge.data.raw_comments.hash(&mut eh);
+      edge.data.is_acceptor.hash(&mut eh);
+      (child_h, eh.finish())
+    })
+    .collect();
+  let mut hashes2: Vec<(u64, u64)> = nd2
+    .children
+    .iter()
+    .map(|&ei| {
+      let edge = &g2.edges[ei];
+      let child_h = subtree_hash(g2, edge.child);
+      let mut eh = DefaultHasher::new();
+      edge.data.branch_length.map(f64::to_bits).hash(&mut eh);
+      edge.data.branch_attrs.hash(&mut eh);
+      edge.data.raw_comments.hash(&mut eh);
+      edge.data.is_acceptor.hash(&mut eh);
+      (child_h, eh.finish())
+    })
+    .collect();
+
+  hashes1.sort();
+  hashes2.sort();
+  hashes1 == hashes2
+}
+
+fn eq_subtree_ordered(g1: &NewickGraph, n1: usize, g2: &NewickGraph, n2: usize) -> bool {
+  let nd1 = &g1.nodes[n1];
+  let nd2 = &g2.nodes[n2];
+
+  if nd1.name != nd2.name
+    || nd1.node_attrs != nd2.node_attrs
+    || nd1.raw_comments != nd2.raw_comments
+    || nd1.hybrid != nd2.hybrid
+    || nd1.children.len() != nd2.children.len()
+  {
+    return false;
+  }
+
+  nd1.children.iter().zip(nd2.children.iter()).all(|(&ei1, &ei2)| {
+    let e1 = &g1.edges[ei1];
+    let e2 = &g2.edges[ei2];
+    edge_data_eq(&e1.data, &e2.data) && eq_subtree_ordered(g1, e1.child, g2, e2.child)
+  })
+}
+
+fn edge_data_eq(e1: &NewickEdgeData, e2: &NewickEdgeData) -> bool {
+  let bl_eq = match (e1.branch_length, e2.branch_length) {
+    (Some(a), Some(b)) => a.to_bits() == b.to_bits(),
+    (None, None) => true,
+    _ => false,
+  };
+  bl_eq && e1.branch_attrs == e2.branch_attrs && e1.raw_comments == e2.raw_comments && e1.is_acceptor == e2.is_acceptor
+}

--- a/packages/util-newick/src/write.rs
+++ b/packages/util-newick/src/write.rs
@@ -1,0 +1,315 @@
+//! Newick writer with configurable annotation style.
+
+use crate::types::{NewickEdgeData, NewickGraph, NewickNodeData, NewickValue, NewickWriteOptions, NwkStyle};
+use eyre::Report;
+use std::collections::{BTreeMap, HashSet};
+use std::io::Write;
+
+/// Write a [`NewickGraph`] as a Newick string.
+pub fn newick_to_string(graph: &NewickGraph, options: &NewickWriteOptions) -> Result<String, Report> {
+  let mut buf = Vec::new();
+  newick_to_writer(&mut buf, graph, options)?;
+  Ok(String::from_utf8(buf).expect("Newick output should be valid UTF-8"))
+}
+
+/// Write a [`NewickGraph`] to an `impl Write` destination.
+pub fn newick_to_writer(
+  writer: &mut impl Write,
+  graph: &NewickGraph,
+  options: &NewickWriteOptions,
+) -> Result<(), Report> {
+  if let Some(rooted) = graph.rooted {
+    if rooted {
+      write!(writer, "[&R]")?;
+    } else {
+      write!(writer, "[&U]")?;
+    }
+  }
+
+  let mut visited_hybrids = HashSet::new();
+  write_subtree(writer, graph, graph.root, false, options, &mut visited_hybrids)?;
+  write!(writer, ";")?;
+
+  Ok(())
+}
+
+fn write_subtree(
+  writer: &mut impl Write,
+  graph: &NewickGraph,
+  node_idx: usize,
+  is_acceptor: bool,
+  options: &NewickWriteOptions,
+  visited_hybrids: &mut HashSet<usize>,
+) -> Result<(), Report> {
+  let node = &graph.nodes[node_idx];
+
+  // For hybrid nodes: if already visited, write marker only (no subtree)
+  if node.hybrid.is_some() && !visited_hybrids.insert(node_idx) {
+    write_name(writer, node, is_acceptor)?;
+    return Ok(());
+  }
+
+  let children = &node.children;
+
+  if !children.is_empty() {
+    write!(writer, "(")?;
+    for (i, &edge_idx) in children.iter().enumerate() {
+      if i > 0 {
+        write!(writer, ",")?;
+      }
+      let edge = &graph.edges[edge_idx];
+      write_subtree(
+        writer,
+        graph,
+        edge.child,
+        edge.data.is_acceptor,
+        options,
+        visited_hybrids,
+      )?;
+      write_edge(writer, &edge.data, options)?;
+    }
+    write!(writer, ")")?;
+  }
+
+  write_name(writer, node, is_acceptor)?;
+  write_node_annotations(writer, node, options)?;
+
+  Ok(())
+}
+
+fn write_name(writer: &mut impl Write, node: &NewickNodeData, is_acceptor: bool) -> Result<(), Report> {
+  if node.hybrid.is_none() {
+    if let Some(name) = &node.name {
+      return write_label(writer, name);
+    }
+    return Ok(());
+  }
+
+  let mut label = String::new();
+  if let Some(name) = &node.name {
+    label.push_str(name);
+  }
+  if let Some(hybrid) = &node.hybrid {
+    label.push('#');
+    if is_acceptor {
+      label.push('#');
+    }
+    if let Some(kind) = &hybrid.kind {
+      label.push_str(kind);
+    }
+    label.push_str(&hybrid.index.to_string());
+  }
+  if !label.is_empty() {
+    write_label(writer, &label)?;
+  }
+  Ok(())
+}
+
+fn write_label(writer: &mut impl Write, label: &str) -> Result<(), Report> {
+  if needs_quoting(label) {
+    write!(writer, "'")?;
+    for part in label.split_inclusive('\'') {
+      if let Some(prefix) = part.strip_suffix('\'') {
+        write!(writer, "{prefix}''")?;
+      } else {
+        write!(writer, "{part}")?;
+      }
+    }
+    write!(writer, "'")?;
+  } else {
+    write!(writer, "{label}")?;
+  }
+  Ok(())
+}
+
+fn needs_quoting(name: &str) -> bool {
+  name.contains(|c: char| matches!(c, '(' | ')' | '[' | ']' | ',' | ';' | ':' | '\'') || c.is_whitespace())
+}
+
+fn write_node_annotations(
+  writer: &mut impl Write,
+  node: &NewickNodeData,
+  options: &NewickWriteOptions,
+) -> Result<(), Report> {
+  match options.style {
+    NwkStyle::Plain => {},
+    NwkStyle::Beast => {
+      write_beast_attrs(writer, &node.node_attrs)?;
+      write_raw_comments(writer, &node.raw_comments)?;
+    },
+    NwkStyle::Nhx => {
+      write_nhx_attrs(writer, &node.node_attrs)?;
+      write_raw_comments(writer, &node.raw_comments)?;
+    },
+  }
+  Ok(())
+}
+
+fn write_edge(writer: &mut impl Write, edge: &NewickEdgeData, options: &NewickWriteOptions) -> Result<(), Report> {
+  let has_length = edge.branch_length.is_some();
+  let has_branch_attrs = !edge.branch_attrs.is_empty();
+  let has_raw = !edge.raw_comments.is_empty();
+
+  if !has_length && !has_branch_attrs && !has_raw {
+    return Ok(());
+  }
+
+  if has_length {
+    write!(writer, ":")?;
+
+    // BEAST2 canonical: branch attrs between `:` and number
+    if options.style == NwkStyle::Beast {
+      write_beast_attrs(writer, &edge.branch_attrs)?;
+    }
+
+    write!(writer, "{}", format_float(edge.branch_length.unwrap_or(0.0), options))?;
+
+    // NHX and MrBayes: branch attrs after number
+    if options.style == NwkStyle::Nhx {
+      write_nhx_attrs(writer, &edge.branch_attrs)?;
+    }
+
+    // Raw comments after number for both Beast and Nhx
+    if options.style != NwkStyle::Plain {
+      write_raw_comments(writer, &edge.raw_comments)?;
+    }
+  } else if options.style != NwkStyle::Plain && (has_branch_attrs || has_raw) {
+    // No length: emit attrs and raw comments without `:` prefix.
+    // These will be parsed back as pre-colon branch comments.
+    match options.style {
+      NwkStyle::Beast => write_beast_attrs(writer, &edge.branch_attrs)?,
+      NwkStyle::Nhx => write_nhx_attrs(writer, &edge.branch_attrs)?,
+      NwkStyle::Plain => {},
+    }
+    write_raw_comments(writer, &edge.raw_comments)?;
+  }
+
+  Ok(())
+}
+
+fn write_beast_attrs(writer: &mut impl Write, attrs: &BTreeMap<String, NewickValue>) -> Result<(), Report> {
+  if attrs.is_empty() {
+    return Ok(());
+  }
+  write!(writer, "[&")?;
+  for (i, (key, value)) in attrs.iter().enumerate() {
+    if i > 0 {
+      write!(writer, ",")?;
+    }
+    if needs_beast_quoting(key) {
+      let escaped = key.replace('"', "\"\"");
+      write!(writer, "\"{escaped}\"=")?;
+    } else {
+      write!(writer, "{key}=")?;
+    }
+    write_beast_value(writer, value)?;
+  }
+  write!(writer, "]")?;
+  Ok(())
+}
+
+fn write_beast_value(writer: &mut impl Write, value: &NewickValue) -> Result<(), Report> {
+  match value {
+    NewickValue::Boolean(b) => {
+      if *b {
+        write!(writer, "TRUE")?;
+      } else {
+        write!(writer, "FALSE")?;
+      }
+    },
+    NewickValue::Number(n) => {
+      write!(writer, "{n}")?;
+    },
+    NewickValue::String(s) => {
+      if needs_beast_quoting(s) {
+        let escaped = s.replace('"', "\"\"");
+        write!(writer, "\"{escaped}\"")?;
+      } else {
+        write!(writer, "{s}")?;
+      }
+    },
+    NewickValue::Array(arr) => {
+      write!(writer, "{{")?;
+      for (i, elem) in arr.iter().enumerate() {
+        if i > 0 {
+          write!(writer, ",")?;
+        }
+        write_beast_value(writer, elem)?;
+      }
+      write!(writer, "}}")?;
+    },
+  }
+  Ok(())
+}
+
+fn needs_beast_quoting(s: &str) -> bool {
+  if s.contains(|c: char| matches!(c, ',' | '=' | ']' | '[' | '\'' | '"') || c.is_whitespace()) {
+    return true;
+  }
+  if s.eq_ignore_ascii_case("true") || s.eq_ignore_ascii_case("false") {
+    return true;
+  }
+  if s.starts_with(|c: char| c.is_ascii_digit() || c == '-') && s.parse::<f64>().is_ok() {
+    return true;
+  }
+  false
+}
+
+fn write_nhx_attrs(writer: &mut impl Write, attrs: &BTreeMap<String, NewickValue>) -> Result<(), Report> {
+  if attrs.is_empty() {
+    return Ok(());
+  }
+  write!(writer, "[&&NHX")?;
+  for (key, value) in attrs {
+    write!(writer, ":{key}=")?;
+    write_nhx_value(writer, value)?;
+  }
+  write!(writer, "]")?;
+  Ok(())
+}
+
+fn write_nhx_value(writer: &mut impl Write, value: &NewickValue) -> Result<(), Report> {
+  match value {
+    NewickValue::Boolean(b) => write!(writer, "{b}")?,
+    NewickValue::Number(n) => write!(writer, "{n}")?,
+    NewickValue::String(s) => {
+      if s.contains(|c: char| matches!(c, ':' | '=' | ']')) {
+        return Err(eyre::eyre!(
+          "NHX cannot represent value containing reserved character (':', '=', or ']'): {s}"
+        ));
+      }
+      write!(writer, "{s}")?;
+    },
+    NewickValue::Array(arr) => {
+      for (i, elem) in arr.iter().enumerate() {
+        if i > 0 {
+          write!(writer, ">")?;
+        }
+        write_nhx_value(writer, elem)?;
+      }
+    },
+  }
+  Ok(())
+}
+
+fn write_raw_comments(writer: &mut impl Write, comments: &[String]) -> Result<(), Report> {
+  for comment in comments {
+    write!(writer, "{comment}")?;
+  }
+  Ok(())
+}
+
+fn format_float(value: f64, options: &NewickWriteOptions) -> String {
+  let mut config = pretty_dtoa::FmtFloatConfig::default()
+    .add_point_zero(false)
+    .radix_point('.');
+
+  if let Some(sig) = options.significant_digits {
+    config = config.max_significant_digits(sig);
+  }
+  if let Some(dec) = options.decimal_digits {
+    config = config.max_decimal_digits(dec);
+  }
+
+  pretty_dtoa::dtoa(value, config)
+}


### PR DESCRIPTION
The `bio` crate's Newick parser rejects all `[...]` content (BEAST annotations, NHX tags, plain comments), and reads branch lengths as `f32`. This blocks annotation round-tripping and loses precision beyond 1e-6. No existing Rust crate handles the full Newick dialect landscape or the Nexus container format.

Add `util-newick`, a standalone crate with a pest-based Newick grammar that auto-detects annotation dialects per comment, parses branch lengths as `f64`, and handles eNewick hybrid network markers. The writer supports Plain, Beast, and Nhx output styles with BEAST2 canonical annotation placement. The Nexus container layer parses TREES blocks, applies TRANSLATE table substitution, and handles multi-tree files. The data model uses a flat adjacency list with order-insensitive tree equality via canonical subtree hashing.

The crate is intentionally standalone with no `treetime-*` dependencies. Integration into `treetime-io` is separate follow-up work.

### Work items

- [x] Implement pest grammar with inline dialect detection (BEAST `[&k=v]`, NHX `[&&NHX:k=v]`, plain `[text]`)
- [x] Implement Newick writer with three configurable styles, BEAST key/value escaping, and NHX reserved-char rejection
- [x] Implement eNewick hybrid node merging with edge-level `is_acceptor` tracking
- [x] Implement Nexus reader (block extraction, quote-aware TRANSLATE scanner, bracket-aware semicolon detection) and streaming writer
- [x] Implement order-insensitive `PartialEq` via recursive canonical subtree hashing
- [x] Add unit tests for parser, writer, Nexus, and eNewick; property-based round-trip tests for all styles; doc tests for public API
- [x] Add crate README with data model guide, traversal patterns, and usage examples
- [x] File issue: [kb/issues/N-io-nexus-parser-limited-subset.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/issues/N-io-nexus-parser-limited-subset.md), [kb/issues/N-io-newick-root-branch-length-discarded.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/issues/N-io-newick-root-branch-length-discarded.md)
- [x] Update ticket: [kb/tickets/io-replace-bio-parser-with-pest.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/tickets/io-replace-bio-parser-with-pest.md), [kb/tickets/io-nwk-writer-style-dispatch.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/tickets/io-nwk-writer-style-dispatch.md), [kb/tickets/io-nwk-comment-dialect-parsing.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/tickets/io-nwk-comment-dialect-parsing.md): done/remaining sections

### Possible improvements

- [ ] Integrate into `treetime-io` to replace `bio::io::newick` ([kb/tickets/io-replace-bio-parser-with-pest.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/tickets/io-replace-bio-parser-with-pest.md))
- [ ] Add `root_branch_length: Option<f64>` to `NewickGraph` ([kb/issues/N-io-newick-root-branch-length-discarded.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/issues/N-io-newick-root-branch-length-discarded.md))
- [ ] Replace Nexus string scanner with formal grammar ([kb/issues/N-io-nexus-parser-limited-subset.md](https://github.com/neherlab/treetime/blob/284a7030f6e7519e4e5bea377e2f143a6740bd40/kb/issues/N-io-nexus-parser-limited-subset.md))

---

