### PR TITLE
feat: parse bare float labels on internal nodes as confidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,6 +4390,7 @@ dependencies = [
  "csv",
  "ctor 0.5.0",
  "eyre",
+ "indoc",
  "itertools 0.14.0",
  "log",
  "maplit",

--- a/kb/issues/N-timetree-node-data-confidence-not-emitted.md
+++ b/kb/issues/N-timetree-node-data-confidence-not-emitted.md
@@ -1,9 +1,0 @@
-# Node data JSON omits input-tree branch confidence
-
-The timetree node data JSON (`timetree.augur-node-data.json`) and the optimize node data JSON (`optimize.augur-node-data.json`) never emit the per-node `confidence` field. Augur's `augur refine` reads `confidence` from the input tree via `getattr(n, 'confidence')` (a branch support value parsed from the input Newick/Nexus), then copies it into the node data, in both the timetree and non-timetree paths (`attributes = ['branch_length', 'confidence']`); `augur export v2` colors by `node_attrs.confidence.value`.
-
-v1's Newick reader (`packages/treetime-io/src/nwk.rs`) does not parse internal-node support/confidence values into the node payload, so both the timetree writer (`packages/treetime/src/commands/timetree/output/augur_node_data.rs`) and the optimize writer (`packages/treetime/src/commands/optimize/augur_node_data.rs`) always set `confidence` to `None`. When the input tree carries no support values augur also omits the field, so output matches in that case. The gap appears only when the input Newick has branch support values: v1 silently drops them.
-
-This is distinct from the auspice pseudo-bootstrap `confidence` (`1 - exp(-n_mutations)`) tracked in [Auspice JSON output missing mutations, branch confidence, and genome annotations](N-timetree-auspice-json-incomplete.md); that value is computed, whereas this one is read from the input tree.
-
-Fixing requires the Newick/Nexus reader to parse branch support values into a node payload field, which would also benefit other commands. The `util-newick` parser already extracts support/confidence annotations; they need to be wired through `NodeFromNwk` (tracked in [kb/tickets/io-nwk-comment-dialect-parsing.md](../tickets/io-nwk-comment-dialect-parsing.md)).

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -125,7 +125,6 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Timetree     | [--keep-polytomies and --resolve-polytomies no conflicts_with declaration](N-timetree-polytomy-flags-no-conflict.md)                                |
 | Negligible | Timetree     | [Stochastic polytomy resolution not implemented](N-timetree-stochastic-polytomy-unimplemented.md)                                                   |
 | Negligible | Timetree     | [Auspice JSON output missing mutations, branch confidence, and genome annotations](N-timetree-auspice-json-incomplete.md)                           |
-| Negligible | Timetree     | [Node data JSON omits input-tree branch confidence](N-timetree-node-data-confidence-not-emitted.md)                                                 |
 | Negligible | Timetree     | [Node data date string can differ by one day at year-fraction boundaries](N-timetree-node-data-date-string-fp-boundary.md)                          |
 | Negligible | Timetree     | [Root node omits placeholder branch-length fields in node data JSON](N-timetree-node-data-root-branch-fields-omitted.md)                            |
 | Negligible | Timetree     | [Rerooted root and polytomy-resolution nodes stay unnamed](N-timetree-unnamed-root-after-reroot.md)                                                 |

--- a/packages/treetime-io/Cargo.toml
+++ b/packages/treetime-io/Cargo.toml
@@ -39,6 +39,7 @@ traversal = { workspace = true }
 [dev-dependencies]
 approx = { workspace = true }
 ctor = { workspace = true }
+indoc = { workspace = true }
 pretty_assertions = { workspace = true }
 rayon = { workspace = true }
 rstest = { workspace = true }

--- a/packages/treetime-io/src/__tests__/test_nex.rs
+++ b/packages/treetime-io/src/__tests__/test_nex.rs
@@ -28,7 +28,11 @@ mod tests {
   }
 
   impl NodeFromNwk for TestNode {
-    fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+    fn from_nwk(
+      name: Option<impl AsRef<str>>,
+      _confidence: Option<f64>,
+      _: &BTreeMap<String, String>,
+    ) -> Result<Self, Report> {
       Ok(Self {
         name: name.map(|n| n.as_ref().to_owned()),
       })

--- a/packages/treetime-io/src/__tests__/test_nwk_annotations.rs
+++ b/packages/treetime-io/src/__tests__/test_nwk_annotations.rs
@@ -29,7 +29,11 @@ mod tests {
   }
 
   impl NodeFromNwk for AnnotNode {
-    fn from_nwk(name: Option<impl AsRef<str>>, comments: &BTreeMap<String, String>) -> Result<Self, Report> {
+    fn from_nwk(
+      name: Option<impl AsRef<str>>,
+      _confidence: Option<f64>,
+      comments: &BTreeMap<String, String>,
+    ) -> Result<Self, Report> {
       Ok(Self {
         name: name.map(|n| n.as_ref().to_owned()),
         comments: comments.clone(),

--- a/packages/treetime-io/src/__tests__/test_nwk_providers.rs
+++ b/packages/treetime-io/src/__tests__/test_nwk_providers.rs
@@ -246,7 +246,11 @@ mod tests {
     }
 
     impl NodeFromNwk for TestNode {
-      fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+      fn from_nwk(
+        name: Option<impl AsRef<str>>,
+        _confidence: Option<f64>,
+        _: &BTreeMap<String, String>,
+      ) -> Result<Self, Report> {
         Ok(Self::new(name.map(|name| name.as_ref().to_owned())))
       }
     }

--- a/packages/treetime-io/src/nwk.rs
+++ b/packages/treetime-io/src/nwk.rs
@@ -76,7 +76,7 @@ where
       .iter()
       .map(|(k, v)| (k.clone(), v.to_string()))
       .collect();
-    let node = N::from_nwk(name, &comments)
+    let node = N::from_nwk(name, nwk_node.confidence, &comments)
       .wrap_err_with(|| format!("When reading node #{nwk_idx} '{}'", name.unwrap_or_default()))?;
     node_keys.push(graph.add_node(node));
   }
@@ -305,7 +305,11 @@ pub fn format_weight(weight: f64, options: &NwkWriteOptions) -> String {
 
 /// Defines how to construct node when reading from Newick and Nexus files
 pub trait NodeFromNwk: Sized {
-  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report>;
+  fn from_nwk(
+    name: Option<impl AsRef<str>>,
+    confidence: Option<f64>,
+    comments: &BTreeMap<String, String>,
+  ) -> Result<Self, Report>;
 }
 
 /// Defines how to display node information when writing to Newick and Nexus files

--- a/packages/treetime/src/clock/__tests__/test_date_constraints.rs
+++ b/packages/treetime/src/clock/__tests__/test_date_constraints.rs
@@ -54,7 +54,11 @@ mod tests {
   }
 
   impl NodeFromNwk for TestNode {
-    fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+    fn from_nwk(
+      name: Option<impl AsRef<str>>,
+      _confidence: Option<f64>,
+      _: &BTreeMap<String, String>,
+    ) -> Result<Self, Report> {
       Ok(Self {
         name: name.map(|n| o!(n.as_ref())),
         ..Default::default()

--- a/packages/treetime/src/clock/clock_graph.rs
+++ b/packages/treetime/src/clock/clock_graph.rs
@@ -24,7 +24,11 @@ pub struct NodeClock {
 impl GraphNode for NodeClock {}
 
 impl NodeFromNwk for NodeClock {
-  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+  fn from_nwk(
+    name: Option<impl AsRef<str>>,
+    _confidence: Option<f64>,
+    _: &BTreeMap<String, String>,
+  ) -> Result<Self, Report> {
     Ok(Self {
       name: name.map(|s| s.as_ref().to_owned()),
       ..NodeClock::default()

--- a/packages/treetime/src/commands/optimize/__tests__/test_augur_node_data.rs
+++ b/packages/treetime/src/commands/optimize/__tests__/test_augur_node_data.rs
@@ -72,6 +72,37 @@ mod tests {
     assert_eq!(original, roundtripped);
   }
 
+  // --- Confidence from input tree ---
+
+  #[test]
+  fn test_augur_node_data_optimize_confidence_from_float_label() {
+    let data = helpers::write_and_read("(leaf_a:0.005,leaf_b:0.010)0.999:0.003;");
+
+    assert_eq!(
+      data.nodes["NODE_0000000"].confidence,
+      Some(0.999),
+      "Internal node with float label should emit confidence"
+    );
+    assert!(
+      data.nodes["leaf_a"].confidence.is_none(),
+      "Leaf nodes should not have confidence from float labels"
+    );
+    assert!(
+      data.nodes["leaf_b"].confidence.is_none(),
+      "Leaf nodes should not have confidence from float labels"
+    );
+  }
+
+  #[test]
+  fn test_augur_node_data_optimize_no_confidence_for_text_label() {
+    let data = helpers::write_and_read("(leaf_a:0.005,leaf_b:0.010)root;");
+
+    assert!(
+      data.nodes["root"].confidence.is_none(),
+      "Text-labeled internal node should not have confidence"
+    );
+  }
+
   // --- Divergence units: mutations mode ---
 
   #[test]

--- a/packages/treetime/src/commands/optimize/augur_node_data.rs
+++ b/packages/treetime/src/commands/optimize/augur_node_data.rs
@@ -34,9 +34,8 @@ use util_augur_node_data_json::{
 ///   `branch_length` for cumulative divergence when `mutation_length` is absent.
 ///   The root has no incoming edge, so it carries `0.0` (the field is
 ///   non-optional; `export v2` sets the root divergence to 0 regardless).
-/// - `confidence` is omitted: v1's Newick reader does not parse input-tree branch
-///   support values (shared gap with `timetree`, tracked in
-///   `kb/issues/N-timetree-node-data-confidence-not-emitted.md`).
+/// - `confidence` = input-tree branch support (bootstrap/posterior) parsed from bare
+///   numeric labels on internal nodes via the Biopython heuristic.
 ///
 /// When `mutation_counts` is `Some`, `branch_length` is set to the per-edge
 /// mutation count instead of the ML branch length (subs/site).

--- a/packages/treetime/src/commands/optimize/augur_node_data.rs
+++ b/packages/treetime/src/commands/optimize/augur_node_data.rs
@@ -72,12 +72,13 @@ pub fn build_augur_node_data_json(
       None => 0.0,
     };
 
+    let confidence = payload.confidence;
+
     nodes.insert(
       node_name,
       AugurNodeDataJsonRefineNode {
         branch_length,
-        // optimize emits no temporal or confidence fields.
-        confidence: None,
+        confidence,
         numdate: None,
         clock_length: None,
         mutation_length: None,

--- a/packages/treetime/src/commands/shared/__tests__/test_output_resolution.rs
+++ b/packages/treetime/src/commands/shared/__tests__/test_output_resolution.rs
@@ -304,6 +304,7 @@ mod tests {
   impl NodeFromNwk for TestNode {
     fn from_nwk(
       name: Option<impl AsRef<str>>,
+      _confidence: Option<f64>,
       _: &std::collections::BTreeMap<String, String>,
     ) -> Result<Self, eyre::Report> {
       Ok(Self {

--- a/packages/treetime/src/commands/shared/output.rs
+++ b/packages/treetime/src/commands/shared/output.rs
@@ -877,7 +877,11 @@ impl Named for OrderNode {
 }
 
 impl NodeFromNwk for OrderNode {
-  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+  fn from_nwk(
+    name: Option<impl AsRef<str>>,
+    _confidence: Option<f64>,
+    _: &BTreeMap<String, String>,
+  ) -> Result<Self, Report> {
     Ok(Self {
       name: name.map(|name| name.as_ref().to_owned()),
     })

--- a/packages/treetime/src/commands/timetree/output/augur_node_data.rs
+++ b/packages/treetime/src/commands/timetree/output/augur_node_data.rs
@@ -110,12 +110,13 @@ pub fn build_augur_node_data_json(
     let date = numdate.map(year_fraction_to_datestring);
     let num_date_confidence = ci_map.as_ref().and_then(|ci_map| ci_map.get(&node_key).copied());
 
+    let confidence = payload.base.confidence;
+
     nodes.insert(
       node_name,
       AugurNodeDataJsonRefineNode {
         branch_length,
-        // v1 does not parse input-tree branch support values, so confidence is omitted.
-        confidence: None,
+        confidence,
         numdate,
         clock_length,
         mutation_length,

--- a/packages/treetime/src/payload/ancestral.rs
+++ b/packages/treetime/src/payload/ancestral.rs
@@ -13,12 +13,19 @@ pub type GraphAncestral = Graph<NodeAncestral, EdgeAncestral, ()>;
 pub struct NodeAncestral {
   pub name: Option<String>,
   pub desc: Option<String>,
+  /// Input-tree branch support / bootstrap / posterior probability.
+  pub confidence: Option<f64>,
 }
 
 impl NodeFromNwk for NodeAncestral {
-  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+  fn from_nwk(
+    name: Option<impl AsRef<str>>,
+    confidence: Option<f64>,
+    _: &BTreeMap<String, String>,
+  ) -> Result<Self, Report> {
     Ok(Self {
       name: name.map(|s| s.as_ref().to_owned()),
+      confidence,
       ..NodeAncestral::default()
     })
   }

--- a/packages/treetime/src/payload/timetree.rs
+++ b/packages/treetime/src/payload/timetree.rs
@@ -114,9 +114,13 @@ impl TimeConstraint<Arc<Distribution>> for NodeTimetree {
 impl DateConstraintNode for NodeTimetree {}
 
 impl NodeFromNwk for NodeTimetree {
-  fn from_nwk(name: Option<impl AsRef<str>>, comments: &BTreeMap<String, String>) -> Result<Self, Report> {
+  fn from_nwk(
+    name: Option<impl AsRef<str>>,
+    confidence: Option<f64>,
+    comments: &BTreeMap<String, String>,
+  ) -> Result<Self, Report> {
     Ok(Self {
-      base: NodeAncestral::from_nwk(name, comments)?,
+      base: NodeAncestral::from_nwk(name, confidence, comments)?,
       ..NodeTimetree::default()
     })
   }

--- a/packages/treetime/src/prune/__tests__/test_prune.rs
+++ b/packages/treetime/src/prune/__tests__/test_prune.rs
@@ -455,11 +455,11 @@ mod tests {
 
     let root = graph.add_node(NodeAncestral {
       name: Some("root".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let a = graph.add_node(NodeAncestral {
       name: Some("A".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
 
     graph.add_edge(
@@ -991,19 +991,19 @@ mod tests {
 
     let root = graph.add_node(NodeAncestral {
       name: Some("root".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let internal = graph.add_node(NodeAncestral {
       name: Some("internal".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let a = graph.add_node(NodeAncestral {
       name: Some("A".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let b = graph.add_node(NodeAncestral {
       name: Some("B".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
 
     // Root -> internal has branch length, internal -> A has None
@@ -1063,19 +1063,19 @@ mod tests {
 
     let root = graph.add_node(NodeAncestral {
       name: Some("root".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let internal = graph.add_node(NodeAncestral {
       name: Some("internal".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let a = graph.add_node(NodeAncestral {
       name: Some("A".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let b = graph.add_node(NodeAncestral {
       name: Some("B".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
 
     // Root -> internal has None, internal -> A has Some
@@ -1134,19 +1134,19 @@ mod tests {
 
     let root = graph.add_node(NodeAncestral {
       name: Some("root".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let internal = graph.add_node(NodeAncestral {
       name: Some("internal".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let a = graph.add_node(NodeAncestral {
       name: Some("A".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
     let b = graph.add_node(NodeAncestral {
       name: Some("B".to_owned()),
-      desc: None,
+      ..NodeAncestral::default()
     });
 
     graph.add_edge(root, internal, EdgeAncestral { branch_length: None })?;

--- a/packages/treetime/src/test_utils/graph_fixtures.rs
+++ b/packages/treetime/src/test_utils/graph_fixtures.rs
@@ -21,7 +21,11 @@ impl Named for TestNode {
 }
 
 impl NodeFromNwk for TestNode {
-  fn from_nwk(name: Option<impl AsRef<str>>, _: &BTreeMap<String, String>) -> Result<Self, Report> {
+  fn from_nwk(
+    name: Option<impl AsRef<str>>,
+    _confidence: Option<f64>,
+    _: &BTreeMap<String, String>,
+  ) -> Result<Self, Report> {
     Ok(Self(name.map(|n| n.as_ref().to_owned())))
   }
 }

--- a/packages/util-newick/src/__tests__/test_parse.rs
+++ b/packages/util-newick/src/__tests__/test_parse.rs
@@ -4,6 +4,7 @@ mod tests {
   use crate::types::NewickValue;
   use indoc::indoc;
   use pretty_assertions::assert_eq;
+  use rstest::rstest;
 
   #[test]
   fn test_parse_single_leaf() {
@@ -459,6 +460,67 @@ mod tests {
       g.nodes[a_idx].node_attrs.get("note"),
       Some(&NewickValue::String("yes".to_owned()))
     );
+  }
+
+  // Confidence parsing: Biopython heuristic on internal node labels
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::float(        "(A:0.1,B:0.2)0.999:0.3;", (None,          Some(0.999)))]
+  #[case::integer(      "(A,B)100;",                (None,          Some(100.0)))]
+  #[case::zero(         "(A,B)0;",                  (None,          Some(0.0)  ))]
+  #[case::scientific(   "(A,B)1e-5;",               (None,          Some(1e-5) ))]
+  #[case::text_label(   "(A,B)root;",               (Some("root"),  None       ))]
+  #[case::no_label(     "(A,B);",                   (None,          None       ))]
+  #[trace]
+  fn test_parse_confidence_on_root(
+    #[case] nwk: &str,
+    #[case] (expected_name, expected_confidence): (Option<&str>, Option<f64>),
+  ) {
+    let g = newick_from_string(nwk).unwrap();
+    let root = &g.nodes[g.root];
+    assert_eq!(root.name.as_deref(), expected_name);
+    assert_eq!(root.confidence, expected_confidence);
+  }
+
+  #[test]
+  fn test_parse_confidence_not_applied_to_leaves() {
+    let g = newick_from_string("(0.999:0.1,B:0.2);").unwrap();
+    let leaf = g.nodes.iter().find(|n| n.name.as_deref() == Some("0.999")).unwrap();
+    assert_eq!(leaf.confidence, None);
+  }
+
+  #[test]
+  fn test_parse_confidence_nested_internals() {
+    let g = newick_from_string("((A,B)0.95:0.1,(C,D)0.80:0.2)0.50;").unwrap();
+    let internals: Vec<_> = g
+      .nodes
+      .iter()
+      .filter(|n| !n.children.is_empty() && n.confidence.is_some())
+      .collect();
+    assert_eq!(internals.len(), 3);
+    assert_eq!(g.nodes[g.root].confidence, Some(0.50));
+  }
+
+  #[test]
+  fn test_parse_confidence_mixed_named_and_float_internals() {
+    let g = newick_from_string("((A,B)clade1:0.1,(C,D)0.90:0.2)root;").unwrap();
+    let clade1 = g.nodes.iter().find(|n| n.name.as_deref() == Some("clade1")).unwrap();
+    assert_eq!(clade1.confidence, None);
+
+    let float_node = g.nodes.iter().find(|n| n.confidence == Some(0.90)).unwrap();
+    assert_eq!(float_node.name, None);
+
+    let root = &g.nodes[g.root];
+    assert_eq!(root.name.as_deref(), Some("root"));
+    assert_eq!(root.confidence, None);
+  }
+
+  #[test]
+  fn test_parse_confidence_roundtrip() {
+    let g = newick_from_string("(A:0.1,B:0.2)0.999;").unwrap();
+    let written = crate::write::newick_to_string(&g, &crate::types::NewickWriteOptions::default()).unwrap();
+    assert_eq!(written, "(A:0.1,B:0.2)0.999;");
   }
 
   #[test]

--- a/packages/util-newick/src/__tests__/test_prop_roundtrip.rs
+++ b/packages/util-newick/src/__tests__/test_prop_roundtrip.rs
@@ -32,6 +32,7 @@ mod tests {
         (
           NewickNodeData {
             name,
+            confidence: None,
             node_attrs,
             raw_comments: Vec::new(),
             hybrid: None,

--- a/packages/util-newick/src/__tests__/test_write.rs
+++ b/packages/util-newick/src/__tests__/test_write.rs
@@ -44,6 +44,7 @@ mod tests {
     attrs.insert("prob".to_owned(), NewickValue::Number(0.95));
     let root = g.add_node(NewickNodeData {
       name: None,
+      confidence: None,
       node_attrs: BTreeMap::new(),
       raw_comments: Vec::new(),
       hybrid: None,
@@ -51,6 +52,7 @@ mod tests {
     });
     let a = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -96,6 +98,7 @@ mod tests {
     attrs.insert("fixed".to_owned(), NewickValue::Boolean(false));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -117,6 +120,7 @@ mod tests {
     );
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -135,6 +139,7 @@ mod tests {
     attrs.insert("label".to_owned(), NewickValue::String("hello, world".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -151,6 +156,7 @@ mod tests {
     let mut g = NewickGraph::new();
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: BTreeMap::new(),
       raw_comments: vec!["[some note]".to_owned()],
       hybrid: None,
@@ -171,6 +177,7 @@ mod tests {
     attrs.insert("T".to_owned(), NewickValue::String("9606".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -280,6 +287,7 @@ mod tests {
     attrs.insert("val".to_owned(), NewickValue::String("TRUE".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -300,6 +308,7 @@ mod tests {
     attrs.insert("id".to_owned(), NewickValue::String("123".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -321,6 +330,7 @@ mod tests {
     attrs.insert("note".to_owned(), NewickValue::String("say \"hello\"".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -345,6 +355,7 @@ mod tests {
     attrs.insert("key".to_owned(), NewickValue::String("a:b".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -383,6 +394,7 @@ mod tests {
     attrs.insert("posterior prob".to_owned(), NewickValue::Number(0.95));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,
@@ -404,6 +416,7 @@ mod tests {
     attrs.insert("k".to_owned(), NewickValue::String("a:b".to_owned()));
     let node = g.add_node(NewickNodeData {
       name: Some("A".to_owned()),
+      confidence: None,
       node_attrs: attrs,
       raw_comments: Vec::new(),
       hybrid: None,

--- a/packages/util-newick/src/parse.rs
+++ b/packages/util-newick/src/parse.rs
@@ -144,6 +144,7 @@ fn visit_leaf(
   let extraction = extract_hybrid(name);
   let node_data = NewickNodeData {
     name: extraction.clean_name,
+    confidence: None,
     node_attrs,
     raw_comments,
     hybrid: extraction.hybrid.clone(),
@@ -184,8 +185,17 @@ fn visit_internal(
   }
 
   let extraction = extract_hybrid(name);
+
+  // Biopython heuristic: bare numeric label on an internal node is branch support,
+  // not a taxon name. Try parse as float; on success, store as confidence and clear name.
+  let (final_name, confidence) = match extraction.clean_name {
+    Some(ref label) if label.parse::<f64>().is_ok() => (None, label.parse::<f64>().ok()),
+    other => (other, None),
+  };
+
   let node_data = NewickNodeData {
-    name: extraction.clean_name,
+    name: final_name,
+    confidence,
     node_attrs,
     raw_comments,
     hybrid: extraction.hybrid.clone(),

--- a/packages/util-newick/src/types.rs
+++ b/packages/util-newick/src/types.rs
@@ -27,6 +27,10 @@ pub struct NewickEdgeEntry {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NewickNodeData {
   pub name: Option<String>,
+  /// Branch support / bootstrap / posterior probability parsed from a bare numeric
+  /// label on an internal node (Biopython heuristic: try parse label as float,
+  /// on success use as confidence and clear name).
+  pub confidence: Option<f64>,
   /// Structured annotations from `[&...]` or `[&&NHX:...]` before `:`.
   pub node_attrs: BTreeMap<String, NewickValue>,
   /// Plain `[text]` comments without `&` prefix, preserved verbatim.
@@ -201,6 +205,7 @@ impl NewickNodeData {
   pub fn new() -> Self {
     Self {
       name: None,
+      confidence: None,
       node_attrs: BTreeMap::new(),
       raw_comments: Vec::new(),
       hybrid: None,
@@ -251,6 +256,7 @@ fn subtree_hash(graph: &NewickGraph, node_idx: usize) -> u64 {
   let mut hasher = DefaultHasher::new();
   let node = &graph.nodes[node_idx];
   node.name.hash(&mut hasher);
+  node.confidence.map(f64::to_bits).hash(&mut hasher);
   node.node_attrs.hash(&mut hasher);
   node.raw_comments.hash(&mut hasher);
   node.hybrid.hash(&mut hasher);
@@ -280,6 +286,7 @@ fn eq_subtree_unordered(g1: &NewickGraph, n1: usize, g2: &NewickGraph, n2: usize
   let nd2 = &g2.nodes[n2];
 
   if nd1.name != nd2.name
+    || nd1.confidence.map(f64::to_bits) != nd2.confidence.map(f64::to_bits)
     || nd1.node_attrs != nd2.node_attrs
     || nd1.raw_comments != nd2.raw_comments
     || nd1.hybrid != nd2.hybrid
@@ -332,6 +339,7 @@ fn eq_subtree_ordered(g1: &NewickGraph, n1: usize, g2: &NewickGraph, n2: usize) 
   let nd2 = &g2.nodes[n2];
 
   if nd1.name != nd2.name
+    || nd1.confidence.map(f64::to_bits) != nd2.confidence.map(f64::to_bits)
     || nd1.node_attrs != nd2.node_attrs
     || nd1.raw_comments != nd2.raw_comments
     || nd1.hybrid != nd2.hybrid

--- a/packages/util-newick/src/write.rs
+++ b/packages/util-newick/src/write.rs
@@ -82,6 +82,10 @@ fn write_name(writer: &mut impl Write, node: &NewickNodeData, is_acceptor: bool)
     if let Some(name) = &node.name {
       return write_label(writer, name);
     }
+    if let Some(confidence) = node.confidence {
+      write!(writer, "{confidence}")?;
+      return Ok(());
+    }
     return Ok(());
   }
 


### PR DESCRIPTION
- Resolves: [kb/issues/N-timetree-node-data-confidence-not-emitted.md](https://github.com/neherlab/treetime/blob/95a244a3/kb/issues/N-timetree-node-data-confidence-not-emitted.md)
- Follow-up to: `fix/nex-double-semicolon`

Internal node labels like `0.999` in Newick trees conventionally represent branch support (bootstrap or posterior probability), not taxon names. Biopython's `NewickIO.py` implements this as a heuristic: try to parse the label as a number; on success, store as confidence and clear the name. v1's parser stored all labels as names regardless, so augur node-data JSON never emitted the `confidence` field for input trees carrying support values.

This adds confidence parsing to the standalone Newick parser using the Biopython heuristic: try to parse internal node labels as a float, store as confidence on success. Leaves are unaffected.

The parsed confidence propagates through `NodeFromNwk` to `NodeAncestral` and into augur node-data JSON. The standalone writer preserves confidence as a label for round-trip fidelity.

### Work items

- [x] Add `confidence: Option<f64>` to `NewickNodeData`, update equality and hash comparisons
- [x] Apply Biopython float-parsing heuristic in `visit_internal` (parser), leaves unchanged
- [x] Write confidence as label in standalone writer for round-trip fidelity
- [x] Extend `NodeFromNwk::from_nwk` with confidence parameter, update all implementations
- [x] Add `confidence: Option<f64>` to `NodeAncestral`, wire through `NodeTimetree`
- [x] Emit parsed confidence in augur node-data JSON for optimize and timetree
- [x] Parameterized tests for confidence parsing, augur propagation, and roundtrip
- [x] Resolve issue: [kb/issues/N-timetree-node-data-confidence-not-emitted.md](https://github.com/neherlab/treetime/blob/95a244a3/kb/issues/N-timetree-node-data-confidence-not-emitted.md)
