### PR TITLE
refactor: fix clippy warnings and format

### DIFF
--- a/packages/app-cli/src/cli/treetime_cli.rs
+++ b/packages/app-cli/src/cli/treetime_cli.rs
@@ -62,7 +62,7 @@ pub enum TreetimeCommands {
   },
 
   /// Estimates time trees from an initial tree topology, a set of date constraints (e.g. tip dates), and an alignment (optional).
-  Timetree(TreetimeTimetreeArgs),
+  Timetree(Box<TreetimeTimetreeArgs>),
 
   /// Optimizes the branch lengths and likelihood of a phylogenetic tree given aligned sequences.
   Optimize(TreetimeOptimizeArgs),

--- a/packages/treetime-io/src/__tests__/test_nwk_providers.rs
+++ b/packages/treetime-io/src/__tests__/test_nwk_providers.rs
@@ -221,7 +221,7 @@ mod tests {
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub(super) struct TestNode {
       name: Option<String>,
-      pub(super) comments: BTreeMap<String, String>,
+      comments: BTreeMap<String, String>,
     }
 
     impl TestNode {

--- a/packages/treetime/src/commands/ancestral/__tests__/test_smoke_gtr_iterations.rs
+++ b/packages/treetime/src/commands/ancestral/__tests__/test_smoke_gtr_iterations.rs
@@ -47,7 +47,11 @@ mod tests {
     let result = crate::ancestral::pipeline::run(&params, input, |_, _| Ok(()), &NoopProgress)?;
 
     let gtr = result.output.gtr.expect("GTR should be fitted with --model=infer");
-    assert!(gtr.mu > 0.0, "mu should be positive after GTR iterations, got {}", gtr.mu);
+    assert!(
+      gtr.mu > 0.0,
+      "mu should be positive after GTR iterations, got {}",
+      gtr.mu
+    );
 
     Ok(())
   }
@@ -79,7 +83,11 @@ mod tests {
     let result = crate::ancestral::pipeline::run(&params, input, |_, _| Ok(()), &NoopProgress)?;
 
     let gtr = result.output.gtr.expect("GTR should be fitted with --model=infer");
-    assert!(gtr.mu > 0.0, "mu should be positive after GTR iterations, got {}", gtr.mu);
+    assert!(
+      gtr.mu > 0.0,
+      "mu should be positive after GTR iterations, got {}",
+      gtr.mu
+    );
 
     Ok(())
   }

--- a/packages/treetime/src/commands/ancestral/run.rs
+++ b/packages/treetime/src/commands/ancestral/run.rs
@@ -11,11 +11,11 @@ use crate::commands::ancestral::augur_node_data::write_augur_node_data_json_with
 use crate::commands::ancestral::result::AncestralResult;
 use crate::commands::shared::output::{CommandKind, OutputSelection};
 use crate::gtr::get_gtr::{GtrOutput, write_gtr_json};
-use crate::{make_error, make_report};
 use crate::partition::traits::MutationCommentProvider;
 use crate::payload::ancestral::GraphAncestral;
 use crate::progress::ProgressSink;
 use crate::seq::gap_fill::apply_gap_fill;
+use crate::{make_error, make_report};
 use eyre::Report;
 use log::{info, warn};
 use treetime_graph::node::Named;

--- a/packages/treetime/src/commands/prune/run.rs
+++ b/packages/treetime/src/commands/prune/run.rs
@@ -76,7 +76,9 @@ pub fn run_prune(
 
   if let Some(path) = resolved.non_tree_outputs.get(&OutputSelection::Gtr) {
     let gtr = output.gtr.as_ref().ok_or_else(|| {
-      crate::make_report!("GTR output requested but no GTR model was fitted. Provide sequence alignment input with --aln.")
+      crate::make_report!(
+        "GTR output requested but no GTR model was fitted. Provide sequence alignment input with --aln."
+      )
     })?;
     let gtr_output = GtrOutput::new(gtr, GtrModelName::JC69);
     write_gtr_json(&gtr_output, path)?;

--- a/packages/treetime/src/commands/shared/__tests__/test_output_resolution.rs
+++ b/packages/treetime/src/commands/shared/__tests__/test_output_resolution.rs
@@ -19,20 +19,24 @@ mod tests {
     let leaf_b = graph.add_node(TestNode {
       name: Some("B".to_owned()),
     });
-    let _ = graph.add_edge(
-      root,
-      leaf_a,
-      TestEdge {
-        branch_length: Some(0.1),
-      },
-    );
-    let _ = graph.add_edge(
-      root,
-      leaf_b,
-      TestEdge {
-        branch_length: Some(0.2),
-      },
-    );
+    graph
+      .add_edge(
+        root,
+        leaf_a,
+        TestEdge {
+          branch_length: Some(0.1),
+        },
+      )
+      .unwrap();
+    graph
+      .add_edge(
+        root,
+        leaf_b,
+        TestEdge {
+          branch_length: Some(0.2),
+        },
+      )
+      .unwrap();
     graph
   }
 

--- a/packages/treetime/src/commands/timetree/run.rs
+++ b/packages/treetime/src/commands/timetree/run.rs
@@ -6,11 +6,11 @@ use crate::commands::timetree::output::augur_node_data::write_augur_node_data_js
 use crate::commands::timetree::output::auspice::write_auspice_json;
 use crate::commands::timetree::result::TimetreeResult;
 use crate::gtr::get_gtr::{GtrOutput, write_gtr_json};
-use crate::{make_error, make_report};
 use crate::partition::traits::MutationCommentProvider;
 use crate::seq::div::compute_edge_mutation_counts;
 use crate::timetree::confidence::write_confidence_intervals_file;
 use crate::timetree::pipeline::{self, TimetreeInput, TimetreeParams};
+use crate::{make_error, make_report};
 use eyre::{Report, WrapErr};
 use log::info;
 use std::path::{Path, PathBuf};

--- a/packages/util-newick/src/nexus.rs
+++ b/packages/util-newick/src/nexus.rs
@@ -10,8 +10,8 @@ use std::io::{Read, Write};
 /// Parse a Nexus string, returning all trees from TREES blocks.
 pub fn nexus_from_string(input: &str) -> Result<Vec<NexusTree>, Report> {
   let input = input.trim();
-  let header_end = input.find(|c: char| c.is_ascii_whitespace()).unwrap_or(input.len());
-  if !input[..header_end].eq_ignore_ascii_case("#nexus") {
+  let header = input.split_ascii_whitespace().next().unwrap_or("");
+  if !header.eq_ignore_ascii_case("#nexus") {
     return Err(eyre::eyre!("Input does not start with #NEXUS header"));
   }
 

--- a/packages/util-newick/src/types.rs
+++ b/packages/util-newick/src/types.rs
@@ -255,6 +255,7 @@ fn subtree_hash(graph: &NewickGraph, node_idx: usize) -> u64 {
   node.raw_comments.hash(&mut hasher);
   node.hybrid.hash(&mut hasher);
 
+  #[allow(clippy::collection_is_never_read)] // false positive: vec is read by .hash()
   let mut child_hashes: Vec<(u64, u64)> = node
     .children
     .iter()


### PR DESCRIPTION
Clippy warnings after the output selection infrastructure, addressed at root cause except one false-positive suppression (`collection_is_never_read` on a vec read by `.hash()`).

### Work items

- [x] Box `TreetimeTimetreeArgs` in CLI enum to fix `large_enum_variant`
- [x] Replace string slice with `split_ascii_whitespace` in nexus header parsing
- [x] Narrow `TestNode.comments` visibility from `pub(super)` to private
- [x] Unwrap `add_edge` `Result` in test setup instead of discarding with `let _ =`
- [x] Suppress false-positive `collection_is_never_read` with justification
- [x] Run `cargo fmt`
