### PR TITLE
docs: file CLI help text audit

### DIFF
--- a/kb/issues/M-cli-help-text-defects.md
+++ b/kb/issues/M-cli-help-text-defects.md
@@ -1,0 +1,231 @@
+# CLI help text defects, inconsistencies, and UX violations
+
+Systematic audit of `--help` output across all commands reveals defects affecting three audiences: human scientists, AI agents, and workflow engines (Snakemake, Nextflow).
+
+## Defects
+
+### D1: `--method-anc=joint` accepted by parser, errors at runtime
+
+Commands: `timetree`, `ancestral`, `clock`, `homoplasy`.
+
+`[possible values: marginal, parsimony, joint]` lists `joint`, but the pipeline rejects it: "Joint ancestral reconstruction has been removed. Available methods: marginal, parsimony" (`ancestral/pipeline.rs:231`). Users and automation discover this only at runtime, after setup completes.
+
+Fix: remove `joint` from the enum or hide it with a clap `hide` attribute and add a deprecation note.
+
+### D2: `--tree` description promises fallback on required-tree commands
+
+Commands: `optimize`, `ancestral`.
+
+Description says "If none is provided, treetime will attempt to build a tree from the alignment using fasttree, iqtree, or raxml" but `--tree` is **required** (`PathBuf`, shown as `--tree <TREE>` in usage line). The fallback text is unreachable.
+
+Fix: use a different description for commands where `--tree` is required. `prune` already does this correctly ("Name of file containing the tree in newick, nexus, or phylip format" with no fallback clause).
+
+Related: [H-timetree-tree-inference-unimplemented.md](H-timetree-tree-inference-unimplemented.md) covers the `timetree`/`clock` case where `--tree` is optional but tree inference is not implemented.
+
+### D3: `--prune-short` in `clock` has empty description and type mismatch
+
+`clock` command: `--prune-short` renders with no description at all (no doc comment on `commands/clock/args.rs:76`). It is a `bool` flag. In `prune`, the same name takes an `Option<f64>` threshold (`--prune-short <THRESHOLD>`). Same flag name, different types, different semantics.
+
+Related: [M-clock-dead-cli-arguments.md](M-clock-dead-cli-arguments.md) tracks that `--prune-short` in `clock` is parsed but never wired.
+
+### D4: `clock` command description has `--keep_root` typo
+
+Top-level `clock` description: "unless run with --keep_root" (underscore). The actual flag is `--keep-root` (hyphen). Copy-pasting from the description will fail at parse time.
+
+### D5: `--model-params` references Python source files
+
+Commands: `timetree`, `optimize`, `ancestral`, `clock`, `homoplasy`.
+
+Description: "See the exact definitions of the parameters in the GTR creation methods in treetime/nuc_models.py or treetime/aa_models.py". These are v0 Python paths that do not exist in the Rust codebase. Users of the Rust binary cannot find these files.
+
+Fix: reference the v1 Rust module paths or link to documentation.
+
+### D6: `--jobs` default is build-time environment-specific
+
+All commands.
+
+Displays `[default: 20]` which is `available_parallelism()` evaluated at Docker build time. Description says "all available CPU threads will be used" which contradicts the fixed numeric default. Users on 8-core machines see `20` and either trust a wrong default or are confused.
+
+Fix: display `[default: auto]` or suppress the numeric default.
+
+### D7: `ancestral` command description hardcodes output filenames
+
+Description: "The output consists of a file 'ancestral.fasta' with ancestral sequences and a tree 'annotated_tree.nexus'". Actual output is controlled by `--output-all` and per-file flags. These specific filenames are not guaranteed.
+
+### D8: `--n-iqd` in `timetree` is unused
+
+Defined at `commands/timetree/args.rs:184` but never read or used anywhere. The `--clock-filter` flag already controls interquartile-based outlier detection. The relationship between the two is unexplained.
+
+Related: [N-timetree-dead-cli-flags.md](N-timetree-dead-cli-flags.md) lists `--n-iqd`.
+
+### D9: `homoplasy` and `arg` show full help for unimplemented commands
+
+`homoplasy` displays a complete options page but `run_homoplasy` returns "not yet implemented in v1". `arg` shows global flags only with no indication of being unimplemented.
+
+Related: [H-homoplasy-command-unimplemented.md](H-homoplasy-command-unimplemented.md).
+
+## Inconsistencies
+
+### I1: `--metadata` short flag and alias differ across commands
+
+`timetree`/`clock`: `-d --metadata` with alias `--dates`. `mugration`: `-s --metadata` with alias `--states`. Same long flag name, different short flags.
+
+### I2: `--clock-filter` description differs between `timetree` and `clock`
+
+"inter-quartile" (hyphenated) in `timetree` vs "interquartile" (one word) in `clock`. Both include redundant prose "Default=3.0" alongside the `[default: 3.0]` metadata.
+
+### I3: `--dense` description differs across four commands
+
+`timetree`: "store full probability distributions". `optimize`: "stores full probability vectors ... Dense is more accurate..." (extra paragraph). `ancestral`/`homoplasy`: "stores full probability vectors at each position" (extra GTR paragraph).
+
+### I4: `--vcf-reference` description has two phrasings
+
+`timetree`/`clock`: "Only for vcf input: fasta file of the sequence the VCF was mapped to". `ancestral`/`homoplasy`: "FASTA file of the sequence the VCF was mapped to (only for vcf input)".
+
+### I5: `--max-iter` default and description differ
+
+`timetree`: default 2, "maximal number" (lowercase). `optimize`: default 10, "Maximum number" (capitalized). Different defaults are intentional but the descriptions diverge without reason.
+
+### I6: `--confidence` has incompatible semantics across commands
+
+`timetree`: boolean flag ("Add rate-uncertainty to confidence intervals"). `mugration`: output path alias for `--output-confidence`.
+
+### I7: Capitalization inconsistent across all commands
+
+Some descriptions start lowercase ("don't reroot the tree", "ignore tips", "excess variance", "maximal number", "use an autocorrelated", "rescale branch lengths"), others uppercase ("If set to 'input'", "Method used for", "Length of the sequence").
+
+### I8: `--output-selection` shows full superset regardless of command
+
+Every command lists all possible values (`clock-csv`, `traits-csv`, `confidence`, `reconstructed-nuc-fasta`, etc.) even when the command cannot produce those outputs.
+
+### I9: `--branch-length-mode` description differs subtly
+
+`timetree`: "Branch lengths optimized by treetime are only accurate at short evolutionary distances". `clock`: "Note that branch lengths optimized by treetime are only accurate at short evolutionary distances".
+
+## UX / ergonomics
+
+### U1: `--dense` takes `true`/`false` string instead of boolean flag
+
+Commands: `timetree`, `optimize`, `ancestral`, `homoplasy`. `[possible values: true, false]` requires `--dense=true` or `--dense true`. Idiomatic CLI would be `--dense`/`--no-dense` flag pair or a tri-state with auto-detection.
+
+### U2: `--opt-method` renders LaTeX in terminal
+
+Command: `optimize`. Possible value descriptions contain `$t$`, `$\sqrt{t}$`, `$\ln(t)$` which display as raw LaTeX in terminal output. Should be `t`, `sqrt(t)`, `ln(t)`.
+
+### U3: No `--outdir` alias for v0 migration
+
+v0 uses `--outdir`; v1 uses `-O`/`--output-all`. Users migrating from v0 get parse errors. An `--outdir` visible alias would ease migration.
+
+### U4: `--relax` uses unusual multi-value syntax
+
+Command: `timetree`. Takes two positional-style values (`--relax 1.0 0.5`). Most CLIs use separate flags or comma-separated values.
+
+### U5: `--detailed` in `homoplasy` takes opaque string value
+
+`--detailed <DETAILED>` with description "generate a more detailed report". No documentation of valid values.
+
+### U6: `--pc` in `mugration` default not shown in metadata
+
+Description says "Default: 1.0" but no `[default: 1.0]` metadata (field is `Option<f64>`). Automation parsers miss it.
+
+### U7: `--keep-polytomies`/`--resolve-polytomies` no conflict guard
+
+Command: `timetree`. Both are `bool` flags with no `conflicts_with`. Both can be set simultaneously.
+
+Related: [N-timetree-polytomy-flags-no-conflict.md](N-timetree-polytomy-flags-no-conflict.md).
+
+### U8: Global flags on non-analysis commands
+
+`--jobs`, `--verbosity`, `--no-progress` appear on `completions`, `schema`, `help-markdown`, `arg` where they serve no purpose.
+
+## Style
+
+### S1: Format name capitalization
+
+"newick, nexus, or phylip" should be "Newick, Nexus, or PHYLIP" consistently.
+
+### S2: "compressed fasta" should be "compressed FASTA"
+
+### S3: `mugration --weights` grammar error
+
+"probabilities of that a randomly sampled sequence..." should be "probability that a randomly sampled sequence...".
+
+### S4: `--alphabet aa-no-stop` unexplained
+
+No description of what `aa-no-stop` means or when to choose it over `aa`.
+
+### S5: Various descriptions reference v0 internals
+
+`--smooth-initial-pi`, `--filter-uninformative-root` in `mugration` reference "TreeTime v0" behavior and `infer_gtr regularization`.
+
+### S6: `--sampling-bias-correction` vague
+
+No indication of expected range, units, or typical values.
+
+## Workflow/automation
+
+### W1: Output flags appear optional but at least one is required at runtime
+
+Usage lines show all output flags as optional (`[OPTIONS]`), but `output.rs:562` errors when no output destination is provided. Users following the usage pattern get a runtime error after input loading completes. Workflow generators cannot infer that `-O`/`--output-all` or a per-file flag is required.
+
+### W2: `--output-selection` accepts values that the command rejects at runtime
+
+Verified: `treetime prune --output-all=tmp --output-selection=auspice` parses successfully, then errors: "Output format '--output-tree-auspice' is not available for this command." The `possible values` list is the full superset, not the per-command subset.
+
+### W3: `--alignment` says "multiple FASTA files" but does not show repeat syntax
+
+Help renders `-a, --alignment <FILEPATH>` with singular value name. No indication whether multiple files use repeated flags (`--alignment a --alignment b`), space-separated values, or comma-separated values.
+
+### W4: Stdin fallback text appears on commands where it is irrelevant
+
+Shared alignment help says "If no input files provided, the plain fasta input is read from standard input (stdin)." This appears on `clock` (metadata/tree-based, not sequence-based) and `prune` (sequence only needed for `--prune-empty`).
+
+### W5: Root help links to Python v0 documentation
+
+Root `--help` links to `https://treetime.readthedocs.io/en/stable/` and the Python TreeTime publication. Users and agents will look up v0 behavior for a v1 binary.
+
+### W6: No usage examples in any scientific command
+
+Only `completions` includes an example. Core commands (`timetree`, `ancestral`, `clock`, `mugration`, `optimize`, `prune`) have no canonical command-line examples showing required input combinations.
+
+### W7: `mugration` metadata format examples are unreadable inline prose
+
+`--metadata` description: "CSV or TSV file with discrete characters. #name,country,continent taxon1,micronesia,oceania ..." -- column structure is not visually separated from data rows.
+
+### W8: `schema` and `help-markdown` mixed with scientific commands
+
+Root help lists tooling commands at the same level as analysis commands with no grouping or labeling.
+
+## Grammar
+
+### G1: "If there's multiple input files" should be "If there are multiple input files"
+
+`commands/shared/alignment.rs:21`
+
+### G2: "gaussian" should be "Gaussian"
+
+`commands/timetree/args.rs:102`
+
+### G3: "Higher numbers results" should be "Higher numbers result"
+
+`commands/mugration/args.rs:44`
+
+### G4: Root `ancestral` summary is a full paragraph; other summaries are one-liners
+
+`app-cli/src/cli/treetime_cli.rs:73` -- uneven length makes root help hard to scan.
+
+## Affected code
+
+- CLI arg definitions: `packages/treetime/src/commands/*/args.rs`
+- Shared arg structs: `packages/treetime/src/commands/shared/*.rs`
+- Top-level command descriptions: `packages/app-cli/src/cli/treetime_cli.rs`
+- Method enum: `packages/treetime/src/ancestral/params.rs`
+
+## Related issues
+
+- [N-timetree-dead-cli-flags.md](N-timetree-dead-cli-flags.md): unused flags in timetree (overlaps D8)
+- [M-clock-dead-cli-arguments.md](M-clock-dead-cli-arguments.md): unused flags in clock (overlaps D3)
+- [H-timetree-tree-inference-unimplemented.md](H-timetree-tree-inference-unimplemented.md): tree inference fallback not implemented (overlaps D2)
+- [H-homoplasy-command-unimplemented.md](H-homoplasy-command-unimplemented.md): homoplasy unimplemented (overlaps D9)
+- [N-timetree-polytomy-flags-no-conflict.md](N-timetree-polytomy-flags-no-conflict.md): polytomy flag conflict (overlaps U7)
+- [M-timetree-method-anc-ignored.md](M-timetree-method-anc-ignored.md): `--method-anc` dead in timetree (related to D1)

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -156,6 +156,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Coalescent   | [Coalescent subsystem time notation conflict](M-coalescent-time-notation-conflict.md)                                                               |
 | Medium     | Inference    | [Inference forward/backward pass asymmetries](M-inference-forward-backward-asymmetry.md)                                                            |
 | Medium     | Clock        | [Clock pre-filter ignores user-provided variance parameters](M-clock-prefilter-ignores-user-variance.md)                                            |
