### PR TITLE
perf: index clock and timetree passes

### DIFF
--- a/packages/treetime/src/clock/clock_filter.rs
+++ b/packages/treetime/src/clock/clock_filter.rs
@@ -4,6 +4,7 @@ use crate::payload::traits::{ClockEdge, ClockNode};
 use eyre::Report;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
+use rayon::prelude::*;
 use treetime_graph::breadth_first::GraphTraversalContinuation;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
@@ -25,7 +26,7 @@ pub struct ClockFilterResult {
 #[allow(clippy::integer_division_remainder_used)]
 pub fn clock_filter_inplace<N, E, D>(
   graph: &Graph<N, E, D>,
-  clock_line: &impl ClockLine,
+  clock_line: &(impl ClockLine + Sync),
   threshold: f64,
 ) -> Result<ClockFilterResult, Report>
 where
@@ -54,7 +55,7 @@ where
   // collect clock_deviation of leaf nodes into a vector
   let leaf_clock_deviations: Vec<f64> = graph
     .get_leaves()
-    .iter()
+    .par_iter()
     .filter_map(|leaf| {
       let node = leaf.read_arc();
       let payload_arc = node.payload();
@@ -63,6 +64,8 @@ where
       let time = payload.likely_time();
       time.map(|time| clock_line.clock_deviation(time, div))
     })
+    .collect::<Vec<_>>()
+    .into_iter()
     .map(OrderedFloat)
     .sorted()
     .map(OrderedFloat::into_inner)
@@ -77,24 +80,27 @@ where
   let iq25 = n / 4;
   let iqd = leaf_clock_deviations[iq75] - leaf_clock_deviations[iq25];
 
-  let mut new_outliers: i32 = 0;
   // loop over the leaf nodes and mark the outliers if the absolute value of the deviation is greater than the threshold
-  graph.get_leaves().iter().for_each(|leaf| {
-    let node = leaf.read_arc();
-    let payload_arc = node.payload();
-    let (div, time, was_outlier) = {
-      let payload = payload_arc.read();
-      (payload.div(), payload.likely_time(), payload.is_outlier())
-    };
-    if let Some(time) = time {
-      let clock_deviation = clock_line.clock_deviation(time, div);
-      let is_outlier = clock_deviation.abs() > iqd * threshold;
-      if was_outlier != is_outlier {
-        new_outliers += 1;
+  let new_outliers = graph
+    .get_leaves()
+    .par_iter()
+    .map(|leaf| {
+      let node = leaf.read_arc();
+      let payload_arc = node.payload();
+      let (div, time, was_outlier) = {
+        let payload = payload_arc.read();
+        (payload.div(), payload.likely_time(), payload.is_outlier())
+      };
+      if let Some(time) = time {
+        let clock_deviation = clock_line.clock_deviation(time, div);
+        let is_outlier = clock_deviation.abs() > iqd * threshold;
+        payload_arc.write().set_is_outlier(is_outlier);
+        i32::from(was_outlier != is_outlier)
+      } else {
+        0
       }
-      payload_arc.write().set_is_outlier(is_outlier);
-    }
-  });
+    })
+    .sum();
 
   log::info!("Outlier filtering: {new_outliers} leaves changed status, IQD={iqd:.6e}");
   log::debug!(

--- a/packages/treetime/src/clock/clock_regression.rs
+++ b/packages/treetime/src/clock/clock_regression.rs
@@ -1,14 +1,15 @@
 use crate::clock::clock_model::{ClockModel, ClockRegression};
 use crate::clock::find_best_root::params::{BranchPointOptimizationParams, RootObjective};
 use crate::clock::reroot::{RerootParams, reroot_in_place};
+use crate::partition::indexed_pass::{IndexedPassSlot, with_indexed_graph_payloads};
 use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
 use eyre::Report;
 use log::{debug, info};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
 use std::fmt::Debug;
-use treetime_graph::breadth_first::GraphTraversalContinuation;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
@@ -79,50 +80,71 @@ pub fn clock_regression_backward<N, E, D>(
   prev_clock_rate: Option<f64>,
 ) -> Result<(), Report>
 where
+  N: GraphNode + ClockNode + Default,
+  E: GraphEdge + ClockEdge + Default,
+  D: Send + Sync,
+{
+  with_indexed_graph_payloads(graph, |pass| {
+    pass.try_for_each_backward_frontier(|node_indices, _, _, completed, frontier| {
+      frontier.par_iter_mut().try_for_each(|slot| {
+        clock_regression_backward_slot(graph, options, prev_clock_rate, node_indices, completed, slot)
+      })
+    })
+  })
+}
+
+fn clock_regression_backward_slot<N, E, D>(
+  graph: &Graph<N, E, D>,
+  options: &ClockParams,
+  prev_clock_rate: Option<f64>,
+  node_indices: &[Option<usize>],
+  completed: &[IndexedPassSlot<N, E>],
+  slot: &mut IndexedPassSlot<N, E>,
+) -> Result<(), Report>
+where
   N: GraphNode + ClockNode,
   E: GraphEdge + ClockEdge,
   D: Send + Sync,
 {
-  graph.par_iter_breadth_first_backward(|mut n| {
-    let date = n.payload.likely_time();
-    let q_to_parent = if n.is_leaf {
-      if n.payload.is_outlier() {
-        ClockSet::outlier_contribution()
-      } else {
-        ClockSet::leaf_contribution(date)
-      }
+  let is_leaf = graph.is_leaf(slot.key);
+  let date = slot.node.likely_time();
+  let q_to_parent = if is_leaf {
+    if slot.node.is_outlier() {
+      ClockSet::outlier_contribution()
     } else {
-      let mut q_dest = ClockSet::default();
-      for (_, e) in &n.children {
-        q_dest += e.read_arc().from_child();
-      }
-      q_dest
-    };
-
-    let is_leaf = n.is_leaf;
-    let is_root = n.is_root;
-
-    if is_root {
-      *n.payload.clock_set_mut() = q_to_parent;
-    } else {
-      let edge_to_parent = n.get_exactly_one_parent_edge()?;
-      *edge_to_parent.to_parent_mut() = q_to_parent;
-      let edge_len = edge_divergence(
-        edge_to_parent.branch_length(),
-        edge_to_parent.time_length(),
-        edge_to_parent.gamma(),
-        prev_clock_rate,
-      );
-      let mut branch_variance = options.variance_factor * edge_len + options.variance_offset;
-      *edge_to_parent.from_child_mut() = if is_leaf {
-        branch_variance += options.variance_offset_leaf;
-        ClockSet::leaf_contribution_to_parent(date, edge_len, branch_variance)
-      } else {
-        edge_to_parent.to_parent().propagate_averages(edge_len, branch_variance)
-      };
+      ClockSet::leaf_contribution(date)
     }
-    Ok(GraphTraversalContinuation::Continue)
-  })
+  } else {
+    graph
+      .children_of(&graph.get_node(slot.key).expect("Indexed node must exist").read_arc())
+      .iter()
+      .fold(ClockSet::default(), |mut total, (child, _)| {
+        let child_key = child.read_arc().key();
+        let child_index = node_indices[child_key.as_usize()].expect("Indexed child must have a slot");
+        let edge = &completed[child_index]
+          .parent_edge
+          .as_ref()
+          .expect("Non-root indexed node must own its parent edge")
+          .1;
+        total += edge.from_child();
+        total
+      })
+  };
+
+  if let Some((_, edge)) = slot.parent_edge.as_mut() {
+    *edge.to_parent_mut() = q_to_parent;
+    let edge_len = edge_divergence(edge.branch_length(), edge.time_length(), edge.gamma(), prev_clock_rate);
+    let mut branch_variance = options.variance_factor * edge_len + options.variance_offset;
+    *edge.from_child_mut() = if is_leaf {
+      branch_variance += options.variance_offset_leaf;
+      ClockSet::leaf_contribution_to_parent(date, edge_len, branch_variance)
+    } else {
+      edge.to_parent().propagate_averages(edge_len, branch_variance)
+    };
+  } else {
+    *slot.node.clock_set_mut() = q_to_parent;
+  }
+  Ok(())
 }
 
 /// Runs forward clock regression pass.
@@ -135,28 +157,33 @@ pub fn clock_regression_forward<N, E, D>(
   prev_clock_rate: Option<f64>,
 ) -> Result<(), Report>
 where
-  N: GraphNode + ClockNode,
-  E: GraphEdge + ClockEdge,
+  N: GraphNode + ClockNode + Default,
+  E: GraphEdge + ClockEdge + Default,
   D: Sync + Send,
 {
-  graph.par_iter_breadth_first_forward(|mut n| {
-    if !n.is_root {
-      let (_, edge) = n.get_exactly_one_parent()?;
-      let edge = edge.read_arc();
-      let edge_len = edge_divergence(edge.branch_length(), edge.time_length(), edge.gamma(), prev_clock_rate);
-      let branch_variance = options.variance_factor * edge_len + options.variance_offset;
+  with_indexed_graph_payloads(graph, |pass| {
+    pass.try_for_each_forward_frontier(|node_indices, _, _, completed_start, frontier, completed| {
+      frontier.par_iter_mut().for_each(|slot| {
+        if let Some(parent_key) = slot.parent_key {
+          let parent_index = node_indices[parent_key.as_usize()].expect("Indexed parent must have a slot");
+          let parent = &completed[parent_index - completed_start].node;
+          let (_, edge) = slot
+            .parent_edge
+            .as_mut()
+            .expect("Non-root indexed node must own its parent edge");
+          let mut q_to_child = parent.clock_set().clone();
+          q_to_child -= edge.from_child();
+          *edge.to_child_mut() = q_to_child;
 
-      let mut q_dest = edge.to_parent().clone();
-      q_dest += edge.to_child().propagate_averages(edge_len, branch_variance);
-      *n.payload.clock_set_mut() = q_dest;
-    }
-
-    for mut child_edge in n.child_edges {
-      let mut q = n.payload.clock_set().clone();
-      q -= child_edge.from_child();
-      *child_edge.to_child_mut() = q;
-    }
-    Ok(GraphTraversalContinuation::Continue)
+          let edge_len = edge_divergence(edge.branch_length(), edge.time_length(), edge.gamma(), prev_clock_rate);
+          let branch_variance = options.variance_factor * edge_len + options.variance_offset;
+          let mut q_dest = edge.to_parent().clone();
+          q_dest += edge.to_child().propagate_averages(edge_len, branch_variance);
+          *slot.node.clock_set_mut() = q_dest;
+        }
+      });
+      Ok(())
+    })
   })
 }
 

--- a/packages/treetime/src/clock/find_best_root/find_best_root.rs
+++ b/packages/treetime/src/clock/find_best_root/find_best_root.rs
@@ -6,6 +6,7 @@ use crate::payload::clock_set::ClockSet;
 use crate::payload::traits::{ClockEdge, ClockNode};
 use eyre::Report;
 use log::{debug, info};
+use rayon::prelude::*;
 use std::sync::Arc;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
@@ -35,46 +36,51 @@ where
 
   // Initialize with the current root, only accepting it if it has a positive clock rate
   // (or if force_positive is false)
-  let root = root.read_arc().payload().read_arc();
-  let root_acceptable = !force_positive || has_positive_clock_rate(root.clock_set());
+  let root_clock_set = root.read_arc().payload().read_arc().clock_set().clone();
+  let root_acceptable = !force_positive || has_positive_clock_rate(&root_clock_set);
   let mut best_chisq = if root_acceptable {
-    objective.score(root.clock_set())
+    objective.score(&root_clock_set)
   } else {
     f64::INFINITY
   };
   debug!(
     "Initial root chi-squared: {:.6e} (acceptable: {root_acceptable})",
-    objective.score(root.clock_set())
+    objective.score(&root_clock_set)
   );
 
   let mut best_res = FindRootResult {
     edge: None,
     split: 0.0,
     chisq: best_chisq,
-    clock_set: root.clock_set().clone(),
+    clock_set: root_clock_set,
   };
 
   // Find best node (with positive clock rate when force_positive is true)
   let mut node_count = 0;
   let mut improvements = 0;
   let mut rejected_negative_rate = 0;
-  for n in graph.get_nodes() {
-    let node_guard = n.read_arc();
-    let payload_guard = node_guard.payload().read_arc();
-    let clock_set = payload_guard.clock_set();
-    if force_positive && !has_positive_clock_rate(clock_set) {
+  let candidates = graph
+    .get_nodes()
+    .par_iter()
+    .map(|node| {
+      let node_guard = node.read_arc();
+      let payload_guard = node_guard.payload().read_arc();
+      let clock_set = payload_guard.clock_set();
+      let acceptable = !force_positive || has_positive_clock_rate(clock_set);
+      (Arc::clone(node), acceptable.then(|| objective.score(clock_set)))
+    })
+    .collect::<Vec<_>>();
+  for (n, score) in candidates {
+    let Some(tmp_chisq) = score else {
       rejected_negative_rate += 1;
       node_count += 1;
       continue;
-    }
-    let tmp_chisq = objective.score(clock_set);
-    drop(payload_guard);
-    drop(node_guard);
+    };
     if tmp_chisq < best_chisq {
       improvements += 1;
       debug!("Found better node {improvements}: chi-squared improved from {best_chisq:.6e} to {tmp_chisq:.6e}");
       best_chisq = tmp_chisq;
-      best_root_node = Arc::clone(&n);
+      best_root_node = n;
     }
     node_count += 1;
   }

--- a/packages/treetime/src/partition/__tests__/test_indexed_pass.rs
+++ b/packages/treetime/src/partition/__tests__/test_indexed_pass.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-  use crate::partition::indexed_pass::IndexedPass;
+  use crate::partition::indexed_pass::{IndexedPass, with_indexed_graph_payloads};
   use crate::payload::ancestral::GraphAncestral;
   use eyre::Report;
   use pretty_assertions::assert_eq;
@@ -68,6 +68,50 @@ mod tests {
     let result = pass.try_for_each_backward_frontier(|_, _, _, _, _| Err(make_report!("injected pass failure")));
     assert_error!(result, "injected pass failure");
     let (actual_nodes, actual_edges) = pass.into_maps()?;
+
+    assert_eq!(expected_nodes, actual_nodes);
+    assert_eq!(expected_edges, actual_edges);
+    Ok(())
+  }
+
+  #[test]
+  fn test_indexed_graph_payloads_error_restores_graph() -> Result<(), Report> {
+    let graph: GraphAncestral = nwk_read_str("((A:1,B:2)AB:3,C:4)root;")?;
+    let expected_nodes = graph
+      .get_nodes()
+      .iter()
+      .map(|node| {
+        let node = node.read_arc();
+        (node.key(), node.payload().read_arc().name.clone())
+      })
+      .collect::<BTreeMap<_, _>>();
+    let expected_edges = graph
+      .get_edges()
+      .iter()
+      .map(|edge| {
+        let edge = edge.read_arc();
+        (edge.key(), edge.payload().read_arc().branch_length)
+      })
+      .collect::<BTreeMap<_, _>>();
+
+    let result = with_indexed_graph_payloads(&graph, |_| Err::<(), _>(make_report!("injected graph pass failure")));
+    assert_error!(result, "injected graph pass failure");
+    let actual_nodes = graph
+      .get_nodes()
+      .iter()
+      .map(|node| {
+        let node = node.read_arc();
+        (node.key(), node.payload().read_arc().name.clone())
+      })
+      .collect::<BTreeMap<_, _>>();
+    let actual_edges = graph
+      .get_edges()
+      .iter()
+      .map(|edge| {
+        let edge = edge.read_arc();
+        (edge.key(), edge.payload().read_arc().branch_length)
+      })
+      .collect::<BTreeMap<_, _>>();
 
     assert_eq!(expected_nodes, actual_nodes);
     assert_eq!(expected_edges, actual_edges);

--- a/packages/treetime/src/partition/indexed_pass.rs
+++ b/packages/treetime/src/partition/indexed_pass.rs
@@ -5,6 +5,61 @@ use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, GraphNodeKey};
 use treetime_utils::make_internal_report;
 
+pub fn with_indexed_graph_payloads<N, E, D, R>(
+  graph: &Graph<N, E, D>,
+  visit: impl FnOnce(&mut IndexedPass<N, E>) -> Result<R, Report>,
+) -> Result<R, Report>
+where
+  N: GraphNode + Default,
+  E: GraphEdge + Default,
+  D: Send + Sync,
+{
+  let frontiers = graph.breadth_first_frontiers_backward()?;
+  for key in frontiers.iter().flatten() {
+    graph.parent_inbound_edge(*key)?;
+  }
+
+  let mut nodes = graph
+    .get_nodes()
+    .iter()
+    .map(|node| {
+      let node = node.read_arc();
+      let key = node.key();
+      let data = std::mem::take(&mut *node.payload().write_arc());
+      (key, data)
+    })
+    .collect::<BTreeMap<_, _>>();
+  let mut edges = graph
+    .get_edges()
+    .iter()
+    .map(|edge| {
+      let edge = edge.read_arc();
+      let key = edge.key();
+      let data = std::mem::take(&mut *edge.payload().write_arc());
+      (key, data)
+    })
+    .collect::<BTreeMap<_, _>>();
+
+  let mut pass = IndexedPass::new(graph, &mut nodes, &mut edges, |_| {
+    unreachable!("graph payload extraction includes every node")
+  })?;
+  let result = visit(&mut pass);
+  let (mut nodes, mut edges) = pass.into_maps()?;
+
+  for node in graph.get_nodes() {
+    let node = node.read_arc();
+    let key = node.key();
+    *node.payload().write_arc() = nodes.remove(&key).expect("Indexed pass must restore every graph node");
+  }
+  for edge in graph.get_edges() {
+    let edge = edge.read_arc();
+    let key = edge.key();
+    *edge.payload().write_arc() = edges.remove(&key).expect("Indexed pass must restore every graph edge");
+  }
+
+  result
+}
+
 pub struct IndexedPass<N, E> {
   slots: Vec<IndexedPassSlot<N, E>>,
   node_indices: Vec<Option<usize>>,
@@ -21,7 +76,7 @@ pub struct IndexedPassSlot<N, E> {
 
 impl<N, E> IndexedPass<N, E> {
   pub fn new<GN, GE>(
-    graph: &Graph<GN, GE, ()>,
+    graph: &Graph<GN, GE, impl Send + Sync>,
     nodes: &mut BTreeMap<GraphNodeKey, N>,
     edges: &mut BTreeMap<GraphEdgeKey, E>,
     mut missing_node: impl FnMut(GraphNodeKey) -> Result<N, Report>,

--- a/packages/treetime/src/partition/traits.rs
+++ b/packages/treetime/src/partition/traits.rs
@@ -11,6 +11,7 @@ use eyre::Report;
 use itertools::Itertools;
 use maplit::btreemap;
 use parking_lot::RwLock;
+use rayon::prelude::*;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey};
@@ -310,7 +311,7 @@ where
 /// Calculate the total log likelihood of the graph given the partitions
 pub fn graph_log_lh<P, N, E, D>(graph: &Graph<N, E, D>, partitions: &[Arc<RwLock<P>>]) -> Result<f64, Report>
 where
-  P: HasLogLh + ?Sized,
+  P: HasLogLh + Send + Sync + ?Sized,
   N: GraphNode,
   E: GraphEdge,
   D: Sync + Send + Default,
@@ -319,8 +320,10 @@ where
   let root_key = root.read_arc().key();
 
   let log_lh = partitions
-    .iter()
+    .par_iter()
     .map(|partition| partition.read_arc().get_log_lh(root_key))
+    .collect::<Vec<_>>()
+    .into_iter()
     .sum();
 
   Ok(log_lh)

--- a/packages/treetime/src/timetree/inference/backward_pass.rs
+++ b/packages/treetime/src/timetree/inference/backward_pass.rs
@@ -1,14 +1,15 @@
+use crate::partition::indexed_pass::{IndexedPassSlot, with_indexed_graph_payloads};
 use crate::payload::traits::{TimetreeEdge, TimetreeNode};
 use eyre::Report;
 use indexmap::IndexMap;
+use rayon::prelude::*;
 use std::sync::Arc;
 use treetime_distribution::distribution_convolution;
 use treetime_distribution::distribution_multiplication;
 use treetime_distribution::{Distribution, DistributionNegLog};
-use treetime_graph::breadth_first::GraphTraversalContinuation;
+use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
-use treetime_graph::graph_traverse::GraphNodeBackward;
-use treetime_graph::node::GraphNodeKey;
+use treetime_graph::node::{GraphNode, GraphNodeKey};
 
 /// Propagates time distributions backward from leaves to root.
 ///
@@ -19,63 +20,64 @@ pub fn propagate_distributions_backward<N, E, D>(
   coalescent_contributions: Option<&IndexMap<GraphNodeKey, Arc<DistributionNegLog>>>,
 ) -> Result<(), Report>
 where
-  N: TimetreeNode,
-  E: TimetreeEdge,
+  N: GraphNode + TimetreeNode + Default,
+  E: GraphEdge + TimetreeEdge + Default,
   D: Send + Sync,
 {
-  graph.par_iter_breadth_first_backward(|mut node| {
-    propagate_distributions_backward_single_node(&mut node, coalescent_contributions)?;
-    Ok(GraphTraversalContinuation::Continue)
+  with_indexed_graph_payloads(graph, |pass| {
+    pass.try_for_each_backward_frontier(|node_indices, _, _, completed, frontier| {
+      frontier.par_iter_mut().try_for_each(|slot| {
+        propagate_distributions_backward_slot(graph, coalescent_contributions, node_indices, completed, slot)
+      })
+    })
   })
 }
 
 /// Computes time distribution for a single internal node from its children.
-fn propagate_distributions_backward_single_node<N, E, D>(
-  node: &mut GraphNodeBackward<N, E, D>,
+fn propagate_distributions_backward_slot<N, E, D>(
+  graph: &Graph<N, E, D>,
   coalescent_contribs: Option<&IndexMap<GraphNodeKey, Arc<DistributionNegLog>>>,
+  node_indices: &[Option<usize>],
+  completed: &[IndexedPassSlot<N, E>],
+  slot: &mut IndexedPassSlot<N, E>,
 ) -> Result<(), Report>
 where
-  N: TimetreeNode,
-  E: TimetreeEdge,
+  N: GraphNode + TimetreeNode,
+  E: GraphEdge + TimetreeEdge,
   D: Send + Sync,
 {
-  let coalescent_contribution = if node.is_leaf {
+  let coalescent_contribution = if graph.is_leaf(slot.key) {
     None
   } else {
-    coalescent_contribs.and_then(|contributions| contributions.get(&node.key))
+    coalescent_contribs.and_then(|contributions| contributions.get(&slot.key))
   };
   let mut result: Option<Distribution> = None;
 
-  for (child, edge) in &node.children {
-    let child = child.read_arc();
-    let mut edge = edge.write_arc();
-
-    // Skip bad branches: outlier leaves and dateless leaves should not constrain parent time
-    if child.bad_branch() {
+  for (child, _) in graph.children_of(&graph.get_node(slot.key).expect("Indexed node must exist").read_arc()) {
+    let child_key = child.read_arc().key();
+    let child_index = node_indices[child_key.as_usize()].expect("Indexed child must have a slot");
+    let child = &completed[child_index];
+    if child.node.bad_branch() {
       continue;
     }
-
-    if let (Some(branch_dist), Some(child_time_dist)) = (edge.branch_length_distribution(), child.time_distribution()) {
-      // Compute parent time distribution using regular convolution with negated branch: parent_time = child_time + (-branch_length)
-      let negated_branch_dist = branch_dist.negate()?;
-      let parent_message = distribution_convolution(child_time_dist.as_ref(), &negated_branch_dist)?;
-      let parent_message_arc = Arc::new(parent_message);
-
-      // Store message on edge
-      edge.set_msg_to_parent(Some(Arc::clone(&parent_message_arc)));
-
+    let edge = &child
+      .parent_edge
+      .as_ref()
+      .expect("Non-root indexed node must own its parent edge")
+      .1;
+    if let Some(parent_message) = edge.msg_to_parent() {
       // Combine messages from all children using multiplication (intersection of constraints).
       // Normalize after each step to prevent numerical underflow in plain probability space:
       // without normalization, the peak decays as ~(peak)^N across N children, underflowing
       // to zero for large trees. Normalization (max=1.0) is safe because all downstream
       // consumers (likely_time, quantile, hpd_region) are scale-invariant.
       result = Some(if let Some(current) = result {
-        distribution_multiplication(&current, &parent_message_arc)?.normalize()
+        distribution_multiplication(&current, parent_message)?.normalize()
       } else if let Some(contribution) = coalescent_contribution {
-        let parent_message = parent_message_arc.to_neglog();
+        let parent_message = parent_message.to_neglog();
         distribution_multiplication(contribution, &parent_message)?.to_plain_normalized()
       } else {
-        (*parent_message_arc).clone()
+        parent_message.as_ref().clone()
       });
     }
   }
@@ -88,7 +90,17 @@ where
 
   // Store final distribution on node
   if let Some(dist) = result {
-    node.payload.set_time_distribution(Some(Arc::new(dist)));
+    slot.node.set_time_distribution(Some(Arc::new(dist)));
+  }
+
+  if !slot.node.bad_branch()
+    && let Some((_, edge)) = slot.parent_edge.as_mut()
+    && let (Some(branch_dist), Some(node_time_dist)) =
+      (edge.branch_length_distribution(), slot.node.time_distribution())
+  {
+    let negated_branch_dist = branch_dist.negate()?;
+    let parent_message = distribution_convolution(node_time_dist.as_ref(), &negated_branch_dist)?;
+    edge.set_msg_to_parent(Some(Arc::new(parent_message)));
   }
 
   Ok(())

--- a/packages/treetime/src/timetree/inference/forward_pass.rs
+++ b/packages/treetime/src/timetree/inference/forward_pass.rs
@@ -1,76 +1,91 @@
+use crate::partition::indexed_pass::{IndexedPassSlot, with_indexed_graph_payloads};
 use crate::payload::traits::{TimetreeEdge, TimetreeNode};
 use eyre::Report;
+use rayon::prelude::*;
 use std::sync::Arc;
 use treetime_distribution::distribution_convolution;
 use treetime_distribution::distribution_division;
 use treetime_distribution::distribution_multiplication;
-use treetime_graph::breadth_first::GraphTraversalContinuation;
+use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
-use treetime_graph::graph_traverse::GraphNodeForward;
+use treetime_graph::node::GraphNode;
 
 pub fn propagate_distributions_forward<N, E, D>(graph: &Graph<N, E, D>) -> Result<(), Report>
 where
-  N: TimetreeNode,
-  E: TimetreeEdge,
+  N: GraphNode + TimetreeNode + Default,
+  E: GraphEdge + TimetreeEdge + Default,
   D: Send + Sync,
 {
-  graph.par_iter_breadth_first_forward(|mut node| {
-    propagate_distributions_forward_single_node(&mut node)?;
-    Ok(GraphTraversalContinuation::Continue)
+  with_indexed_graph_payloads(graph, |pass| {
+    pass.try_for_each_forward_frontier(|node_indices, _, _, completed_start, frontier, completed| {
+      frontier.par_iter_mut().try_for_each(|slot| {
+        propagate_distributions_forward_slot(graph, node_indices, completed_start, completed, slot)
+      })
+    })
   })
 }
 
-fn propagate_distributions_forward_single_node<N, E, D>(node: &mut GraphNodeForward<N, E, D>) -> Result<(), Report>
+fn propagate_distributions_forward_slot<N, E, D>(
+  graph: &Graph<N, E, D>,
+  node_indices: &[Option<usize>],
+  completed_start: usize,
+  completed: &[IndexedPassSlot<N, E>],
+  slot: &mut IndexedPassSlot<N, E>,
+) -> Result<(), Report>
 where
-  N: TimetreeNode,
-  E: TimetreeEdge,
+  N: GraphNode + TimetreeNode,
+  E: GraphEdge + TimetreeEdge,
   D: Send + Sync,
 {
-  refine_distribution_from_parent(node)?;
-  set_likely_time(node);
+  refine_distribution_from_parent(graph, node_indices, completed_start, completed, slot)?;
+  set_likely_time(&mut slot.node);
   Ok(())
 }
 
-fn set_likely_time<N, E, D>(node: &mut GraphNodeForward<N, E, D>)
-where
-  N: TimetreeNode,
-  E: TimetreeEdge,
-  D: Send + Sync,
-{
+fn set_likely_time(node: &mut impl TimetreeNode) {
   let time = node
-    .payload
     .time_distribution()
     .as_ref()
     .and_then(|time_dist| time_dist.likely_time());
 
   if let Some(time) = time {
-    node.payload.set_time(Some(time));
+    node.set_time(Some(time));
   }
 }
 
-fn refine_distribution_from_parent<N, E, D>(node: &mut GraphNodeForward<N, E, D>) -> Result<(), Report>
+fn refine_distribution_from_parent<N, E, D>(
+  graph: &Graph<N, E, D>,
+  node_indices: &[Option<usize>],
+  completed_start: usize,
+  completed: &[IndexedPassSlot<N, E>],
+  slot: &mut IndexedPassSlot<N, E>,
+) -> Result<(), Report>
 where
-  N: TimetreeNode,
-  E: TimetreeEdge,
+  N: GraphNode + TimetreeNode,
+  E: GraphEdge + TimetreeEdge,
   D: Send + Sync,
 {
-  if node.is_root {
+  if slot.parent_key.is_none() {
     return Ok(());
   }
 
   // Do not overwrite leaf time_distribution (date constraint)
-  if node.is_leaf {
+  if graph.is_leaf(slot.key) {
     return Ok(());
   }
 
-  if let Ok((parent, edge)) = node.get_exactly_one_parent() {
-    let parent = parent.read_arc();
-    let edge = edge.read_arc();
+  if let Some(parent_key) = slot.parent_key {
+    let parent_index = node_indices[parent_key.as_usize()].expect("Indexed parent must have a slot");
+    let parent = &completed[parent_index - completed_start].node;
+    let (_, edge) = slot
+      .parent_edge
+      .as_ref()
+      .expect("Non-root indexed node must own its parent edge");
 
     if let (Some(parent_time_dist), Some(branch_dist), Some(subtree_dist)) = (
       parent.time_distribution(),
       edge.branch_length_distribution(),
-      node.payload.time_distribution(),
+      slot.node.time_distribution(),
     ) {
       let parent_except_subtree = if let Some(msg_to_parent) = edge.msg_to_parent() {
         distribution_division(parent_time_dist, msg_to_parent)?
@@ -83,12 +98,12 @@ where
       // distributions (max=1.0), and the convolution/division can produce arbitrary scales.
       // Without normalization, values accumulate downward across tree depth.
       let combined = distribution_multiplication(&dist_from_parent, subtree_dist)?.normalize();
-      node.payload.set_time_distribution(Some(Arc::new(combined)));
+      slot.node.set_time_distribution(Some(Arc::new(combined)));
     } else if let (Some(parent_time_dist), Some(branch_dist)) =
       (parent.time_distribution(), edge.branch_length_distribution())
     {
       let dist_from_parent = distribution_convolution(parent_time_dist, branch_dist)?.normalize();
-      node.payload.set_time_distribution(Some(Arc::new(dist_from_parent)));
+      slot.node.set_time_distribution(Some(Arc::new(dist_from_parent)));
     }
   }
 

--- a/packages/treetime/src/timetree/inference/runner.rs
+++ b/packages/treetime/src/timetree/inference/runner.rs
@@ -29,8 +29,8 @@ pub fn run_timetree<N, E, P>(
   no_indels: bool,
 ) -> Result<(), Report>
 where
-  N: GraphNode + Named + TimetreeNode + ClockNode,
-  E: GraphEdge + HasBranchLength + TimetreeEdge,
+  N: GraphNode + Named + TimetreeNode + ClockNode + Default,
+  E: GraphEdge + HasBranchLength + TimetreeEdge + Default,
   P: PartitionTimetreeAll<N, E> + ?Sized,
 {
   info!("# Running timetree inference");


### PR DESCRIPTION


- Depends on: #829

Temporal inference still mutated graph payloads during traversal. This PR moves those payloads into indexed storage and uses deterministic parallel reductions.

The indexed contract now spans ancestral and temporal inference while topology mutation remains outside the passes.

Sources: `pub fn clock_filter_inplace()` [[src](https://github.com/neherlab/treetime/blob/e8099c1065885704df699db1cf4d35203e6157a3/packages/treetime/src/clock/clock_filter.rs#L27-L74)] and `pub fn run_timetree()` [[src](https://github.com/neherlab/treetime/blob/e8099c1065885704df699db1cf4d35203e6157a3/packages/treetime/src/timetree/inference/runner.rs#L24-L68)]

### Work items

- [x] Index clock and timetree traversal payloads
- [x] Parallelize clock-filter, regression, and reroot reductions
- [x] Preserve deterministic reduction order and error propagation
- [x] Cover payload slot invariants

