### PR TITLE
docs: add I/O proposals, extract issues, clarify artifact types

### DIFF
--- a/kb/README.md
+++ b/kb/README.md
@@ -2,6 +2,10 @@
 
 Shared knowledge base (KB). AI agents and humans collaborate here: documenting progress, tracking issues, recording design decisions, and maintaining project knowledge.
 
+> 💡 ## LLM wiki pattern
+>
+> This knowledge base follows the [LLM wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern: raw source material is compiled by AI agents into structured, cross-linked knowledge articles. The organizing structure is human-defined. AI maintains content within that structure.
+
 ## Motivation
 
 - AI continuity. Sessions start with zero memory. KB persists decisions, defects, and findings so knowledge compounds instead of being rediscovered.
@@ -13,18 +17,18 @@ Shared knowledge base (KB). AI agents and humans collaborate here: documenting p
 
 ## Directories
 
-| Directory                  | Description                                                                                       |
-| -------------------------- | ------------------------------------------------------------------------------------------------- |
-| [`_raw/`](_raw/)           | Human-produced source material (specifications, papers, notes). Read-only for AI.                 |
-| [`algo/`](algo/)           | Algorithm documentation: scientific background, implementation status, v0/v1 locations            |
-| [`decisions/`](decisions/) | Deliberate v1 design choices with rationale (one file per decision)                               |
-| [`features/`](features/)   | Feature parity checklist: `[x]` done, `[/]` partial, `[ ]` not done                               |
-| [`issues/`](issues/)       | Open work items by severity (H/M/N prefix): bugs, missing features, stubs, behavioral differences |
-| [`proposals/`](proposals/) | New features with motivation, impact, and validation plan (pre-implementation)                    |
-| [`reports/`](reports/)     | Research reports on algorithms, optimization methods, and implementation analysis                 |
-| [`tests/`](tests/)         | Test coverage documentation by domain                                                             |
-| [`tickets/`](tickets/)     | Actionable work items derived from issues, ready for execution                                    |
-| [`v0-errata/`](v0-errata/) | Defects in v0 that v1 correctly avoids (2+ evidence sources required)                             |
+| Directory                  | Description                                                                                                                                                                                                                                     |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`_raw/`](_raw/)           | Human-produced source material (specifications, papers, notes). Read-only for AI.                                                                                                                                                               |
+| [`algo/`](algo/)           | Algorithm documentation: scientific background, implementation status, v0/v1 locations                                                                                                                                                          |
+| [`decisions/`](decisions/) | Deliberate v1 design choices with rationale (one file per decision)                                                                                                                                                                             |
+| [`features/`](features/)   | Feature parity checklist: `[x]` done, `[/]` partial, `[ ]` not done                                                                                                                                                                             |
+| [`issues/`](issues/)       | Concrete problems. Severity-prefixed (H/M/N). The working list agents consult before domain work. PREFER independent issues, but entangled problems may share a file when splitting would lose clarity                                          |
+| [`proposals/`](proposals/) | Design documents analyzing a problem space with options and tradeoffs. Source material for issues -- every actionable item in a proposal must be extracted into a separate issue so it is not lost when the proposal is no longer actively read |
+| [`reports/`](reports/)     | Research reports on algorithms, optimization methods, and implementation analysis                                                                                                                                                               |
+| [`tests/`](tests/)         | Test coverage documentation by domain                                                                                                                                                                                                           |
+| [`tickets/`](tickets/)     | Implementation instructions for a coding agent. One task per file, executable in one session without further research or decisions. Derived from issues only when the implementation path is fully decided                                      |
+| [`v0-errata/`](v0-errata/) | Defects in v0 that v1 correctly avoids (2+ evidence sources required)                                                                                                                                                                           |
 
 ## Structure
 
@@ -62,37 +66,16 @@ Every work item falls into exactly one category:
 | `M-`   | Medium     | Wrong results under specific conditions, or missing feature affecting workflows |
 | `N-`   | Negligible | Edge cases, niche missing features, weak assertions, cosmetic                   |
 
+### Proposal lifecycle
+
+- Proposal created during research session with ecosystem survey, design axes, options, tradeoffs
+- Every actionable item extracted into a separate issue in [`issues/`](issues/). Items left only in proposals are effectively invisible to agents
+- User decides per axis. Decided items become tickets (if immediately implementable) or stay as issues (if further research needed)
+- Implemented proposals move to [`decisions/`](decisions/)
+
 ### Ticket lifecycle
 
-- Issue exists in [`issues/`](issues/). Ticket created in [`tickets/`](tickets/) with `## Related issues` linking back.
-- Ticket executed. Both deleted if fully resolved.
-- Partial resolution: update both to reflect remaining work.
-
-## LLM wiki pattern
-
-This knowledge base follows the [LLM wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) pattern: raw source material is compiled by AI agents into structured, cross-linked knowledge articles. The organizing structure is human-defined. AI maintains content within that structure.
-
-### How this KB maps to the canonical pattern
-
-- [`_raw/`](_raw/) = `raw/` in the canonical pattern. Human-curated source documents that AI reads but does not modify.
-- All other directories = compiled wiki. AI-maintained articles derived from raw material, code analysis, and ongoing development.
-- `README.md` per directory = index files. Provide navigation and summary without requiring full-text search.
-- Automated review and lint passes = health checks. Detect inconsistencies, stale content, and quality issues.
-- Ticket resolution cycle = filing outputs back. Findings from code work feed back as new issues, decisions, and proposals.
-
-### Differences from canonical
-
-What this KB adds:
-
-- Severity-tracked issues with H/M/N classification
-- Ticket dispatch layer separating problem acknowledgement from actionable work items
-- Cross-category taxonomy enforcing one category per item
-- Deterministic lint via specialized skills (not just LLM judgment)
-
-What the canonical pattern has that this KB lacks:
-
-- Systematic contradiction detection across the entire KB
-- Automated stale-claim propagation (when one article changes, dependent articles flagged)
-- Claim-level provenance notation (tracing specific claims to source lines)
-
-These are possible future improvements.
+- Issue exists in [`issues/`](issues/). Ticket created in [`tickets/`](tickets/) with `## Related issues` linking back
+- Ticket readiness: all design decisions made, implementation path clear, no open questions requiring user input. An issue with undecided design axes is not ready for a ticket
+- Ticket executed. Both deleted if fully resolved
+- Partial resolution: update both to reflect remaining work