+| Medium     | CLI          | [CLI help text defects, inconsistencies, and UX violations](M-cli-help-text-defects.md)                                                             |
 | Medium     | Core         | [Remaining architectural debt after domain module extraction](M-core-remaining-architectural-debt-after-extraction.md)                              |
 | Negligible | Timetree     | [Timetree indel rate recomputed per refinement iteration](N-timetree-indel-rate-recomputed-per-iteration.md)                                        |
 | Negligible | Numerical    | [Numerical stability magic constants](N-numerical-stability-magic-constants.md)                                                                     |

--- a/kb/tickets/cli-help-text-fix-defects-and-inconsistencies.md
+++ b/kb/tickets/cli-help-text-fix-defects-and-inconsistencies.md
@@ -1,0 +1,76 @@
+# Fix CLI help text defects and inconsistencies
+
+Fix incorrect, misleading, and inconsistent `--help` output across all commands to serve human scientists, AI agents, and workflow engines.
+
+## Tasks
+
+### Defect fixes (high priority)
+
+1. Remove `joint` from `--method-anc` possible values or hide it with a clap `hide` attribute and produce a parse-time error pointing users to `marginal`/`parsimony`
+2. Use a different `--tree` description for commands where it is required (`optimize`, `ancestral`) -- remove the "If none is provided..." fallback clause. `prune` is already correct
+3. Add a doc comment to `--prune-short` in `clock/args.rs` explaining what it does, or remove it if it should not exist on `clock`
+4. Fix `--keep_root` underscore typo in `clock` command description to `--keep-root`
+5. Replace `treetime/nuc_models.py` and `treetime/aa_models.py` references in `--model-params` with v1 Rust paths or documentation links
+6. Fix `--jobs` default display: show `auto` instead of the build-time CPU count, or suppress the numeric default
+7. Update `ancestral` command description to not hardcode output filenames
+8. Mark `homoplasy` and `arg` commands as unimplemented in their help text (add `[not yet implemented]` to the description)
+
+### Inconsistency fixes
+
+9. Unify `--clock-filter` description: pick one spelling of "interquartile", remove the redundant prose "Default=3.0"
+10. Unify `--dense` descriptions across commands to a single shared doc comment
+11. Unify `--vcf-reference` descriptions across commands
+12. Unify `--max-iter` description capitalization ("Maximum" everywhere)
+13. Unify `--branch-length-mode` description (remove stray "Note that" prefix in `clock`)
+14. Standardize capitalization: sentence case for all flag descriptions
+
+### UX improvements
+
+15. Convert `--dense` from `true`/`false` string value to a boolean flag pair or tri-state with auto-detection
+16. Replace LaTeX math notation in `--opt-method` possible values with plain text (`t`, `sqrt(t)`, `ln(t)`)
+17. Add `--outdir` as a visible alias for `--output-all` for v0 migration
+18. Add doc comment to `--pc` in `mugration` with a proper `#[default]` so `[default: 1.0]` appears in metadata
+19. Add doc comment to `--detailed` in `homoplasy` explaining valid values
+20. Restrict `--output-selection` possible values to the subset each command can produce
+
+### Style fixes
+
+21. Capitalize format names consistently: "Newick", "Nexus", "PHYLIP", "FASTA"
+22. Fix grammar in `mugration --weights`: "probabilities of that" -> "probability that"
+23. Add brief explanation for `--alphabet aa-no-stop`
+24. Remove v0 internal references from `--smooth-initial-pi` and `--filter-uninformative-root` descriptions
+
+### Workflow/automation fixes
+
+25. Document that at least one output flag (`-O`/`--output-all` or a per-file flag) is required, or make it a clap validation
+26. Generate per-command `--output-selection` possible values instead of the full superset
+27. Document `--alignment` repeat syntax for multiple files (repeated flag, space-separated, etc.)
+28. Make alignment stdin fallback text command-specific (remove from commands where stdin is irrelevant)
+29. Replace root help docs link with v1 documentation or a disclaimer that linked docs cover v0
+30. Add one minimal usage example per scientific command
+31. Reformat `mugration --metadata` and `--weights` examples as structured multi-line help
+32. Group root commands by purpose (Analysis, Tooling, Documentation)
+
+### Grammar fixes
+
+33. "If there's multiple input files" -> "If there are multiple input files" in `alignment.rs`
+34. "gaussian" -> "Gaussian" in `timetree/args.rs`
+35. "Higher numbers results" -> "Higher numbers result" in `mugration/args.rs`
+36. Shorten `ancestral` root summary to one sentence, move detail to long help
+
+## Scope
+
+All changes are doc comments and clap attributes in `packages/treetime/src/commands/` and `packages/app-cli/src/cli/`. No runtime behavior changes except making `--method-anc=joint` a parse-time error instead of runtime error, fixing `--jobs` default display, and optionally adding clap validation for required output.
+
+## Related issues
+
+Source: [kb/issues/M-cli-help-text-defects.md](../issues/M-cli-help-text-defects.md)
+
+Related:
+
+- [kb/issues/N-timetree-dead-cli-flags.md](../issues/N-timetree-dead-cli-flags.md)
+- [kb/issues/M-clock-dead-cli-arguments.md](../issues/M-clock-dead-cli-arguments.md)
+- [kb/issues/H-timetree-tree-inference-unimplemented.md](../issues/H-timetree-tree-inference-unimplemented.md)
+- [kb/issues/H-homoplasy-command-unimplemented.md](../issues/H-homoplasy-command-unimplemented.md)
+- [kb/issues/N-timetree-polytomy-flags-no-conflict.md](../issues/N-timetree-polytomy-flags-no-conflict.md)
+- [kb/issues/M-timetree-method-anc-ignored.md](../issues/M-timetree-method-anc-ignored.md)


### PR DESCRIPTION
Systematic audit of `--help` output across all commands targeting scientists unfamiliar with project internals, AI agents, and workflow engines (Snakemake, Nextflow). Audited by Claude and Codex peer agent with Docker access.

The audit found misleading descriptions (tree inference promised but unimplemented, removed method still listed), inconsistencies across commands (different descriptions for shared flags), UX violations (boolean flag requiring string argument, LaTeX in terminal output), and workflow blockers (required output flags not documented, selection superset not filtered per command).

### Work items

- [x] File issue: [kb/issues/M-cli-help-text-defects.md](https://github.com/neherlab/treetime/blob/ca909a5f/kb/issues/M-cli-help-text-defects.md): defects, inconsistencies, UX violations, and workflow blockers across all commands
- [x] File ticket: [kb/tickets/cli-help-text-fix-defects-and-inconsistencies.md](https://github.com/neherlab/treetime/blob/ca909a5f/kb/tickets/cli-help-text-fix-defects-and-inconsistencies.md): actionable tasks for all findings
- [x] Cross-reference existing KB issues that overlap with findings
- [x] Update `kb/issues/README.md` summary table
