### PR TITLE
perf: parallelize independent inference kernels

### DIFF
--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use maplit::btreemap;
 use parking_lot::RwLock;
 use rayon::prelude::*;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
@@ -62,6 +62,10 @@ where
   E: GraphEdge,
   P: PartitionCompressed,
 {
+  let aln_by_name = aln.iter().fold(BTreeMap::new(), |mut records, record| {
+    records.entry(record.seq_name.as_str()).or_insert(record);
+    records
+  });
   for leaf in graph.get_leaves() {
     let leaf_key = leaf.read_arc().key();
     let mut leaf = leaf.read_arc().payload().write_arc();
@@ -70,9 +74,9 @@ where
       make_report!("Expected all leaf nodes to have names, such that they can be matched to their corresponding sequences. But found a leaf node that has no name.")
     })?.as_ref().to_owned();
 
-    let leaf_fasta = aln
-      .iter()
-      .find(|fasta| fasta.seq_name == leaf_name)
+    let leaf_fasta = aln_by_name
+      .get(leaf_name.as_str())
+      .copied()
       // Every leaf has a sequence record after alignment completion.
       .ok_or_else(|| make_report!("Leaf sequence not found after alignment completion: '{leaf_name}'"))?;
 
@@ -114,19 +118,10 @@ where
     let length = partition.length();
     let (nodes, edges) = partition.storage_mut();
     let mut pass = IndexedPass::new(graph, nodes, edges, |_| Ok(SparseNodePartition::empty(&alphabet)))?;
-    let result = pass.try_for_each_backward_frontier(|node_indices, edge_indices, edges, _, completed, frontier| {
-      frontier.par_iter_mut().try_for_each(|slot| {
-        run_fitch_backward_indexed(
-          graph,
-          &alphabet,
-          length,
-          node_indices,
-          edge_indices,
-          edges,
-          completed,
-          slot,
-        )
-      })
+    let result = pass.try_for_each_backward_frontier(|node_indices, _, _, completed, frontier| {
+      frontier
+        .par_iter_mut()
+        .try_for_each(|slot| run_fitch_backward_indexed(graph, &alphabet, length, node_indices, completed, slot))
     });
     let (nodes, edges) = pass.into_maps()?;
     *partition.nodes_mut() = nodes;
@@ -141,10 +136,8 @@ fn run_fitch_backward_indexed<N, E>(
   alphabet: &Alphabet,
   length: usize,
   node_indices: &[Option<usize>],
-  edge_indices: &[Option<usize>],
-  edges: &[RwLock<Option<(treetime_graph::edge::GraphEdgeKey, SparseEdgePartition)>>],
-  completed: &[IndexedPassSlot<SparseNodePartition>],
-  slot: &mut IndexedPassSlot<SparseNodePartition>,
+  completed: &[IndexedPassSlot<SparseNodePartition, SparseEdgePartition>],
+  slot: &mut IndexedPassSlot<SparseNodePartition, SparseEdgePartition>,
 ) -> Result<(), Report>
 where
   N: GraphNode,
@@ -158,20 +151,17 @@ where
   let child_keys = graph.children_of(&graph_node);
   let children = child_keys
     .iter()
-    .map(|(child, edge)| {
+    .map(|(child, _)| {
       let child_key = child.read_arc().key();
       let child_index = node_indices[child_key.as_usize()].expect("Indexed child must have a slot");
-      let child = &completed[child_index].node.seq;
-      let edge_key = edge.read_arc().key();
-      let edge_index = edge_indices[edge_key.as_usize()].expect("Indexed edge must have a slot");
-      let edge = edges[edge_index].read();
-      (child, edge)
+      let child = &completed[child_index];
+      let edge = &child
+        .parent_edge
+        .as_ref()
+        .expect("Non-root indexed node must own its parent edge")
+        .1;
+      (&child.node.seq, edge)
     })
-    .collect_vec();
-
-  let children = children
-    .iter()
-    .map(|(child, edge)| (*child, &edge.as_ref().expect("Indexed edge slot must be populated").1))
     .collect_vec();
 
   let child_non_chars: Vec<&Vec<(usize, usize)>> = children.iter().map(|(c, _)| &c.non_char).collect_vec();
@@ -233,12 +223,11 @@ where
         "Partition node {key} is missing before the Fitch forward pass"
       ))
     })?;
-    let result =
-      pass.try_for_each_forward_frontier(|node_indices, _, edges, _, completed_start, frontier, completed| {
-        frontier.par_iter_mut().try_for_each(|slot| {
-          run_fitch_forward_indexed(&alphabet, node_indices, edges, completed_start, completed, slot)
-        })
-      });
+    let result = pass.try_for_each_forward_frontier(|node_indices, _, _, completed_start, frontier, completed| {
+      frontier
+        .par_iter_mut()
+        .try_for_each(|slot| run_fitch_forward_indexed(&alphabet, node_indices, completed_start, completed, slot))
+    });
     let (nodes, edges) = pass.into_maps()?;
     *partition.nodes_mut() = nodes;
     *partition.edges_mut() = edges;
