### PR TITLE
fix(optimize): clean up bifurcating root preservation

### DIFF
--- a/kb/issues/M-optimize-root-bifurcating-independent-vs-joint.md
+++ b/kb/issues/M-optimize-root-bifurcating-independent-vs-joint.md
@@ -1,0 +1,78 @@
+# Bifurcating root optimization: independent per-edge vs joint arc optimization
+
+## Summary
+
+`fn run_optimize_mixed_inner()` optimizes root-incident edges independently in the per-edge loop, then redistributes the total by the pre-optimization ratio. v0 skips root edges from the per-edge loop and jointly optimizes the total root arc length using profiles from both subtrees. These approaches produce different optimized totals.
+
+Two additional issues in the redistribution logic:
+
+1. Post-loop redistribution unconditionally overrides edges the optimizer set to zero via `is_zero_branch_optimal()`.
+2. The independent optimization is a form of coordinate descent: it converges to the same stationary point as joint optimization across iterations, but the per-iteration total differs from v0's joint optimum.
+
+## Scientific Background
+
+For time-reversible substitution models (JC69, HKY85, GTR), the likelihood depends only on the total distance between the two subtrees adjacent to the root, not on how that distance is partitioned between the two edges (Felsenstein 1981, "Pulley Principle"). The transition probability satisfies $P(t_1) P(t_2) = P(t_1 + t_2)$ for reversible $Q$, making only the sum $t_1 + t_2$ identifiable from sequence data.
+
+Standard phylogenetic tools (RAxML, IQ-TREE, PhyML) operate on unrooted trees to avoid this ambiguity. When operating on rooted trees, the principled approach is to optimize the root arc jointly as a single parameter.
+
+## v0 Behavior
+
+In `fn optimize_tree_marginal()` [[src](https://github.com/neherlab/treetime/blob/1a5c93d4f7929c3cc9302859015a32562dae02fd/packages/legacy/treetime/treetime/treeanc.py#L1317-L1337)], when the root has exactly two children:
+
+1. Captures `total_bl = n1.branch_length + n2.branch_length` and `bl_ratio = n1.branch_length / total_bl`
+2. Constructs profiles from both subtrees: `prof_c = n1.marginal_subtree_LH`, `prof_p = normalize_profile(n2.marginal_subtree_LH * root.marginal_outgroup_LH)`
+3. Calls `optimal_t_compressed((prof_p, prof_c), ...)` once for the total arc length
+4. Applies damping to the total: `update_val = new_bl * (1 - d^(i+1)) + total_bl * d^(i+1)`
+5. Distributes by ratio: `n1.bl = update_val * bl_ratio`, `n2.bl = update_val * (1 - bl_ratio)`
+
+v0 quirk: the loop visits each clade, and both root children satisfy the condition `n.up.up is None and len(n.up.clades) == 2`. The joint optimization block executes twice per iteration (once per child), with updated branch lengths on the second pass but unchanged profiles. This effectively applies double damping to the root arc.
+
+## v1 Behavior
+
+In `fn run_optimize_mixed_inner()` [[src](https://github.com/neherlab/treetime/blob/27ad41454083ddbc09e6ef654063bb3e2b588137/packages/treetime/src/optimize/dispatch.rs#L75-L93)]:
+
+1. Captures ratio from current branch lengths before the loop
+2. Optimizes ALL edges (including both root edges) independently in the per-edge loop
+3. After the loop, reads the independently optimized branch lengths and redistributes the total by the original ratio [[src](https://github.com/neherlab/treetime/blob/27ad41454083ddbc09e6ef654063bb3e2b588137/packages/treetime/src/optimize/dispatch.rs#L232-L238)]
+
+Each root edge's optimization uses the marginal profiles at both endpoints. The root endpoint's profile incorporates information from the other subtree through the message-passing algorithm. So v1 does not use "partial information" -- it uses coordinate descent (optimize $t_0$ with $t_1$ fixed via profiles, then $t_1$ with $t_0$ fixed) rather than joint optimization (optimize $t_{total}$ directly).
+
+## Issue 1: Zero-branch override
+
+If `is_zero_branch_optimal()` determines one root edge should be zero [[src](https://github.com/neherlab/treetime/blob/27ad41454083ddbc09e6ef654063bb3e2b588137/packages/treetime/src/optimize/dispatch.rs#L135-L138)], the post-loop redistribution unconditionally assigns `total * ratio` (non-zero) to that edge, overriding the optimizer's decision. v0 does not have this problem because root edges are excluded from the per-edge loop.
+
+## Issue 2: Coordinate descent vs joint optimization
+
+The likelihood $L = \sum_r [\pi(r) \cdot P(\text{data}_1 | r, t_1) \cdot P(\text{data}_2 | r, t_2)]$ couples $t_1$ and $t_2$ through the root state summation. Optimizing each independently (coordinate descent) converges to the same stationary point as joint optimization across the outer iteration loop, but the per-iteration total $t_1^* + t_2^*$ may differ from v0's joint optimum $t_{total}^*$. The magnitude depends on tree asymmetry and branch lengths.
+
+## Damping Interaction
+
+The ratio IS preserved through damping. Proof: after redistribution, root edges have ratio `r`. The saved pre-optimization values also have ratio `r` (by construction for iteration 1; by induction for subsequent iterations, since the previous iteration's damping preserves the ratio). Per-edge damping computes `damped = w * redistributed + (1-w) * old`, and since both terms have the same ratio, the result does too.
+
+The damped TOTAL differs from v0's damped total because the independently optimized total differs from v0's jointly optimized total. This is a consequence of Issue 2 above, not an independent problem. Fixing Issue 2 (joint optimization) would make the damped totals match.
+
+Formal: let `ratio = old_0 / (old_0 + old_1)`. After redistribution: `edge_0 = total_opt * ratio`. After damping: `damped_0 = w * total_opt * ratio + (1-w) * old_0 = w * total_opt * ratio + (1-w) * ratio * old_total = ratio * (w * total_opt + (1-w) * old_total)`. Similarly for edge_1 with `(1-ratio)`. The damped ratio equals `ratio`. QED.
+
+## Options
+
+1. Match v0: skip both root-incident edges from the per-edge loop, jointly optimize the total root arc length using contributions from both subtrees, distribute by ratio. Resolves both Issue 1 and Issue 2.
+2. Fix Issue 1 only: skip redistribution when either root edge was set to zero. Accept the coordinate descent approach as an intentional change (converges to same point eventually, may take more iterations). Document as a decision.
+3. Current approach unchanged: accept both issues as negligible in practice (the difference may be small for well-behaved trees). Quantify with golden master comparison.
+
+## Per-Iteration Divergence
+
+The independent optimization produces a per-iteration root total that is a reflection of the old total about the joint optimum $t^*$:
+
+$$t_0^* + t_1^* = 2t^* - t_{\text{old}}$$
+
+After damping with weight $d$, the per-iteration divergence from v0 is:
+
+$$v1 - v0 = (1 - d) \cdot (t^* - t_{\text{old}})$$
+
+With the default $d = 0.75$, the excess is $0.25 (t^* - t_{\text{old}})$ per step, contracting as the total approaches $t^*$.
+
+At $d = 0$ (damping disabled, a supported CLI option), the map $s_{n+1} = 2t^* - s_n$ is a pure period-2 reflection that never converges. The loop's `Oscillating` stop criterion would halt at an arbitrary phase of the cycle. Joint optimization (Option 1) makes $t^*$ a true fixed point independent of damping.
+
+## Quantification Needed
+
+Empirical comparison of root branch lengths between v0 and v1 on existing datasets (`flu/h3n2/20`, `ebola`, `zika`) would determine whether the coordinate descent approach produces materially different results or converges quickly enough that the per-iteration difference is negligible.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -73,6 +73,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | GTR          | [Site-specific GTR inference lacks end-to-end test from real tree data](N-gtr-site-specific-e2e-inference-test.md)                                  |
 | Negligible | Partition    | [`infer_dense()` stub always returns false](N-representation-infer-dense-stub.md)                                                                   |
 | Negligible | Partition    | [Dense and sparse partition types have structural and naming asymmetries](N-representation-dense-sparse-partition-asymmetry.md)                     |
+| Medium     | Optimize     | [Bifurcating root optimization: independent per-edge vs joint arc optimization](M-optimize-root-bifurcating-independent-vs-joint.md)                |
 | Medium     | Optimize     | [Optimize per-branch lengths diverge from v0 fixture beyond 10% relative tolerance](M-optimize-gm-per-branch-divergence.md)                         |
 | Medium     | Optimize     | [Sparse branch optimization reads stale Fitch-era states](M-optimize-sparse-stale-fitch-states.md)                                                  |
 | Medium     | GTR          | [Sparse GTR inference mixes MAP mutations with Fitch-era compositions](M-gtr-sparse-composition-stale-after-marginal.md)                            |

--- a/packages/treetime/src/optimize/__tests__/mod.rs
+++ b/packages/treetime/src/optimize/__tests__/mod.rs
@@ -25,5 +25,6 @@ mod test_optimize_method;
 mod test_optimize_method_step_clamping;
 mod test_optimize_zero_sequence_length;
 mod test_pipeline_gtr_normalized;
+mod test_root_preservation;
 mod test_run_optimize_loop;
 mod test_topology_cleanup;

--- a/packages/treetime/src/optimize/__tests__/test_root_preservation.rs
+++ b/packages/treetime/src/optimize/__tests__/test_root_preservation.rs
@@ -1,0 +1,165 @@
+#[cfg(test)]
+mod tests {
+  use crate::alphabet::alphabet::{Alphabet, AlphabetName};
+  use crate::ancestral::marginal::{initialize_marginal, update_marginal};
+  use crate::gtr::get_gtr::{JC69Params, jc69};
+  use crate::optimize::dispatch::run_optimize_mixed_inner;
+  use crate::optimize::params::BranchOptMethod;
+  use crate::partition::marginal_dense::PartitionMarginalDense;
+  use crate::partition::traits::PartitionOptimizeOps;
+  use crate::payload::ancestral::GraphAncestral;
+  use crate::seq::alignment::get_common_length;
+  use approx::assert_abs_diff_eq;
+  use eyre::Report;
+  use indoc::indoc;
+  use parking_lot::RwLock;
+  use std::sync::Arc;
+  use treetime_graph::edge::HasBranchLength;
+  use treetime_io::fasta::read_many_fasta_str;
+  use treetime_io::nwk::nwk_read_str;
+
+  fn setup_dense(
+    newick: &str,
+    fasta: &str,
+  ) -> Result<(GraphAncestral, Vec<Arc<RwLock<dyn PartitionOptimizeOps>>>), Report> {
+    let alphabet = Alphabet::new(AlphabetName::Nuc)?;
+    let aln = read_many_fasta_str(fasta, &alphabet)?;
+    let graph: GraphAncestral = nwk_read_str(newick)?;
+    let gtr = jc69(JC69Params::default())?;
+    let partition = PartitionMarginalDense::new(0, gtr, alphabet, get_common_length(&aln)?);
+    let partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![Arc::new(RwLock::new(partition))];
+    initialize_marginal(&graph, &partitions, &aln)?;
+    update_marginal(&graph, &partitions)?;
+    let mixed: Vec<Arc<RwLock<dyn PartitionOptimizeOps>>> = partitions
+      .into_iter()
+      .map(|p| -> Arc<RwLock<dyn PartitionOptimizeOps>> { p })
+      .collect();
+    Ok((graph, mixed))
+  }
+
+  fn root_edge_branch_lengths(graph: &GraphAncestral) -> (f64, f64) {
+    let root = graph.get_exactly_one_root().unwrap();
+    let children = graph.children_of(&root.read_arc());
+    assert_eq!(children.len(), 2);
+    let bl0 = children[0]
+      .1
+      .read_arc()
+      .payload()
+      .read_arc()
+      .branch_length()
+      .unwrap_or(0.0);
+    let bl1 = children[1]
+      .1
+      .read_arc()
+      .payload()
+      .read_arc()
+      .branch_length()
+      .unwrap_or(0.0);
+    (bl0, bl1)
+  }
+
+  #[rustfmt::skip]
+  const BIFURCATING_TREE: &str = "((A:0.05,B:0.05)AB:0.15,(C:0.05,D:0.05)CD:0.05)root:0.0;";
+
+  // Subtree AB has A/G at variable sites, subtree CD has T/C.
+  // This ensures the root arc carries real substitution signal and is not zero-optimal.
+  const ALIGNMENT: &str = indoc! {r#"
+    >A
+    ACGTACGTAAGGACGT
+    >B
+    ACGTACGTAAGGACGA
+    >C
+    TCGATCGATTCCACGT
+    >D
+    TCGATCGATTCCACGC
+  "#};
+
+  #[test]
+  fn test_root_preservation_ratio_preserved_after_optimization() -> Result<(), Report> {
+    let (graph, partitions) = setup_dense(BIFURCATING_TREE, ALIGNMENT)?;
+
+    let (bl0_before, bl1_before) = root_edge_branch_lengths(&graph);
+    let total_before = bl0_before + bl1_before;
+    let ratio_before = bl0_before / total_before;
+
+    run_optimize_mixed_inner(&graph, &partitions, BranchOptMethod::BrentSqrt, 0.0, true)?;
+
+    let (bl0_after, bl1_after) = root_edge_branch_lengths(&graph);
+    let total_after = bl0_after + bl1_after;
+    let ratio_after = bl0_after / total_after;
+
+    assert_abs_diff_eq!(ratio_before, ratio_after, epsilon = 1e-12);
+    assert!(total_after > 0.0, "optimized total should be positive");
+    Ok(())
+  }
+
+  #[test]
+  fn test_root_preservation_both_edges_zero_uses_equal_split() -> Result<(), Report> {
+    let tree = "((A:0.1,B:0.2)AB:0.0,(C:0.15,D:0.12)CD:0.0)root:0.0;";
+    let (graph, partitions) = setup_dense(tree, ALIGNMENT)?;
+
+    run_optimize_mixed_inner(&graph, &partitions, BranchOptMethod::BrentSqrt, 0.0, true)?;
+
+    let (bl0, bl1) = root_edge_branch_lengths(&graph);
+    let total = bl0 + bl1;
+    assert!(
+      total > 0.0,
+      "optimizer should produce positive total from zero-start edges"
+    );
+    let ratio = bl0 / total;
+    assert_abs_diff_eq!(ratio, 0.5, epsilon = 1e-12);
+    Ok(())
+  }
+
+  #[test]
+  fn test_root_preservation_skips_trifurcating_root() -> Result<(), Report> {
+    let tree = "((A:0.05,B:0.05)AB:0.1,(C:0.05,D:0.05)CD:0.1,(E:0.05,F:0.05)EF:0.1)root:0.0;";
+    let fasta = indoc! {r#"
+      >A
+      AAAAACGTACGTACGT
+      >B
+      AAAAACGTACGTACGA
+      >C
+      CCCCACGTACGTACGG
+      >D
+      CCCCACGTACGTACGC
+      >E
+      GGGGACGTACGTACGT
+      >F
+      GGGGACGTACGTACGA
+    "#};
+    let (graph, partitions) = setup_dense(tree, fasta)?;
+
+    {
+      let root = graph.get_exactly_one_root()?;
+      let children = graph.children_of(&root.read_arc());
+      assert_eq!(children.len(), 3);
+    }
+
+    // Trifurcating root: redistribution is skipped (only applies to len==2).
+    // The function should complete without error.
+    run_optimize_mixed_inner(&graph, &partitions, BranchOptMethod::BrentSqrt, 0.0, true)?;
+    Ok(())
+  }
+
+  #[test]
+  fn test_root_preservation_asymmetric_ratio() -> Result<(), Report> {
+    let tree = "((A:0.05,B:0.05)AB:0.9,(C:0.05,D:0.05)CD:0.01)root:0.0;";
+    let (graph, partitions) = setup_dense(tree, ALIGNMENT)?;
+
+    let (bl0_before, bl1_before) = root_edge_branch_lengths(&graph);
+    let total_before = bl0_before + bl1_before;
+    let ratio_before = bl0_before / total_before;
+
+    assert!(ratio_before > 0.9, "pre-condition: asymmetric ratio");
+
+    run_optimize_mixed_inner(&graph, &partitions, BranchOptMethod::BrentSqrt, 0.0, true)?;
+
+    let (bl0_after, bl1_after) = root_edge_branch_lengths(&graph);
+    let total_after = bl0_after + bl1_after;
+    let ratio_after = bl0_after / total_after;
+
+    assert_abs_diff_eq!(ratio_before, ratio_after, epsilon = 1e-12);
+    Ok(())
+  }
+}

--- a/packages/treetime/src/optimize/dispatch.rs
+++ b/packages/treetime/src/optimize/dispatch.rs
@@ -72,172 +72,190 @@ where
 
   let one_mutation = 1.0 / total_length as f64;
 
-  // Before the optimization loop: if the root has exactly two children, capture the ratio of
-  // their branch lengths. Optimizing each edge independently can shift the root placement, so
-  // after the loop we redistribute the optimized total across both root edges in the same ratio.
-  let root_two_child_state: Option<(Arc<RwLock<Edge<E>>>, Arc<RwLock<Edge<E>>>, f64)> =
-    graph.get_exactly_one_root().ok().and_then(|root| {
-      let root_guard = root.read_arc();
-      let children = graph.children_of(&root_guard);
-      if children.len() == 2 {
-        let (_, edge0) = &children[0];
-        let (_, edge1) = &children[1];
-        let bl0 = edge0.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
-        let bl1 = edge1.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
-        let total = bl0 + bl1;
-        let ratio = if total > 0.0 { bl0 / total } else { 0.5 };
-        Some((Arc::clone(edge0), Arc::clone(edge1), ratio))
-      } else {
-        None
-      }
-    });
+  // For a bifurcating root under reversible models, only the sum of root-edge branch
+  // lengths is identifiable (Pulley Principle). Capture the pre-optimization ratio of the
+  // two root edges; after the per-edge loop, redistribute the optimized total in this ratio.
+  // See kb/issues/M-optimize-root-bifurcating-independent-vs-joint.md
+  let root_state = BifurcatingRootState::capture(graph)?;
 
-  graph.get_edges().iter().try_for_each(|edge_ref| -> Result<(), Report> {
-    let edge_key = edge_ref.read_arc().key();
-    let mut edge = edge_ref.write_arc().payload().write_arc();
-    let mut branch_length = edge.branch_length().unwrap_or(0.0);
+  graph
+    .get_edges()
+    .iter()
+    .try_for_each(|edge_ref| -> Result<(), Report> {
+      let edge_key = edge_ref.read_arc().key();
+      let mut edge = edge_ref.write_arc().payload().write_arc();
+      let mut branch_length = edge.branch_length().unwrap_or(0.0);
 
-    let contributions: Vec<OptimizationContribution> = partitions
-      .iter()
-      .map(|partition| partition.read_arc().create_edge_contribution(edge_key))
-      .collect::<Result<_, _>>()?;
-
-    let indel_count: usize = if no_indels {
-      0
-    } else {
-      partitions
+      let contributions: Vec<OptimizationContribution> = partitions
         .iter()
-        .map(|partition| partition.read_arc().edge_indel_count(edge_key))
-        .sum()
-    };
+        .map(|partition| partition.read_arc().create_edge_contribution(edge_key))
+        .collect::<Result<_, _>>()?;
 
-    // The Poisson log-likelihood derivative diverges at t=0 when k > 0, producing
-    // inf/NaN in Newton's method. Use a non-zero starting point for indel-bearing edges.
-    if branch_length == 0.0 && indel_count > 0 {
-      branch_length = if indel_rate > 0.0 {
-        (indel_count as f64 / indel_rate).max(one_mutation)
+      let indel_count: usize = if no_indels {
+        0
       } else {
-        one_mutation
+        partitions
+          .iter()
+          .map(|partition| partition.read_arc().edge_indel_count(edge_key))
+          .sum()
       };
-    }
 
-    // When branch length is zero and any site has non-positive likelihood at t=0
-    // (mismatched certain states), evaluating ln(site_lh) or dividing by site_lh
-    // produces -inf/inf. Bump to a small positive value so the evaluator operates
-    // in the well-defined domain.
-    if branch_length == 0.0 && !contributions.iter().all(|c| c.all_sites_valid_at_zero()) {
-      branch_length = one_mutation;
-    }
-
-    // When indels are present on this edge, the Poisson derivative at t=0 is +infinity,
-    // so zero branch length is never optimal. Only check the substitution-based criterion
-    // when there are no indels.
-    if indel_count == 0 && is_zero_branch_optimal(&contributions) {
-      edge.set_branch_length(Some(0.0));
-      return Ok(());
-    }
-
-    // Lower bound for Newton/Brent steps on indel-bearing edges. The Poisson derivative
-    // diverges at t=0, so we must prevent the optimizer from landing exactly at zero.
-    let min_branch_length = min_branch_length_for_indels(indel_count, one_mutation);
-
-    let new_branch_length = match method {
-      BranchOptMethod::Brent => brent_inner(
-        branch_length,
-        &contributions,
-        indel_count,
-        indel_rate,
-        min_branch_length,
-        one_mutation,
-      ),
-      BranchOptMethod::BrentSqrt => brent_sqrt_inner(
-        branch_length,
-        &contributions,
-        indel_count,
-        indel_rate,
-        min_branch_length,
-        one_mutation,
-      ),
-      BranchOptMethod::BrentLog => brent_log_inner(
-        branch_length,
-        &contributions,
-        indel_count,
-        indel_rate,
-        min_branch_length,
-        one_mutation,
-      ),
-      BranchOptMethod::Newton => {
-        let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
-        newton_inner(
-          branch_length,
-          &metrics,
-          &contributions,
-          indel_count,
-          indel_rate,
-          min_branch_length,
-          one_mutation,
-        )
-      },
-      BranchOptMethod::NewtonSqrt => {
-        let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
-        newton_sqrt_inner(
-          branch_length,
-          &metrics,
-          &contributions,
-          indel_count,
-          indel_rate,
-          min_branch_length,
-          one_mutation,
-        )
-      },
-      BranchOptMethod::NewtonLog => {
-        // ln(t) requires t > 0; bump zero branch lengths to one_mutation
-        let bl = if branch_length == 0.0 {
-          one_mutation
+      // The Poisson log-likelihood derivative diverges at t=0 when k > 0, producing
+      // inf/NaN in Newton's method. Use a non-zero starting point for indel-bearing edges.
+      if branch_length == 0.0 && indel_count > 0 {
+        branch_length = if indel_rate > 0.0 {
+          (indel_count as f64 / indel_rate).max(one_mutation)
         } else {
-          branch_length
+          one_mutation
         };
-        let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, bl);
-        newton_log_inner(
-          bl,
-          &metrics,
+      }
+
+      // When branch length is zero and any site has non-positive likelihood at t=0
+      // (mismatched certain states), evaluating ln(site_lh) or dividing by site_lh
+      // produces -inf/inf. Bump to a small positive value so the evaluator operates
+      // in the well-defined domain.
+      if branch_length == 0.0 && !contributions.iter().all(|c| c.all_sites_valid_at_zero()) {
+        branch_length = one_mutation;
+      }
+
+      // When indels are present on this edge, the Poisson derivative at t=0 is +infinity,
+      // so zero branch length is never optimal. Only check the substitution-based criterion
+      // when there are no indels.
+      if indel_count == 0 && is_zero_branch_optimal(&contributions) {
+        edge.set_branch_length(Some(0.0));
+        return Ok(());
+      }
+
+      // Lower bound for Newton/Brent steps on indel-bearing edges. The Poisson derivative
+      // diverges at t=0, so we must prevent the optimizer from landing exactly at zero.
+      let min_branch_length = min_branch_length_for_indels(indel_count, one_mutation);
+
+      let new_branch_length = match method {
+        BranchOptMethod::Brent => brent_inner(
+          branch_length,
           &contributions,
           indel_count,
           indel_rate,
           min_branch_length,
           one_mutation,
-        )
-      },
-    }?;
+        ),
+        BranchOptMethod::BrentSqrt => brent_sqrt_inner(
+          branch_length,
+          &contributions,
+          indel_count,
+          indel_rate,
+          min_branch_length,
+          one_mutation,
+        ),
+        BranchOptMethod::BrentLog => brent_log_inner(
+          branch_length,
+          &contributions,
+          indel_count,
+          indel_rate,
+          min_branch_length,
+          one_mutation,
+        ),
+        BranchOptMethod::Newton => {
+          let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
+          newton_inner(
+            branch_length,
+            &metrics,
+            &contributions,
+            indel_count,
+            indel_rate,
+            min_branch_length,
+            one_mutation,
+          )
+        },
+        BranchOptMethod::NewtonSqrt => {
+          let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length);
+          newton_sqrt_inner(
+            branch_length,
+            &metrics,
+            &contributions,
+            indel_count,
+            indel_rate,
+            min_branch_length,
+            one_mutation,
+          )
+        },
+        BranchOptMethod::NewtonLog => {
+          // ln(t) requires t > 0; bump zero branch lengths to one_mutation
+          let bl = if branch_length == 0.0 {
+            one_mutation
+          } else {
+            branch_length
+          };
+          let metrics = evaluate_with_indels(&contributions, indel_count, indel_rate, bl);
+          newton_log_inner(
+            bl,
+            &metrics,
+            &contributions,
+            indel_count,
+            indel_rate,
+            min_branch_length,
+            one_mutation,
+          )
+        },
+      }?;
 
-    // Post-optimization boundary reconciliation. See `reconcile_zero_boundary`
-    // for the full rationale. The input `branch_length` is used to size the
-    // verification grid (the optimizer's output may be clamped to zero or to a
-    // tiny floor like $10^{-12}$ and is unsuitable as an extent).
-    let new_branch_length = reconcile_zero_boundary(
-      new_branch_length,
-      branch_length,
-      &contributions,
-      indel_count,
-      indel_rate,
-      one_mutation,
-    )?;
+      // Post-optimization boundary reconciliation. See `reconcile_zero_boundary`
+      // for the full rationale. The input `branch_length` is used to size the
+      // verification grid (the optimizer's output may be clamped to zero or to a
+      // tiny floor like $10^{-12}$ and is unsuitable as an extent).
+      let new_branch_length = reconcile_zero_boundary(
+        new_branch_length,
+        branch_length,
+        &contributions,
+        indel_count,
+        indel_rate,
+        one_mutation,
+      )?;
 
-    edge.set_branch_length(Some(new_branch_length));
-    Ok(())
-  })?;
+      edge.set_branch_length(Some(new_branch_length));
+      Ok(())
+    })?;
 
-  // After the loop: if the root had exactly two children, redistribute the optimized total
-  // branch length across both root edges in the original ratio to preserve the root placement.
-  if let Some((edge0, edge1, ratio)) = root_two_child_state {
-    let bl0 = edge0.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
-    let bl1 = edge1.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
-    let total = bl0 + bl1;
-    edge0.write_arc().payload().write_arc().set_branch_length(Some(total * ratio));
-    edge1.write_arc().payload().write_arc().set_branch_length(Some(total * (1.0 - ratio)));
+  if let Some(state) = root_state {
+    state.restore();
   }
 
   Ok(())
+}
+
+struct BifurcatingRootState<E: GraphEdge> {
+  edge0: Arc<RwLock<Edge<E>>>,
+  edge1: Arc<RwLock<Edge<E>>>,
+  ratio: f64,
+}
+
+impl<E: GraphEdge + HasBranchLength> BifurcatingRootState<E> {
+  fn capture<N: GraphNode>(graph: &Graph<N, E, ()>) -> Result<Option<Self>, Report> {
+    let root = graph.get_exactly_one_root()?;
+    let children = graph.children_of(&root.read_arc());
+    if children.len() == 2 {
+      let (_, edge0) = &children[0];
+      let (_, edge1) = &children[1];
+      let edge0 = Arc::clone(edge0);
+      let edge1 = Arc::clone(edge1);
+      let bl0 = edge0.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
+      let bl1 = edge1.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
+      let total = bl0 + bl1;
+      let ratio = if total > 0.0 { bl0 / total } else { 0.5 };
+      Ok(Some(Self { edge0, edge1, ratio }))
+    } else {
+      Ok(None)
+    }
+  }
+
+  fn restore(self) {
+    let Self { edge0, edge1, ratio } = self;
+    let mut e0 = edge0.write_arc().payload().write_arc();
+    let mut e1 = edge1.write_arc().payload().write_arc();
+    let total = e0.branch_length().unwrap_or(0.0) + e1.branch_length().unwrap_or(0.0);
+    e0.set_branch_length(Some(total * ratio));
+    e1.set_branch_length(Some(total * (1.0 - ratio)));
+  }
 }
 
 /// Initial estimation of branch lengths for mixed partitions.


### PR DESCRIPTION
Refactoring and test coverage for the root preservation mechanism from #805.

### Changes

- **Error handling**: `get_exactly_one_root().ok()` replaced with `?` -- surfaces invariant violations instead of silently skipping root preservation
- **Structure**: `BifurcatingRootState` struct with `capture()`/`restore()` methods replaces inline pre/post blocks and same-type positional tuple
- **Comment**: restated to reference Pulley Principle invariant with KB cross-reference
- **Tests**: 4 tests covering ratio preservation (moderate + asymmetric ratios), zero-start equal-split fallback, trifurcating root skip

### Open

Independent vs joint root-arc optimization tracked in `kb/issues/M-optimize-root-bifurcating-independent-vs-joint.md` -- v1 optimizes root edges independently (coordinate descent) while v0 jointly optimizes the total arc length. The per-iteration divergence is quantified; resolution options documented in the issue.

- Depends on: #805