--- a/kb/issues/M-io-sequence-attachment-quadratic.md
+++ b/kb/issues/M-io-sequence-attachment-quadratic.md
@@ -59,7 +59,8 @@ for fasta in aln {
 }
 ```
 
-## Related issues
+## Related
 
-- [Sequence-to-node name matching is unreliable](M-io-sequence-name-matching-unreliable.md) - the matching itself has reliability issues beyond performance
-- [Dense optimize iteration is slow](N-optimize-dense-iteration-slow.md) - other performance concerns
+- [M-io-sequence-name-matching-unreliable.md](M-io-sequence-name-matching-unreliable.md) - the matching itself has reliability issues beyond performance
+- [N-optimize-dense-iteration-slow.md](N-optimize-dense-iteration-slow.md) - other performance concerns
+- Design: [kb/proposals/input-name-matching-validation.md](../proposals/input-name-matching-validation.md) - axis 1 (index lookup) resolves this issue

--- a/kb/issues/M-io-sequence-name-matching-unreliable.md
+++ b/kb/issues/M-io-sequence-name-matching-unreliable.md
@@ -57,6 +57,8 @@ Users with mismatched names must manually edit either the tree or the FASTA file
 - [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md) - related input architecture gap
 - [Optimize command accepts only a single alignment](N-optimize-multi-alignment-input.md) - related input limitation
 
-## Related proposals
+## Related
 
+- [N-io-name-reconciliation-duplicated.md](N-io-name-reconciliation-duplicated.md) - reconciliation logic duplicated across subsystems
+- Design: [kb/proposals/input-name-matching-validation.md](../proposals/input-name-matching-validation.md) - ecosystem survey, four design axes, architecture analysis
 - [Configuration file format for multi-partition analysis](../proposals/config-file-multi-partition.md) - could include explicit name mappings

--- a/kb/issues/N-io-aa-reconstruction-not-gated-on-output-selection.md
+++ b/kb/issues/N-io-aa-reconstruction-not-gated-on-output-selection.md
@@ -1,0 +1,11 @@
+# AA reconstruction runs unconditionally regardless of output selection
+
+When `ReconstructedAaFasta` is not in the resolved output set, the ancestral and timetree commands still run full amino acid reconstruction. The result is computed then discarded.
+
+## Impact
+
+Wasted compute on large alignments with many coding sequences. No correctness issue.
+
+## Fix
+
+Gate the AA reconstruction call on `resolved.contains(&OutputSelection::ReconstructedAaFasta)`. Skip entirely when the output is not selected.

--- a/kb/issues/N-io-graphviz-dot-branch-length-precision.md
+++ b/kb/issues/N-io-graphviz-dot-branch-length-precision.md
@@ -1,0 +1,25 @@
+# Graphviz DOT writer uses Newick precision defaults for edge labels
+
+The Graphviz DOT writer at `packages/treetime-io/src/graphviz.rs` calls `format_weight` with `NwkWriteOptions::default()`. DOT output is for visualization, not data exchange -- full-precision labels like `0.00123456789012345` on every edge make graphs unreadable.
+
+Currently this produces 3-significant-digit labels (matching the Newick default). After the Newick precision default is fixed ([N-io-nwk-writer-3-sigfig-default-truncates-precision.md](N-io-nwk-writer-3-sigfig-default-truncates-precision.md)), the DOT writer would produce full-precision labels unless it sets its own explicit precision.
+
+## Fix
+
+Use explicit precision for visualization output (e.g. 6 significant digits):
+
+```rust
+format_weight(weight, &NwkWriteOptions {
+  weight_significant_digits: Some(6),
+  ..NwkWriteOptions::default()
+})
+```
+
+## Locations
+
+- `packages/treetime-io/src/graphviz.rs`
+
+## Related
+
+- Blocked by: [N-io-nwk-writer-3-sigfig-default-truncates-precision.md](N-io-nwk-writer-3-sigfig-default-truncates-precision.md)
+- Design: [kb/proposals/newick-branch-length-precision.md](../proposals/newick-branch-length-precision.md) (Follow-up section)

--- a/kb/issues/N-io-name-reconciliation-duplicated.md
+++ b/kb/issues/N-io-name-reconciliation-duplicated.md
@@ -1,0 +1,26 @@
+# Name reconciliation logic duplicated across subsystems
+
+FASTA, dates, and mugration each reimplement tree-to-external-data name reconciliation (collect names, diff, report mismatches) at different quality levels:
+
+| Subsystem            | Call site                      | Lookup                      | Batch errors        | Dedup |
+| -------------------- | ------------------------------ | --------------------------- | ------------------- | ----- |
+| FASTA (fitch)        | `fitch.rs:54-101`              | linear scan O(n\*m)         | first miss aborts   | no    |
+| FASTA (marginal)     | `marginal_dense.rs:319-351`    | linear scan O(n\*m)         | first miss aborts   | no    |
+| FASTA (attach)       | `attach.rs:28-89`              | `BTreeSet` O(n log n)       | warnings + count    | no    |
+| Dates                | `date_constraints.rs:21-90`    | `BTreeMap::get` O(log n)    | warnings            | n/a   |
+| Mugration (validate) | `marginal_discrete.rs:214-247` | `IndexSet::difference` O(n) | bidirectional batch | n/a   |
+| Mugration (attach)   | `marginal_discrete.rs:47-90`   | `BTreeMap::get` O(log n)    | via validate above  | n/a   |
+
+The mugration validator is the best implementation (bidirectional batch via `IndexSet::difference`). The FASTA sites are the worst (linear scan, first-miss abort, no dedup). Bug fixes and improvements must be applied to each site independently.
+
+## Impact
+
+- Inconsistent error quality across commands (mugration reports all mismatches; ancestral reports one and aborts)
+- Duplicate detection absent from FASTA sites (silent wrong-data attachment)
+- Future improvements (fuzzy suggestions, normalization) must be applied per site or left incomplete
+
+## Related
+
+- [M-io-sequence-name-matching-unreliable.md](M-io-sequence-name-matching-unreliable.md) -- user-facing defects caused by the poor reimplementations
+- [M-io-sequence-attachment-quadratic.md](M-io-sequence-attachment-quadratic.md) -- O(n\*m) performance in the FASTA sites
+- Design: [kb/proposals/input-name-matching-validation.md](../proposals/input-name-matching-validation.md) (Architecture section, Option B: shared function)

--- a/kb/issues/N-io-nwk-writer-3-sigfig-default-truncates-precision.md
+++ b/kb/issues/N-io-nwk-writer-3-sigfig-default-truncates-precision.md
@@ -12,7 +12,7 @@ float_to_digits(
 
 `0.123456` becomes `0.123`. This silently destroys precision on read-write-read cycles.
 
-Major parsers write higher precision by default: Biopython uses 5 decimal places (`%1.5f`), ETE uses 6 significant digits (`%g`), DendroPy uses 10 digits (`%.10e`), gotree writes full precision.
+Major parsers write higher precision by default: Biopython uses 5 decimal places (`%1.5f`), ETE uses 6 significant digits (`%g`), DendroPy defaults to full precision via Python's `str(float)`, gotree writes full precision. See [kb/proposals/newick-branch-length-precision.md](../proposals/newick-branch-length-precision.md) for a full 10-tool source-verified survey.
 
 ## Impact
 

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -100,6 +100,9 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | I/O          | [Large datasets require all sequences in memory simultaneously](N-io-large-dataset-memory-constraint.md)                                            |
 | Negligible | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                                          |
 | Negligible | I/O          | [Newick writer defaults to 3 significant digits, truncating branch lengths](N-io-nwk-writer-3-sigfig-default-truncates-precision.md)                |
+| Negligible | I/O          | [Graphviz DOT writer uses Newick precision defaults for edge labels](N-io-graphviz-dot-branch-length-precision.md)                                  |
+| Negligible | I/O          | [Name reconciliation logic duplicated across subsystems](N-io-name-reconciliation-duplicated.md)                                                    |
+| Negligible | I/O          | [AA reconstruction runs unconditionally regardless of output selection](N-io-aa-reconstruction-not-gated-on-output-selection.md)                    |
 | Negligible | I/O          | [Edge annotations from Newick not wired into EdgeFromNwk](N-io-edge-annotation-wiring-not-implemented.md)                                           |
 | Negligible | Optimize     | [update_marginal traverses graph twice for mixed partitions](N-optimize-double-graph-traversal-update-marginal.md)                                  |
 | Negligible | Optimize     | [initial_guess_mixed allocates Vec\<Sub\> per edge for count only](N-optimize-initial-guess-alloc.md)                                               |

--- a/kb/proposals/README.md
+++ b/kb/proposals/README.md
@@ -1,6 +1,8 @@
 # Proposals
 
-New v1 features not present in v0. Each proposal records scientific motivation, expected impact, related code, and a validation plan before implementation. Once implemented, the entry moves to [`decisions/`](../decisions/README.md).
+Design documents analyzing a problem space with options and tradeoffs. Each proposal records scientific motivation, expected impact, ecosystem survey, design axes with options, and a validation plan. Once implemented, the entry moves to [`decisions/`](../decisions/README.md).
+
+Proposals are source material for issues, not self-executing plans. Every actionable item in a proposal must be extracted into a separate issue in [`issues/`](../issues/README.md) so it is tracked in the daily workflow. Items left only in proposals are effectively invisible to agents.
 
 v0 features not yet implemented belong in [`issues/`](../issues/README.md) (all types) and [`algo/unimplemented.md`](../algo/unimplemented.md) (algorithms only), not here.
 
@@ -22,6 +24,8 @@ v0 features not yet implemented belong in [`issues/`](../issues/README.md) (all 
 | I/O       | [Configuration file format for multi-partition analysis](config-file-multi-partition.md)                                                         | Multi-segment genomes, mixed data types, per-partition models                            |
 | I/O       | ~~Output format selection for tree-writing commands~~ [implemented](output-format-selection.md)                                                  | Three-tier output: format enum with NWK style variants, per-file flags, selection filter |
 | I/O       | [Unified input format support for analysis commands](unified-input-format-support.md)                                                            | Bypass name matching via Auspice/MAT/PhyloXML direct input                               |
+| I/O       | [Input name matching and validation](input-name-matching-validation.md)                                                                          | Index lookup, batch errors, duplicate detection, fuzzy suggestions, normalization        |
+| I/O       | [Newick branch length precision](newick-branch-length-precision.md)                                                                              | Full-precision default for branch lengths, replacing 3-sigfig truncation                 |
 | Optimize  | ~~Model-aware zero-branch shortcut~~ [implemented](../decisions/optimize-model-aware-zero-branch-shortcut.md)                                    | Restrict derivative shortcut to unimodal models                                          |
 | Optimize  | [Indel model alternatives](optimize-indel-model-alternatives.md)                                                                                 | Length-weighted, separate ins/del, affine-inspired indel models                          |
 | Optimize  | [Per-iteration indel rate re-estimation](optimize-indel-rate-per-iteration-reestimation.md)                                                      | Restore ECM coordinate-ascent re-estimation of indel rate                                |

--- a/kb/proposals/input-name-matching-validation.md
+++ b/kb/proposals/input-name-matching-validation.md
@@ -1,0 +1,596 @@
+# Input name matching and validation for tree-data reconciliation
+
+Analysis commands reconcile names between independent input sources: tree leaf names (Newick), sequence names (FASTA), date labels (metadata TSV), and trait labels (metadata TSV). This reconciliation has correctness defects, poor diagnostics, and a performance regression relative to v0. This proposal introduces indexed lookup, batch error reporting, duplicate detection, and optional fuzzy suggestions as four independent improvements.
+
+## Problem
+
+### Defective call sites
+
+Six call sites perform name reconciliation. Three have known defects:
+
+| Call site                                                                                                    | Lookup                      | Batch errors           | Duplicate detection   |
+| ------------------------------------------------------------------------------------------------------------ | --------------------------- | ---------------------- | --------------------- |
+| `fitch.rs:54-101` [[src](../../packages/treetime/src/ancestral/fitch.rs#L54-L101)]                           | linear scan O(n\*m)         | no (first miss aborts) | no                    |
+| `marginal_dense.rs:319-351` [[src](../../packages/treetime/src/partition/marginal_dense.rs#L319-L351)]       | linear scan O(n\*m)         | no (first miss aborts) | no                    |
+| `attach.rs:28-89` [[src](../../packages/treetime/src/ancestral/attach.rs#L28-L89)]                           | `BTreeSet` O(n log n)       | warnings + count       | no                    |
+| `date_constraints.rs:21-90` [[src](../../packages/treetime/src/clock/date_constraints.rs#L21-L90)]           | `BTreeMap::get` O(log n)    | warnings               | n/a (map keys unique) |
+| `marginal_discrete.rs:214-247` [[src](../../packages/treetime/src/partition/marginal_discrete.rs#L214-L247)] | `IndexSet::difference` O(n) | bidirectional batch    | n/a (map keys unique) |
+| `marginal_discrete.rs:47-90` [[src](../../packages/treetime/src/partition/marginal_discrete.rs#L47-L90)]     | `BTreeMap::get` O(log n)    | via validate above     | n/a                   |
+
+The two sequence attachment functions (`fitch.rs` and `marginal_dense.rs`) use `aln.iter().find(|fasta| fasta.seq_name == leaf_name)` -- a linear scan per leaf node, yielding O(n\*m) total comparisons where n = leaves and m = sequences. They abort on the first unmatched name, forcing the user to fix one mismatch at a time and re-run. Neither detects duplicate names in the input, so duplicate tree leaves silently receive the first matching sequence and duplicate FASTA names silently shadow each other.
+
+The mugration validator `validate_trait_names` (`marginal_discrete.rs:214-247` [[src](../../packages/treetime/src/partition/marginal_discrete.rs#L214-L247)]) already solves all three problems: it uses `IndexSet::difference` for O(n) bidirectional batch reporting. This is the internal model the sequence attachment sites should follow.
+
+### Performance regression from v0
+
+v0 stores the alignment as a Python `dict` keyed by name (`treeanc.py:395-444` [[src](../../packages/legacy/treetime/treetime/treeanc.py#L395-L444)]), giving O(1) lookup per leaf. v1's linear scan is a regression:
+
+| Sequences | v1 current (linear scan) | v0 / indexed  |
+| --------- | ------------------------ | ------------- |
+| 1,000     | 1,000,000 comparisons    | 1,000 lookups |
+| 10,000    | 100,000,000              | 10,000        |
+| 100,000   | 10,000,000,000           | 100,000       |
+| 1,000,000 | 1,000,000,000,000        | 1,000,000     |
+
+Pandemic-scale datasets reach millions of sequences (SARS-CoV-2 phylogenetics with UShER processes 14M+ genomes). The quadratic loop becomes the dominant cost before any phylogenetic algorithm runs.
+
+### Poor diagnostic quality
+
+Current error on mismatch:
+
+```
+Leaf sequence not found after alignment completion: 'A/California/07/2009'
+```
+
+The user must manually diff thousands of names across tree and FASTA files to find whether the cause is a typo, case mismatch, underscore/space swap, truncation, or entirely wrong file. The error provides no list of near-matches, no count of total failures, and no indication of whether the problem is systematic or isolated.
+
+## Ecosystem survey
+
+Nine phylogenetics tools were inspected at the source level to understand how the ecosystem handles tree-alignment name reconciliation. For each tool, the actual comparison function, duplicate detection logic, and error reporting code were traced in source. Every claim below links to the specific source location.
+
+### Matching semantics
+
+All tools use exact string equality for the primary lookup. Where normalization exists, it is applied symmetrically to both sides as a preprocessing step before the exact match -- not as a fuzzy fallback. This distinction matters: normalization changes which data attaches to which tree node and therefore affects scientific results. Fuzzy suggestions (axis 3 in this proposal) are purely diagnostic and do not change matching behavior.
+
+| Tool        | Comparison                                             | Normalization                             | Source                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------- | ------------------------------------------------------ | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| v0 TreeTime | `name not in dict` (exact)                             | none                                      | [[src](https://github.com/neherlab/treetime/blob/ea8a21a74d8cbfd36466caa89f60e4736621de82/packages/legacy/treetime/treetime/treeanc.py#L395-L444)]                                                                                                                                                                                                                                                                                                                                     |
+| augur       | delegates to v0                                        | space-split for IQ-TREE compat only       | [[src](https://github.com/nextstrain/augur/blob/024292af6daf1f8aae7e8d690bd2f944e1c7322d/augur/align.py#L197-L211)]                                                                                                                                                                                                                                                                                                                                                                                                     |
+| IQ-TREE 2   | exact after `renameString()`                           | non-alphanum -> `_` on both sides         | [[src](https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/utils/tools.cpp#L503-L511)], [[src](https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/tree/phylotree.cpp#L349-L383)]                                                                                                                                                          |
+| BEAST2      | `String.equals()` (exact)                              | none                                      | [[src](https://github.com/CompEvol/beast2/blob/9321c88df6e5e90da4db5c0fc4872576990c015c/src/beast/base/evolution/alignment/Alignment.java#L321)], [[src](https://github.com/CompEvol/beast2/blob/9321c88df6e5e90da4db5c0fc4872576990c015c/src/beast/base/evolution/tree/TreeParser.java#L424)]                           |
+| BEAST v1    | `String.equals()` (exact)                              | FASTA header trim only                    | [[src](https://github.com/beast-dev/beast-mcmc/blob/248263332d365fb97b1df0f5c2d4e28debdaa804/src/dr/evolution/util/TaxonList.java#L114)], [[src](https://github.com/beast-dev/beast-mcmc/blob/248263332d365fb97b1df0f5c2d4e28debdaa804/src/dr/evomodel/treelikelihood/BeagleTreeLikelihood.java#L490)] |
+| MrBayes     | exact after `tolower()`                                | case fold on both sides (always)          | [[src](https://github.com/NBISweden/MrBayes/blob/bb09fffbf9967cba62a4e8af2d487f443e9438d9/src/utils.c#L1707-L1726)]                                                                                                                                                                                                                                                                                                                                                                                                       |
+| DendroPy    | `str.lower()` when `is_case_sensitive=False` (default) | unquoted `_` -> space per Newick standard | [[src](https://github.com/jeetsukumaran/DendroPy/blob/75bc2aea3450ef48a7aba5017551318f6586b0f6/src/dendropy/datamodel/taxonmodel.py#L538)]                                                                                                                                                                                                                                                                                                                                        |
+| gotree      | Go map lookup (exact)                                  | none                                      | [[src](https://github.com/evolbioinfo/gotree/blob/83cca67fdcf64af47f6f3318d3eebdcb417d45a4/tree/tree.go#L454-L468)]                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ETE 4       | Python dict lookup (exact)                             | none                                      | [[src](https://github.com/etetoolkit/ete/blob/9562dfb6a02795dfda3975be5025f83b8dc884b1/ete4/phylo/phylotree.py#L346-L369)]                                                                                                                                                                                                                                                                                                                                                                                   |
+
+IQ-TREE's `renameString()` is the most aggressive normalizer: it replaces any character outside `[A-Za-z0-9_.-]` with `_`, applied to both tree and alignment names at parse time. MrBayes applies `tolower()` unconditionally through its central `StrCmpCaseInsensitive()` function used in all name lookups. DendroPy is the only tool implementing the Newick-standard underscore-to-space rule (`preserve_underscores=False` default in its Newick reader).
+
+### Duplicate detection
+
+| Tool        | Tree duplicates                   | Alignment duplicates                 | Source                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ----------- | --------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MrBayes     | hard error (all contexts)         | hard error                           | [[src](https://github.com/NBISweden/MrBayes/blob/bb09fffbf9967cba62a4e8af2d487f443e9438d9/src/command.c#L7234-L7285)]                                                                                                                                                                                                                                                                                                                                                                            |
+| gotree      | hard error on index build         | n/a                                  | [[src](https://github.com/evolbioinfo/gotree/blob/83cca67fdcf64af47f6f3318d3eebdcb417d45a4/tree/tree.go#L454-L468)]                                                                                                                                                                                                                                                                                                                                                                                 |
+| BEAST2      | hard error (first)                | hard error (first)                   | [[src](https://github.com/CompEvol/beast2/blob/9321c88df6e5e90da4db5c0fc4872576990c015c/src/beast/base/evolution/tree/TreeParser.java#L462-L471)], [[src](https://github.com/CompEvol/beast2/blob/9321c88df6e5e90da4db5c0fc4872576990c015c/src/beast/base/evolution/alignment/Alignment.java#L321)] |
+| IQ-TREE 2   | none                              | batch (sorted adjacent scan)         | [[src](https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/alignment/alignment.cpp#L136-L161)]                                                                                                                                                                                                                                                                                                                                                               |
+| augur       | none                              | batch (sorted set, all dupes listed) | [[src](https://github.com/nextstrain/augur/blob/024292af6daf1f8aae7e8d690bd2f944e1c7322d/augur/io/sequences.py#L506-L540)]                                                                                                                                                                                                                                                                                                                                                              |
+| BEAST v1    | silent dedup in `Taxa.addTaxon()` | none                                 | [[src](https://github.com/beast-dev/beast-mcmc/blob/248263332d365fb97b1df0f5c2d4e28debdaa804/src/dr/evolution/util/TaxonList.java#L114)]                                                                                                                                                                                                                                                                                                                           |
+| v0 TreeTime | none                              | silent (dict key overwrite)          | [[src](https://github.com/neherlab/treetime/blob/ea8a21a74d8cbfd36466caa89f60e4736621de82/packages/legacy/treetime/treetime/treeanc.py#L419)]                                                                                                                                                                                                                                                                                                                     |
+| ETE 4       | error in EvolTree only            | silent auto-rename (`2_name`)        | [[src](https://github.com/etetoolkit/ete/blob/9562dfb6a02795dfda3975be5025f83b8dc884b1/ete4/parser/fasta.py#L8-L50)]                                                                                                                                                                                                                                                                                                                                                                             |
+
+MrBayes and gotree are the strictest: any duplicate name is a hard error. BEAST2 detects duplicates in both sources but reports only the first. IQ-TREE and augur detect alignment duplicates in batch but not tree duplicates. v0, BEAST v1, and ETE handle duplicates silently (overwrite, dedup, or rename), masking data errors.
+
+### Batch error reporting
+
+| Tool        | Behavior                                                                                         | Source                                                                                                                                                                                                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IQ-TREE 2   | bidirectional batch: all alignment-not-in-tree + all tree-not-in-alignment reported before abort | [[src](https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/tree/phylotree.cpp#L349-L383)]                                                             |
+| augur       | batch for FASTA duplicates (sorted list); one-at-a-time elsewhere                                | [[src](https://github.com/nextstrain/augur/blob/024292af6daf1f8aae7e8d690bd2f944e1c7322d/augur/io/sequences.py#L506-L540)]                                                  |
+| BEAST2      | set-difference warnings (non-fatal, both directions); one-at-a-time for hard errors              | [[src](https://github.com/CompEvol/beast2/blob/9321c88df6e5e90da4db5c0fc4872576990c015c/src/beast/base/evolution/tree/TreeParser.java#L162-L181)] |
+| v0 TreeTime | per-leaf warning + cumulative count + abort when >1/3 missing                                    | [[src](https://github.com/neherlab/treetime/blob/ea8a21a74d8cbfd36466caa89f60e4736621de82/packages/legacy/treetime/treetime/treeanc.py#L395-L444)]    |
+| All others  | one-at-a-time (abort on first mismatch)                                                          | see matching semantics table                                                                                                                                                                                                                                                                             |
+
+IQ-TREE's `setAlignment()` is the best implementation: it iterates both directions (alignment -> tree, tree -> alignment), collects all mismatches, and reports them in a single error. This is the external model for batch reporting.
+
+### Fuzzy suggestions
+
+No surveyed tool provides fuzzy matching suggestions for unmatched names. This would be novel in the phylogenetics ecosystem.
+
+### Newick underscore-space standard
+
+The Newick specification (Felsenstein, 1986) states that underscores in unquoted labels represent spaces: "it is assumed that an underscore character stands for a blank; any of these in a name will be converted to a blank when it is read in" ([source](https://phylipweb.github.io/phylip/newicktree.html)). See also [kb/decisions/multi-format-tree-io.md](../decisions/multi-format-tree-io.md).
+
+DendroPy and scikit-bio implement this conversion by default. All other surveyed tools (v0, v1, augur, BEAST, IQ-TREE, gotree, ETE, MrBayes) keep underscores verbatim. The v1 Newick parser does not convert underscores ([[src](https://github.com/neherlab/treetime/blob/ea8a21a74d8cbfd36466caa89f60e4736621de82/packages/util-newick/src/parse.rs)]).
+
+## Design axes
+
+Four independent decision axes. Each can be adopted, deferred, or rejected independently.
+
+### Axis 1: Lookup data structure
+
+Replace linear-scan `.find()` with indexed lookup. Pure performance fix, no behavior change.
+
+The two affected sites are `fitch.rs:72-76` [[src](../../packages/treetime/src/ancestral/fitch.rs#L72-L76)] and `marginal_dense.rs:331-335` [[src](../../packages/treetime/src/partition/marginal_dense.rs#L331-L335)], both using `aln.iter().find(|fasta| fasta.seq_name == leaf_name)`.
+
+| Sequences | Current (linear scan)         | HashMap           |
+| --------- | ----------------------------- | ----------------- |
+| 1,000     | 1,000,000 comparisons         | 1,000 lookups     |
+| 100,000   | 10,000,000,000 comparisons    | 100,000 lookups   |
+| 1,000,000 | 1,000,000,000,000 comparisons | 1,000,000 lookups |
+
+#### Ordering impact of Vec -> HashMap
+
+Replacing `Vec<FastaRecord>` with `HashMap<String, FastaRecord>` destroys insertion order. Code analysis confirms this is safe:
+
+- All leaf-to-sequence matching is by name, not position (`.find()` by `seq_name`)
+- `FastaRecord.index` (set during reading) is unused -- never read in production
+- `complete_alignment_for_leaves` builds a `BTreeSet` from names internally, then appends synthetic records; append position is irrelevant since downstream lookup is by name
+- `create_mask` ORs non-ambiguous positions across all records -- commutative, order-independent
+- `get_common_length` checks all records have equal length -- set check, order-independent
+- Output FASTA order is determined by tree traversal (preorder), not input FASTA order
+- Node data JSON is keyed by `GraphNodeKey`, not by FASTA position
+
+One test generator (`prop_generators/alignment.rs:94`) asserts positional ordering of generated records -- cosmetic, easy to adjust.
+
+#### Where to build the index
+
+The FASTA data flows through three stages:
+
+1. `read_many_fasta()` (`treetime-io/src/fasta.rs` [[src](../../packages/treetime-io/src/fasta.rs)]) produces `Vec<FastaRecord>`
+2. `complete_alignment_for_leaves()` (`attach.rs:28-89` [[src](../../packages/treetime/src/ancestral/attach.rs#L28-L89)]) checks for missing leaves (builds a temporary `BTreeSet` of names internally), appends synthetic ambiguous records for missing tips, returns `Vec<FastaRecord>`
+3. `attach_seqs_to_graph()` / `attach_sequences()` iterates leaves, does the linear `.find()` lookup
+
+##### Option A: Index at attachment boundary
+
+Build `HashMap<&str, &FastaRecord>` inside `attach_seqs_to_graph` and `attach_sequences`, from the incoming `&[FastaRecord]`.
+
+Pros:
+
+- Smallest diff -- changes scoped to two functions
+- No API change, all callers unaffected
+- No risk to downstream consumers of `Vec<FastaRecord>`
+
+Cons:
+
+- `complete_alignment_for_leaves` retains its own redundant `BTreeSet` index
+- FASTA duplicate detection happens late (at attachment, not at read time)
+- Two attachment sites must each build the index independently (duplication)
+
+##### Option B: Index at parse time
+
+Have `read_many_fasta` return `HashMap<String, FastaRecord>`. The indexed representation propagates through the entire pipeline.
+
+Pros:
+
+- Single index, built once, reused everywhere
+- `complete_alignment_for_leaves` uses the map directly -- no redundant `BTreeSet`
+- FASTA duplicates detected at the earliest point (during reading)
+- Cleaner data model: the map enforces name uniqueness structurally
+
+Cons:
+
+- `Vec<FastaRecord>` appears in ~50 files (mostly tests); type change propagates
+- Tests constructing inline alignments need adjustment (build a `HashMap` instead of `vec![]`)
+
+##### Recommendation: Option B
+
+The type change propagation is mechanical (largely `vec![...]` -> map construction in tests). The benefits are structural: duplicate detection at the earliest point, one index instead of three redundant ones (`BTreeSet` in `complete_alignment_for_leaves`, `.find()` in `fitch.rs`, `.find()` in `marginal_dense.rs`), and the data model itself prevents the class of duplication bugs.
+
+### Axis 2: Error collection and reporting
+
+Replace one-at-a-time abort with batch collection and structured error messages. Diagnostic improvement only -- no change to matching semantics.
+
+Pros:
+
+- Users see all problems at once instead of fixing one, re-running, fixing the next
+- Bidirectional reporting (IQ-TREE model) makes systematic causes visible (e.g. all names differ by underscore/space)
+- Duplicate detection prevents silent wrong-sequence attachment -- a correctness defect, not just UX
+- Both the external model (IQ-TREE) and internal model (mugration `validate_trait_names`) already demonstrate this approach
+
+Cons:
+
+- Error messages become longer for large mismatch counts; need truncation for readability
+- Collecting all mismatches before aborting means running the full matching loop even when the first mismatch indicates total failure (wrong file). Mitigated by the >1/3 threshold from v0
+
+Recommendation: implement both 2a and 2b. These are correctness fixes, not optional features.
+
+#### 2a: Batch mismatch reporting
+
+Collect all unmatched names, report in a single error. Bidirectional: both "leaves not in alignment" and "alignment names not in tree", following the patterns of IQ-TREE's `setAlignment()` ([[src](https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/tree/phylotree.cpp#L349-L383)]) externally and mugration's `validate_trait_names` (`marginal_discrete.rs:214-247` [[src](../../packages/treetime/src/partition/marginal_discrete.rs#L214-L247)]) internally.
+
+Example error output:
+
+```
+Name reconciliation failed: 3 tree leaves not in alignment, 2 alignment names not in tree.
+
+Tree leaves not in alignment:
+  'A/California/07/2009'
+  'A/Texas/50/2012'
+  'B/Brisbane/60/2008'
+
+Alignment names not in tree:
+  'A_California_07_2009'
+  'A_Texas_50_2012'
+```
+
+When both sides have unmatched names showing the same transformation pattern (underscore/space, case), the pattern becomes visible in the output, letting the user diagnose systematic causes without manual diffing.
+
+#### 2b: Duplicate detection
+
+During index construction, detect and report duplicate names in both inputs before matching begins. Duplicates in either source are a data error: duplicate tree leaves cause ambiguous sequence attachment, and duplicate FASTA names cause silent shadowing.
+
+Example error output:
+
+```
+Duplicate leaf names in tree: 'USA' (2 occurrences), 'CHN' (3 occurrences)
+Duplicate sequence names in alignment: 'sample_1' (2 occurrences)
+```
+
+Detection is free with `HashMap`: on `insert`, check the return value for a displaced entry. Track collisions in a `Vec<(&str, usize)>` and report all before aborting.
+
+### Axis 3: Fuzzy suggestions for unmatched names
+
+For each unmatched name, compute string similarity against names from the other source and report top-N near-matches in the error message. Advisory only -- matching semantics remain exact. No surveyed tool provides this.
+
+Pros:
+
+- Turns opaque "name not found" errors into actionable diagnostics (shows what the name is close to)
+- Zero risk to correctness -- suggestions are displayed in error output, never used for matching
+- Zero new dependencies (`strsim` already in dependency tree via `clap`)
+- Novel in the phylogenetics ecosystem -- no surveyed tool offers this
+
+Cons:
+
+- O(U \* M) search for U unmatched names against M candidates; requires capping and filtering for large datasets (see performance analysis below)
+- Suggestions can be misleading when names are structurally similar but semantically distinct (`A/California/07/2009` vs `A/California/08/2009` are different strains, not typos)
+- Adds complexity to error formatting code
+
+Recommendation: implement with the capping strategy described below. The UX benefit is high and the risk is zero (advisory only).
+
+#### Algorithm
+
+Taxon names are short strings (10-100 characters, ASCII-dominated). Relevant similarity metrics:
+
+| Metric              | Complexity per pair | Properties                                                                                                                                  |
+| ------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Jaro-Winkler        | O(n)                | Prefix-weighted. Phylogenetic names share long prefixes (`A/California/07/2009` vs `A/California/7/2009`), making this metric a natural fit |
+| Levenshtein         | O(n\*m)             | Edit operations (insert, delete, substitute). Intuitive interpretation                                                                      |
+| Damerau-Levenshtein | O(n\*m)             | Adds transposition. Catches `AB` vs `BA` swaps                                                                                              |
+
+Jaro-Winkler is the recommended primary metric: O(n) per pair, produces a 0-1 similarity score, and prefix weighting aligns with phylogenetic naming conventions where the informative variation is at the end of the name.
+
+#### Dependency
+
+`strsim 0.11.1` is already in the dependency tree as a transitive dependency of `clap` (via the `suggestions` feature, which `clap` uses for "did you mean" hints on mistyped subcommands). Using `strsim` directly adds zero new dependencies to the build. It provides Jaro-Winkler, Levenshtein, Damerau-Levenshtein, and normalized variants.
+
+For higher-throughput needs if profiling identifies a bottleneck:
+
+- `rapidfuzz` (Rust port): `BatchComparator` caches preprocessing for 1-to-many comparisons with `score_cutoff` for early termination
+- `editdistancek`: bounded Levenshtein at O(d \* min(n,m)), sublinear when most pairs are distant
+- `triple_accel`: SIMD-accelerated (AVX2/SSE4.1), `u8`-only, designed for bioinformatics sequence comparison
+
+#### Performance at scale
+
+Fuzzy search runs only for unmatched names, not for all names. Cost is O(U _ M _ c) where U = unmatched count, M = candidate count from the other source, c = per-pair cost.
+
+| Scenario                  | U (unmatched) | M (candidates) | Pairs          | Per-pair cost | Estimated wall time |
+| ------------------------- | ------------- | -------------- | -------------- | ------------- | ------------------- |
+| Few typos, small dataset  | 5             | 1,000          | 5,000          | O(n), n~30    | <1ms                |
+| Few typos, large dataset  | 5             | 100,000        | 500,000        | O(n), n~30    | ~5ms                |
+| Few typos, pandemic scale | 5             | 1,000,000      | 5,000,000      | O(n), n~30    | ~50ms               |
+| Wrong file, all mismatch  | 100,000       | 100,000        | 10,000,000,000 | O(n), n~30    | hours               |
+| Wrong file, capped        | 20 (capped)   | 100,000        | 2,000,000      | O(n), n~30    | ~20ms               |
+
+The "wrong file" scenario (all names unmatched) must be capped. When U exceeds a threshold, the error is systematic, not individual typos. The proposed cap: compute fuzzy suggestions for at most 20 unmatched names. Report all unmatched names in the batch error, but annotate only the first 20 with near-match suggestions.
+
+Additional candidate filtering reduces M per query:
+
+- Length filter: skip candidates differing in length by more than `max(3, len/3)` from the query. For typical taxon names, this eliminates 70-90% of candidates
+- Score threshold: skip candidates scoring below 0.7 Jaro-Winkler similarity (too dissimilar to be useful)
+
+With both filters on a 1M candidate set, effective M per query drops to 10K-100K.
+
+#### Suggestion quality
+
+String similarity does not understand domain structure. `A/California/07/2009` vs `A/California/08/2009` (Jaro-Winkler ~0.98) is a different strain, not a typo. Suggestions can surface misleading near-matches.
+
+Mitigations:
+
+- Suggestions are advisory only -- displayed in error messages, never used for matching
+- Show the similarity score so the user can judge relevance
+- Cap at top-3 per unmatched name to limit noise
+
+### Axis 4: Name normalization
+
+Unlike axes 1-3, this axis changes matching semantics: different inputs succeed that would otherwise fail, and different sequences attach to different nodes. Wrong normalization causes wrong data attachment, which produces wrong phylogenetic results silently.
+
+Pros:
+
+- Solves real-world mismatches that fuzzy suggestions can only diagnose but not fix (user still has to manually edit files)
+- Ecosystem precedent: 2 of 9 surveyed tools normalize case (DendroPy, MrBayes), 1 normalizes characters (IQ-TREE), 2 normalize underscores (DendroPy, scikit-bio)
+- Underscore-space equivalence in particular is the Newick standard, not an invention
+
+Cons:
+
+- Changes which data attaches to which node -- scientific correctness risk if normalization creates false matches
+- Requires post-normalization collision detection (two distinct names folding to the same form)
+- Adds CLI flags and configuration surface area
+- Complicates reasoning about name identity throughout the pipeline (is `Sample_1` the same entity as `Sample 1`?)
+
+Recommendation: 4a and 4b as opt-in CLI flags, off by default. Both require post-normalization collision detection. 4c deferred.
+
+#### 4a: Case-insensitive matching (`--match-case-insensitive`)
+
+Fold both tree and alignment names to lowercase before matching. Precedent: DendroPy (default, [[src](https://github.com/jeetsukumaran/DendroPy/blob/75bc2aea3450ef48a7aba5017551318f6586b0f6/src/dendropy/datamodel/taxonmodel.py#L538)]), MrBayes (always, [[src](https://github.com/NBISweden/MrBayes/blob/bb09fffbf9967cba62a4e8af2d487f443e9438d9/src/utils.c#L1707-L1726)]).
+
+Pros:
+
+- Solves the common `USA` vs `usa` class of mismatch
+- Well-established precedent (2 tools do this by default)
+
+Cons:
+
+- Names that are intentionally case-distinct (`USA` and `usa` as separate taxa) would collide
+- Must detect and error on post-folding collisions
+
+#### 4b: Underscore-space equivalence (`--match-underscore-as-space`)
+
+Treat `_` and ` ` as equivalent in name comparisons. Precedent: DendroPy (`preserve_underscores=False` default), scikit-bio (`convert_underscores=True` default), Newick standard (Felsenstein, 1986).
+
+Two implementation approaches:
+
+- At match time: normalize `_` to ` ` in both map keys and lookup keys before matching. Store original names for output. Scoped to the matching boundary -- name identity unchanged elsewhere in the pipeline
+- At parse time: apply the Newick standard conversion in the Newick reader ([[src](https://github.com/neherlab/treetime/blob/ea8a21a74d8cbfd36466caa89f60e4736621de82/packages/util-newick/src/parse.rs)]). Makes `_`-to-space the default for all Newick inputs, matching DendroPy and scikit-bio. But changes name identity globally, not just at matching
+
+Pros (match-time):
+
+- Scoped -- only affects matching, not downstream name identity
+- Explicit opt-in via CLI flag
+
+Pros (parse-time):
+
+- Newick-standard-compliant by default
+- Consistent with DendroPy and scikit-bio behavior
+- No CLI flag needed
+
+Cons (match-time):
+
+- Non-standard: Newick spec says underscores ARE spaces in unquoted labels; treating them as different is the deviation
+
+Cons (parse-time):
+
+- Changes name identity globally -- output files would contain spaces where input had underscores
+- Breaks round-trip: `tree.nwk` -> parse -> write might produce different names
+- Names with intentional underscores (not representing spaces) would be corrupted
+
+Recommendation: match-time normalization as opt-in flag. The parse-time approach is what the Newick standard specifies, but the ecosystem consensus (7 of 9 tools keep underscores verbatim) suggests that users do not expect underscores to become spaces.
+
+#### 4c: Character normalization (`--match-normalize-names`)
+
+Replace non-alphanumeric characters (except `_`, `-`, `.`) with `_` in both sources before matching. Precedent: IQ-TREE `renameString()` ([[src](https://github.com/Cibiv/IQ-TREE/blob/6776a95f15a2eccda2aa330497291dc246575995/utils/tools.cpp#L503-L511)]).
+
+Pros:
+
+- Handles the broadest class of mismatches (`A/California/07/2009` vs `A_California_07_2009`)
+- Useful for interop with IQ-TREE-generated trees
+
+Cons:
+
+- Highest false-match risk: many semantically distinct names collapse to the same normalized form
+- Only 1 of 9 tools does this (IQ-TREE), and IQ-TREE applies it unconditionally (not opt-in)
+- No concrete user request for this
+
+Recommendation: defer until a concrete user need emerges.
+
+## Generality across input sources
+
+The proposal introduction mentions four input sources (FASTA, dates, traits, tree), but the analysis so far focuses on FASTA+tree. This section examines whether the matching problem is the same across all sources and whether a shared solution is appropriate.
+
+### What varies across reconciliation sites
+
+| Dimension                  | FASTA sequences                         | Date constraints                                         | Mugration traits                         |
+| -------------------------- | --------------------------------------- | -------------------------------------------------------- | ---------------------------------------- |
+| Tree scope                 | leaves only                             | all nodes (leaves + internal)                            | leaves only                              |
+| External source type       | `Vec<FastaRecord>` (unindexed)          | `BTreeMap<String, Option<DateConstraint>>` (pre-indexed) | `BTreeMap<String, String>` (pre-indexed) |
+| Missing leaf in external   | fill with ambiguous if <1/3, else error | mark `bad_branch`, warn                                  | hard error                               |
+| Missing external in tree   | silently ignored                        | warn (unused constraints)                                | hard error                               |
+| Duplicate risk in external | yes (`Vec` allows dupes)                | no (map keys unique)                                     | no (map keys unique)                     |
+| Lookup method              | `.find()` linear scan                   | `BTreeMap::get` O(log n)                                 | `BTreeMap::get` O(log n)                 |
+
+### What is the same
+
+The core operation at every site:
+
+1. Collect tree node names (from a configurable scope: leaves, all nodes)
+2. Collect external data names (from a heterogeneous source)
+3. Compute: matched pairs, unmatched-in-tree, unmatched-in-external, duplicates-in-tree, duplicates-in-external
+4. Optionally compute fuzzy suggestions for unmatched names
+5. Return the reconciliation result; let the caller decide policy (error, warn, fill)
+
+This is a set-reconciliation operation parameterized by policy. The algorithm (index, diff, dedup, suggest) is identical; only the reaction to results differs.
+
+### Current state: three independent reimplementations
+
+- FASTA: worst implementation (linear scan, first-miss abort, no dedup)
+- Dates: middle implementation (pre-indexed input, partial batch reporting via `warn_unused_date_constraints`, no bidirectional mismatch report)
+- Mugration: best implementation (`IndexSet::difference` bidirectional batch, but no dedup because input is already a map, no fuzzy suggestions)
+
+Each site reinvents the name-collection and diff logic. The dates site has its own `warn_unused_date_constraints` function that is essentially a one-directional set-difference. The mugration site's `validate_trait_names` is a bidirectional set-difference. Neither is reusable by the others.
+
+### Architecture options
+
+#### Option A: Fix each site independently
+
+Apply the index+batch+dedup improvements to each site separately, duplicating the logic.
+
+Pros:
+
+- Each site can optimize for its specific types and constraints
+- No abstraction overhead or indirection
+- Simplest diff per site
+
+Cons:
+
+- Three copies of the same algorithm with the same bugs and the same future improvements
+- New reconciliation sites (config file partitions, multi-segment genomes) would need a fourth copy
+- Normalization and fuzzy logic duplicated or absent from some sites
+
+#### Option B: Shared reconciliation function, type-erased
+
+Extract the algorithm into a shared function that operates on two sets of `&str` names. The function knows nothing about `FastaRecord`, `DateConstraint`, or trait values -- it only reconciles name sets and returns the result. Each caller maps its domain types to name sets before calling, and interprets the result (error/warn/fill) after.
+
+```rust
+pub struct ReconciliationResult<'a> {
+    pub matched_tree_names: Vec<&'a str>,
+    pub unmatched_in_tree: Vec<&'a str>,
+    pub unmatched_in_external: Vec<&'a str>,
+    pub duplicate_tree_names: Vec<(&'a str, usize)>,
+    pub duplicate_external_names: Vec<(&'a str, usize)>,
+    pub suggestions: BTreeMap<&'a str, Vec<(&'a str, f64)>>,
+}
+
+pub struct ReconciliationConfig {
+    pub case_insensitive: bool,
+    pub underscore_as_space: bool,
+    pub max_suggestions_per_name: usize,
+    pub max_names_with_suggestions: usize,
+    pub suggestion_threshold: f64,
+}
+
+pub fn reconcile_names<'a>(
+    tree_names: &[&'a str],
+    external_names: &[&'a str],
+    config: &ReconciliationConfig,
+) -> ReconciliationResult<'a>;
+```
+
+Pros:
+
+- One implementation of index, diff, dedup, fuzzy -- tested and maintained once
+- All sites automatically benefit from normalization options and fuzzy suggestions
+- New reconciliation sites (config file, multi-segment) call the same function
+- Type-erased: no dependency on `FastaRecord` or any domain type -- lives in `treetime-utils`
+- Policy stays at the call site where domain knowledge lives (dates: warn+mark-bad; FASTA: fill-or-error; mugration: hard error)
+
+Cons:
+
+- Extra name-extraction step at each call site (collect `&str` names from domain types before calling)
+- Dates site operates on all nodes, not just leaves -- caller must filter the tree scope before calling
+- For pre-indexed sources (`BTreeMap` dates, traits), the function rebuilds an internal `HashMap` from the provided `&[&str]`, which is redundant. Minor cost (O(n) on already-indexed data)
+
+#### Option C: Trait-based reconciliation
+
+Define a `NameSource` trait that abstracts over different input types:
+
+```rust
+pub trait NameSource {
+    fn names(&self) -> Vec<&str>;
+    fn has_duplicates(&self) -> bool;
+}
+```
+
+Implement for `Vec<FastaRecord>`, `BTreeMap<String, T>`, etc. The reconciliation function accepts `impl NameSource` for both sides.
+
+Pros:
+
+- Type-safe: each source type implements its own name extraction
+- Can optimize: `BTreeMap` impl knows keys are unique, skips duplicate check
+
+Cons:
+
+- Trait abstraction for a function that runs once at startup -- overengineered for the use case
+- The trait interface is trivial (just `.names()`) -- a closure or `.iter().map()` achieves the same thing without a trait definition
+- Harder to test: need to construct trait objects instead of plain `&[&str]`
+
+### Recommendation: Option B
+
+The reconciliation algorithm is a pure function on two name sets. The domain-specific types (`FastaRecord`, `DateConstraint`, trait `String`) are irrelevant to the matching logic -- only the names matter. Option B separates the algorithm from the policy cleanly:
+
+- The shared function in `treetime-utils` handles: indexing, dedup detection, bidirectional set-difference, fuzzy suggestions, normalization
+- Each call site handles: extracting names from domain types, choosing tree scope (leaves vs all), interpreting the result (error vs warn vs fill)
+
+This replaces three ad-hoc reimplementations with one tested function, and naturally extends to future input sources.
+
+Proposed location: `packages/treetime-utils/src/reconcile.rs`.
+
+### How input formats affect reconciliation
+
+Not all input paths require name matching. Unified formats embed data in the tree structure, bypassing the reconciliation step entirely. This table maps each format to whether it needs reconciliation for each data type:
+
+| Input format           | Sequences                                        | Dates                       | Traits                          | Name matching needed?                                                                                                         |
+| ---------------------- | ------------------------------------------------ | --------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Newick + FASTA + TSV   | separate file                                    | separate TSV                | separate TSV                    | yes -- all three require name reconciliation                                                                                  |
+| Auspice JSON           | mutations on branches (`branch_attrs.mutations`) | `num_date` in node attrs    | `country` etc. in node attrs    | no -- all data embedded in tree nodes/edges                                                                                   |
+| UShER MAT protobuf     | mutations in preorder                            | not carried                 | not carried                     | no for sequences; yes if dates/traits needed (separate TSV)                                                                   |
+| PhyloXML               | per-clade `<sequence>` elements                  | per-clade `<date>` elements | per-clade `<property>` elements | no -- all data embedded in tree                                                                                               |
+| Nexus + FASTA + TSV    | tree only (TRANSLATE resolves names internally)  | separate TSV                | separate TSV                    | yes for sequences/dates/traits, but Nexus TRANSLATE table handles tree-internal name aliasing                                 |
+| Config file (proposed) | per-partition alignment paths                    | per config                  | per config                      | depends on whether config includes explicit name mappings (see [config-file-multi-partition](config-file-multi-partition.md)) |
+
+Key observations:
+
+- Auspice JSON and PhyloXML are fully self-contained: sequences, dates, and traits are all node/edge attributes. No name matching needed. The reader populates the graph directly
+- UShER MAT carries only mutations. If a timetree analysis needs dates, a separate TSV is still required, and name matching applies to the dates-to-tree reconciliation even though sequences are embedded
+- The Nexus TRANSLATE table is a name-mapping mechanism built into the format: numeric tokens in the Newick string map to full taxon names. The v1 Nexus parser (`util-newick/src/nexus.rs`) already resolves these during parsing. This is not the same as the proposal's normalization (axis 4) -- it's format-level aliasing, handled before matching begins
+- The proposed config file format could include explicit name mappings, making reconciliation configurable per-partition
+
+The reconciliation function from Option B fits naturally: it runs only when the input path requires name matching (Newick+FASTA, or UShER MAT + dates TSV). Unified-format readers skip it entirely. This makes the function a component of the Newick+separate-files input path, not a universal pipeline stage.
+
+## Validation plan
+
+### Correctness
+
+- Existing tests with matching names pass unchanged
+- Duplicate leaf names in tree: error listing all duplicates
+- Duplicate FASTA names: error listing all duplicates
+- Single mismatch: error with fuzzy suggestions
+- Multiple mismatches: batch error listing all, suggestions for first 20
+- Case mismatch (`USA` vs `usa`): exact match fails; suggestion shows the case-different name; `--match-case-insensitive` makes it succeed
+- Underscore/space swap (`Sample_1` vs `Sample 1`): exact match fails; suggestion shows the variant; `--match-underscore-as-space` makes it succeed
+- Post-normalization collision: error even with normalization flags enabled
+
+### Performance targets
+
+- 1K sequences: indexing + matching <1ms
+- 100K sequences: indexing + matching <100ms
+- 1M sequences: indexing + matching <1s
+- 10 unmatched among 100K candidates with fuzzy suggestions: <50ms
+- 10 unmatched among 1M candidates with fuzzy suggestions: <500ms
+- 100K unmatched (wrong file): capped at 20 fuzzy, rest reported without suggestions
+- Benchmark with `criterion` at 1K, 10K, 100K, 1M name sets
+
+### Regression
+
+- Golden master tests for ancestral, timetree, optimize, mugration pass unchanged
+- Error message format changes: update tests that check exact error text
+
+## Implementation order
+
+1. Axis 1 + 2b (index + duplicate detection): combined, since index construction naturally detects duplicates. Fixes the quadratic performance regression and the silent-wrong-data defect
+2. Axis 2a (batch mismatch reporting): requires the index from step 1. Brings sequence attachment to parity with the mugration validator internally and IQ-TREE's `setAlignment()` externally
+3. Axis 3 (fuzzy suggestions): builds on the batch mismatch data from step 2
+4. Axis 4a-4b (normalization): independent CLI flags, can be done in any order after step 1
+
+Steps 1-2 are correctness fixes. Step 3 is a diagnostic improvement. Step 4 changes matching semantics.
+
+## Related
+
+### Issues
+
+- [kb/issues/M-io-sequence-attachment-quadratic.md](../issues/M-io-sequence-attachment-quadratic.md) -- O(n^2) performance, resolved by Axis 1
+- [kb/issues/M-io-sequence-name-matching-unreliable.md](../issues/M-io-sequence-name-matching-unreliable.md) -- source issue for this proposal
+- [kb/issues/M-dates-column-auto-detection-gaps.md](../issues/M-dates-column-auto-detection-gaps.md) -- similar name reconciliation defects in CSV metadata readers
+- [kb/issues/N-io-large-dataset-memory-constraint.md](../issues/N-io-large-dataset-memory-constraint.md) -- large-dataset memory considerations; the name index adds negligible overhead relative to sequence data
+
+### Tickets
+
+- [kb/tickets/io-sequence-name-matching-unreliable.md](../tickets/io-sequence-name-matching-unreliable.md) -- implementation ticket derived from this proposal
+
+### Proposals
+
+- [kb/proposals/config-file-multi-partition.md](config-file-multi-partition.md) -- configuration file format that could include explicit name mappings as an alternative to fuzzy matching
+- [kb/proposals/unified-input-format-support.md](unified-input-format-support.md) -- unified input formats (Auspice JSON, UShER MAT) bypass name matching entirely by embedding sequence data in the tree structure
+
+### Decisions
+
+- [kb/decisions/multi-format-tree-io.md](../decisions/multi-format-tree-io.md) -- documents the Newick underscore-space standard and annotation dialect landscape

--- a/kb/proposals/newick-branch-length-precision.md
+++ b/kb/proposals/newick-branch-length-precision.md
@@ -1,0 +1,195 @@
+# Newick branch length precision
+
+The `treetime-io` Newick writer defaults to 3 significant digits for branch lengths, the lowest precision of any phylogenetic tool surveyed. This silently destroys information on every write cycle. Branch lengths of `0.123456789` become `0.123` -- a 0.4% relative error that compounds across downstream analyses reading v1 output. v0 uses 7 decimal places for divergence trees; the Nextstrain ecosystem (Augur) uses 8 decimal places; four major tools default to full f64 precision.
+
+## Problem
+
+`fn format_weight()` [[src](https://github.com/neherlab/treetime/blob/d9e5936b/packages/treetime-io/src/nwk.rs#L295-L304)] applies a hardcoded `Some(3)` fallback when no precision is configured:
+
+```rust
+pub fn format_weight(weight: f64, options: &NwkWriteOptions) -> String {
+  float_to_digits(
+    weight,
+    options.weight_significant_digits.or(Some(3)),  // <- hardcoded 3
+    options.weight_decimal_digits,
+  )
+}
+```
+
+`struct NwkWriteOptions` [[src](https://github.com/neherlab/treetime/blob/d9e5936b/packages/treetime-io/src/nwk.rs#L114-L123)] defaults both `weight_significant_digits` and `weight_decimal_digits` to `None`. All command output flows through `fn write_tree_outputs()` [[src](https://github.com/neherlab/treetime/blob/f5710471/packages/treetime-io/src/graph.rs#L57-L62)] which constructs `NwkWriteOptions::default()`, leaving both fields as `None` and triggering the 3-sigfig fallback. The Graphviz DOT writer [[src](https://github.com/neherlab/treetime/blob/b6c643bd/packages/treetime-io/src/graphviz.rs#L189)] also calls `format_weight` with `NwkWriteOptions::default()`, so it has the same truncation.
+
+A second instance of the same default exists in `fn float_to_digits()` [[src](https://github.com/neherlab/treetime/blob/0535f431/packages/treetime-utils/src/fmt/float.rs#L73-L94)] at line 82: when neither constraint is specified, it also falls back to 3 significant digits. This affects any caller of the general-purpose float formatter.
+
+The standalone `util-newick` crate's `fn format_float()` [[src](https://github.com/neherlab/treetime/blob/d9e5936b/packages/util-newick/src/write.rs)] does not have this problem -- it passes `None`/`None` through to `pretty_dtoa` which then uses full precision.
+
+## Ecosystem survey
+
+All tools inspected from source at commit SHAs listed below. Claims in the original issue file ([kb/issues/N-io-nwk-writer-3-sigfig-default-truncates-precision.md](../issues/N-io-nwk-writer-3-sigfig-default-truncates-precision.md)) that DendroPy uses `%.10e` by default are incorrect -- DendroPy defaults to Python's `str(float)` (full precision).
+
+### Full-precision defaults
+
+| Tool     | Mechanism                                                                                   | Configurable                            | Source                                                                                                                                                                                                                    |
+| -------- | ------------------------------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| gotree   | `strconv.FormatFloat(length, 'f', -1, 64)` -- shortest exact round-trip representation      | no                                      | [[src](https://github.com/evolbioinfo/gotree/blob/83cca67f/tree/node.go#L259)]                                                                                                                                            |
+| BEAST2   | `StringBuilder.append(double)` -> Java `Double.toString()` -- shortest exact representation | yes (`dp` parameter, default -1 = full) | [[src](https://github.com/CompEvol/beast2/blob/9321c88d/src/beast/base/evolution/tree/Node.java#L404)] [[src](https://github.com/CompEvol/beast2/blob/9321c88d/src/beast/base/evolution/TreeWithMetaDataLogger.java#L29)] |
+| BEAST1   | `PrintStream.print(double)` -> `Double.toString()`                                          | yes (`setNumberFormat()`)               | [[src](https://github.com/beast-dev/beast-mcmc/blob/24826333/src/dr/app/tools/NexusExporter.java#L296-L302)]                                                                                                              |
+| DendroPy | `str(float)` -- Python repr, full precision                                                 | yes (`real_value_format_specifier`)     | [[src](https://github.com/jeetsukumaran/DendroPy/blob/ffffe49f/src/dendropy/dataio/newickwriter.py#L189)]                                                                                                                 |
+
+### Fixed-precision defaults
+
+| Tool             | Default                   | Type                                                                                | Configurable                                       | Source                                                                                                                                                                        |
+| ---------------- | ------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IQ-TREE          | 10 decimal places         | `std::fixed` with `precision(10)`                                                   | adaptive (scales with `min_branch_length`)         | [[src](https://github.com/iqtree/iqtree2/blob/6776a95f/tree/mtree.cpp#L430-L447)]                                                                                             |
+| Augur            | 8 decimal places          | `%1.8f`                                                                             | no                                                 | [[src](https://github.com/nextstrain/augur/blob/024292af/augur/tree.py#L564)] [[src](https://github.com/nextstrain/augur/blob/024292af/augur/refine.py#L438)]                 |
+| TreeTime v0      | 7 decimal / 9 significant | `%1.7f` (short aln) or `%1.9e` (long aln); timetree falls back to Biopython `%1.5f` | no                                                 | [src](../../packages/legacy/treetime/treetime/CLI_io.py#L209)                                                                    |
+| RAxML-NG         | 6 decimal places          | `%.*lf` with `RAXML_DEFAULT_PRECISION = 6`                                          | yes (`--precision N`); adaptive with `--brlen-min` | [[src](https://github.com/amkozlov/raxml-ng/blob/d850b2cf/src/io/NewickStream.cpp#L10-L21)] [[src](https://github.com/amkozlov/raxml-ng/blob/d850b2cf/src/constants.hpp#L44)] |
+| MrBayes          | 6 decimal (scientific)    | `%.*le`                                                                             | yes (`set precision=N`, range 3-15)                | [[src](https://github.com/NBISweden/MrBayes/blob/bb09fffb/src/utils.c#L1041-L1051)]                                                                                           |
+| ETE4             | 6 significant digits      | `%g`                                                                                | yes (parser dict)                                  | [[src](https://github.com/etetoolkit/ete/blob/9562dfb6/ete4/parser/newick.pyx#L111)]                                                                                          |
+| Biopython        | 5 decimal places          | `%1.5f`                                                                             | yes (`format_branch_length` kwarg)                 | [[src](https://github.com/biopython/biopython/blob/75bc2aea/Bio/Phylo/NewickIO.py#L281)]                                                                                      |
+| **v1 (current)** | **3 significant digits**  | `pretty_dtoa` with `max_significant_digits(3)`                                      | fields exist but not wired                         | [[src](https://github.com/neherlab/treetime/blob/d9e5936b/packages/treetime-io/src/nwk.rs#L295-L304)]                                                                         |
+
+v1 is the least-precise writer in the survey by a substantial margin.
+
+### Precision comparison on representative branch lengths
+
+| Value       | v1 (3 sig) | v0 (7 dec) | Augur (8 dec) | Full        |
+| ----------- | ---------- | ---------- | ------------- | ----------- |
+| 0.123456789 | 0.123      | 0.1234568  | 0.12345679    | 0.123456789 |
+| 0.00123456  | 0.00123    | 0.0012346  | 0.00123456    | 0.00123456  |
+| 0.0001234   | 0.000123   | 0.0001234  | 0.00012340    | 0.0001234   |
+| 0.99876543  | 0.999      | 0.9987654  | 0.99876543    | 0.99876543  |
+
+## Design decisions
+
+Three independent axes. Each can be decided separately.
+
+### Axis 1: default precision level
+
+What precision does `treetime-io` use when no explicit constraint is set?
+
+#### A. Full precision (shortest round-trip, Ryu-based)
+
+`pretty_dtoa` with no digit limit produces the shortest decimal string that round-trips to the same f64 value (typically 15-17 significant digits, trailing zeros trimmed). This is what `util-newick`'s writer already does.
+
+- Pro: lossless -- write-read-write cycles preserve values exactly
+- Pro: simplest implementation -- remove the fallback, let `pretty_dtoa` do its default
+- Pro: aligns with gotree, BEAST1/2, DendroPy (4 of 10 surveyed tools)
+- Pro: aligns with `util-newick` writer already in this codebase, eliminating inconsistency between the two Newick writers
+- Pro: overshoots v0 rather than undershooting -- strictly more information preserved
+- Con: output files slightly larger (e.g. `0.00123456789012345` vs `0.00123`)
+- Con: output differs visually from v0 (more digits than `%1.7f`)
+
+#### B. Match v0 precision (7 decimal / 9 significant, adaptive)
+
+Replicate v0's `%1.7f` (short alignments) / `%1.9e` (long alignments) logic.
+
+- Pro: golden master tests pass without tolerance adjustments
+- Pro: output visually identical to v0
+- Con: requires alignment-length-dependent formatting logic in the I/O layer, coupling serialization to analysis state
+- Con: still lossy for branch lengths near 1e-7 (7 decimal places truncates `1.23e-8` to `0.0000000`)
+- Con: replicates a Biopython-specific pattern (`%1.7f` / `%1.9e`) with no scientific justification -- the digit count was chosen for Biopython's `format_branch_length` kwarg, not for any precision requirement
+- Con: scientific notation (`%1.9e`) is avoided by IQ-TREE explicitly because "some software does not handle number format like '1.234e-6'" (see `mtree.cpp:462`)
+
+#### C. Fixed high precision (e.g. 8 decimal, matching Augur)
+
+Hardcode a generous fixed-decimal default like `%1.8f`.
+
+- Pro: compact, predictable column widths in output files
+- Pro: matches the Nextstrain ecosystem (Augur uses `%1.8f`)
+- Con: still lossy -- small branch lengths (1e-9, common in large SARS-CoV-2 trees with ~30k sites) truncate to zero with fixed decimal
+- Con: still an arbitrary choice requiring justification
+- Con: fixed-decimal is the wrong unit -- significant digits preserve relative precision across magnitudes, decimal digits do not
+
+#### D. Keep 3 significant digits (status quo)
+
+- Pro: none identified
+- Con: worst precision of any tool surveyed -- the next-lowest is Biopython at 5 decimal places
+- Con: 0.4% relative error on typical branch lengths, destroys small branches entirely
+- Con: contradicts `util-newick` behavior in the same codebase
+
+Recommendation: A (full precision). Serialization should be lossless by default. Truncation is a consumer/display concern, not a writer concern. The `NwkWriteOptions` fields already exist for callers who want explicit truncation.
+
+### Axis 2: scope of the `float_to_digits` fallback fix
+
+The 3-sigfig default exists in two places: `fn format_weight()` in `treetime-io` (`.or(Some(3))`) and `fn float_to_digits()` in `treetime-utils` (line 82 fallback). Fix one or both?
+
+#### A. Fix both
+
+Remove the fallback in both locations: the `.or(Some(3))` in `format_weight` and the `max_significant_digits(3)` default in `float_to_digits`.
+
+- Pro: consistent behavior -- `None` means "no limit" everywhere, matching the API contract implied by `Option<u8>`
+- Pro: the `float_to_digits` fallback is a contract violation: the caller passes `None` ("no constraint") but the function secretly applies a constraint. This is a bug regardless of the precision debate
+- Pro: zero blast radius -- every non-test caller of `float_to_digits` / `float_to_significant_digits` already passes an explicit digit count (verified: `run_loop.rs`, `clock_model.rs`, `rtt_chart_render.rs`, `console.rs`, `console_metrics.rs`, `console_tables.rs`, `domain_agreement.rs`)
+- Con: changes `float_to_digits(x, None, None)` semantics for any future caller that relies on the implicit 3
+
+#### B. Fix only `format_weight`, leave `float_to_digits` fallback
+
+- Pro: narrower change surface
+- Con: leaves a broken API contract in the general-purpose formatter -- `None` secretly means `Some(3)`
+- Con: any future caller of `float_to_digits(x, None, None)` silently gets truncated to 3 significant digits
+- Con: inconsistency between the two layers -- `format_weight` says "no limit" but `float_to_digits` disagrees
+
+Recommendation: A (fix both). The `float_to_digits` fallback is independently wrong as an API contract. `Option::None` should mean "no constraint". No existing caller relies on it.
+
+### Axis 3: CLI configurability
+
+Should precision be exposed as a CLI flag?
+
+#### A. No CLI flag (default full precision, API-only override via `NwkWriteOptions`)
+
+- Pro: simpler CLI surface
+- Pro: full precision is correct for all scientific use cases; truncation is a display/post-processing concern
+- Con: users wanting compact output for visual inspection have no recourse except post-processing
+
+#### B. Add `--precision N` flag (like RAxML-NG `--precision`)
+
+- Pro: 3 of 10 surveyed tools expose this (RAxML-NG, MrBayes, BEAST2)
+- Pro: useful for interop with parsers that struggle with long decimals
+- Con: adds a flag that rarely matters; the correct default should not need overriding
+- Con: requires plumbing through `OutputArgs` -> `NwkWriteOptions`
+
+#### C. Defer CLI flag to a separate ticket
+
+- Pro: keeps this change focused on fixing the bad default
+- Pro: `NwkWriteOptions` fields already exist for programmatic use; CLI wiring is independent work
+- Pro: no user has requested configurable precision -- solve the concrete problem first
+- Con: if a user does need truncated output, they must wait for a follow-up
+
+Recommendation: C (defer). The fix is removing a bad default. CLI exposure is orthogonal and should be tracked separately if a use case arises.
+
+### Combined recommendation
+
+A1 + A2 + C3: full precision default, fix both fallback sites, defer CLI flag.
+
+Two-line code change: remove `.or(Some(3))` in `nwk.rs:301`, remove the `max_significant_digits(3)` fallback in `float.rs:82`. Zero blast radius on existing callers. Aligns `treetime-io` with `util-newick`'s existing full-precision behavior.
+
+## Follow-up: Graphviz DOT writer
+
+The Graphviz DOT writer [[src](https://github.com/neherlab/treetime/blob/b6c643bd/packages/treetime-io/src/graphviz.rs#L189)] also calls `format_weight` with `NwkWriteOptions::default()`. DOT output is for visualization, not data exchange -- full-precision labels like `0.00123456789012345` on every edge make graphs unreadable. After the default changes to full precision, the DOT writer should use its own truncated precision (e.g. 6 significant digits):
+
+```rust
+format_weight(weight, &NwkWriteOptions {
+  weight_significant_digits: Some(6),
+  ..NwkWriteOptions::default()
+})
+```
+
+## Impact
+
+- All analysis commands (ancestral, timetree, clock, optimize, prune, mugration) gain full-precision Newick output
+- Existing `NwkWriteOptions` API is unchanged -- callers setting explicit digit limits see no behavior change
+- Output files grow slightly (a few extra characters per branch length)
+- Downstream tools consuming v1 output receive accurate branch lengths without silent truncation
+
+## Validation
+
+1. Round-trip property test: parse a tree with known branch lengths, write it, re-parse, assert values match within 1 ulp
+2. Golden master comparison: v1 output branch lengths match v0 output within v0's formatting precision (7 decimal places)
+3. Verify `util-newick` standalone writer behavior is unchanged (already full-precision)
+4. Update existing `float_to_digits` test: `float.rs:126` test case `default_behavior` asserts `float_to_digits(1.23456, None, None)` produces `"1.23"` -- must change to expect `"1.23456"` after removing the 3-sigfig fallback
+
+## Related
+
+- Source issue: [kb/issues/N-io-nwk-writer-3-sigfig-default-truncates-precision.md](../issues/N-io-nwk-writer-3-sigfig-default-truncates-precision.md)
+- Newick annotation dialects report: [kb/reports/newick-annotation-dialects.md](../reports/newick-annotation-dialects.md)
+- Output format selection (implemented): [kb/proposals/output-format-selection.md](output-format-selection.md)

--- a/kb/tickets/io-sequence-attachment-quadratic-complexity.md
+++ b/kb/tickets/io-sequence-attachment-quadratic-complexity.md
@@ -1,4 +1,10 @@
-# Sequence attachment has O(n squared) complexity
+# Fix O(n squared) sequence attachment complexity
+
+## Pending decisions
+
+This ticket is subsumed by [io-sequence-name-matching-unreliable.md](io-sequence-name-matching-unreliable.md) -- axis 1 of the name matching proposal resolves the quadratic scan as part of the index introduction. The architecture decision (where to build the index) blocks both tickets. See [kb/proposals/input-name-matching-validation.md](../proposals/input-name-matching-validation.md).
+
+## Problem
 
 The sequence attachment loop performs a linear search through all sequences for each leaf node, resulting in O(n squared) complexity where n is the number of leaves/sequences.
 

--- a/kb/tickets/io-sequence-name-matching-unreliable.md
+++ b/kb/tickets/io-sequence-name-matching-unreliable.md
@@ -1,4 +1,15 @@
-# Sequence-to-node name matching is unreliable
+# Implement reliable name reconciliation for tree-data attachment
+
+## Pending decisions
+
+This ticket is blocked on design decisions in [kb/proposals/input-name-matching-validation.md](../proposals/input-name-matching-validation.md):
+
+- Architecture: shared reconciliation function (Option B) vs per-site fix (Option A) vs trait-based (Option C)
+- Axis 1: where to build the index (parse time vs attachment boundary)
+- Axis 3: fuzzy suggestions (include or defer)
+- Axis 4a-4b: name normalization flags (include or defer)
+
+## Problem
 
 The current input model reads tree topology from Newick and sequences from FASTA as separate files, then reconciles them by matching sequence names to leaf node names. This name-based matching is inherently fragile.
 
@@ -101,11 +112,8 @@ Users with mismatched names must manually edit either the tree or the FASTA file
 
 ## Related issues
 
-- Source: [M-io-sequence-name-matching-unreliable.md](../issues/M-io-sequence-name-matching-unreliable.md) -- delete after full resolution
-- [Column auto-detection gaps in CSV readers](../issues/M-dates-column-auto-detection-gaps.md) - similar name matching issues for metadata columns
-- [Multi-segment genome input not wired](../issues/N-io-multi-segment-genome-input.md) - related input architecture deficiency
-- [Optimize command accepts only a single alignment](../issues/N-optimize-multi-alignment-input.md) - related input limitation
-
-## Related proposals
-
-- [Configuration file format for multi-partition analysis](../proposals/config-file-multi-partition.md) - could include explicit name mappings
+- Source: [M-io-sequence-name-matching-unreliable.md](../issues/M-io-sequence-name-matching-unreliable.md)
+- Also resolves: [M-io-sequence-attachment-quadratic.md](../issues/M-io-sequence-attachment-quadratic.md)
+- Also resolves: [N-io-name-reconciliation-duplicated.md](../issues/N-io-name-reconciliation-duplicated.md)
+- Related: [M-dates-column-auto-detection-gaps.md](../issues/M-dates-column-auto-detection-gaps.md)
+- Design: [kb/proposals/input-name-matching-validation.md](../proposals/input-name-matching-validation.md)


### PR DESCRIPTION
Newick branch length precision and tree-alignment name matching had known issues but no design analysis. Source-verified ecosystem surveys establish where v1 stands relative to the field: precision default is the lowest of any surveyed tool, and linear-scan attachment is a quadratic regression from v0's dict lookup.

KB artifact type definitions clarified: proposals require item extraction into issues, tickets require all design decisions made.

### Work items

- [x] File proposal: [kb/proposals/newick-branch-length-precision.md](https://github.com/neherlab/treetime/blob/100e0624/kb/proposals/newick-branch-length-precision.md): ecosystem survey of precision defaults, options for v1
- [x] File proposal: [kb/proposals/input-name-matching-validation.md](https://github.com/neherlab/treetime/blob/100e0624/kb/proposals/input-name-matching-validation.md): name reconciliation design with v0 comparison
- [x] Extract issue: [kb/issues/N-io-graphviz-dot-branch-length-precision.md](https://github.com/neherlab/treetime/blob/100e0624/kb/issues/N-io-graphviz-dot-branch-length-precision.md): DOT writer inherits Newick's 3-sigfig default
- [x] Extract issue: [kb/issues/N-io-name-reconciliation-duplicated.md](https://github.com/neherlab/treetime/blob/100e0624/kb/issues/N-io-name-reconciliation-duplicated.md): reconciliation logic duplicated across subsystems
- [x] File issue: [kb/issues/N-io-aa-reconstruction-not-gated-on-output-selection.md](https://github.com/neherlab/treetime/blob/100e0624/kb/issues/N-io-aa-reconstruction-not-gated-on-output-selection.md): AA reconstruction runs unconditionally regardless of output selection
- [x] Cross-reference existing issues and tickets to proposals
- [x] Clarify artifact type definitions in `kb/README.md` and `kb/proposals/README.md`