@@ -250,16 +239,16 @@ where
 fn run_fitch_forward_indexed(
   alphabet: &Alphabet,
   node_indices: &[Option<usize>],
-  edges: &[RwLock<Option<(treetime_graph::edge::GraphEdgeKey, SparseEdgePartition)>>],
   completed_start: usize,
-  completed: &[IndexedPassSlot<SparseNodePartition>],
-  slot: &mut IndexedPassSlot<SparseNodePartition>,
+  completed: &[IndexedPassSlot<SparseNodePartition, SparseEdgePartition>],
+  slot: &mut IndexedPassSlot<SparseNodePartition, SparseEdgePartition>,
 ) -> Result<(), Report> {
   let node_data = &mut slot.node;
   if let Some(parent_key) = slot.parent_key {
-    let slot_index = node_indices[slot.key.as_usize()].expect("Indexed node must have a slot");
-    let mut edge = edges[slot_index].write();
-    let (_, edge) = edge.as_mut().expect("Non-root node must own its parent edge");
+    let (_, edge) = slot
+      .parent_edge
+      .as_mut()
+      .expect("Non-root node must own its parent edge");
     let parent_index = node_indices[parent_key.as_usize()].expect("Indexed parent must have a slot");
     let parent = &completed[parent_index - completed_start].node.seq;
     let seq = &mut node_data.seq;

--- a/packages/treetime/src/optimize/dispatch.rs
+++ b/packages/treetime/src/optimize/dispatch.rs
@@ -10,6 +10,7 @@ use crate::partition::traits::PartitionOptimizeOps;
 use crate::{make_error, make_internal_report, make_report};
 use eyre::{Report, WrapErr};
 use parking_lot::RwLock;
+use rayon::prelude::*;
 use std::sync::Arc;
 use treetime_graph::edge::{Edge, GraphEdge, HasBranchLength};
 use treetime_graph::graph::Graph;
@@ -92,7 +93,7 @@ where
 
   graph
     .get_edges()
-    .iter()
+    .par_iter()
     .try_for_each(|edge_ref| -> Result<(), Report> {
       let edge_key = edge_ref.read_arc().key();
       let mut edge = edge_ref.write_arc().payload().write_arc();

--- a/packages/treetime/src/optimize/indel.rs
+++ b/packages/treetime/src/optimize/indel.rs
@@ -3,6 +3,7 @@ use crate::optimize::likelihood::OptimizationMetrics;
 use crate::partition::traits::PartitionOptimizeOps;
 use eyre::Report;
 use parking_lot::RwLock;
+use rayon::prelude::*;
 use statrs::function::factorial::ln_factorial;
 use std::sync::Arc;
 use treetime_graph::edge::{GraphEdge, HasBranchLength};
@@ -65,18 +66,21 @@ where
   E: GraphEdge + HasBranchLength,
   P: PartitionOptimizeOps + ?Sized,
 {
-  let mut total_indels: usize = 0;
-  let mut total_branch_length: f64 = 0.0;
-
-  for edge_ref in graph.get_edges() {
-    let edge_key = edge_ref.read_arc().key();
-    let branch_length = edge_ref.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
-
-    let edge_indels: usize = partitions.iter().map(|p| p.read_arc().edge_indel_count(edge_key)).sum();
-
-    total_indels += edge_indels;
-    total_branch_length += branch_length;
-  }
+  let per_edge = graph
+    .get_edges()
+    .par_iter()
+    .map(|edge_ref| {
+      let edge_key = edge_ref.read_arc().key();
+      let branch_length = edge_ref.read_arc().payload().read_arc().branch_length().unwrap_or(0.0);
+      let edge_indels = partitions
+        .iter()
+        .map(|p| p.read_arc().edge_indel_count(edge_key))
+        .sum::<usize>();
+      (edge_indels, branch_length)
+    })
+    .collect::<Vec<_>>();
+  let total_indels = per_edge.iter().map(|(indels, _)| indels).sum::<usize>();
+  let total_branch_length = per_edge.iter().map(|(_, branch_length)| branch_length).sum::<f64>();
 
   if total_branch_length > 0.0 && total_indels > 0 {
     total_indels as f64 / total_branch_length
@@ -103,7 +107,7 @@ where
 {
   graph
     .get_edges()
-    .iter()
+    .par_iter()
     .map(|edge_ref| -> Result<f64, Report> {
       let edge_key = edge_ref.read_arc().key();
       let edge = edge_ref.read_arc();
@@ -121,6 +125,8 @@ where
         Ok(poisson_indel_log_lh(indel_count, indel_rate, branch_length)?.log_lh)
       }
     })
+    .collect::<Vec<_>>()
+    .into_iter()
     .sum()
 }
 

--- a/packages/treetime/src/partition/__tests__/mod.rs
+++ b/packages/treetime/src/partition/__tests__/mod.rs
@@ -1,3 +1,4 @@
+mod test_indexed_pass;
 mod test_marginal_core;
 mod test_partition_marginal_sparse;
 mod test_sparse_transition_counting;

--- a/packages/treetime/src/partition/__tests__/test_indexed_pass.rs
+++ b/packages/treetime/src/partition/__tests__/test_indexed_pass.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+mod tests {
+  use crate::partition::indexed_pass::IndexedPass;
+  use crate::payload::ancestral::GraphAncestral;
+  use eyre::Report;
+  use pretty_assertions::assert_eq;
+  use std::collections::BTreeMap;
+  use treetime_io::nwk::nwk_read_str;
+  use treetime_utils::{assert_error, make_report};
+
+  #[test]
+  fn test_indexed_pass_roundtrip_preserves_all_values() -> Result<(), Report> {
+    let graph: GraphAncestral = nwk_read_str("((A:1,B:2)AB:3,C:4)root;")?;
+    let mut nodes = graph
+      .get_nodes()
+      .iter()
+      .map(|node| {
+        let key = node.read_arc().key();
+        (key, key.as_usize())
+      })
+      .collect::<BTreeMap<_, _>>();
+    let mut edges = graph
+      .get_edges()
+      .iter()
+      .map(|edge| {
+        let key = edge.read_arc().key();
+        (key, key.as_usize())
+      })
+      .collect::<BTreeMap<_, _>>();
+    let expected_nodes = nodes.clone();
+    let expected_edges = edges.clone();
+
+    let pass = IndexedPass::new(&graph, &mut nodes, &mut edges, |_| {
+      unreachable!("all graph nodes are present")
+    })?;
+    let (actual_nodes, actual_edges) = pass.into_maps()?;
+
+    assert_eq!(expected_nodes, actual_nodes);
+    assert_eq!(expected_edges, actual_edges);
+    Ok(())
+  }
+
+  #[test]
+  fn test_indexed_pass_error_restores_all_values() -> Result<(), Report> {
+    let graph: GraphAncestral = nwk_read_str("((A:1,B:2)AB:3,C:4)root;")?;
+    let mut nodes = graph
+      .get_nodes()
+      .iter()
+      .map(|node| {
+        let key = node.read_arc().key();
+        (key, key.as_usize())
+      })
+      .collect::<BTreeMap<_, _>>();
+    let mut edges = graph
+      .get_edges()
+      .iter()
+      .map(|edge| {
+        let key = edge.read_arc().key();
+        (key, key.as_usize())
+      })
+      .collect::<BTreeMap<_, _>>();
+    let expected_nodes = nodes.clone();
+    let expected_edges = edges.clone();
+    let mut pass = IndexedPass::new(&graph, &mut nodes, &mut edges, |_| {
+      unreachable!("all graph nodes are present")
+    })?;
+
+    let result = pass.try_for_each_backward_frontier(|_, _, _, _, _| Err(make_report!("injected pass failure")));
+    assert_error!(result, "injected pass failure");
+    let (actual_nodes, actual_edges) = pass.into_maps()?;
+
+    assert_eq!(expected_nodes, actual_nodes);
+    assert_eq!(expected_edges, actual_edges);
+    Ok(())
+  }
+}

--- a/packages/treetime/src/partition/indexed_pass.rs
+++ b/packages/treetime/src/partition/indexed_pass.rs
@@ -1,5 +1,4 @@
 use eyre::Report;
-use parking_lot::RwLock;
 use std::collections::BTreeMap;
 use treetime_graph::edge::{GraphEdge, GraphEdgeKey};
 use treetime_graph::graph::Graph;
@@ -7,17 +6,17 @@ use treetime_graph::node::{GraphNode, GraphNodeKey};
 use treetime_utils::make_internal_report;
 
 pub struct IndexedPass<N, E> {
-  slots: Vec<IndexedPassSlot<N>>,
-  edges: Vec<RwLock<Option<(GraphEdgeKey, E)>>>,
+  slots: Vec<IndexedPassSlot<N, E>>,
   node_indices: Vec<Option<usize>>,
   edge_indices: Vec<Option<usize>>,
   frontiers: Vec<std::ops::Range<usize>>,
 }
 
-pub struct IndexedPassSlot<N> {
+pub struct IndexedPassSlot<N, E> {
   pub key: GraphNodeKey,
   pub node: N,
   pub parent_key: Option<GraphNodeKey>,
+  pub parent_edge: Option<(GraphEdgeKey, E)>,
 }
 
 impl<N, E> IndexedPass<N, E> {
@@ -80,7 +79,6 @@ impl<N, E> IndexedPass<N, E> {
       .map_or(0, |index| index + 1);
     let mut edge_indices = vec![None; edge_capacity];
     let mut slots = Vec::with_capacity(nodes.len());
-    let mut edge_slots = Vec::with_capacity(nodes.len());
     let mut ranges = Vec::with_capacity(frontiers.len());
 
     for frontier in frontiers {
@@ -99,8 +97,12 @@ impl<N, E> IndexedPass<N, E> {
         if let Some((edge_key, _)) = &parent_edge {
           edge_indices[edge_key.as_usize()] = Some(index);
         }
-        slots.push(IndexedPassSlot { key, node, parent_key });
-        edge_slots.push(RwLock::new(parent_edge));
+        slots.push(IndexedPassSlot {
+          key,
+          node,
+          parent_key,
+          parent_edge,
+        });
       }
       ranges.push(start..slots.len());
     }
@@ -109,7 +111,6 @@ impl<N, E> IndexedPass<N, E> {
 
     Ok(Self {
       slots,
-      edges: edge_slots,
       node_indices,
       edge_indices,
       frontiers: ranges,
@@ -121,23 +122,15 @@ impl<N, E> IndexedPass<N, E> {
     mut visit: impl FnMut(
       &[Option<usize>],
       &[Option<usize>],
-      &[RwLock<Option<(GraphEdgeKey, E)>>],
       usize,
-      &[IndexedPassSlot<N>],
-      &mut [IndexedPassSlot<N>],
+      &[IndexedPassSlot<N, E>],
+      &mut [IndexedPassSlot<N, E>],
     ) -> Result<(), Report>,
   ) -> Result<(), Report> {
     for range in self.frontiers.clone() {
       let (completed, remaining) = self.slots.split_at_mut(range.start);
       let (frontier, _) = remaining.split_at_mut(range.len());
-      visit(
-        &self.node_indices,
-        &self.edge_indices,
-        &self.edges,
-        0,
-        completed,
-        frontier,
-      )?;
+      visit(&self.node_indices, &self.edge_indices, 0, completed, frontier)?;
     }
     Ok(())
   }
@@ -147,11 +140,10 @@ impl<N, E> IndexedPass<N, E> {
     mut visit: impl FnMut(
       &[Option<usize>],
       &[Option<usize>],
-      &[RwLock<Option<(GraphEdgeKey, E)>>],
-      &[IndexedPassSlot<N>],
+      &[IndexedPassSlot<N, E>],
       usize,
-      &mut [IndexedPassSlot<N>],
-      &[IndexedPassSlot<N>],
+      &mut [IndexedPassSlot<N, E>],
+      &[IndexedPassSlot<N, E>],
     ) -> Result<(), Report>,
   ) -> Result<(), Report> {
     for range in self.frontiers.clone().into_iter().rev() {
@@ -160,7 +152,6 @@ impl<N, E> IndexedPass<N, E> {
       visit(
         &self.node_indices,
         &self.edge_indices,
-        &self.edges,
         future,
         range.end,
         frontier,
@@ -173,14 +164,14 @@ impl<N, E> IndexedPass<N, E> {
   pub fn into_maps(self) -> Result<(BTreeMap<GraphNodeKey, N>, BTreeMap<GraphEdgeKey, E>), Report> {
     let mut nodes = BTreeMap::new();
     let mut edges = BTreeMap::new();
-    for (slot, edge_slot) in self.slots.into_iter().zip(self.edges) {
+    for slot in self.slots {
       if nodes.insert(slot.key, slot.node).is_some() {
         return Err(make_internal_report!(
           "Duplicate partition node {} while restoring a pass",
           slot.key
         ));
       }
-      if let Some((edge_key, edge)) = edge_slot.into_inner()
+      if let Some((edge_key, edge)) = slot.parent_edge
         && edges.insert(edge_key, edge).is_some()
       {
         return Err(make_internal_report!(

--- a/packages/treetime/src/partition/marginal_core.rs
+++ b/packages/treetime/src/partition/marginal_core.rs
@@ -403,13 +403,40 @@ where
     let safe_child = child_edge_data.msg_from_child.dis.mapv(|v| v.max(f64::MIN_POSITIVE));
     let mut dis = &node_profile_dis / &safe_child;
     let delta_ll = normalize_inplace(&mut dis);
-    child_edge_data.msg_to_child = DenseSeqDistribution {
-      dis,
-      log_lh: node_profile_log_lh - child_edge_data.msg_from_child.log_lh + delta_ll,
-    };
+    let log_lh = forward_log_lh_remove_child(node_profile_log_lh, child_edge_data.msg_from_child.log_lh);
+    let log_lh = forward_log_lh_add_normalization(log_lh, delta_ll);
+    child_edge_data.msg_to_child = DenseSeqDistribution { dis, log_lh };
   }
 
   Ok(())
+}
+
+/// Remove a child's normalization scale from a forward cavity message.
+///
+/// A degenerate profile is represented by a uniform fallback with a
+/// `f64::NEG_INFINITY` scale. Matching sentinels refer to the same removed
+/// factor, so they cancel instead of performing the undefined IEEE-754
+/// operation `-inf - (-inf)`.
+pub(crate) fn forward_log_lh_remove_child(node_log_lh: f64, child_log_lh: f64) -> f64 {
+  if node_log_lh == f64::NEG_INFINITY && child_log_lh == f64::NEG_INFINITY {
+    0.0
+  } else {
+    node_log_lh - child_log_lh
+  }
+}
+
+/// Add a normalization scale to a forward cavity message.
+///
+/// The `f64::NEG_INFINITY` value marks a distribution replaced by the uniform
+/// fallback. It has no finite scale to add to the conditional message. Other
+/// non-finite values still propagate so unexpected NaN and positive infinity
+/// remain observable.
+pub(crate) fn forward_log_lh_add_normalization(log_lh: f64, normalization: f64) -> f64 {
+  if normalization == f64::NEG_INFINITY {
+    log_lh
+  } else {
+    log_lh + normalization
+  }
 }
 
 /// 1D specialization of [`normalize_inplace`] for sparse marginal passes.

--- a/packages/treetime/src/partition/marginal_core.rs
+++ b/packages/treetime/src/partition/marginal_core.rs
@@ -8,7 +8,6 @@ use crate::partition::indexed_pass::{IndexedPass, IndexedPassSlot};
 use eyre::Report;
 use itertools::{Itertools, izip};
 use ndarray::prelude::*;
-use parking_lot::RwLock;
 use rayon::prelude::*;
 use std::collections::BTreeMap;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey, HasBranchLength};
@@ -97,9 +96,9 @@ where
   partition.marginal_data_mut().nodes.append(&mut missing_nodes);
   let (nodes, edges) = partition.indexed_storage_mut();
   let mut pass = IndexedPass::new(graph, nodes, edges, |_| unreachable!("Missing nodes were initialized"))?;
-  let result = pass.try_for_each_backward_frontier(|node_indices, edge_indices, edges, _, completed, frontier| {
+  let result = pass.try_for_each_backward_frontier(|node_indices, edge_indices, _, completed, frontier| {
     frontier.par_iter_mut().try_for_each(|slot| {
-      marginal_process_node_backward_indexed(partition, graph, node_indices, edge_indices, edges, completed, slot)
+      marginal_process_node_backward_indexed(partition, graph, node_indices, edge_indices, completed, slot)
     })
   });
   let (nodes, edges) = pass.into_maps()?;
@@ -113,9 +112,8 @@ fn marginal_process_node_backward_indexed<N, E>(
   graph: &Graph<N, E, ()>,
   node_indices: &[Option<usize>],
   edge_indices: &[Option<usize>],
-  edges: &[RwLock<Option<(GraphEdgeKey, DenseEdgePartition)>>],
-  completed: &[IndexedPassSlot<DenseNodePartition>],
-  slot: &mut IndexedPassSlot<DenseNodePartition>,
+  completed: &[IndexedPassSlot<DenseNodePartition, DenseEdgePartition>],
+  slot: &mut IndexedPassSlot<DenseNodePartition, DenseEdgePartition>,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
@@ -142,31 +140,20 @@ where
       .map(|(_, edge)| {
         let edge_key = edge.read_arc().key();
         let edge_index = edge_indices[edge_key.as_usize()].expect("Indexed child edge must have a slot");
-        edges[edge_index].read()
+        &completed[edge_index]
+          .parent_edge
+          .as_ref()
+          .expect("Non-root indexed node must own its parent edge")
+          .1
       })
       .collect_vec();
-    let (_, first_edge) = child_edges
-      .first()
-      .and_then(|edge| edge.as_ref())
-      .expect("Internal node must have children");
+    let first_edge = child_edges.first().expect("Internal node must have children");
     let mut log_dis = first_edge.msg_from_child.dis.mapv(f64::ln);
     for edge in child_edges.iter().skip(1) {
-      let (_, edge) = edge.as_ref().expect("Indexed edge slot must be populated");
       log_dis += &edge.msg_from_child.dis.mapv(f64::ln);
     }
     let (dis, delta_ll) = normalize_from_log(&log_dis);
-    let log_lh = child_edges
-      .iter()
-      .map(|edge| {
-        edge
-          .as_ref()
-          .expect("Indexed edge slot must be populated")
-          .1
-          .msg_from_child
-          .log_lh
-      })
-      .sum::<f64>()
-      + delta_ll;
+    let log_lh = child_edges.iter().map(|edge| edge.msg_from_child.log_lh).sum::<f64>() + delta_ll;
     slot.node.profile = DenseSeqDistribution {
       dis: dis.clone(),
       log_lh,
@@ -183,9 +170,10 @@ where
       log_lh: msg_to_parent.log_lh + delta_ll,
     };
   } else {
-    let slot_index = node_indices[slot.key.as_usize()].expect("Indexed node must have a slot");
-    let mut edge = edges[slot_index].write();
-    let (edge_key, edge) = edge.as_mut().expect("Non-root node must own its parent edge");
+    let (edge_key, edge) = slot
+      .parent_edge
+      .as_mut()
+      .expect("Non-root node must own its parent edge");
     let branch_length = graph
       .get_edge(*edge_key)
       .expect("Indexed edge must exist in graph")
@@ -219,22 +207,11 @@ where
   let mut pass = IndexedPass::new(graph, nodes, edges, |key| {
     treetime_utils::make_internal_error!("Partition node {key} is missing before the marginal forward pass")
   })?;
-  let result = pass.try_for_each_forward_frontier(
-    |node_indices, edge_indices, edges, _, completed_start, frontier, completed| {
-      frontier.par_iter_mut().try_for_each(|slot| {
-        marginal_process_node_forward_indexed(
-          partition,
-          graph,
-          node_indices,
-          edge_indices,
-          edges,
-          completed_start,
-          completed,
-          slot,
-        )
-      })
-    },
-  );
+  let result = pass.try_for_each_forward_frontier(|node_indices, _, _, completed_start, frontier, completed| {
+    frontier.par_iter_mut().try_for_each(|slot| {
+      marginal_process_node_forward_indexed(partition, graph, node_indices, completed_start, completed, slot)
+    })
+  });
   let (nodes, edges) = pass.into_maps()?;
   partition.marginal_data_mut().nodes = nodes;
   partition.marginal_data_mut().edges = edges;
@@ -246,11 +223,9 @@ fn marginal_process_node_forward_indexed<N, E>(
   partition: &impl IndexedMarginalPartition<N, E>,
   graph: &Graph<N, E, ()>,
   node_indices: &[Option<usize>],
-  edge_indices: &[Option<usize>],
-  edges: &[RwLock<Option<(GraphEdgeKey, DenseEdgePartition)>>],
   completed_start: usize,
-  completed: &[IndexedPassSlot<DenseNodePartition>],
-  slot: &mut IndexedPassSlot<DenseNodePartition>,
+  completed: &[IndexedPassSlot<DenseNodePartition, DenseEdgePartition>],
+  slot: &mut IndexedPassSlot<DenseNodePartition, DenseEdgePartition>,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
@@ -260,16 +235,22 @@ where
   let parent = if let Some(parent_key) = slot.parent_key {
     let parent_index = node_indices[parent_key.as_usize()].expect("Indexed parent must have a slot");
     let parent = &completed[parent_index - completed_start].node;
-    let slot_index = node_indices[slot.key.as_usize()].expect("Indexed node must have a slot");
-    let edge = edges[slot_index].write();
-    parent_edge = Some(edge);
+    parent_edge = slot.parent_edge.as_mut();
     Some(parent)
   } else {
     None
   };
 
-  if let Some(edge) = parent_edge.as_mut() {
-    let (edge_key, edge) = edge.as_mut().expect("Non-root node must own its parent edge");
+  if let Some((edge_key, edge)) = parent_edge.as_mut() {
+    let safe_child = edge.msg_from_child.dis.mapv(|value| value.max(f64::MIN_POSITIVE));
+    let mut dis = &parent.expect("Non-root node must have a parent").profile.dis / &safe_child;
+    let delta_ll = normalize_inplace(&mut dis);
+    let log_lh = forward_log_lh_remove_child(
+      parent.expect("Non-root node must have a parent").profile.log_lh,
+      edge.msg_from_child.log_lh,
+    );
+    let log_lh = forward_log_lh_add_normalization(log_lh, delta_ll);
+    edge.msg_to_child = DenseSeqDistribution { dis, log_lh };
     let branch_length = graph
       .get_edge(*edge_key)
       .expect("Indexed edge must exist in graph")
@@ -296,24 +277,8 @@ where
     graph.is_leaf(slot.key),
     parent,
     &mut slot.node,
-    parent_edge
-      .as_mut()
-      .and_then(|edge| edge.as_mut().map(|(_, edge)| edge)),
+    parent_edge.as_mut().map(|(_, edge)| edge),
   )?;
-
-  let graph_node = graph.get_node(slot.key).expect("Indexed node must exist in graph");
-  for (_, child_edge) in graph.children_of(&graph_node.read_arc()) {
-    let child_edge_key = child_edge.read_arc().key();
-    let child_edge_index = edge_indices[child_edge_key.as_usize()].expect("Indexed child edge must have a slot");
-    let mut child_edge = edges[child_edge_index].write();
-    let (_, child_edge) = child_edge.as_mut().expect("Indexed child edge slot must be populated");
-    let safe_child = child_edge.msg_from_child.dis.mapv(|value| value.max(f64::MIN_POSITIVE));
-    let mut dis = &slot.node.profile.dis / &safe_child;
-    let delta_ll = normalize_inplace(&mut dis);
-    let log_lh = forward_log_lh_remove_child(slot.node.profile.log_lh, child_edge.msg_from_child.log_lh);
-    let log_lh = forward_log_lh_add_normalization(log_lh, delta_ll);
-    child_edge.msg_to_child = DenseSeqDistribution { dis, log_lh };
-  }
   Ok(())
 }
 
@@ -438,40 +403,13 @@ where
     let safe_child = child_edge_data.msg_from_child.dis.mapv(|v| v.max(f64::MIN_POSITIVE));
     let mut dis = &node_profile_dis / &safe_child;
     let delta_ll = normalize_inplace(&mut dis);
-    let log_lh = forward_log_lh_remove_child(node_profile_log_lh, child_edge_data.msg_from_child.log_lh);
-    let log_lh = forward_log_lh_add_normalization(log_lh, delta_ll);
-    child_edge_data.msg_to_child = DenseSeqDistribution { dis, log_lh };
+    child_edge_data.msg_to_child = DenseSeqDistribution {
+      dis,
+      log_lh: node_profile_log_lh - child_edge_data.msg_from_child.log_lh + delta_ll,
+    };
   }
 
   Ok(())
-}
-
-/// Remove a child's normalization scale from a forward cavity message.
-///
-/// A degenerate profile is represented by a uniform fallback with a
-/// `f64::NEG_INFINITY` scale. Matching sentinels refer to the same removed
-/// factor, so they cancel instead of performing the undefined IEEE-754
-/// operation `-inf - (-inf)`.
-pub(crate) fn forward_log_lh_remove_child(node_log_lh: f64, child_log_lh: f64) -> f64 {
-  if node_log_lh == f64::NEG_INFINITY && child_log_lh == f64::NEG_INFINITY {
-    0.0
-  } else {
-    node_log_lh - child_log_lh
-  }
-}
-
-/// Add a normalization scale to a forward cavity message.
-///
-/// The `f64::NEG_INFINITY` value marks a distribution replaced by the uniform
-/// fallback. It has no finite scale to add to the conditional message. Other
-/// non-finite values still propagate so unexpected NaN and positive infinity
-/// remain observable.
-pub(crate) fn forward_log_lh_add_normalization(log_lh: f64, normalization: f64) -> f64 {
-  if normalization == f64::NEG_INFINITY {
-    log_lh
-  } else {
-    log_lh + normalization
-  }
 }
 
 /// 1D specialization of [`normalize_inplace`] for sparse marginal passes.

--- a/packages/treetime/src/partition/marginal_dense.rs
+++ b/packages/treetime/src/partition/marginal_dense.rs
@@ -19,7 +19,7 @@ use crate::seq::mutation::Sub;
 use eyre::Report;
 use itertools::{Itertools, izip};
 use maplit::btreemap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
@@ -223,8 +223,8 @@ where
   fn indexed_storage_mut(
     &mut self,
   ) -> (
-    &mut std::collections::BTreeMap<GraphNodeKey, DenseNodePartition>,
-    &mut std::collections::BTreeMap<GraphEdgeKey, DenseEdgePartition>,
+    &mut BTreeMap<GraphNodeKey, DenseNodePartition>,
+    &mut BTreeMap<GraphEdgeKey, DenseEdgePartition>,
   ) {
     (&mut self.data.nodes, &mut self.data.edges)
   }
@@ -430,6 +430,10 @@ where
   E: EdgeOptimizeOps,
 {
   fn attach_sequences(&mut self, graph: &Graph<N, E, ()>, aln: &[FastaRecord]) -> Result<(), Report> {
+    let aln_by_name = aln.iter().fold(BTreeMap::new(), |mut records, record| {
+      records.entry(record.seq_name.as_str()).or_insert(record);
+      records
+    });
     for leaf in graph.get_leaves() {
       let leaf_key = leaf.read_arc().key();
       let mut leaf = leaf.read_arc().payload().write_arc();
@@ -441,9 +445,9 @@ where
         name.as_ref().to_owned()
       };
 
-      let leaf_fasta = aln
-        .iter()
-        .find(|fasta| fasta.seq_name == leaf_name)
+      let leaf_fasta = aln_by_name
+        .get(leaf_name.as_str())
+        .copied()
         .ok_or_else(|| make_report!("Leaf sequence not found: '{leaf_name}'"))?;
 
       leaf.set_desc(leaf_fasta.desc.clone());

--- a/packages/treetime/src/partition/marginal_passes.rs
+++ b/packages/treetime/src/partition/marginal_passes.rs
@@ -10,10 +10,9 @@ use crate::seq::mutation::Sub;
 use eyre::Report;
 use itertools::Itertools;
 use maplit::btreemap;
-use parking_lot::RwLock;
 use rayon::prelude::*;
 use std::collections::BTreeSet;
-use treetime_graph::edge::{EdgeOptimizeOps, GraphEdgeKey};
+use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
 use treetime_primitives::AsciiChar;
@@ -35,7 +34,7 @@ where
   let mut pass = IndexedPass::new(graph, nodes, edges, |key| {
     treetime_utils::make_internal_error!("Partition node {key} is missing before the sparse marginal pass")
   })?;
-  let result = pass.try_for_each_backward_frontier(|node_indices, edge_indices, edges, _, completed, frontier| {
+  let result = pass.try_for_each_backward_frontier(|node_indices, edge_indices, _, completed, frontier| {
     frontier.par_iter_mut().try_for_each(|slot| {
       process_node_backward_indexed(
         graph,
@@ -44,7 +43,6 @@ where
         length,
         node_indices,
         edge_indices,
-        edges,
         completed,
         slot,
       )
@@ -72,26 +70,21 @@ where
   let mut pass = IndexedPass::new(graph, nodes, edges, |key| {
     treetime_utils::make_internal_error!("Partition node {key} is missing before the sparse marginal pass")
   })?;
-  let result = pass.try_for_each_forward_frontier(
-    |node_indices, edge_indices, edges, future, completed_start, frontier, completed| {
-      frontier.par_iter_mut().try_for_each(|slot| {
-        process_node_forward_indexed(
-          graph,
-          &alphabet,
-          &gtr,
-          length,
-          &root_sequence,
-          node_indices,
-          edge_indices,
-          edges,
-          future,
-          completed_start,
-          completed,
-          slot,
-        )
-      })
-    },
-  );
+  let result = pass.try_for_each_forward_frontier(|node_indices, _, _, completed_start, frontier, completed| {
+    frontier.par_iter_mut().try_for_each(|slot| {
+      process_node_forward_indexed(
+        graph,
+        &alphabet,
+        &gtr,
+        length,
+        &root_sequence,
+        node_indices,
+        completed_start,
+        completed,
+        slot,
+      )
+    })
+  });
   let (nodes, edges) = pass.into_maps()?;
   partition.nodes = nodes;
   partition.edges = edges;
@@ -106,12 +99,9 @@ fn process_node_forward_indexed<N, E>(
   length: usize,
   root_sequence: &treetime_primitives::Seq,
   node_indices: &[Option<usize>],
-  edge_indices: &[Option<usize>],
-  edges: &[RwLock<Option<(GraphEdgeKey, SparseEdgePartition)>>],
-  future: &[IndexedPassSlot<SparseNodePartition>],
   completed_start: usize,
-  completed: &[IndexedPassSlot<SparseNodePartition>],
-  slot: &mut IndexedPassSlot<SparseNodePartition>,
+  completed: &[IndexedPassSlot<SparseNodePartition, SparseEdgePartition>],
+  slot: &mut IndexedPassSlot<SparseNodePartition, SparseEdgePartition>,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
@@ -120,9 +110,12 @@ where
   if let Some(parent_key) = slot.parent_key {
     let parent_index = node_indices[parent_key.as_usize()].expect("Indexed parent must have a slot");
     let parent = &completed[parent_index - completed_start].node;
-    let slot_index = node_indices[slot.key.as_usize()].expect("Indexed node must have a slot");
-    let mut edge = edges[slot_index].write();
-    let (edge_key, edge_data) = edge.as_mut().expect("Non-root node must own its parent edge");
+    let (edge_key, edge_data) = slot
+      .parent_edge
+      .as_mut()
+      .expect("Non-root node must own its parent edge");
+
+    edge_data.msg_to_child = compute_msg_to_child(&slot.node, parent, edge_data)?;
 
     let mut variable_pos = btreemap! {};
     let mut parent_state = btreemap! {};
@@ -186,83 +179,75 @@ where
     slot.node.seq.sequence = root_sequence.clone();
   }
 
-  let graph_node = graph.get_node(slot.key).expect("Indexed node must exist in graph");
-  let graph_node = graph_node.read_arc();
-  for (child, child_edge) in graph.children_of(&graph_node) {
-    let child_key = child.read_arc().key();
-    let child_index = node_indices[child_key.as_usize()].expect("Indexed child must have a slot");
-    let child_node = &future[child_index].node;
-    let child_edge_key = child_edge.read_arc().key();
-    let child_edge_index = edge_indices[child_edge_key.as_usize()].expect("Indexed child edge must have a slot");
-    let mut child_edge = edges[child_edge_index].write();
-    let (_, child_edge) = child_edge.as_mut().expect("Indexed child edge slot must be populated");
-
-    let mut seq_dis = SparseSeqDistribution {
-      variable: btreemap! {},
-      variable_indel: BTreeSet::new(),
-      fixed: btreemap! {},
-      fixed_counts: slot.node.seq.composition.clone(),
-      log_lh: forward_log_lh_remove_child(slot.node.profile.log_lh, child_edge.msg_from_child.log_lh),
-    };
-    let child_dis = child_edge.msg_from_child.clone();
-    let mut parent_states = btreemap! {};
-    let mut child_states = btreemap! {};
-    for mutation in child_edge.fitch_subs() {
-      child_states.insert(mutation.pos(), mutation.qry());
-      parent_states.insert(mutation.pos(), mutation.reff());
-    }
-    for (pos, profile) in &slot.node.profile.variable {
-      if !range_contains(&child_node.seq.non_char, *pos) {
-        child_states.entry(*pos).or_insert(profile.state);
-        parent_states.entry(*pos).or_insert(profile.state);
-      }
-    }
-    for (pos, profile) in &child_dis.variable {
-      if !range_contains(&child_node.seq.non_char, *pos) {
-        child_states.entry(*pos).or_insert(profile.state);
-        parent_states.entry(*pos).or_insert(profile.state);
-      }
-    }
-
-    let mut delta_ll = 0.0;
-    for (pos, parent_state) in parent_states {
-      let divisor = child_dis
-        .variable
-        .get(&pos)
-        .map_or(&child_dis.fixed[&child_states[&pos]], |distribution| &distribution.dis);
-      let numerator = slot
-        .node
-        .profile
-        .variable
-        .get(&pos)
-        .map_or(&slot.node.profile.fixed[&parent_state], |distribution| {
-          &distribution.dis
-        });
-      let safe_divisor = divisor.mapv(|value| value.max(f64::MIN_POSITIVE));
-      let mut dis = numerator / &safe_divisor;
-      let normalization = normalize_1d_inplace(&mut dis, 1.0);
-      delta_ll = forward_log_lh_add_normalization(delta_ll, normalization);
-      seq_dis.variable.insert(
-        pos,
-        VarPos {
-          dis,
-          state: parent_state,
-        },
-      );
-      seq_dis.fixed_counts.adjust_count(parent_state, -1);
-    }
-    for (state, profile) in &slot.node.profile.fixed {
-      let safe_fixed = child_dis.fixed[state].mapv(|value| value.max(f64::MIN_POSITIVE));
-      let mut dis = profile / &safe_fixed;
-      let weight = seq_dis.fixed_counts.get(*state).unwrap() as f64;
-      let normalization = normalize_1d_inplace(&mut dis, weight);
-      delta_ll = forward_log_lh_add_normalization(delta_ll, normalization);
-      seq_dis.fixed.insert(*state, dis);
-    }
-    seq_dis.log_lh = forward_log_lh_add_normalization(seq_dis.log_lh, delta_ll);
-    child_edge.msg_to_child = seq_dis;
-  }
   Ok(())
+}
+
+fn compute_msg_to_child(
+  child: &SparseNodePartition,
+  parent: &SparseNodePartition,
+  edge: &SparseEdgePartition,
+) -> Result<SparseSeqDistribution, Report> {
+  let mut seq_dis = SparseSeqDistribution {
+    variable: btreemap! {},
+    variable_indel: BTreeSet::new(),
+    fixed: btreemap! {},
+    fixed_counts: parent.seq.composition.clone(),
+    log_lh: forward_log_lh_remove_child(parent.profile.log_lh, edge.msg_from_child.log_lh),
+  };
+  let child_dis = &edge.msg_from_child;
+  let mut parent_states = btreemap! {};
+  let mut child_states = btreemap! {};
+  for mutation in edge.fitch_subs() {
+    child_states.insert(mutation.pos(), mutation.qry());
+    parent_states.insert(mutation.pos(), mutation.reff());
+  }
+  for (pos, profile) in &parent.profile.variable {
+    if !range_contains(&child.seq.non_char, *pos) {
+      child_states.entry(*pos).or_insert(profile.state);
+      parent_states.entry(*pos).or_insert(profile.state);
+    }
+  }
+  for (pos, profile) in &child_dis.variable {
+    if !range_contains(&child.seq.non_char, *pos) {
+      child_states.entry(*pos).or_insert(profile.state);
+      parent_states.entry(*pos).or_insert(profile.state);
+    }
+  }
+
+  let mut delta_ll = 0.0;
+  for (pos, parent_state) in parent_states {
+    let divisor = child_dis
+      .variable
+      .get(&pos)
+      .map_or(&child_dis.fixed[&child_states[&pos]], |distribution| &distribution.dis);
+    let numerator = parent
+      .profile
+      .variable
+      .get(&pos)
+      .map_or(&parent.profile.fixed[&parent_state], |distribution| &distribution.dis);
+    let safe_divisor = divisor.mapv(|value| value.max(f64::MIN_POSITIVE));
+    let mut dis = numerator / &safe_divisor;
+    let normalization = normalize_1d_inplace(&mut dis, 1.0);
+    delta_ll = forward_log_lh_add_normalization(delta_ll, normalization);
+    seq_dis.variable.insert(
+      pos,
+      VarPos {
+        dis,
+        state: parent_state,
+      },
+    );
+    seq_dis.fixed_counts.adjust_count(parent_state, -1);
+  }
+  for (state, profile) in &parent.profile.fixed {
+    let safe_fixed = child_dis.fixed[state].mapv(|value| value.max(f64::MIN_POSITIVE));
+    let mut dis = profile / &safe_fixed;
+    let weight = seq_dis.fixed_counts.get(*state).unwrap() as f64;
+    let normalization = normalize_1d_inplace(&mut dis, weight);
+    delta_ll = forward_log_lh_add_normalization(delta_ll, normalization);
+    seq_dis.fixed.insert(*state, dis);
+  }
+  seq_dis.log_lh = forward_log_lh_add_normalization(seq_dis.log_lh, delta_ll);
+  Ok(seq_dis)
 }
 
 fn compute_ml_subs_for_nodes(
@@ -297,9 +282,8 @@ fn process_node_backward_indexed<N, E>(
   length: usize,
   node_indices: &[Option<usize>],
   edge_indices: &[Option<usize>],
-  edges: &[RwLock<Option<(GraphEdgeKey, SparseEdgePartition)>>],
-  completed: &[IndexedPassSlot<SparseNodePartition>],
-  slot: &mut IndexedPassSlot<SparseNodePartition>,
+  completed: &[IndexedPassSlot<SparseNodePartition, SparseEdgePartition>],
+  slot: &mut IndexedPassSlot<SparseNodePartition, SparseEdgePartition>,
 ) -> Result<(), Report>
 where
   N: GraphNode + Named,
@@ -344,14 +328,17 @@ where
     let child_pairs = graph.children_of(&graph_node);
     let mut child_states = vec![btreemap! {}; child_pairs.len()];
     let mut child_messages = Vec::with_capacity(child_pairs.len());
-    let mut child_edge_guards = Vec::with_capacity(child_pairs.len());
+    let mut child_keys = Vec::with_capacity(child_pairs.len());
 
     for (ci, (child, edge)) in child_pairs.iter().enumerate() {
       let child_key = child.read_arc().key();
       let edge_key = edge.read_arc().key();
       let edge_index = edge_indices[edge_key.as_usize()].expect("Indexed child edge must have a slot");
-      let edge = edges[edge_index].read();
-      let edge_data = &edge.as_ref().expect("Indexed child edge slot must be populated").1;
+      let edge_data = &completed[edge_index]
+        .parent_edge
+        .as_ref()
+        .expect("Non-root indexed node must own its parent edge")
+        .1;
       for mutation in edge_data.fitch_subs() {
         variable_pos.insert(mutation.pos(), mutation.reff());
         child_states[ci].insert(mutation.pos(), mutation.qry());
@@ -360,10 +347,10 @@ where
         variable_pos.entry(*pos).or_insert(profile.state);
       }
       child_messages.push(edge_data.msg_from_child.clone());
-      child_edge_guards.push((child_key, edge));
+      child_keys.push(child_key);
     }
 
-    for (ci, (child_key, _)) in child_edge_guards.iter().enumerate() {
+    for (ci, child_key) in child_keys.iter().enumerate() {
       let child_index = node_indices[child_key.as_usize()].expect("Indexed child must have a slot");
       let child_data = &completed[child_index].node;
       for (pos, parent_state) in &variable_pos {
@@ -396,9 +383,10 @@ where
   if graph_node.is_root() {
     slot.node.profile = msg_to_parent;
   } else {
-    let slot_index = node_indices[slot.key.as_usize()].expect("Indexed node must have a slot");
-    let mut edge = edges[slot_index].write();
-    let (edge_key, edge_data) = edge.as_mut().expect("Non-root node must own its parent edge");
+    let (edge_key, edge_data) = slot
+      .parent_edge
+      .as_mut()
+      .expect("Non-root node must own its parent edge");
     let branch_length = graph
       .get_edge(*edge_key)
       .expect("Indexed edge must exist in graph")

--- a/packages/treetime/src/seq/composition.rs
+++ b/packages/treetime/src/seq/composition.rs
@@ -1,7 +1,6 @@
 use crate::seq::indel::InDel;
 use crate::seq::mutation::Sub;
 use eyre::Report;
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use treetime_primitives::AsciiChar;
@@ -58,8 +57,13 @@ impl Composition {
   }
 
   pub fn add_seq(&mut self, sequence: impl AsRef<[AsciiChar]>) {
-    for (&c, n) in sequence.as_ref().iter().counts() {
-      *self.counts.entry(c).or_default() += n;
+    let mut additions = [0; 128];
+    for &c in sequence.as_ref() {
+      additions[usize::from(c)] += 1;
+    }
+    for (index, count) in additions.into_iter().enumerate().filter(|(_, count)| *count > 0) {
+      let c = AsciiChar::from_byte_unchecked(index as u8);
+      *self.counts.entry(c).or_default() += count;
     }
   }
 

--- a/packages/treetime/src/timetree/inference/runner.rs
+++ b/packages/treetime/src/timetree/inference/runner.rs
@@ -12,6 +12,7 @@ use crate::timetree::utils::initialize_node_divergences;
 use eyre::Report;
 use log::{debug, info};
 use parking_lot::RwLock;
+use rayon::prelude::*;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
 use treetime_graph::edge::{GraphEdge, GraphEdgeKey, HasBranchLength};
@@ -94,41 +95,45 @@ where
   debug!("One mutation = {one_mutation:.6e} substitutions/site");
   debug!("Indel rate = {indel_rate:.6e} indels/(site*time)");
 
-  for edge_ref in graph.get_edges() {
-    let edge_key = edge_ref.read_arc().key();
-    let mut edge = edge_ref.write_arc().payload().write_arc();
-    let branch_length = edge.branch_length().unwrap_or(one_mutation);
-    let gamma = edge.gamma();
+  graph
+    .get_edges()
+    .par_iter()
+    .try_for_each(|edge_ref| -> Result<(), Report> {
+      let edge_key = edge_ref.read_arc().key();
+      let mut edge = edge_ref.write_arc().payload().write_arc();
+      let branch_length = edge.branch_length().unwrap_or(one_mutation);
+      let gamma = edge.gamma();
 
-    debug!("Edge {edge_key:?}: input branch_length = {branch_length:.6e}, gamma = {gamma:.4}");
+      debug!("Edge {edge_key:?}: input branch_length = {branch_length:.6e}, gamma = {gamma:.4}");
 
-    let contributions = collect_contributions(partitions, edge_key)?;
-    let indel_count: usize = if no_indels {
-      0
-    } else {
-      partitions
-        .iter()
-        .map(|partition| partition.read_arc().edge_indel_count(edge_key))
-        .sum()
-    };
-    let distribution = compute_branch_length_distribution(
-      &contributions,
-      indel_count,
-      indel_rate,
-      branch_length,
-      one_mutation,
-      BRANCH_GRID_SIZE,
-      clock_rate,
-      gamma,
-    )?;
+      let contributions = collect_contributions(partitions, edge_key)?;
+      let indel_count: usize = if no_indels {
+        0
+      } else {
+        partitions
+          .iter()
+          .map(|partition| partition.read_arc().edge_indel_count(edge_key))
+          .sum()
+      };
+      let distribution = compute_branch_length_distribution(
+        &contributions,
+        indel_count,
+        indel_rate,
+        branch_length,
+        one_mutation,
+        BRANCH_GRID_SIZE,
+        clock_rate,
+        gamma,
+      )?;
 
-    if let Some(likely_time) = distribution.likely_time() {
-      debug!("Edge {edge_key:?}: distribution peak at time = {likely_time:.6e}");
-    }
+      if let Some(likely_time) = distribution.likely_time() {
+        debug!("Edge {edge_key:?}: distribution peak at time = {likely_time:.6e}");
+      }
 
-    edge.set_time_length(distribution.likely_time());
-    edge.set_branch_length_distribution(Some(distribution));
-  }
+      edge.set_time_length(distribution.likely_time());
+      edge.set_branch_length_distribution(Some(distribution));
+      Ok(())
+    })?;
   Ok(())
 }
 
@@ -168,7 +173,7 @@ where
   N: GraphNode + TimetreeNode,
   E: GraphEdge + HasBranchLength + TimetreeEdge,
 {
-  for edge_ref in graph.get_edges() {
+  graph.get_edges().par_iter().for_each(|edge_ref| {
     let mut edge = edge_ref.write_arc().payload().write_arc();
 
     if let Some(branch_length) = edge.branch_length() {
@@ -180,7 +185,7 @@ where
       edge.set_time_length(Some(time_duration));
       edge.set_branch_length_distribution(Some(Arc::new(distribution)));
     }
-  }
+  });
 
   Ok(())
 }


### PR DESCRIPTION


- Depends on: #828

Indexed ownership makes edge-local work independent. This PR removes the remaining edge locks and parallelizes the affected inference kernels.

Fallible calculations are collected before shared state is committed. The forward normalization helpers retain the sentinel semantics established by the earlier correctness fix.

Source: `fn run_fitch_backward_indexed()` [[src](https://github.com/neherlab/treetime/blob/811237ae501927dfdf0788612dd7095b58afa662/packages/treetime/src/ancestral/fitch.rs#L134-L192)]

### Work items

- [x] Remove edge locks from indexed ancestral passes
- [x] Parallelize independent inference and indel calculations
- [x] Collect fallible results before committing shared state
- [x] Preserve corrected forward normalization in indexed storage
- [x] Extend failure and determinism coverage

