### PR TITLE
docs: add parallel scaling reports

### DIFF
--- a/dev/bench-graph-pass-report
+++ b/dev/bench-graph-pass-report
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""
+Usage: bench-graph-pass-report [options] <summary-json>
+
+Generate SVG charts and a markdown report from bench-graph-pass-cli output.
+
+Options:
+  --output DIR    Output directory for charts and report (default: alongside summary.json)
+  --dataset NAME  Dataset label for the report (default: derived from summary.json metadata)
+  -h, --help      Show this help
+
+Reads summary.json produced by bench-graph-pass-cli, generates:
+  assets/<dataset>_wall-time.svg
+  assets/<dataset>_speedup.svg
+  assets/<dataset>_efficiency.svg
+  assets/<dataset>_peak-rss.svg
+  <dataset>.md
+"""
+
+import argparse
+import json
+import math
+import sys
+import textwrap
+from pathlib import Path
+
+WORKLOAD_ORDER = ["timetree", "optimize", "ancestral", "mugration", "clock"]
+WORKLOAD_LABELS = {
+    "timetree": "Timetree",
+    "optimize": "Optimize",
+    "ancestral": "Ancestral",
+    "mugration": "Mugration",
+    "clock": "Clock",
+}
+
+# Dataviz palette: categorical slots 1-5
+COLORS = ["#2a78d6", "#1baf7a", "#eda100", "#008300", "#4a3aa7"]
+
+# Chart chrome (light mode)
+SURFACE = "#fcfcfb"
+INK = "#0b0b0b"
+SECONDARY = "#52514e"
+MUTED = "#898781"
+GRIDLINE = "#e1e0d9"
+BASELINE = "#c3c2b7"
+THRESHOLD = "#c3c2b7"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate benchmark report")
+    parser.add_argument("summary_json", type=Path)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--dataset", type=str, default=None)
+    return parser.parse_args()
+
+
+def load_data(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def compute_metrics(data):
+    results = data["results"]
+    threads = sorted(set(r["jobs"] for r in results))
+    workloads = [w for w in WORKLOAD_ORDER if any(r["workload"] == w for r in results)]
+
+    averaged = {}
+    for r in results:
+        key = (r["workload"], r["jobs"])
+        if key not in averaged:
+            averaged[key] = {"wall": [], "rss": [], "user": [], "system": [], "min": [], "max": []}
+        averaged[key]["wall"].append(r["mean_seconds"])
+        averaged[key]["rss"].append(r["peak_rss_kb"])
+        averaged[key]["user"].append(r["user_seconds"])
+        averaged[key]["system"].append(r["system_seconds"])
+        averaged[key]["min"].append(r["min_seconds"])
+        averaged[key]["max"].append(r["max_seconds"])
+
+    metrics = {}
+    for (w, j), v in averaged.items():
+        wall = sum(v["wall"]) / len(v["wall"])
+        rss_mb = sum(v["rss"]) / len(v["rss"]) / 1024
+        user = sum(v["user"]) / len(v["user"])
+        system = sum(v["system"]) / len(v["system"])
+        run_min = min(v["min"])
+        run_max = max(v["max"])
+        metrics[(w, j)] = {
+            "wall": wall,
+            "rss_mb": rss_mb,
+            "user": user,
+            "system": system,
+            "min": run_min,
+            "max": run_max,
+        }
+
+    for w in workloads:
+        base = metrics[(w, threads[0])]["wall"]
+        for j in threads:
+            m = metrics[(w, j)]
+            m["speedup"] = base / m["wall"]
+            m["efficiency"] = (base / m["wall"]) / j * 100
+            m["cpu_util"] = (m["user"] + m["system"]) / m["wall"]
+
+    return workloads, threads, metrics
+
+
+def svg_line_chart(
+    title, ylabel, workloads, threads, value_fn, y_max, y_ticks,
+    y_format=lambda v: f"{v:.1f}", show_ideal=False, threshold=None,
+    threshold_label=None, show_whiskers=False, whisker_fn=None,
+):
+    W, H = 700, 400
+    ML, MR, MT, MB = 72, 168, 50, 52
+    pw = W - ML - MR
+    ph = H - MT - MB
+
+    log_positions = [math.log2(j) for j in threads]
+    log_min = log_positions[0]
+    log_max = log_positions[-1]
+    log_range = log_max - log_min if log_max > log_min else 1
+
+    def px(j):
+        return ML + (math.log2(j) - log_min) / log_range * pw
+
+    def py(v):
+        return MT + ph - (v / y_max) * ph
+
+    lines = []
+    lines.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}"'
+        f' font-family="system-ui,-apple-system,sans-serif">'
+    )
+    lines.append(f'<rect width="{W}" height="{H}" fill="{SURFACE}"/>')
+    lines.append(
+        f'<text x="{ML}" y="28" fill="{INK}" font-size="15" font-weight="600">{title}</text>'
+    )
+
+    for yt in y_ticks:
+        y = py(yt)
+        lines.append(
+            f'<line x1="{ML}" y1="{y:.1f}" x2="{ML + pw}" y2="{y:.1f}"'
+            f' stroke="{GRIDLINE}" stroke-width="1"/>'
+        )
+        lines.append(
+            f'<text x="{ML - 10}" y="{y + 4:.1f}" fill="{MUTED}" font-size="11"'
+            f' text-anchor="end">{y_format(yt)}</text>'
+        )
+
+    lines.append(
+        f'<line x1="{ML}" y1="{py(0):.1f}" x2="{ML + pw}" y2="{py(0):.1f}"'
+        f' stroke="{BASELINE}" stroke-width="1"/>'
+    )
+
+    for j in threads:
+        x = px(j)
+        lines.append(
+            f'<text x="{x:.1f}" y="{H - MB + 18:.1f}" fill="{MUTED}" font-size="11"'
+            f' text-anchor="middle">{j}</text>'
+        )
+
+    lines.append(
+        f'<text x="{ML + pw / 2:.1f}" y="{H - 8:.1f}" fill="{SECONDARY}" font-size="12"'
+        f' text-anchor="middle">Threads</text>'
+    )
+    lines.append(
+        f'<text x="14" y="{MT + ph / 2:.1f}" fill="{SECONDARY}" font-size="12"'
+        f' text-anchor="middle" transform="rotate(-90,14,{MT + ph / 2:.1f})">{ylabel}</text>'
+    )
+
+    if show_ideal:
+        ideal_pts = []
+        for j in threads:
+            v = min(j, y_max)
+            if v <= y_max:
+                ideal_pts.append(f"{px(j):.1f},{py(v):.1f}")
+        lines.append(
+            f'<polyline points="{" ".join(ideal_pts)}" fill="none" stroke="{GRIDLINE}"'
+            f' stroke-width="1.5" stroke-dasharray="6,4"/>'
+        )
+        last_j = threads[-1]
+        ideal_v = min(last_j, y_max)
+        lines.append(
+            f'<text x="{px(last_j) + 6:.1f}" y="{py(ideal_v) + 4:.1f}" fill="{MUTED}"'
+            f' font-size="10">ideal</text>'
+        )
+
+    if threshold is not None:
+        ty = py(threshold)
+        lines.append(
+            f'<line x1="{ML}" y1="{ty:.1f}" x2="{ML + pw}" y2="{ty:.1f}"'
+            f' stroke="{THRESHOLD}" stroke-width="1" stroke-dasharray="4,3"/>'
+        )
+        if threshold_label:
+            lines.append(
+                f'<text x="{ML + pw + 4:.1f}" y="{ty + 4:.1f}" fill="{MUTED}"'
+                f' font-size="9">{threshold_label}</text>'
+            )
+
+    all_labels = []
+
+    for i, w in enumerate(workloads):
+        c = COLORS[i]
+        pts = []
+        for j in threads:
+            v = value_fn(w, j)
+            pts.append((px(j), py(v), v, j))
+
+        polyline = " ".join(f"{x:.1f},{y:.1f}" for x, y, _, _ in pts)
+        lines.append(
+            f'<polyline points="{polyline}" fill="none" stroke="{c}" stroke-width="2"'
+            f' stroke-linejoin="round" stroke-linecap="round"/>'
+        )
+
+        if show_whiskers and whisker_fn:
+            for x, y, v, j in pts:
+                lo, hi = whisker_fn(w, j)
+                y_lo, y_hi = py(lo), py(hi)
+                lines.append(
+                    f'<line x1="{x:.1f}" y1="{y_lo:.1f}" x2="{x:.1f}" y2="{y_hi:.1f}"'
+                    f' stroke="{c}" stroke-width="1" opacity="0.4"/>'
+                )
+                lines.append(
+                    f'<line x1="{x - 3:.1f}" y1="{y_lo:.1f}" x2="{x + 3:.1f}" y2="{y_lo:.1f}"'
+                    f' stroke="{c}" stroke-width="1" opacity="0.4"/>'
+                )
+                lines.append(
+                    f'<line x1="{x - 3:.1f}" y1="{y_hi:.1f}" x2="{x + 3:.1f}" y2="{y_hi:.1f}"'
+                    f' stroke="{c}" stroke-width="1" opacity="0.4"/>'
+                )
+
+        for x, y, v, j in pts:
+            lines.append(
+                f'<circle cx="{x:.1f}" cy="{y:.1f}" r="4" fill="{c}"'
+                f' stroke="{SURFACE}" stroke-width="2"/>'
+            )
+
+        for x, y, v, j in pts:
+            all_labels.append((x, y, v, j, i))
+
+    resolved = _resolve_label_collisions(all_labels)
+    for x, label_y, v, j, series_idx in resolved:
+        lines.append(
+            f'<text x="{x + 8:.1f}" y="{label_y + 3:.1f}" fill="{SECONDARY}"'
+            f' font-size="9">{y_format(v)}</text>'
+        )
+
+    lx = ML + pw + 30
+    ly_start = MT + 10
+    for i, w in enumerate(workloads):
+        y = ly_start + i * 22
+        lines.append(
+            f'<line x1="{lx}" y1="{y}" x2="{lx + 16}" y2="{y}" stroke="{COLORS[i]}"'
+            f' stroke-width="2" stroke-linecap="round"/>'
+        )
+        lines.append(
+            f'<circle cx="{lx + 8}" cy="{y}" r="3.5" fill="{COLORS[i]}"'
+            f' stroke="{SURFACE}" stroke-width="1.5"/>'
+        )
+        lines.append(
+            f'<text x="{lx + 22}" y="{y + 4}" fill="{INK}"'
+            f' font-size="12">{WORKLOAD_LABELS[w]}</text>'
+        )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def _resolve_label_collisions(labels, min_spacing=11):
+    """Spread labels vertically so none overlap within the same x-column."""
+    if not labels:
+        return []
+
+    from collections import defaultdict
+    columns = defaultdict(list)
+    for x, y, v, j, series_idx in labels:
+        columns[x].append((y, v, j, series_idx))
+
+    result = []
+    for x, entries in columns.items():
+        entries.sort(key=lambda e: e[0])
+        ys = [e[0] for e in entries]
+        adjusted = _spread_ys(ys, min_spacing)
+        for (_, v, j, si), new_y in zip(entries, adjusted):
+            result.append((x, new_y, v, j, si))
+
+    return result
+
+
+def _spread_ys(ys, min_spacing):
+    """Push y-positions apart so adjacent labels have at least min_spacing pixels."""
+    if len(ys) <= 1:
+        return list(ys)
+    adjusted = list(ys)
+    for _ in range(10):
+        changed = False
+        for i in range(len(adjusted) - 1):
+            overlap = min_spacing - (adjusted[i + 1] - adjusted[i])
+            if overlap > 0:
+                adjusted[i] -= overlap / 2
+                adjusted[i + 1] += overlap / 2
+                changed = True
+        if not changed:
+            break
+    return adjusted
+
+
+def svg_bar_chart(title, ylabel, workloads, threads, value_fn, y_max, y_ticks, y_format=lambda v: f"{v:.0f}"):
+    W, H = 700, 400
+    ML, MR, MT, MB = 72, 20, 50, 52
+    pw = W - ML - MR
+    ph = H - MT - MB
+
+    n_groups = len(threads)
+    n_bars = len(workloads)
+    group_w = pw / n_groups
+    bar_w = min(20, (group_w - 16) / n_bars)
+    spacer = 2
+
+    def py(v):
+        return MT + ph - (v / y_max) * ph
+
+    lines = []
+    lines.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}"'
+        f' font-family="system-ui,-apple-system,sans-serif">'
+    )
+    lines.append(f'<rect width="{W}" height="{H}" fill="{SURFACE}"/>')
+    lines.append(
+        f'<text x="{ML}" y="28" fill="{INK}" font-size="15" font-weight="600">{title}</text>'
+    )
+
+    for yt in y_ticks:
+        y = py(yt)
+        lines.append(
+            f'<line x1="{ML}" y1="{y:.1f}" x2="{ML + pw}" y2="{y:.1f}"'
+            f' stroke="{GRIDLINE}" stroke-width="1"/>'
+        )
+        lines.append(
+            f'<text x="{ML - 10}" y="{y + 4:.1f}" fill="{MUTED}" font-size="11"'
+            f' text-anchor="end">{y_format(yt)}</text>'
+        )
+
+    lines.append(
+        f'<line x1="{ML}" y1="{py(0):.1f}" x2="{ML + pw}" y2="{py(0):.1f}"'
+        f' stroke="{BASELINE}" stroke-width="1"/>'
+    )
+    lines.append(
+        f'<text x="14" y="{MT + ph / 2:.1f}" fill="{SECONDARY}" font-size="12"'
+        f' text-anchor="middle" transform="rotate(-90,14,{MT + ph / 2:.1f})">{ylabel}</text>'
+    )
+
+    total_bars_w = n_bars * bar_w + (n_bars - 1) * spacer
+    for gi, j in enumerate(threads):
+        gx = ML + gi * group_w + group_w / 2 - total_bars_w / 2
+        for bi, w in enumerate(workloads):
+            v = value_fn(w, j)
+            bx = gx + bi * (bar_w + spacer)
+            by = py(v)
+            bh = py(0) - by
+            if bh > 0:
+                lines.append(
+                    f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_w:.1f}"'
+                    f' height="{bh:.1f}" rx="2" fill="{COLORS[bi]}"/>'
+                )
+
+        cx = ML + gi * group_w + group_w / 2
+        lines.append(
+            f'<text x="{cx:.1f}" y="{H - MB + 18:.1f}" fill="{MUTED}" font-size="11"'
+            f' text-anchor="middle">{j}</text>'
+        )
+
+    lines.append(
+        f'<text x="{ML + pw / 2:.1f}" y="{H - 8:.1f}" fill="{SECONDARY}" font-size="12"'
+        f' text-anchor="middle">Threads</text>'
+    )
+
+    lx_start = W - MR - 10
+    ly = MT + 2
+    for i in range(len(workloads) - 1, -1, -1):
+        w = workloads[i]
+        tw = len(WORKLOAD_LABELS[w]) * 7 + 20
+        lx_start -= tw
+        lines.append(
+            f'<rect x="{lx_start}" y="{ly - 5}" width="10" height="10" rx="2"'
+            f' fill="{COLORS[i]}"/>'
+        )
+        lines.append(
+            f'<text x="{lx_start + 14}" y="{ly + 4}" fill="{INK}"'
+            f' font-size="10">{WORKLOAD_LABELS[w]}</text>'
+        )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def nice_y_max(values, headroom=1.15):
+    raw = max(values) * headroom
+    magnitude = 10 ** math.floor(math.log10(raw)) if raw > 0 else 1
+    return math.ceil(raw / magnitude) * magnitude
+
+
+def nice_ticks(y_max, target_count=6):
+    step = y_max / target_count
+    magnitude = 10 ** math.floor(math.log10(step)) if step > 0 else 1
+    nice_steps = [1, 2, 2.5, 5, 10]
+    for ns in nice_steps:
+        candidate = ns * magnitude
+        if y_max / candidate <= target_count + 1:
+            step = candidate
+            break
+    ticks = []
+    v = 0
+    while v <= y_max:
+        ticks.append(v)
+        v = round(v + step, 10)
+    return ticks
+
+
+def generate_charts(workloads, threads, metrics, output_dir, dataset_name):
+    assets_dir = output_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    def get(w, j, field):
+        return metrics[(w, j)][field]
+
+    wall_values = [get(w, j, "wall") for w in workloads for j in threads]
+    wall_max = nice_y_max(wall_values)
+    wall_ticks = nice_ticks(wall_max)
+    wall_svg = svg_line_chart(
+        "Wall-Clock Time vs Thread Count", "Time (seconds)",
+        workloads, threads,
+        lambda w, j: get(w, j, "wall"),
+        wall_max, wall_ticks,
+        y_format=lambda v: f"{v:.1f}s" if v >= 0.1 else (f"{v * 1000:.0f}ms" if v > 0 else "0"),
+        show_whiskers=True,
+        whisker_fn=lambda w, j: (get(w, j, "min"), get(w, j, "max")),
+    )
+    (assets_dir / f"{dataset_name}_wall-time.svg").write_text(wall_svg)
+
+    speedup_values = [get(w, j, "speedup") for w in workloads for j in threads]
+    speedup_max = nice_y_max(speedup_values + [threads[-1]], headroom=1.1)
+    speedup_max = max(speedup_max, threads[-1])
+    speedup_ticks = nice_ticks(speedup_max)
+    speedup_svg = svg_line_chart(
+        "Parallel Speedup vs Thread Count", "Speedup (x)",
+        workloads, threads,
+        lambda w, j: get(w, j, "speedup"),
+        speedup_max, speedup_ticks,
+        y_format=lambda v: f"{v:.1f}x" if v != int(v) else f"{int(v)}x",
+        show_ideal=True,
+    )
+    (assets_dir / f"{dataset_name}_speedup.svg").write_text(speedup_svg)
+
+    eff_svg = svg_line_chart(
+        "Parallel Efficiency vs Thread Count", "Efficiency (%)",
+        workloads, threads,
+        lambda w, j: get(w, j, "efficiency"),
+        110, [0, 25, 50, 75, 100],
+        y_format=lambda v: f"{v:.0f}%",
+        threshold=75, threshold_label="75%",
+    )
+    (assets_dir / f"{dataset_name}_efficiency.svg").write_text(eff_svg)
+
+    rss_values = [get(w, j, "rss_mb") for w in workloads for j in threads]
+    rss_max = nice_y_max(rss_values)
+    rss_ticks = nice_ticks(rss_max)
+    rss_svg = svg_bar_chart(
+        "Peak Resident Memory vs Thread Count", "Peak RSS (MB)",
+        workloads, threads,
+        lambda w, j: get(w, j, "rss_mb"),
+        rss_max, rss_ticks,
+    )
+    (assets_dir / f"{dataset_name}_peak-rss.svg").write_text(rss_svg)
+
+    return [
+        f"{dataset_name}_wall-time.svg",
+        f"{dataset_name}_speedup.svg",
+        f"{dataset_name}_efficiency.svg",
+        f"{dataset_name}_peak-rss.svg",
+    ]
+
+
+def fmt_time(v):
+    if v >= 1:
+        return f"{v:.3f} s"
+    return f"{v * 1000:.1f} ms"
+
+
+def fmt_speedup(v):
+    return f"{v:.2f}x"
+
+
+def fmt_pct(v):
+    return f"{v:.0f}%"
+
+
+def fmt_mb(v):
+    return f"{v:.0f} MB"
+
+
+def fmt_cpu(v):
+    return f"{v:.2f}"
+
+
+def generate_report(data, workloads, threads, metrics, chart_files, dataset_name):
+    meta = data["metadata"]
+    dataset_path = meta["dataset"]
+
+    def get(w, j, field):
+        return metrics[(w, j)][field]
+
+    def table(header_fn, row_fn, fmt):
+        hdr = "| Workload |" + "|".join(f" {header_fn(j)} " for j in threads) + "|"
+        sep = "|---|" + "|".join("---:" for _ in threads) + "|"
+        rows = []
+        for w in workloads:
+            cols = "|".join(f" {fmt(row_fn(w, j))} " for j in threads)
+            rows.append(f"| **{WORKLOAD_LABELS[w]}** |{cols}|")
+        return "\n".join([hdr, sep] + rows)
+
+    thread_hdr = lambda j: f"{j} thread{'s' if j > 1 else ''}"
+
+    wall_table = table(thread_hdr, lambda w, j: get(w, j, "wall"), fmt_time)
+    speedup_table = table(thread_hdr, lambda w, j: get(w, j, "speedup"), fmt_speedup)
+    eff_table = table(thread_hdr, lambda w, j: get(w, j, "efficiency"), fmt_pct)
+    rss_table = table(thread_hdr, lambda w, j: get(w, j, "rss_mb"), fmt_mb)
+    cpu_table = table(thread_hdr, lambda w, j: get(w, j, "cpu_util"), fmt_cpu)
+
+    runs = meta.get("runs", "N/A")
+    warmup = meta.get("warmup", "N/A")
+    thread_csv = ", ".join(str(j) for j in threads)
+
+    report = f"""\
+# Parallel Scaling: {dataset_name}
+
+**Commit:** `{meta.get("after_ref", "N/A")}`
+**Dataset:** `{dataset_path}`
+**Threads:** {thread_csv}
+**Runs:** {runs} measured + {warmup} warmup per configuration
+
+## Methodology
+
+A single release binary was benchmarked across five CLI subcommands at thread counts {thread_csv} using [hyperfine](https://github.com/sharkdp/hyperfine) ({runs} measured runs, {warmup} warmup). Peak RSS was captured separately via `/usr/bin/time`. The benchmark harness (`dev/bench-graph-pass-cli`) ran each workload twice per configuration; results are the mean of both runs.
+
+### Workloads
+
+| Subcommand | Description | Key parameters |
+|---|---|---|
+| **ancestral** | Marginal ancestral sequence reconstruction | `--method-anc=marginal --dense=false` |
+| **mugration** | Discrete trait reconstruction (country) | `--attribute=country --pc=1.0` |
+| **clock** | Molecular clock inference | default |
+| **optimize** | Branch length optimization | `--dense=false` |
+| **timetree** | Full time-scaled phylogeny | all output formats |
+
+## Results
+
+### Wall-clock time
+
+![Wall-clock time](assets/{chart_files[0]})
+
+{wall_table}
+
+### Speedup
+
+![Speedup](assets/{chart_files[1]})
+
+{speedup_table}
+
+### Parallel efficiency
+
+![Efficiency](assets/{chart_files[2]})
+
+Efficiency = speedup / thread count.
+
+{eff_table}
+
+### Peak resident memory
+
+![Peak RSS](assets/{chart_files[3]})
+
+{rss_table}
+
+### CPU utilization
+
+User + system time / wall-clock time. Values above 1.0 indicate parallel CPU use.
+
+{cpu_table}
+"""
+    return report
+
+
+def main():
+    args = parse_args()
+    data = load_data(args.summary_json)
+    output_dir = args.output or args.summary_json.parent
+    dataset_label = args.dataset
+    if not dataset_label:
+        ds = data["metadata"].get("dataset", "unknown")
+        dataset_label = ds.replace("/", "-").replace("data-", "")
+
+    workloads, threads, metrics = compute_metrics(data)
+    chart_files = generate_charts(workloads, threads, metrics, output_dir, dataset_label)
+    report = generate_report(data, workloads, threads, metrics, chart_files, dataset_label)
+
+    report_path = output_dir / f"{dataset_label}.md"
+    report_path.write_text(report)
+    print(f"Report: {report_path}")
+    for cf in chart_files:
+        print(f"Chart:  {output_dir / 'assets' / cf}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/profile
+++ b/dev/profile
@@ -1,62 +1,137 @@
 #!/usr/bin/env bash
+#
+# Usage: $0 [options] <program> [-- program-args...]
+#
+# Sampling profiler for the treetime binaries. Builds the "profiling" cargo
+# profile (release optimizations + debug symbols) inside the container, then
+# records a profile on the host, where kernel perf access lives.
+#
+# Two backends:
+#   samply (default)  Interactive Firefox Profiler UI. Best for exploration.
+#   perf              Textual hotspots to stdout. Best for scripted or
+#                     agent-driven analysis and for pasting into reports.
+#
+# Options:
+#   --perf             Use perf, print textual self-time + call-graph report
+#   --samply           Use samply, open Firefox Profiler UI (default)
+#   --rate N           Sampling frequency in Hz (default: 1234)
+#   --output PATH      Recording output path (default: tmp/profiling/<program>.<ext>)
+#   --no-build         Skip the container build step, reuse existing binary
+#   -h, --help         Show this help
+#
+# The program is an executable name without a path (e.g. treetime). Everything
+# after -- is passed to the program unchanged.
+#
+# Examples:
+#   $0 --perf treetime -- ancestral --dense=false --tree=data/mpox/clade-ii/2000/tree.nwk \
+#     --aln=data/mpox/clade-ii/2000/aln.fasta.xz --output-all=tmp/anc -j 1 --silent
+#   $0 treetime -- clock --tree=data/flu/h3n2/200/tree.nwk --dates=data/flu/h3n2/200/metadata.tsv
+#
+# Requirements (host):
+#   perf     linux-tools matching the running kernel
+#   samply   cargo install samply  (only for the default backend)
+#
+# Kernel perf access (until reboot):
+#   echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null
+#   echo  0 | sudo tee /proc/sys/kernel/kptr_restrict       >/dev/null
+#
 set -euo pipefail
 trap "exit" INT
 
-# Perform sampling performance profiling and display the results in a web UI.
-#
-# This will do the following:
-#  * build the project using special "profiling" cargo profile (see .cargo/config.toml). This profile configures cargo
-#  for optimized (release) build, but with debug symbols emitted and kept (not stripped).
-#  * run the given program under sampling profiler called samply (https://github.com/mstange/samply),
-#  * upon finishing the recording, samply will open Firefox Profiler (https://profiler.firefox.com) in default browser
-#  with the results. If not, navigate to url printed to the console, then click "Open the profile in the profiler UI".
-#
-# NOTE: Sampling is performed at frequency about 1000 times per second, so for meaningful results you probably want
-# to run your program with a workload which runs for at least a few seconds.
-#
-# NOTE: At first, you might want to run your program in single-threaded mode.
-#
-#
-# Usage:
-#
-#   ./dev/profile <program_name> [arguments]
-#
-# Note: <program> is executable name without path
-#
-#
-# Requirements:
-#  * perf (https://perf.wiki.kernel.org)
-#
-#    On Ubuntu:
-#
-#      /!\ WARNING: If linux-tools-<kernel-version-string> package is not already installed make sure that you are
-#      installing it specifically for your current version of kernel, and make sure to not install some broken kernel
-#      which bricks your system on next reboot!
-#
-#      sudo apt-get install linux-tools-common linux-tools-$(uname -r)
-#
-#  * samply (https://github.com/mstange/samply)
-#
-#      cargo install samply
-#
-#  * [optional] Access to performance events system for unprivileged users. The samply tool might work without these,
-#    but the results might be incomplete.
-#
-#      /!\ WARNING: Learn about security implications of these settings:
-#      https://www.kernel.org/doc/html/latest/admin-guide/perf-security.html
-#
-#    until next reboot:
-#      echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null
-#      echo 0 | sudo tee /proc/sys/kernel/kptr_restrict >/dev/null
-#
-#    you can reset this back by rebooting, or with these commands:
-#
-#      echo 2 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null
-#      echo 1 | sudo tee /proc/sys/kernel/kptr_restrict >/dev/null
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+PROJECT_DIR="$(dirname "${THIS_DIR}")"
 
-set -x
+BIN_DIR=".build/docker/profiling"
+SAMPLE_RATE=1234
 
-cargo -q build --profile=profiling --bin="$(basename "$1")"
+build_binary() {
+  local program="${1}"
+  "${THIS_DIR}/docker/run" "${THIS_DIR}/dev" bp "${program}" >&2
+}
 
-# shellcheck disable=SC2068
-samply record --rate=1234 -o tmp/samply.json -- ./target/profiling/"$(basename "$1")" ${@:2}
+profile_perf() {
+  local binary="${1}"
+  local output="${2}"
+  shift 2
+
+  perf record -F "${SAMPLE_RATE}" --call-graph dwarf -o "${output}" -- "${binary}" "$@"
+
+  printf "\n===== Self-time (top 30, userspace) =====\n"
+  perf report -i "${output}" --stdio --no-children -g none 2>/dev/null \
+    | grep -vE '^\s*#' | head -30
+
+  printf "\n===== Call graph (callers, >=1%%) =====\n"
+  perf report -i "${output}" --stdio -g graph,1,caller 2>/dev/null \
+    | grep -vE '^\s*#' | head -60
+
+  printf "\nRecording saved: %s\n" "${output}" >&2
+}
+
+profile_samply() {
+  local binary="${1}"
+  local output="${2}"
+  shift 2
+  samply record --rate="${SAMPLE_RATE}" -o "${output}" -- "${binary}" "$@"
+}
+
+main() {
+  show_help() {
+    sed -n '2,${/^#/!q; s/^# \?//p}' "${BASH_SOURCE[0]}" | sed "s|\$0|${0##*/}|g"
+  }
+
+  local backend="samply"
+  local do_build=true
+  local output=""
+
+  # shfmt:off
+  while (( $# > 0 )); do
+    case "${1}" in
+      -h|--help) show_help; exit 0 ;;
+      --perf) backend="perf"; shift ;;
+      --samply) backend="samply"; shift ;;
+      --rate) SAMPLE_RATE="${2}"; shift 2 ;;
+      --output) output="${2}"; shift 2 ;;
+      --no-build) do_build=false; shift ;;
+      --) shift; break ;;
+      -*) printf "Unknown option: %s\n" "${1}" >&2; exit 1 ;;
+      *) break ;;
+    esac
+  done
+  # shfmt:on
+
+  local program="${1:-}"
+  if [[ -z "${program}" ]]; then
+    printf "Error: program name required\n" >&2
+    show_help
+    exit 1
+  fi
+  shift || true
+  [[ "${1:-}" == "--" ]] && shift
+
+  program="$(basename "${program}")"
+  local binary="${PROJECT_DIR}/${BIN_DIR}/${program}"
+
+  if "${do_build}"; then
+    build_binary "${program}"
+  fi
+  if [[ ! -x "${binary}" ]]; then
+    printf "Error: binary not found or not executable: %s\n" "${binary}" >&2
+    exit 1
+  fi
+
+  if [[ -z "${output}" ]]; then
+    local ext="json"
+    [[ "${backend}" == "perf" ]] && ext="data"
+    output="tmp/profiling/${program}.${ext}"
+  fi
+  mkdir -p "$(dirname "${output}")"
+
+  case "${backend}" in
+    perf) profile_perf "${binary}" "${output}" "$@" ;;
+    samply) profile_samply "${binary}" "${output}" "$@" ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_efficiency.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_efficiency.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Efficiency vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0%</text>
+<line x1="72" y1="280.3" x2="532" y2="280.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="284.3" fill="#898781" font-size="11" text-anchor="end">25%</text>
+<line x1="72" y1="212.5" x2="532" y2="212.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="216.5" fill="#898781" font-size="11" text-anchor="end">50%</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="148.8" fill="#898781" font-size="11" text-anchor="end">75%</text>
+<line x1="72" y1="77.1" x2="532" y2="77.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="81.1" fill="#898781" font-size="11" text-anchor="end">100%</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Efficiency (%)</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#c3c2b7" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="536.0" y="148.8" fill="#898781" font-size="9">75%</text>
+<polyline points="72.0,77.1 187.0,118.6 302.0,171.0 417.0,251.4 532.0,305.5" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="118.6" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="171.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="251.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="305.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,187.5 302.0,245.0 417.0,304.5 532.0,323.4" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="187.5" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="245.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="304.5" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="323.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,192.5 302.0,263.7 417.0,306.8 532.0,328.0" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="192.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="263.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="306.8" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="328.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,168.5 302.0,227.8 417.0,290.9 532.0,317.2" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="168.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="227.8" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="290.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="317.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,215.4 302.0,278.5 417.0,324.8 532.0,334.5" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="215.4" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="278.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="324.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="334.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="58.6" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="69.2" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="80.0" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="90.8" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="101.8" fill="#52514e" font-size="9">100%</text>
+<text x="195.0" y="121.6" fill="#52514e" font-size="9">85%</text>
+<text x="195.0" y="171.5" fill="#52514e" font-size="9">66%</text>
+<text x="195.0" y="187.5" fill="#52514e" font-size="9">59%</text>
+<text x="195.0" y="198.5" fill="#52514e" font-size="9">57%</text>
+<text x="195.0" y="218.4" fill="#52514e" font-size="9">49%</text>
+<text x="310.0" y="174.0" fill="#52514e" font-size="9">65%</text>
+<text x="310.0" y="230.8" fill="#52514e" font-size="9">44%</text>
+<text x="310.0" y="248.0" fill="#52514e" font-size="9">38%</text>
+<text x="310.0" y="266.7" fill="#52514e" font-size="9">31%</text>
+<text x="310.0" y="281.5" fill="#52514e" font-size="9">26%</text>
+<text x="425.0" y="254.4" fill="#52514e" font-size="9">36%</text>
+<text x="425.0" y="292.7" fill="#52514e" font-size="9">21%</text>
+<text x="425.0" y="303.7" fill="#52514e" font-size="9">16%</text>
+<text x="425.0" y="314.7" fill="#52514e" font-size="9">15%</text>
+<text x="425.0" y="327.8" fill="#52514e" font-size="9">9%</text>
+<text x="540.0" y="302.9" fill="#52514e" font-size="9">16%</text>
+<text x="540.0" y="313.8" fill="#52514e" font-size="9">11%</text>
+<text x="540.0" y="324.7" fill="#52514e" font-size="9">9%</text>
+<text x="540.0" y="335.6" fill="#52514e" font-size="9">7%</text>
+<text x="540.0" y="346.6" fill="#52514e" font-size="9">5%</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_peak-rss.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_peak-rss.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Peak Resident Memory vs Thread Count</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="298.3" x2="680" y2="298.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="302.3" fill="#898781" font-size="11" text-anchor="end">500</text>
+<line x1="72" y1="248.7" x2="680" y2="248.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="252.7" fill="#898781" font-size="11" text-anchor="end">1000</text>
+<line x1="72" y1="199.0" x2="680" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">1500</text>
+<line x1="72" y1="149.3" x2="680" y2="149.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="153.3" fill="#898781" font-size="11" text-anchor="end">2000</text>
+<line x1="72" y1="99.7" x2="680" y2="99.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="103.7" fill="#898781" font-size="11" text-anchor="end">2500</text>
+<line x1="72" y1="50.0" x2="680" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">3000</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Peak RSS (MB)</text>
+<rect x="78.8" y="133.6" width="20.0" height="214.4" rx="2" fill="#2a78d6"/>
+<rect x="100.8" y="224.4" width="20.0" height="123.6" rx="2" fill="#1baf7a"/>
+<rect x="122.8" y="186.7" width="20.0" height="161.3" rx="2" fill="#eda100"/>
+<rect x="144.8" y="345.2" width="20.0" height="2.8" rx="2" fill="#008300"/>
+<rect x="166.8" y="345.8" width="20.0" height="2.2" rx="2" fill="#4a3aa7"/>
+<text x="132.8" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<rect x="200.4" y="135.1" width="20.0" height="212.9" rx="2" fill="#2a78d6"/>
+<rect x="222.4" y="205.3" width="20.0" height="142.7" rx="2" fill="#1baf7a"/>
+<rect x="244.4" y="169.8" width="20.0" height="178.2" rx="2" fill="#eda100"/>
+<rect x="266.4" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="288.4" y="345.9" width="20.0" height="2.1" rx="2" fill="#4a3aa7"/>
+<text x="254.4" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<rect x="322.0" y="133.9" width="20.0" height="214.1" rx="2" fill="#2a78d6"/>
+<rect x="344.0" y="201.1" width="20.0" height="146.9" rx="2" fill="#1baf7a"/>
+<rect x="366.0" y="165.4" width="20.0" height="182.6" rx="2" fill="#eda100"/>
+<rect x="388.0" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="410.0" y="345.8" width="20.0" height="2.2" rx="2" fill="#4a3aa7"/>
+<text x="376.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<rect x="443.6" y="130.0" width="20.0" height="218.0" rx="2" fill="#2a78d6"/>
+<rect x="465.6" y="201.5" width="20.0" height="146.5" rx="2" fill="#1baf7a"/>
+<rect x="487.6" y="157.9" width="20.0" height="190.1" rx="2" fill="#eda100"/>
+<rect x="509.6" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="531.6" y="345.9" width="20.0" height="2.1" rx="2" fill="#4a3aa7"/>
+<text x="497.6" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<rect x="565.2" y="121.7" width="20.0" height="226.3" rx="2" fill="#2a78d6"/>
+<rect x="587.2" y="197.0" width="20.0" height="151.0" rx="2" fill="#1baf7a"/>
+<rect x="609.2" y="150.8" width="20.0" height="197.2" rx="2" fill="#eda100"/>
+<rect x="631.2" y="344.9" width="20.0" height="3.1" rx="2" fill="#008300"/>
+<rect x="653.2" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="619.2" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="376.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<rect x="615" y="47" width="10" height="10" rx="2" fill="#4a3aa7"/>
+<text x="629" y="56" fill="#0b0b0b" font-size="10">Clock</text>
+<rect x="532" y="47" width="10" height="10" rx="2" fill="#008300"/>
+<text x="546" y="56" fill="#0b0b0b" font-size="10">Mugration</text>
+<rect x="449" y="47" width="10" height="10" rx="2" fill="#eda100"/>
+<text x="463" y="56" fill="#0b0b0b" font-size="10">Ancestral</text>
+<rect x="373" y="47" width="10" height="10" rx="2" fill="#1baf7a"/>
+<text x="387" y="56" fill="#0b0b0b" font-size="10">Optimize</text>
+<rect x="297" y="47" width="10" height="10" rx="2" fill="#2a78d6"/>
+<text x="311" y="56" fill="#0b0b0b" font-size="10">Timetree</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_speedup.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_speedup.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Speedup vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0x</text>
+<line x1="72" y1="273.5" x2="532" y2="273.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="277.5" fill="#898781" font-size="11" text-anchor="end">5x</text>
+<line x1="72" y1="199.0" x2="532" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">10x</text>
+<line x1="72" y1="124.5" x2="532" y2="124.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="128.5" fill="#898781" font-size="11" text-anchor="end">15x</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">20x</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Speedup (x)</text>
+<polyline points="72.0,333.1 187.0,318.2 302.0,288.4 417.0,228.8 532.0,109.6" fill="none" stroke="#e1e0d9" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="538.0" y="113.6" fill="#898781" font-size="10">ideal</text>
+<polyline points="72.0,333.1 187.0,322.8 302.0,309.1 417.0,305.5 532.0,310.6" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="322.8" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="309.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="305.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="310.6" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,330.3 302.0,325.3 417.0,328.8 532.0,326.3" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="330.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="325.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="328.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="326.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,330.9 302.0,329.5 417.0,329.9 532.0,330.4" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="330.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="329.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="329.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="330.4" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,328.3 302.0,321.6 417.0,322.9 532.0,320.9" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="328.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="321.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="322.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="320.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,333.4 302.0,332.7 417.0,337.8 532.0,336.2" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="333.4" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="332.7" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="337.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="336.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="314.6" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="325.2" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="336.0" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="346.9" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="357.9" fill="#52514e" font-size="9">1x</text>
+<text x="195.0" y="310.5" fill="#52514e" font-size="9">1.7x</text>
+<text x="195.0" y="321.3" fill="#52514e" font-size="9">1.3x</text>
+<text x="195.0" y="332.0" fill="#52514e" font-size="9">1.2x</text>
+<text x="195.0" y="342.9" fill="#52514e" font-size="9">1.1x</text>
+<text x="195.0" y="353.9" fill="#52514e" font-size="9">1.0x</text>
+<text x="310.0" y="304.9" fill="#52514e" font-size="9">2.6x</text>
+<text x="310.0" y="315.7" fill="#52514e" font-size="9">1.8x</text>
+<text x="310.0" y="326.6" fill="#52514e" font-size="9">1.5x</text>
+<text x="310.0" y="337.5" fill="#52514e" font-size="9">1.2x</text>
+<text x="310.0" y="348.5" fill="#52514e" font-size="9">1.0x</text>
+<text x="425.0" y="306.1" fill="#52514e" font-size="9">2.9x</text>
+<text x="425.0" y="317.0" fill="#52514e" font-size="9">1.7x</text>
+<text x="425.0" y="327.9" fill="#52514e" font-size="9">1.3x</text>
+<text x="425.0" y="338.9" fill="#52514e" font-size="9">1.2x</text>
+<text x="425.0" y="349.9" fill="#52514e" font-size="9">0.7x</text>
+<text x="540.0" y="306.1" fill="#52514e" font-size="9">2.5x</text>
+<text x="540.0" y="316.9" fill="#52514e" font-size="9">1.8x</text>
+<text x="540.0" y="327.8" fill="#52514e" font-size="9">1.5x</text>
+<text x="540.0" y="338.8" fill="#52514e" font-size="9">1.2x</text>
+<text x="540.0" y="349.8" fill="#52514e" font-size="9">0.8x</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_wall-time.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-zstd_wall-time.svg
@@ -1,0 +1,169 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Wall-Clock Time vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="288.4" x2="532" y2="288.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="292.4" fill="#898781" font-size="11" text-anchor="end">10.0s</text>
+<line x1="72" y1="228.8" x2="532" y2="228.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="232.8" fill="#898781" font-size="11" text-anchor="end">20.0s</text>
+<line x1="72" y1="169.2" x2="532" y2="169.2" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="173.2" fill="#898781" font-size="11" text-anchor="end">30.0s</text>
+<line x1="72" y1="109.6" x2="532" y2="109.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="113.6" fill="#898781" font-size="11" text-anchor="end">40.0s</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">50.0s</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Time (seconds)</text>
+<polyline points="72.0,135.0 187.0,222.3 302.0,266.5 417.0,273.3 532.0,263.2" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="143.2" x2="72.0" y2="113.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="143.2" x2="75.0" y2="143.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="113.5" x2="75.0" y2="113.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="225.1" x2="187.0" y2="216.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="225.1" x2="190.0" y2="225.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="216.2" x2="190.0" y2="216.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="268.7" x2="302.0" y2="263.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="268.7" x2="305.0" y2="268.7" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="263.6" x2="305.0" y2="263.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="284.9" x2="417.0" y2="250.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="284.9" x2="420.0" y2="284.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="250.3" x2="420.0" y2="250.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="266.9" x2="532.0" y2="259.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="266.9" x2="535.0" y2="266.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="259.9" x2="535.0" y2="259.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="135.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="222.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="266.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="273.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="263.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,313.1 187.0,318.5 302.0,325.0 417.0,320.8 532.0,324.0" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="314.7" x2="72.0" y2="309.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="314.7" x2="75.0" y2="314.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="309.7" x2="75.0" y2="309.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="321.3" x2="187.0" y2="315.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="321.3" x2="190.0" y2="321.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="315.4" x2="190.0" y2="315.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="325.9" x2="302.0" y2="322.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="325.9" x2="305.0" y2="325.9" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="322.7" x2="305.0" y2="322.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="326.0" x2="417.0" y2="309.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="326.0" x2="420.0" y2="326.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="309.2" x2="420.0" y2="309.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="326.1" x2="532.0" y2="321.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="326.1" x2="535.0" y2="326.1" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="321.7" x2="535.0" y2="321.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="313.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="318.5" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="325.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="320.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="324.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,313.8 187.0,318.2 302.0,320.5 417.0,319.9 532.0,319.1" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="314.8" x2="72.0" y2="312.4" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="314.8" x2="75.0" y2="314.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="312.4" x2="75.0" y2="312.4" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="318.6" x2="187.0" y2="317.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="318.6" x2="190.0" y2="318.6" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="317.8" x2="190.0" y2="317.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="321.0" x2="302.0" y2="319.2" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="321.0" x2="305.0" y2="321.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="319.2" x2="305.0" y2="319.2" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="322.1" x2="417.0" y2="317.4" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="322.1" x2="420.0" y2="322.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="317.4" x2="420.0" y2="317.4" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="321.6" x2="532.0" y2="315.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="321.6" x2="535.0" y2="321.6" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="315.5" x2="535.0" y2="315.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="313.8" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="318.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="320.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="319.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="319.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,328.4 187.0,333.2 302.0,336.9 417.0,336.4 532.0,337.2" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="329.5" x2="72.0" y2="326.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="329.5" x2="75.0" y2="329.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="326.8" x2="75.0" y2="326.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="334.2" x2="187.0" y2="332.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="334.2" x2="190.0" y2="334.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="332.0" x2="190.0" y2="332.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="338.2" x2="302.0" y2="335.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="338.2" x2="305.0" y2="338.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="335.3" x2="305.0" y2="335.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="338.8" x2="417.0" y2="334.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="338.8" x2="420.0" y2="338.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="334.0" x2="420.0" y2="334.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="337.8" x2="532.0" y2="336.7" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="337.8" x2="535.0" y2="337.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="336.7" x2="535.0" y2="336.7" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="328.4" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="333.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="336.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="336.4" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="337.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,347.6 187.0,347.6 302.0,347.6 417.0,347.4 532.0,347.5" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="347.6" x2="72.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.6" x2="75.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.6" x2="75.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="347.6" x2="187.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.6" x2="190.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.5" x2="190.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="347.6" x2="302.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.6" x2="305.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.6" x2="305.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="347.4" x2="417.0" y2="347.2" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.4" x2="420.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.2" x2="420.0" y2="347.2" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="347.5" x2="532.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.5" x2="535.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.4" x2="535.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="347.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="347.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="347.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="347.4" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="138.0" fill="#52514e" font-size="9">35.7s</text>
+<text x="80.0" y="310.4" fill="#52514e" font-size="9">5.9s</text>
+<text x="80.0" y="321.4" fill="#52514e" font-size="9">5.7s</text>
+<text x="80.0" y="332.4" fill="#52514e" font-size="9">3.3s</text>
+<text x="80.0" y="350.6" fill="#52514e" font-size="9">73ms</text>
+<text x="195.0" y="225.3" fill="#52514e" font-size="9">21.1s</text>
+<text x="195.0" y="315.3" fill="#52514e" font-size="9">5.0s</text>
+<text x="195.0" y="326.3" fill="#52514e" font-size="9">4.9s</text>
+<text x="195.0" y="337.3" fill="#52514e" font-size="9">2.5s</text>
+<text x="195.0" y="350.6" fill="#52514e" font-size="9">74ms</text>
+<text x="310.0" y="269.5" fill="#52514e" font-size="9">13.7s</text>
+<text x="310.0" y="319.0" fill="#52514e" font-size="9">4.6s</text>
+<text x="310.0" y="330.0" fill="#52514e" font-size="9">3.9s</text>
+<text x="310.0" y="341.0" fill="#52514e" font-size="9">1.9s</text>
+<text x="310.0" y="352.0" fill="#52514e" font-size="9">71ms</text>
+<text x="425.0" y="276.3" fill="#52514e" font-size="9">12.5s</text>
+<text x="425.0" y="317.6" fill="#52514e" font-size="9">4.7s</text>
+<text x="425.0" y="328.6" fill="#52514e" font-size="9">4.6s</text>
+<text x="425.0" y="339.6" fill="#52514e" font-size="9">2.0s</text>
+<text x="425.0" y="350.6" fill="#52514e" font-size="9">0.1s</text>
+<text x="540.0" y="266.2" fill="#52514e" font-size="9">14.2s</text>
+<text x="540.0" y="318.4" fill="#52514e" font-size="9">4.9s</text>
+<text x="540.0" y="329.4" fill="#52514e" font-size="9">4.0s</text>
+<text x="540.0" y="340.4" fill="#52514e" font-size="9">1.8s</text>
+<text x="540.0" y="351.4" fill="#52514e" font-size="9">91ms</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_efficiency.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_efficiency.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Efficiency vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0%</text>
+<line x1="72" y1="280.3" x2="532" y2="280.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="284.3" fill="#898781" font-size="11" text-anchor="end">25%</text>
+<line x1="72" y1="212.5" x2="532" y2="212.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="216.5" fill="#898781" font-size="11" text-anchor="end">50%</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="148.8" fill="#898781" font-size="11" text-anchor="end">75%</text>
+<line x1="72" y1="77.1" x2="532" y2="77.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="81.1" fill="#898781" font-size="11" text-anchor="end">100%</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Efficiency (%)</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#c3c2b7" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="536.0" y="148.8" fill="#898781" font-size="9">75%</text>
+<polyline points="72.0,77.1 187.0,124.4 302.0,179.9 417.0,240.5 532.0,287.3" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="124.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="179.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="240.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="287.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,184.9 302.0,256.1 417.0,307.8 532.0,323.4" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="184.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="256.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="307.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="323.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,204.9 302.0,269.2 417.0,305.8 532.0,326.7" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="204.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="269.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="305.8" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="326.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,162.9 302.0,234.8 417.0,283.3 532.0,313.4" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="162.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="234.8" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="283.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="313.4" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,309.1 302.0,279.8 417.0,316.7 532.0,332.7" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="309.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="279.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="316.7" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="332.7" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="58.6" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="69.2" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="80.0" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="90.8" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="101.8" fill="#52514e" font-size="9">100%</text>
+<text x="195.0" y="127.4" fill="#52514e" font-size="9">83%</text>
+<text x="195.0" y="165.9" fill="#52514e" font-size="9">68%</text>
+<text x="195.0" y="187.9" fill="#52514e" font-size="9">60%</text>
+<text x="195.0" y="207.9" fill="#52514e" font-size="9">53%</text>
+<text x="195.0" y="312.1" fill="#52514e" font-size="9">14%</text>
+<text x="310.0" y="182.9" fill="#52514e" font-size="9">62%</text>
+<text x="310.0" y="237.8" fill="#52514e" font-size="9">42%</text>
+<text x="310.0" y="259.1" fill="#52514e" font-size="9">34%</text>
+<text x="310.0" y="272.0" fill="#52514e" font-size="9">29%</text>
+<text x="310.0" y="283.0" fill="#52514e" font-size="9">25%</text>
+<text x="425.0" y="243.5" fill="#52514e" font-size="9">40%</text>
+<text x="425.0" y="286.3" fill="#52514e" font-size="9">24%</text>
+<text x="425.0" y="302.1" fill="#52514e" font-size="9">16%</text>
+<text x="425.0" y="313.1" fill="#52514e" font-size="9">15%</text>
+<text x="425.0" y="324.1" fill="#52514e" font-size="9">12%</text>
+<text x="540.0" y="290.3" fill="#52514e" font-size="9">22%</text>
+<text x="540.0" y="310.6" fill="#52514e" font-size="9">13%</text>
+<text x="540.0" y="321.5" fill="#52514e" font-size="9">9%</text>
+<text x="540.0" y="332.5" fill="#52514e" font-size="9">8%</text>
+<text x="540.0" y="343.5" fill="#52514e" font-size="9">6%</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_peak-rss.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_peak-rss.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Peak Resident Memory vs Thread Count</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="298.3" x2="680" y2="298.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="302.3" fill="#898781" font-size="11" text-anchor="end">500</text>
+<line x1="72" y1="248.7" x2="680" y2="248.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="252.7" fill="#898781" font-size="11" text-anchor="end">1000</text>
+<line x1="72" y1="199.0" x2="680" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">1500</text>
+<line x1="72" y1="149.3" x2="680" y2="149.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="153.3" fill="#898781" font-size="11" text-anchor="end">2000</text>
+<line x1="72" y1="99.7" x2="680" y2="99.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="103.7" fill="#898781" font-size="11" text-anchor="end">2500</text>
+<line x1="72" y1="50.0" x2="680" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">3000</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Peak RSS (MB)</text>
+<rect x="78.8" y="133.4" width="20.0" height="214.6" rx="2" fill="#2a78d6"/>
+<rect x="100.8" y="224.4" width="20.0" height="123.6" rx="2" fill="#1baf7a"/>
+<rect x="122.8" y="187.3" width="20.0" height="160.7" rx="2" fill="#eda100"/>
+<rect x="144.8" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="166.8" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="132.8" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<rect x="200.4" y="135.0" width="20.0" height="213.0" rx="2" fill="#2a78d6"/>
+<rect x="222.4" y="205.1" width="20.0" height="142.9" rx="2" fill="#1baf7a"/>
+<rect x="244.4" y="168.5" width="20.0" height="179.5" rx="2" fill="#eda100"/>
+<rect x="266.4" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="288.4" y="345.9" width="20.0" height="2.1" rx="2" fill="#4a3aa7"/>
+<text x="254.4" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<rect x="322.0" y="133.3" width="20.0" height="214.7" rx="2" fill="#2a78d6"/>
+<rect x="344.0" y="200.8" width="20.0" height="147.2" rx="2" fill="#1baf7a"/>
+<rect x="366.0" y="166.7" width="20.0" height="181.3" rx="2" fill="#eda100"/>
+<rect x="388.0" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="410.0" y="345.9" width="20.0" height="2.1" rx="2" fill="#4a3aa7"/>
+<text x="376.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<rect x="443.6" y="130.0" width="20.0" height="218.0" rx="2" fill="#2a78d6"/>
+<rect x="465.6" y="200.5" width="20.0" height="147.5" rx="2" fill="#1baf7a"/>
+<rect x="487.6" y="158.9" width="20.0" height="189.1" rx="2" fill="#eda100"/>
+<rect x="509.6" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="531.6" y="345.8" width="20.0" height="2.2" rx="2" fill="#4a3aa7"/>
+<text x="497.6" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<rect x="565.2" y="124.5" width="20.0" height="223.5" rx="2" fill="#2a78d6"/>
+<rect x="587.2" y="195.6" width="20.0" height="152.4" rx="2" fill="#1baf7a"/>
+<rect x="609.2" y="150.9" width="20.0" height="197.1" rx="2" fill="#eda100"/>
+<rect x="631.2" y="344.9" width="20.0" height="3.1" rx="2" fill="#008300"/>
+<rect x="653.2" y="345.6" width="20.0" height="2.4" rx="2" fill="#4a3aa7"/>
+<text x="619.2" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="376.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<rect x="615" y="47" width="10" height="10" rx="2" fill="#4a3aa7"/>
+<text x="629" y="56" fill="#0b0b0b" font-size="10">Clock</text>
+<rect x="532" y="47" width="10" height="10" rx="2" fill="#008300"/>
+<text x="546" y="56" fill="#0b0b0b" font-size="10">Mugration</text>
+<rect x="449" y="47" width="10" height="10" rx="2" fill="#eda100"/>
+<text x="463" y="56" fill="#0b0b0b" font-size="10">Ancestral</text>
+<rect x="373" y="47" width="10" height="10" rx="2" fill="#1baf7a"/>
+<text x="387" y="56" fill="#0b0b0b" font-size="10">Optimize</text>
+<rect x="297" y="47" width="10" height="10" rx="2" fill="#2a78d6"/>
+<text x="311" y="56" fill="#0b0b0b" font-size="10">Timetree</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_speedup.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_speedup.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Speedup vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0x</text>
+<line x1="72" y1="273.5" x2="532" y2="273.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="277.5" fill="#898781" font-size="11" text-anchor="end">5x</text>
+<line x1="72" y1="199.0" x2="532" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">10x</text>
+<line x1="72" y1="124.5" x2="532" y2="124.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="128.5" fill="#898781" font-size="11" text-anchor="end">15x</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">20x</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Speedup (x)</text>
+<polyline points="72.0,333.1 187.0,318.2 302.0,288.4 417.0,228.8 532.0,109.6" fill="none" stroke="#e1e0d9" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="538.0" y="113.6" fill="#898781" font-size="10">ideal</text>
+<polyline points="72.0,333.1 187.0,323.4 302.0,311.0 417.0,300.7 532.0,294.6" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="323.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="311.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="300.7" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="294.6" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,330.1 302.0,327.8 417.0,330.3 532.0,326.3" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="330.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="327.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="330.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="326.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,332.3 302.0,330.7 417.0,329.4 532.0,329.2" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="332.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="330.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="329.4" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="329.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,327.6 302.0,323.1 417.0,319.5 532.0,317.6" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="327.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="323.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="319.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="317.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,343.7 302.0,333.0 417.0,334.2 532.0,334.5" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="343.7" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="333.0" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="334.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="334.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="314.6" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="325.2" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="336.0" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="346.9" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="357.9" fill="#52514e" font-size="9">1x</text>
+<text x="195.0" y="312.7" fill="#52514e" font-size="9">1.7x</text>
+<text x="195.0" y="323.5" fill="#52514e" font-size="9">1.4x</text>
+<text x="195.0" y="334.4" fill="#52514e" font-size="9">1.2x</text>
+<text x="195.0" y="345.3" fill="#52514e" font-size="9">1.1x</text>
+<text x="195.0" y="356.3" fill="#52514e" font-size="9">0.3x</text>
+<text x="310.0" y="306.4" fill="#52514e" font-size="9">2.5x</text>
+<text x="310.0" y="317.2" fill="#52514e" font-size="9">1.7x</text>
+<text x="310.0" y="328.0" fill="#52514e" font-size="9">1.4x</text>
+<text x="310.0" y="339.0" fill="#52514e" font-size="9">1.2x</text>
+<text x="310.0" y="350.0" fill="#52514e" font-size="9">1.0x</text>
+<text x="425.0" y="303.7" fill="#52514e" font-size="9">3.2x</text>
+<text x="425.0" y="314.9" fill="#52514e" font-size="9">1.9x</text>
+<text x="425.0" y="325.9" fill="#52514e" font-size="9">1.2x</text>
+<text x="425.0" y="336.9" fill="#52514e" font-size="9">1.2x</text>
+<text x="425.0" y="347.9" fill="#52514e" font-size="9">0.9x</text>
+<text x="540.0" y="297.6" fill="#52514e" font-size="9">3.6x</text>
+<text x="540.0" y="313.4" fill="#52514e" font-size="9">2.0x</text>
+<text x="540.0" y="324.4" fill="#52514e" font-size="9">1.5x</text>
+<text x="540.0" y="335.4" fill="#52514e" font-size="9">1.3x</text>
+<text x="540.0" y="346.4" fill="#52514e" font-size="9">0.9x</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_wall-time.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_wall-time.svg
@@ -1,0 +1,169 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Wall-Clock Time vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="288.4" x2="532" y2="288.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="292.4" fill="#898781" font-size="11" text-anchor="end">10.0s</text>
+<line x1="72" y1="228.8" x2="532" y2="228.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="232.8" fill="#898781" font-size="11" text-anchor="end">20.0s</text>
+<line x1="72" y1="169.2" x2="532" y2="169.2" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="173.2" fill="#898781" font-size="11" text-anchor="end">30.0s</text>
+<line x1="72" y1="109.6" x2="532" y2="109.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="113.6" fill="#898781" font-size="11" text-anchor="end">40.0s</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">50.0s</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Time (seconds)</text>
+<polyline points="72.0,139.7 187.0,221.8 302.0,264.1 417.0,282.4 532.0,289.9" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="142.0" x2="72.0" y2="137.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="142.0" x2="75.0" y2="142.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="137.0" x2="75.0" y2="137.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="223.6" x2="187.0" y2="220.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="223.6" x2="190.0" y2="223.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="220.0" x2="190.0" y2="220.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="265.0" x2="302.0" y2="262.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="265.0" x2="305.0" y2="265.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="262.9" x2="305.0" y2="262.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="285.1" x2="417.0" y2="278.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="285.1" x2="420.0" y2="285.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="278.2" x2="420.0" y2="278.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="291.7" x2="532.0" y2="288.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="291.7" x2="535.0" y2="291.7" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="288.0" x2="535.0" y2="288.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="139.7" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="221.8" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="264.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="282.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="289.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,312.9 187.0,318.8 302.0,322.1 417.0,318.4 532.0,323.8" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="313.9" x2="72.0" y2="311.1" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="313.9" x2="75.0" y2="313.9" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="311.1" x2="75.0" y2="311.1" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="320.3" x2="187.0" y2="316.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="320.3" x2="190.0" y2="320.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="316.6" x2="190.0" y2="316.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="323.7" x2="302.0" y2="320.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="323.7" x2="305.0" y2="323.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="320.6" x2="305.0" y2="320.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="320.4" x2="417.0" y2="316.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="320.4" x2="420.0" y2="320.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="316.0" x2="420.0" y2="316.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="325.9" x2="532.0" y2="321.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="325.9" x2="535.0" y2="325.9" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="321.4" x2="535.0" y2="321.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="312.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="318.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="322.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="318.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="323.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,313.3 187.0,315.1 302.0,318.1 417.0,320.1 532.0,320.4" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="314.1" x2="72.0" y2="312.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="314.1" x2="75.0" y2="314.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="312.1" x2="75.0" y2="312.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="317.2" x2="187.0" y2="313.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="317.2" x2="190.0" y2="317.2" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="313.8" x2="190.0" y2="313.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="319.3" x2="302.0" y2="316.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="319.3" x2="305.0" y2="319.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="316.3" x2="305.0" y2="316.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="321.5" x2="417.0" y2="318.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="321.5" x2="420.0" y2="321.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="318.5" x2="420.0" y2="318.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="321.2" x2="532.0" y2="319.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="321.2" x2="535.0" y2="321.2" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="319.0" x2="535.0" y2="319.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="313.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="315.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="318.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="320.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="320.4" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,329.0 187.0,334.1 302.0,336.6 417.0,338.0 532.0,338.7" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="329.6" x2="72.0" y2="328.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="329.6" x2="75.0" y2="329.6" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="328.2" x2="75.0" y2="328.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="334.8" x2="187.0" y2="332.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="334.8" x2="190.0" y2="334.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="332.8" x2="190.0" y2="332.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="337.7" x2="302.0" y2="335.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="337.7" x2="305.0" y2="337.7" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="335.2" x2="305.0" y2="335.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="339.0" x2="417.0" y2="337.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="339.0" x2="420.0" y2="339.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="337.0" x2="420.0" y2="337.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="339.1" x2="532.0" y2="337.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="339.1" x2="535.0" y2="339.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="337.8" x2="535.0" y2="337.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="329.0" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="334.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="336.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="338.0" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="338.7" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,347.6 187.0,346.5 302.0,347.6 417.0,347.5 532.0,347.5" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="347.6" x2="72.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.6" x2="75.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.6" x2="75.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="346.7" x2="187.0" y2="346.0" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="346.7" x2="190.0" y2="346.7" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="346.0" x2="190.0" y2="346.0" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="347.6" x2="302.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.6" x2="305.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.5" x2="305.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="347.6" x2="417.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.6" x2="420.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.4" x2="420.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="347.5" x2="532.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.5" x2="535.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.5" x2="535.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="347.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="346.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="347.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="142.7" fill="#52514e" font-size="9">34.9s</text>
+<text x="80.0" y="310.4" fill="#52514e" font-size="9">5.9s</text>
+<text x="80.0" y="321.4" fill="#52514e" font-size="9">5.8s</text>
+<text x="80.0" y="332.4" fill="#52514e" font-size="9">3.2s</text>
+<text x="80.0" y="350.6" fill="#52514e" font-size="9">73ms</text>
+<text x="195.0" y="224.8" fill="#52514e" font-size="9">21.2s</text>
+<text x="195.0" y="314.5" fill="#52514e" font-size="9">5.5s</text>
+<text x="195.0" y="325.5" fill="#52514e" font-size="9">4.9s</text>
+<text x="195.0" y="337.1" fill="#52514e" font-size="9">2.3s</text>
+<text x="195.0" y="349.5" fill="#52514e" font-size="9">0.3s</text>
+<text x="310.0" y="267.1" fill="#52514e" font-size="9">14.1s</text>
+<text x="310.0" y="317.6" fill="#52514e" font-size="9">5.0s</text>
+<text x="310.0" y="328.6" fill="#52514e" font-size="9">4.3s</text>
+<text x="310.0" y="339.6" fill="#52514e" font-size="9">1.9s</text>
+<text x="310.0" y="350.6" fill="#52514e" font-size="9">72ms</text>
+<text x="425.0" y="285.4" fill="#52514e" font-size="9">11.0s</text>
+<text x="425.0" y="316.7" fill="#52514e" font-size="9">5.0s</text>
+<text x="425.0" y="327.7" fill="#52514e" font-size="9">4.7s</text>
+<text x="425.0" y="340.3" fill="#52514e" font-size="9">1.7s</text>
+<text x="425.0" y="351.3" fill="#52514e" font-size="9">79ms</text>
+<text x="540.0" y="292.9" fill="#52514e" font-size="9">9.7s</text>
+<text x="540.0" y="319.1" fill="#52514e" font-size="9">4.6s</text>
+<text x="540.0" y="330.1" fill="#52514e" font-size="9">4.1s</text>
+<text x="540.0" y="341.1" fill="#52514e" font-size="9">1.6s</text>
+<text x="540.0" y="352.1" fill="#52514e" font-size="9">81ms</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_efficiency.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_efficiency.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Efficiency vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0%</text>
+<line x1="72" y1="280.3" x2="532" y2="280.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="284.3" fill="#898781" font-size="11" text-anchor="end">25%</text>
+<line x1="72" y1="212.5" x2="532" y2="212.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="216.5" fill="#898781" font-size="11" text-anchor="end">50%</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="148.8" fill="#898781" font-size="11" text-anchor="end">75%</text>
+<line x1="72" y1="77.1" x2="532" y2="77.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="81.1" fill="#898781" font-size="11" text-anchor="end">100%</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Efficiency (%)</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#c3c2b7" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="536.0" y="148.8" fill="#898781" font-size="9">75%</text>
+<polyline points="72.0,77.1 187.0,114.7 302.0,182.3 417.0,234.6 532.0,285.5" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="114.7" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="182.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="234.6" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="285.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,188.3 302.0,258.5 417.0,298.2 532.0,322.0" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="188.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="258.5" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="298.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="322.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,190.0 302.0,267.2 417.0,305.5 532.0,327.6" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="190.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="267.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="305.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="327.6" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,181.9 302.0,258.4 417.0,300.6 532.0,325.5" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="181.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="258.4" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="300.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="325.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,236.2 302.0,284.9 417.0,318.5 532.0,334.2" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="236.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="284.9" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="318.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="334.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="58.6" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="69.2" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="80.0" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="90.8" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="101.8" fill="#52514e" font-size="9">100%</text>
+<text x="195.0" y="117.7" fill="#52514e" font-size="9">86%</text>
+<text x="195.0" y="178.7" fill="#52514e" font-size="9">61%</text>
+<text x="195.0" y="189.7" fill="#52514e" font-size="9">59%</text>
+<text x="195.0" y="200.7" fill="#52514e" font-size="9">58%</text>
+<text x="195.0" y="239.2" fill="#52514e" font-size="9">41%</text>
+<text x="310.0" y="185.3" fill="#52514e" font-size="9">61%</text>
+<text x="310.0" y="253.3" fill="#52514e" font-size="9">33%</text>
+<text x="310.0" y="264.3" fill="#52514e" font-size="9">33%</text>
+<text x="310.0" y="275.3" fill="#52514e" font-size="9">30%</text>
+<text x="310.0" y="287.9" fill="#52514e" font-size="9">23%</text>
+<text x="425.0" y="237.6" fill="#52514e" font-size="9">42%</text>
+<text x="425.0" y="292.2" fill="#52514e" font-size="9">18%</text>
+<text x="425.0" y="303.2" fill="#52514e" font-size="9">18%</text>
+<text x="425.0" y="314.2" fill="#52514e" font-size="9">16%</text>
+<text x="425.0" y="325.2" fill="#52514e" font-size="9">11%</text>
+<text x="540.0" y="288.5" fill="#52514e" font-size="9">23%</text>
+<text x="540.0" y="313.8" fill="#52514e" font-size="9">10%</text>
+<text x="540.0" y="324.8" fill="#52514e" font-size="9">8%</text>
+<text x="540.0" y="335.8" fill="#52514e" font-size="9">8%</text>
+<text x="540.0" y="346.8" fill="#52514e" font-size="9">5%</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_peak-rss.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_peak-rss.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Peak Resident Memory vs Thread Count</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="305.4" x2="680" y2="305.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="309.4" fill="#898781" font-size="11" text-anchor="end">100</text>
+<line x1="72" y1="262.9" x2="680" y2="262.9" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="266.9" fill="#898781" font-size="11" text-anchor="end">200</text>
+<line x1="72" y1="220.3" x2="680" y2="220.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="224.3" fill="#898781" font-size="11" text-anchor="end">300</text>
+<line x1="72" y1="177.7" x2="680" y2="177.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="181.7" fill="#898781" font-size="11" text-anchor="end">400</text>
+<line x1="72" y1="135.1" x2="680" y2="135.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="139.1" fill="#898781" font-size="11" text-anchor="end">500</text>
+<line x1="72" y1="92.6" x2="680" y2="92.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="96.6" fill="#898781" font-size="11" text-anchor="end">600</text>
+<line x1="72" y1="50.0" x2="680" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">700</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Peak RSS (MB)</text>
+<rect x="78.8" y="127.1" width="20.0" height="220.9" rx="2" fill="#2a78d6"/>
+<rect x="100.8" y="219.4" width="20.0" height="128.6" rx="2" fill="#1baf7a"/>
+<rect x="122.8" y="181.6" width="20.0" height="166.4" rx="2" fill="#eda100"/>
+<rect x="144.8" y="341.9" width="20.0" height="6.1" rx="2" fill="#008300"/>
+<rect x="166.8" y="341.5" width="20.0" height="6.5" rx="2" fill="#4a3aa7"/>
+<text x="132.8" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<rect x="200.4" y="126.7" width="20.0" height="221.3" rx="2" fill="#2a78d6"/>
+<rect x="222.4" y="207.9" width="20.0" height="140.1" rx="2" fill="#1baf7a"/>
+<rect x="244.4" y="154.8" width="20.0" height="193.2" rx="2" fill="#eda100"/>
+<rect x="266.4" y="342.0" width="20.0" height="6.0" rx="2" fill="#008300"/>
+<rect x="288.4" y="341.4" width="20.0" height="6.6" rx="2" fill="#4a3aa7"/>
+<text x="254.4" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<rect x="322.0" y="119.7" width="20.0" height="228.3" rx="2" fill="#2a78d6"/>
+<rect x="344.0" y="207.0" width="20.0" height="141.0" rx="2" fill="#1baf7a"/>
+<rect x="366.0" y="148.6" width="20.0" height="199.4" rx="2" fill="#eda100"/>
+<rect x="388.0" y="341.8" width="20.0" height="6.2" rx="2" fill="#008300"/>
+<rect x="410.0" y="341.3" width="20.0" height="6.7" rx="2" fill="#4a3aa7"/>
+<text x="376.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<rect x="443.6" y="114.4" width="20.0" height="233.6" rx="2" fill="#2a78d6"/>
+<rect x="465.6" y="198.1" width="20.0" height="149.9" rx="2" fill="#1baf7a"/>
+<rect x="487.6" y="147.9" width="20.0" height="200.1" rx="2" fill="#eda100"/>
+<rect x="509.6" y="341.7" width="20.0" height="6.3" rx="2" fill="#008300"/>
+<rect x="531.6" y="341.1" width="20.0" height="6.9" rx="2" fill="#4a3aa7"/>
+<text x="497.6" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<rect x="565.2" y="108.8" width="20.0" height="239.2" rx="2" fill="#2a78d6"/>
+<rect x="587.2" y="196.8" width="20.0" height="151.2" rx="2" fill="#1baf7a"/>
+<rect x="609.2" y="147.5" width="20.0" height="200.5" rx="2" fill="#eda100"/>
+<rect x="631.2" y="341.1" width="20.0" height="6.9" rx="2" fill="#008300"/>
+<rect x="653.2" y="340.7" width="20.0" height="7.3" rx="2" fill="#4a3aa7"/>
+<text x="619.2" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="376.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<rect x="615" y="47" width="10" height="10" rx="2" fill="#4a3aa7"/>
+<text x="629" y="56" fill="#0b0b0b" font-size="10">Clock</text>
+<rect x="532" y="47" width="10" height="10" rx="2" fill="#008300"/>
+<text x="546" y="56" fill="#0b0b0b" font-size="10">Mugration</text>
+<rect x="449" y="47" width="10" height="10" rx="2" fill="#eda100"/>
+<text x="463" y="56" fill="#0b0b0b" font-size="10">Ancestral</text>
+<rect x="373" y="47" width="10" height="10" rx="2" fill="#1baf7a"/>
+<text x="387" y="56" fill="#0b0b0b" font-size="10">Optimize</text>
+<rect x="297" y="47" width="10" height="10" rx="2" fill="#2a78d6"/>
+<text x="311" y="56" fill="#0b0b0b" font-size="10">Timetree</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_speedup.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_speedup.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Speedup vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0x</text>
+<line x1="72" y1="273.5" x2="532" y2="273.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="277.5" fill="#898781" font-size="11" text-anchor="end">5x</text>
+<line x1="72" y1="199.0" x2="532" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">10x</text>
+<line x1="72" y1="124.5" x2="532" y2="124.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="128.5" fill="#898781" font-size="11" text-anchor="end">15x</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">20x</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Speedup (x)</text>
+<polyline points="72.0,333.1 187.0,318.2 302.0,288.4 417.0,228.8 532.0,109.6" fill="none" stroke="#e1e0d9" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="538.0" y="113.6" fill="#898781" font-size="10">ideal</text>
+<polyline points="72.0,333.1 187.0,322.3 302.0,311.5 417.0,298.1 532.0,293.0" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="322.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="311.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="298.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="293.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,330.4 302.0,328.3 417.0,326.1 532.0,325.2" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="330.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="328.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="326.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="325.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,330.6 302.0,330.2 417.0,329.3 532.0,330.0" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="330.6" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="330.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="329.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="330.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,329.7 302.0,328.3 417.0,327.1 532.0,328.2" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="329.7" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="328.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="327.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="328.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,335.7 302.0,334.1 417.0,335.0 532.0,335.8" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="335.7" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="334.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="335.0" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="335.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="314.6" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="325.2" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="336.0" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="346.9" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="357.9" fill="#52514e" font-size="9">1x</text>
+<text x="195.0" y="311.1" fill="#52514e" font-size="9">1.7x</text>
+<text x="195.0" y="321.9" fill="#52514e" font-size="9">1.2x</text>
+<text x="195.0" y="332.7" fill="#52514e" font-size="9">1.2x</text>
+<text x="195.0" y="343.6" fill="#52514e" font-size="9">1.2x</text>
+<text x="195.0" y="354.6" fill="#52514e" font-size="9">0.8x</text>
+<text x="310.0" y="307.8" fill="#52514e" font-size="9">2.4x</text>
+<text x="310.0" y="318.6" fill="#52514e" font-size="9">1.3x</text>
+<text x="310.0" y="329.4" fill="#52514e" font-size="9">1.3x</text>
+<text x="310.0" y="340.3" fill="#52514e" font-size="9">1.2x</text>
+<text x="310.0" y="351.3" fill="#52514e" font-size="9">0.9x</text>
+<text x="425.0" y="301.1" fill="#52514e" font-size="9">3.3x</text>
+<text x="425.0" y="315.9" fill="#52514e" font-size="9">1.5x</text>
+<text x="425.0" y="326.9" fill="#52514e" font-size="9">1.4x</text>
+<text x="425.0" y="337.9" fill="#52514e" font-size="9">1.3x</text>
+<text x="425.0" y="348.9" fill="#52514e" font-size="9">0.9x</text>
+<text x="540.0" y="296.0" fill="#52514e" font-size="9">3.7x</text>
+<text x="540.0" y="316.3" fill="#52514e" font-size="9">1.5x</text>
+<text x="540.0" y="327.3" fill="#52514e" font-size="9">1.3x</text>
+<text x="540.0" y="338.3" fill="#52514e" font-size="9">1.2x</text>
+<text x="540.0" y="349.3" fill="#52514e" font-size="9">0.8x</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_wall-time.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-500_wall-time.svg
@@ -1,0 +1,167 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Wall-Clock Time vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="281.8" x2="532" y2="281.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="285.8" fill="#898781" font-size="11" text-anchor="end">2.0s</text>
+<line x1="72" y1="215.6" x2="532" y2="215.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="219.6" fill="#898781" font-size="11" text-anchor="end">4.0s</text>
+<line x1="72" y1="149.3" x2="532" y2="149.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="153.3" fill="#898781" font-size="11" text-anchor="end">6.0s</text>
+<line x1="72" y1="83.1" x2="532" y2="83.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="87.1" fill="#898781" font-size="11" text-anchor="end">8.0s</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Time (seconds)</text>
+<polyline points="72.0,110.7 187.0,210.2 302.0,251.0 417.0,277.1 532.0,283.7" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="124.2" x2="72.0" y2="99.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="124.2" x2="75.0" y2="124.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="99.6" x2="75.0" y2="99.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="214.0" x2="187.0" y2="198.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="214.0" x2="190.0" y2="214.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="198.6" x2="190.0" y2="198.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="257.2" x2="302.0" y2="242.8" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="257.2" x2="305.0" y2="257.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="242.8" x2="305.0" y2="242.8" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="278.1" x2="417.0" y2="274.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="278.1" x2="420.0" y2="278.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="274.9" x2="420.0" y2="274.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="286.3" x2="532.0" y2="281.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="286.3" x2="535.0" y2="286.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="281.2" x2="535.0" y2="281.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="110.7" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="210.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="251.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="277.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="283.7" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,304.7 187.0,311.2 302.0,315.2 417.0,318.5 532.0,319.7" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="306.3" x2="72.0" y2="301.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="306.3" x2="75.0" y2="306.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="301.5" x2="75.0" y2="301.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="314.5" x2="187.0" y2="307.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="314.5" x2="190.0" y2="314.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="307.6" x2="190.0" y2="307.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="318.0" x2="302.0" y2="312.8" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="318.0" x2="305.0" y2="318.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="312.8" x2="305.0" y2="312.8" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="319.6" x2="417.0" y2="315.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="319.6" x2="420.0" y2="319.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="315.0" x2="420.0" y2="315.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="320.6" x2="532.0" y2="318.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="320.6" x2="535.0" y2="320.6" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="318.4" x2="535.0" y2="318.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="304.7" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="311.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="315.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="318.5" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="319.7" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,302.2 187.0,308.8 302.0,309.7 417.0,311.5 532.0,310.0" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="305.6" x2="72.0" y2="297.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="305.6" x2="75.0" y2="305.6" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="297.5" x2="75.0" y2="297.5" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="309.6" x2="187.0" y2="307.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="309.6" x2="190.0" y2="309.6" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="307.7" x2="190.0" y2="307.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="310.7" x2="302.0" y2="307.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="310.7" x2="305.0" y2="310.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="307.8" x2="305.0" y2="307.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="313.8" x2="417.0" y2="307.9" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="313.8" x2="420.0" y2="313.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="307.9" x2="420.0" y2="307.9" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="314.3" x2="532.0" y2="296.4" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="314.3" x2="535.0" y2="314.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="296.4" x2="535.0" y2="296.4" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="302.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="308.8" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="309.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="311.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="310.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,334.9 187.0,337.3 302.0,338.1 417.0,338.6 532.0,338.2" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="335.0" x2="72.0" y2="334.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="335.0" x2="75.0" y2="335.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="334.8" x2="75.0" y2="334.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="337.5" x2="187.0" y2="337.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="337.5" x2="190.0" y2="337.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="337.1" x2="190.0" y2="337.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="338.9" x2="302.0" y2="337.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="338.9" x2="305.0" y2="338.9" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="337.0" x2="305.0" y2="337.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="339.2" x2="417.0" y2="338.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="339.2" x2="420.0" y2="339.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="338.3" x2="420.0" y2="338.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="338.7" x2="532.0" y2="337.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="338.7" x2="535.0" y2="338.7" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="337.3" x2="535.0" y2="337.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="334.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="337.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="338.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="338.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="338.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,347.3 187.0,347.2 302.0,347.3 417.0,347.2 532.0,347.2" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="347.3" x2="72.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.3" x2="75.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.3" x2="75.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="347.3" x2="187.0" y2="347.0" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.3" x2="190.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.0" x2="190.0" y2="347.0" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="347.3" x2="302.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.3" x2="305.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.3" x2="305.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="347.3" x2="417.0" y2="347.1" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.3" x2="420.0" y2="347.3" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.1" x2="420.0" y2="347.1" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="347.2" x2="532.0" y2="347.1" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.2" x2="535.0" y2="347.2" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.1" x2="535.0" y2="347.1" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="347.3" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="347.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="347.3" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="347.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="347.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="113.7" fill="#52514e" font-size="9">7.2s</text>
+<text x="80.0" y="300.9" fill="#52514e" font-size="9">1.4s</text>
+<text x="80.0" y="311.9" fill="#52514e" font-size="9">1.3s</text>
+<text x="80.0" y="337.9" fill="#52514e" font-size="9">0.4s</text>
+<text x="80.0" y="350.3" fill="#52514e" font-size="9">20ms</text>
+<text x="195.0" y="213.2" fill="#52514e" font-size="9">4.2s</text>
+<text x="195.0" y="307.5" fill="#52514e" font-size="9">1.2s</text>
+<text x="195.0" y="318.5" fill="#52514e" font-size="9">1.1s</text>
+<text x="195.0" y="339.8" fill="#52514e" font-size="9">0.3s</text>
+<text x="195.0" y="350.8" fill="#52514e" font-size="9">24ms</text>
+<text x="310.0" y="254.0" fill="#52514e" font-size="9">2.9s</text>
+<text x="310.0" y="309.9" fill="#52514e" font-size="9">1.2s</text>
+<text x="310.0" y="320.9" fill="#52514e" font-size="9">1.0s</text>
+<text x="310.0" y="340.2" fill="#52514e" font-size="9">0.3s</text>
+<text x="310.0" y="351.2" fill="#52514e" font-size="9">22ms</text>
+<text x="425.0" y="280.1" fill="#52514e" font-size="9">2.1s</text>
+<text x="425.0" y="312.5" fill="#52514e" font-size="9">1.1s</text>
+<text x="425.0" y="323.5" fill="#52514e" font-size="9">0.9s</text>
+<text x="425.0" y="340.4" fill="#52514e" font-size="9">0.3s</text>
+<text x="425.0" y="351.4" fill="#52514e" font-size="9">23ms</text>
+<text x="540.0" y="286.7" fill="#52514e" font-size="9">1.9s</text>
+<text x="540.0" y="312.4" fill="#52514e" font-size="9">1.1s</text>
+<text x="540.0" y="323.4" fill="#52514e" font-size="9">0.9s</text>
+<text x="540.0" y="340.2" fill="#52514e" font-size="9">0.3s</text>
+<text x="540.0" y="351.2" fill="#52514e" font-size="9">25ms</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-compression-comparison.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-compression-comparison.md
@@ -1,0 +1,48 @@
+# Alignment Compression: mpox-2000 xz vs zstd
+
+The level-1 zstd alignment preserves the decoded FASTA exactly, increases compressed size from 431,188 bytes to 24,910,268 bytes, and does not produce a measurable end-to-end single-thread speedup. The full scaling results are in [mpox-2000.md](mpox-2000.md) and [mpox-2000-zstd.md](mpox-2000-zstd.md).
+
+## Inputs
+
+| Format | File | Size | Decoded SHA-256 |
+| --- | --- | ---: | --- |
+| xz | `data/mpox/clade-ii/2000/aln.fasta.xz` | 431,188 bytes | `0be5e75cb1b2c3d01c7d0c53528d3bb16493febcc5765459805677c6eeb5640e` |
+| zstd level 1 | `data/mpox/clade-ii/2000/aln.fasta.zst` | 24,910,268 bytes | `0be5e75cb1b2c3d01c7d0c53528d3bb16493febcc5765459805677c6eeb5640e` |
+
+The zstd file was produced with `xz -dc aln.fasta.xz | zstd -1 > aln.fasta.zst`. Level 1 is zstd's fast-compression preset. The resulting file is 57.8x larger than the xz input.
+
+## Methodology
+
+Both reports use the same five workloads, thread counts of 1, 2, 4, 8, and 16, three measured hyperfine runs after one warmup, a second duplicate run per configuration, and separate `/usr/bin/time` peak-RSS measurements. Only the alignment supplied to `ancestral`, `optimize`, and `timetree` differs. `mugration` and `clock` do not read the alignment and serve as environmental controls.
+
+The xz report used commit `3f1820a5ee5f443691624e00ab4aad4e4012a049`; the zstd report used `7e8a78ca6d068dafba5f31946cc25becde0217ec`. No TreeTime production source changed between these commits. The zstd report records identical SHA-256 hashes for its two executable copies.
+
+## Wall-clock comparison
+
+Negative deltas favor zstd. Values are means from separate benchmark sessions, so deltas include session-level scheduling and system-load variation.
+
+| Workload | Threads | xz | zstd | Delta |
+| --- | ---: | ---: | ---: | ---: |
+| **Ancestral** | 1 | 5.830 s | 5.738 s | -1.6% |
+|  | 2 | 5.518 s | 4.999 s | -9.4% |
+|  | 4 | 5.012 s | 4.610 s | -8.0% |
+|  | 8 | 4.681 s | 4.720 s | +0.8% |
+|  | 16 | 4.627 s | 4.854 s | +4.9% |
+| **Optimize** | 1 | 5.897 s | 5.855 s | -0.7% |
+|  | 2 | 4.899 s | 4.942 s | +0.9% |
+|  | 4 | 4.347 s | 3.851 s | -11.4% |
+|  | 8 | 4.967 s | 4.556 s | -8.3% |
+|  | 16 | 4.054 s | 4.024 s | -0.7% |
+| **Timetree** | 1 | 34.947 s | 35.732 s | +2.2% |
+|  | 2 | 21.171 s | 21.098 s | -0.3% |
+|  | 4 | 14.079 s | 13.673 s | -2.9% |
+|  | 8 | 11.011 s | 12.529 s | +13.8% |
+|  | 16 | 9.748 s | 14.220 s | +45.9% |
+
+At one thread, all three differences are within 2.2% and point in mixed directions. Higher-thread deltas are also inconsistent: ancestral and optimize improve at some counts, while timetree regresses sharply at 8 and 16 threads. The no-alignment controls vary between the sessions as well, including mugration and sub-100 ms clock timings. The data therefore support no causal end-to-end speedup from zstd in this run.
+
+## Interpretation
+
+[profiling-findings.md](profiling-findings.md) attributes 18.8% of one-thread ancestral self-time to FASTA reading and xz decompression. That creates an upper bound on the benefit available from changing compression alone. Serial sparse-partition construction, output, page management, and other orchestration remain, while only 25.6% of runtime is parallel Fitch computation. Per-depth-level fork/join barriers continue to constrain parallel scaling regardless of the alignment codec.
+
+Level-1 zstd is therefore a poor trade for this dataset under the measured workflow: it consumes 57.8x more storage without a detectable end-to-end runtime improvement. The codec change does preserve all alignment-dependent outputs at both tested thread extremes.

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-zstd.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-zstd.md
@@ -1,0 +1,110 @@
+# Parallel Scaling: mpox-2000-zstd
+
+**Commit:** `7e8a78ca6d068dafba5f31946cc25becde0217ec`
+**Dataset:** `data/mpox/clade-ii/2000`
+**Alignment:** `data/mpox/clade-ii/2000/aln.fasta.zst`
+**Compression:** zstd level 1 (fast-compression preset), 24,910,268 bytes
+**Threads:** 1, 2, 4, 8, 16
+**Runs:** 3 measured + 1 warmup per configuration
+
+## Methodology
+
+A single release binary was benchmarked across five CLI subcommands at thread counts 1, 2, 4, 8, 16 using [hyperfine](https://github.com/sharkdp/hyperfine) (3 measured runs, 1 warmup). Peak RSS was captured separately via `/usr/bin/time`. The benchmark harness (`dev/bench-graph-pass-cli`) ran each workload twice per configuration; results are the mean of both runs. The two harness binary slots contained the same executable, with SHA-256 `02c0167c255f83ffd3a1fa6194b418320c0cdfe0c228cf9fa5e978c2e0561ada`.
+
+The source alignment was recompressed with `xz -dc aln.fasta.xz | zstd -1 > aln.fasta.zst`. Decompressing either file produces the same SHA-256 digest, `0be5e75cb1b2c3d01c7d0c53528d3bb16493febcc5765459805677c6eeb5640e`. The zstd file replaces the xz alignment argument in `ancestral`, `optimize`, and `timetree`; all other arguments and workloads match [mpox-2000.md](mpox-2000.md).
+
+### Workloads
+
+| Subcommand | Description | Key parameters |
+|---|---|---|
+| **ancestral** | Marginal ancestral sequence reconstruction | `--method-anc=marginal --dense=false` |
+| **mugration** | Discrete trait reconstruction (country) | `--attribute=country --pc=1.0` |
+| **clock** | Molecular clock inference | default |
+| **optimize** | Branch length optimization | `--dense=false` |
+| **timetree** | Full time-scaled phylogeny | all output formats |
+
+## Results
+
+### Wall-clock time
+
+![Wall-clock time](assets/mpox-2000-zstd_wall-time.svg)
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 35.732 s | 21.098 s | 13.673 s | 12.529 s | 14.220 s |
+| **Optimize** | 5.855 s | 4.942 s | 3.851 s | 4.556 s | 4.024 s |
+| **Ancestral** | 5.738 s | 4.999 s | 4.610 s | 4.720 s | 4.854 s |
+| **Mugration** | 3.292 s | 2.484 s | 1.855 s | 1.952 s | 1.812 s |
+| **Clock** | 72.7 ms | 74.2 ms | 70.9 ms | 106.0 ms | 91.4 ms |
+
+### Speedup
+
+![Speedup](assets/mpox-2000-zstd_speedup.svg)
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 1.00x | 1.69x | 2.61x | 2.85x | 2.51x |
+| **Optimize** | 1.00x | 1.18x | 1.52x | 1.29x | 1.46x |
+| **Ancestral** | 1.00x | 1.15x | 1.24x | 1.22x | 1.18x |
+| **Mugration** | 1.00x | 1.32x | 1.77x | 1.69x | 1.82x |
+| **Clock** | 1.00x | 0.98x | 1.03x | 0.69x | 0.79x |
+
+### Parallel efficiency
+
+![Efficiency](assets/mpox-2000-zstd_efficiency.svg)
+
+Efficiency = speedup / thread count.
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 100% | 85% | 65% | 36% | 16% |
+| **Optimize** | 100% | 59% | 38% | 16% | 9% |
+| **Ancestral** | 100% | 57% | 31% | 15% | 7% |
+| **Mugration** | 100% | 66% | 44% | 21% | 11% |
+| **Clock** | 100% | 49% | 26% | 9% | 5% |
+
+### Peak resident memory
+
+![Peak RSS](assets/mpox-2000-zstd_peak-rss.svg)
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 2159 MB | 2143 MB | 2155 MB | 2195 MB | 2278 MB |
+| **Optimize** | 1244 MB | 1436 MB | 1479 MB | 1475 MB | 1520 MB |
+| **Ancestral** | 1624 MB | 1794 MB | 1839 MB | 1914 MB | 1986 MB |
+| **Mugration** | 29 MB | 29 MB | 29 MB | 29 MB | 31 MB |
+| **Clock** | 23 MB | 21 MB | 22 MB | 21 MB | 23 MB |
+
+### CPU utilization
+
+User + system time / wall-clock time. Values above 1.0 indicate parallel CPU use.
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 1.00 | 1.70 | 2.68 | 3.36 | 3.17 |
+| **Optimize** | 1.00 | 1.41 | 1.87 | 2.43 | 4.03 |
+| **Ancestral** | 1.00 | 1.17 | 1.28 | 1.43 | 1.67 |
+| **Mugration** | 1.00 | 1.60 | 2.47 | 3.45 | 5.47 |
+| **Clock** | 1.00 | 1.17 | 1.39 | 1.80 | 3.24 |
+
+## Output equivalence
+
+The harness compared outputs at 1 and 16 threads. `ancestral`, `mugration`, `optimize`, and `timetree` were byte-identical across the duplicate binary slots and across thread counts. `clock` was byte-identical between duplicate runs at 1 thread, while its SVG and `rerooted.clock.csv` varied at 16 threads and between 1 and 16 threads. This variation is independent of alignment compression because `clock` does not read the alignment.
+
+## Summary and Discussion
+
+### Fast zstd decompression does not remove the scaling limits
+
+The strongest results occur at four threads: timetree reaches 2.61x, optimize 1.52x, and ancestral 1.24x. Beyond four threads, all three alignment-reading workloads plateau or regress in this run. Timetree finishes in 13.7 s at four threads, compared with 35.7 s at one thread; its 16-thread result rises to 14.2 s.
+
+The profile in [profiling-findings.md](profiling-findings.md) attributes 18.8% of single-thread ancestral self-time to xz input and decompression, but only 25.6% to parallel Fitch computation. Replacing xz reduces one serial component; it does not change the serial sparse-partition setup, output serialization, or the per-tree-level Rayon barriers. The observed ancestral speedup therefore remains limited to 1.24x at four threads and 1.18x at 16 threads.
+
+### Comparison with xz
+
+Relative to [mpox-2000.md](mpox-2000.md), zstd changes one-thread wall time by -1.6% for ancestral, -0.7% for optimize, and +2.2% for timetree. These differences are small relative to run-to-run variation, so this benchmark does not establish an end-to-end one-thread speedup from recompression. Results at higher thread counts are irregular in both reports; the 16-thread timetree result is 45.9% slower with zstd despite identical decoded input, indicating benchmark noise or system contention rather than a decompression effect.
+
+The storage tradeoff is large: `aln.fasta.zst` is 24,910,268 bytes versus 431,188 bytes for `aln.fasta.xz`, or 57.8x larger. Level-1 zstd prioritizes decode speed and is unsuitable here if compact distribution size is the primary constraint.
+
+## Conclusion
+
+Level-1 zstd preserves results for every alignment-reading workload, but it does not materially improve end-to-end single-thread runtime in this benchmark. Four threads gives the best consistent scaling point for the zstd input. The profiling conclusions remain unchanged: serial sparse setup and fine-grained frontier barriers dominate once alignment decompression is reduced.

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000.md
@@ -1,0 +1,122 @@
+# Parallel Scaling: mpox-2000
+
+**Commit:** `3f1820a5ee5f443691624e00ab4aad4e4012a049`
+**Dataset:** `data/mpox/clade-ii/2000`
+**Threads:** 1, 2, 4, 8, 16
+**Runs:** 3 measured + 1 warmup per configuration
+
+## Methodology
+
+A single release binary was benchmarked across five CLI subcommands at thread counts 1, 2, 4, 8, 16 using [hyperfine](https://github.com/sharkdp/hyperfine) (3 measured runs, 1 warmup). Peak RSS was captured separately via `/usr/bin/time`. The benchmark harness (`dev/bench-graph-pass-cli`) ran each workload twice per configuration; results are the mean of both runs.
+
+### Workloads
+
+| Subcommand    | Description                                | Key parameters                        |
+| ------------- | ------------------------------------------ | ------------------------------------- |
+| **ancestral** | Marginal ancestral sequence reconstruction | `--method-anc=marginal --dense=false` |
+| **mugration** | Discrete trait reconstruction (country)    | `--attribute=country --pc=1.0`        |
+| **clock**     | Molecular clock inference                  | default                               |
+| **optimize**  | Branch length optimization                 | `--dense=false`                       |
+| **timetree**  | Full time-scaled phylogeny                 | all output formats                    |
+
+## Results
+
+### Wall-clock time
+
+![Wall-clock time](assets/mpox-2000_wall-time.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  | 34.947 s |  21.171 s |  14.079 s |  11.011 s |    9.748 s |
+| **Optimize**  |  5.897 s |   4.899 s |   4.347 s |   4.967 s |    4.054 s |
+| **Ancestral** |  5.830 s |   5.518 s |   5.012 s |   4.681 s |    4.627 s |
+| **Mugration** |  3.191 s |   2.335 s |   1.909 s |   1.671 s |    1.563 s |
+| **Clock**     |  73.0 ms |  254.3 ms |   72.4 ms |   78.9 ms |    80.7 ms |
+
+### Speedup
+
+![Speedup](assets/mpox-2000_speedup.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |    1.00x |     1.65x |     2.48x |     3.17x |      3.59x |
+| **Optimize**  |    1.00x |     1.20x |     1.36x |     1.19x |      1.45x |
+| **Ancestral** |    1.00x |     1.06x |     1.16x |     1.25x |      1.26x |
+| **Mugration** |    1.00x |     1.37x |     1.67x |     1.91x |      2.04x |
+| **Clock**     |    1.00x |     0.29x |     1.01x |     0.92x |      0.90x |
+
+### Parallel efficiency
+
+![Efficiency](assets/mpox-2000_efficiency.svg)
+
+Efficiency = speedup / thread count.
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     100% |       83% |       62% |       40% |        22% |
+| **Optimize**  |     100% |       60% |       34% |       15% |         9% |
+| **Ancestral** |     100% |       53% |       29% |       16% |         8% |
+| **Mugration** |     100% |       68% |       42% |       24% |        13% |
+| **Clock**     |     100% |       14% |       25% |       12% |         6% |
+
+### Peak resident memory
+
+![Peak RSS](assets/mpox-2000_peak-rss.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |  2160 MB |   2144 MB |   2162 MB |   2194 MB |    2250 MB |
+| **Optimize**  |  1244 MB |   1439 MB |   1482 MB |   1485 MB |    1534 MB |
+| **Ancestral** |  1618 MB |   1807 MB |   1825 MB |   1904 MB |    1985 MB |
+| **Mugration** |    29 MB |     29 MB |     29 MB |     29 MB |      31 MB |
+| **Clock**     |    23 MB |     21 MB |     21 MB |     22 MB |      24 MB |
+
+### CPU utilization
+
+User + system time / wall-clock time. Values above 1.0 indicate parallel CPU use.
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     1.00 |      1.70 |      2.65 |      3.81 |       4.85 |
+| **Optimize**  |     1.00 |      1.38 |      1.90 |      2.82 |       3.90 |
+| **Ancestral** |     1.00 |      1.17 |      1.28 |      1.40 |       1.66 |
+| **Mugration** |     1.00 |      1.62 |      2.44 |      3.72 |       6.08 |
+| **Clock**     |     1.00 |      0.98 |      1.38 |      1.91 |       3.35 |
+
+## Summary and Discussion
+
+### Comparison with mpox-500
+
+The 4x increase in dataset size (463 to ~2000 tips) yields these changes:
+
+- **Timetree** wall-clock scales from 7.2s to 35s (4.9x), parallel behavior nearly identical (3.59x vs 3.69x at 16T)
+- **Mugration** improves from 1.40x to 1.91x speedup at 8 threads, crossing 2x at 16 -- the larger state space benefits from parallelism
+- **Optimize** and **ancestral** scale roughly with dataset size but show no parallel scaling improvement
+- **Clock** has an anomalous 254 ms outlier at 2 threads (vs 73 ms at 1 thread), likely a measurement artifact from warmup or scheduling noise on the longer-running benchmark session
+
+### Timetree: still the strongest scaler
+
+3.59x at 16 threads, 83% efficiency at 2 threads, 40% at 8. Similar to mpox-500, confirming timetree's parallel behavior is stable across dataset sizes. The absolute time (35s single-threaded to 9.7s at 16 threads) makes parallelism practically valuable here. Memory is flat at ~2.2 GB, barely affected by thread count.
+
+### Mugration: improved scaling at larger size
+
+Mugration benefits from the larger dataset: 2.04x at 16 threads (vs 1.33x on mpox-500) and 68% efficiency at 2 threads. The state space for 2000 tips provides enough per-thread work to justify the coordination overhead. Memory stays under 31 MB.
+
+### Optimize and ancestral: still limited
+
+Optimize reaches 1.45x at 16 threads but shows irregular scaling (drops to 1.19x at 8 threads, recovers at 16). Ancestral reaches 1.26x at 16 threads, nearly identical to mpox-500. Memory for both grows with thread count: ancestral from 1.6 GB to 2.0 GB, optimize from 1.2 GB to 1.5 GB.
+
+### Clock: still too fast
+
+At 73 ms single-threaded, clock remains too fast for parallelism on this dataset. The 254 ms at 2 threads is an anomaly.
+
+## Conclusion
+
+| Category                      | Workloads           | Recommendation                       |
+| ----------------------------- | ------------------- | ------------------------------------ |
+| Scales well (>2x at 8T)       | timetree            | 4-8 threads; 16 still marginal gain  |
+| Improved at scale (2x at 16T) | mugration           | 4-8 threads worthwhile at 2000+ tips |
+| Limited scaling               | optimize, ancestral | 2-4 threads at best                  |
+| No scaling                    | clock               | Single-threaded                      |
+
+For the 2000-tip dataset, **8 threads** is the sweet spot: timetree reaches 3.17x (11s vs 35s), mugration reaches 1.91x (1.7s vs 3.2s). Beyond 8, only timetree shows meaningful gain.

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-500.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-500.md
@@ -1,0 +1,112 @@
+# Parallel Scaling: mpox-500
+
+**Commit:** `3f1820a5ee5f443691624e00ab4aad4e4012a049`
+**Dataset:** `data/mpox/clade-ii/500`
+**Threads:** 1, 2, 4, 8, 16
+**Runs:** 3 measured + 1 warmup per configuration
+
+## Methodology
+
+A single release binary was benchmarked across five CLI subcommands at thread counts 1, 2, 4, 8, 16 using [hyperfine](https://github.com/sharkdp/hyperfine) (3 measured runs, 1 warmup). Peak RSS was captured separately via `/usr/bin/time`. The benchmark harness (`dev/bench-graph-pass-cli`) ran each workload twice per configuration; results are the mean of both runs.
+
+### Workloads
+
+| Subcommand    | Description                                | Key parameters                        |
+| ------------- | ------------------------------------------ | ------------------------------------- |
+| **ancestral** | Marginal ancestral sequence reconstruction | `--method-anc=marginal --dense=false` |
+| **mugration** | Discrete trait reconstruction (country)    | `--attribute=country --pc=1.0`        |
+| **clock**     | Molecular clock inference                  | default                               |
+| **optimize**  | Branch length optimization                 | `--dense=false`                       |
+| **timetree**  | Full time-scaled phylogeny                 | all output formats                    |
+
+## Results
+
+### Wall-clock time
+
+![Wall-clock time](assets/mpox-500_wall-time.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |  7.165 s |   4.161 s |   2.928 s |   2.140 s |    1.941 s |
+| **Optimize**  |  1.309 s |   1.110 s |  990.0 ms |  890.1 ms |   853.6 ms |
+| **Ancestral** |  1.382 s |   1.185 s |   1.158 s |   1.101 s |    1.146 s |
+| **Mugration** | 395.6 ms |  322.5 ms |  298.9 ms |  282.5 ms |   297.4 ms |
+| **Clock**     |  20.2 ms |   24.4 ms |   21.6 ms |   23.1 ms |    24.7 ms |
+
+### Speedup
+
+![Speedup](assets/mpox-500_speedup.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |    1.00x |     1.72x |     2.45x |     3.35x |      3.69x |
+| **Optimize**  |    1.00x |     1.18x |     1.32x |     1.47x |      1.53x |
+| **Ancestral** |    1.00x |     1.17x |     1.19x |     1.26x |      1.21x |
+| **Mugration** |    1.00x |     1.23x |     1.32x |     1.40x |      1.33x |
+| **Clock**     |    1.00x |     0.83x |     0.93x |     0.87x |      0.82x |
+
+### Parallel efficiency
+
+![Efficiency](assets/mpox-500_efficiency.svg)
+
+Efficiency = speedup / thread count.
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     100% |       86% |       61% |       42% |        23% |
+| **Optimize**  |     100% |       59% |       33% |       18% |        10% |
+| **Ancestral** |     100% |       58% |       30% |       16% |         8% |
+| **Mugration** |     100% |       61% |       33% |       18% |         8% |
+| **Clock**     |     100% |       41% |       23% |       11% |         5% |
+
+### Peak resident memory
+
+![Peak RSS](assets/mpox-500_peak-rss.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |   519 MB |    520 MB |    536 MB |    549 MB |     562 MB |
+| **Optimize**  |   302 MB |    329 MB |    331 MB |    352 MB |     355 MB |
+| **Ancestral** |   391 MB |    454 MB |    468 MB |    470 MB |     471 MB |
+| **Mugration** |    14 MB |     14 MB |     15 MB |     15 MB |      16 MB |
+| **Clock**     |    15 MB |     15 MB |     16 MB |     16 MB |      17 MB |
+
+### CPU utilization
+
+User + system time / wall-clock time. Values above 1.0 indicate parallel CPU use.
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     1.00 |      1.69 |      2.59 |      3.67 |       4.90 |
+| **Optimize**  |     1.00 |      1.39 |      1.86 |      2.48 |       3.90 |
+| **Ancestral** |     1.00 |      1.15 |      1.27 |      1.36 |       1.60 |
+| **Mugration** |     1.00 |      1.54 |      2.28 |      3.65 |       6.69 |
+| **Clock**     |     0.99 |      1.12 |      1.36 |      1.84 |       3.25 |
+
+## Summary and Discussion
+
+### Timetree: strong scaling
+
+Timetree is the only workload that scales well: 3.69x speedup at 16 threads, with 86% efficiency at 2 threads and 42% at 8 (above the 75% threshold only at 2 threads). The timetree pipeline iterates over branch-length optimization, ancestral reconstruction, and clock fitting, so the parallelizable fraction dominates serial overhead. CPU utilization reaches 4.9 cores at 16 threads, confirming real parallel work. Peak RSS grows modestly from 519 MB (1 thread) to 562 MB (16 threads), an 8% increase.
+
+### Optimize and mugration: moderate scaling, quick saturation
+
+Both reach ~1.5x and ~1.4x respectively and plateau around 8 threads. The parallelizable portion of these workloads is smaller relative to serial setup and I/O. Mugration regresses from 8 to 16 threads (282 ms to 297 ms), suggesting thread coordination overhead exceeds the marginal gain. Mugration CPU utilization at 16 threads (6.69 cores) is high relative to its wall-clock improvement, pointing to contention. Optimize uses 302-355 MB across thread counts; mugration stays under 16 MB throughout.
+
+### Ancestral: minimal scaling
+
+Ancestral reconstruction reaches only 1.26x at 8 threads and regresses at 16. With `--dense=false` (sparse/Fitch compression), per-site work is reduced to variable sites only, making work units too fine-grained for profitable parallelism at this dataset size. CPU utilization stays below 1.6 even at 16 threads, confirming most cores sit idle. Peak RSS jumps from 391 MB (1 thread) to 454 MB (2 threads), then flattens around 470 MB, indicating a one-time per-thread workspace allocation.
+
+### Clock: no scaling
+
+Clock completes in ~20 ms, too fast for parallelism to help. Thread creation and synchronization overhead exceeds the workload itself. Negligible memory footprint (15-17 MB) confirms this is a lightweight metadata-only pass.
+
+## Conclusion
+
+| Category                | Workloads           | Recommendation                                |
+| ----------------------- | ------------------- | --------------------------------------------- |
+| Scales well (>2x at 8T) | timetree            | 4-8 threads; diminishing returns beyond       |
+| Moderate (1.2-1.5x)     | optimize, mugration | 2-4 threads; beyond is wasted CPU             |
+| No meaningful scaling   | ancestral, clock    | Single-threaded optimal for this dataset size |
+
+For the 463-tip dataset, **4 threads** is the sweet spot balancing throughput against CPU waste. At 8+ threads only timetree continues to benefit. Larger datasets (2000+ tips) would likely show improved parallel efficiency as the work-per-thread ratio increases.

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-findings.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-findings.md
@@ -1,0 +1,106 @@
+# Profiling: Why Sparse-Mode Passes Scale Poorly
+
+**Commit:** `3f1820a5ee5f443691624e00ab4aad4e4012a049`
+**Method:** `perf record --call-graph dwarf` on the `profiling` build (release + debug symbols), run on host. Dataset `data/mpox/clade-ii/2000` (~2000 tips, 197 kb alignment).
+
+## Summary
+
+The modest parallel speedups are not caused by the parallel passes being slow. They are caused by **how little of the total work is actually inside those passes**, and by **fork-join barrier overhead** from parallelising one tree depth level at a time.
+
+Two distinct signatures:
+
+- **Ancestral** (1.26x at 16 threads): dominated by serial work outside the parallel passes. Only ~26% of runtime is parallel compute.
+- **Mugration** (2x at 16 threads, but 6+ cores busy): real per-node compute, but ~21% of thread time is spent spinning in the work-stealing scheduler between depth levels.
+
+## Root cause: per-level fork-join
+
+Both sparse ancestral and mugration traverse the tree one BFS depth level ("frontier") at a time. The pass driver (`packages/treetime/src/partition/indexed_pass.rs:184`) is:
+
+```rust
+for range in self.frontiers.clone() {   // serial loop over depth levels
+    let frontier = &mut slots[range];
+    visit(..., frontier)?;               // calls frontier.par_iter_mut() inside
+}
+```
+
+Every depth level is a separate `par_iter_mut()` with an implicit rayon barrier at its end. The mpox-2000 tree has **121 depth levels** (mpox-500: 38), average frontier width 33 nodes (mpox-500: 24). So per pass, rayon forks and joins ~121 times, each time over a few dozen nodes.
+
+Item count (24-33) is enough to hand every thread something. The problem is the **ratio of useful work per level to fork-join cost per level**: with narrow levels and, in sparse mode, small per-node work, threads finish their slots almost immediately and then spin or sleep at the barrier waiting for the level to close.
+
+## Ancestral: serial work dominates
+
+Single-threaded self-time (`tmp/profiling/anc-j1.data`, 7557 samples), categorised:
+
+| Category                        | Share | Notable symbols                                                                   |
+| ------------------------------- | ----: | --------------------------------------------------------------------------------- |
+| Parallel compute (fitch passes) | 25.6% | `resolve_fixed_positions_backward` (22%), `run_fitch_forward_indexed`             |
+| Serial input I/O                | 18.8% | `FastaReader::read`, `lzma_crc64`, `lzma_decode`                                  |
+| Serial setup                    | 17.2% | `SparseNodePartition::new`                                                        |
+| Serial output                   |  7.5% | `serde_json format_escaped_str`, `write_augur_node_data_json`, `BufWriter::flush` |
+| Kernel page mgmt + memcg + misc | 30.6% | page faults, `clear_page`, `memmove`, orchestration                               |
+
+The serial setup is `attach_seqs_to_graph` (`packages/treetime/src/ancestral/fitch.rs:55`), a plain serial loop over leaves that builds each leaf's sparse partition (`SparseNodePartition::new`). It is 17% of runtime and is embarrassingly parallel (one independent sparse representation per leaf), but runs on one thread.
+
+Even with a perfectly scaling parallel section, Amdahl's law with a serial fraction of ~0.5 caps speedup at ~2x. Measured 1.26x, because the 26% parallel part also pays the per-level barrier cost above.
+
+The j=8 profile (`anc-j8.data`) is nearly identical in relative shares: the serial functions do not shrink, and rayon overhead stays small (`bridge_producer_consumer` 0.19%) because there is so little parallel work to fight over.
+
+## Allocator: jemalloc is in use and is not a bottleneck
+
+The binary links jemalloc as the global allocator (`packages/app-cli/src/bin/treetime.rs:7`, gated to Linux gnu/musl on x86_64/aarch64, active in the profile: `_rjem_malloc`, `do_rallocx`). Breaking down the "kernel page mgmt + memcg + misc" bucket from the ancestral j=1 profile:
+
+| Sub-category                             | Share | Symbols                                                                           |
+| ---------------------------------------- | ----: | --------------------------------------------------------------------------------- |
+| jemalloc userspace                       |  0.5% | `_rjem_malloc`, `do_rallocx`, `_rjem_je_*`                                        |
+| Kernel page fault + zeroing              | ~6.0% | `clear_page_erms`, `__alloc_pages`, `do_anonymous_page`, `get_page_from_freelist` |
+| cgroup memory accounting                 | ~2.1% | memcg hooks from the host's cgroup v2 memory controller (systemd)                 |
+| BTreeMap ops                             |  0.4% | node inserts                                                                      |
+| Other kernel + `memmove` + orchestration |  ~21% | I/O syscalls, JSON/FASTA copies, `pipeline::run`                                  |
+
+The allocator itself is 0.5%: swapping it (mimalloc, etc.) is not worthwhile. The allocator-adjacent cost is the ~6% kernel page-fault + zeroing, driven by allocation churn: `SparseNodePartition::new` builds many small per-node `BTreeMap`s and `Vec`s and frees them, so the growing heap keeps faulting and zeroing fresh pages. Levers, by expected value:
+
+- **L1. Cut allocation churn in sparse construction.** Reuse buffers/arenas across nodes, pre-size collections, or replace per-node `BTreeMap` with a flat sorted `Vec<(pos, val)>` where ordered-map lookup is not needed. Shrinks both the 17% construction compute and its page-fault tail at the source.
+- **L2. Tune jemalloc page retention.** Raise `dirty_decay_ms`/`muzzy_decay_ms` or enable background threads via `MALLOC_CONF` so freed pages stay mapped instead of being returned to the kernel and re-faulted. Targets the ~6% page-fault cost; cheap to try.
+- **L3. The ~2% memcg is host cgroup v2 overhead** (systemd puts every process in a memory cgroup; the profile ran on the host, not in a container). It tracks the same page-fault traffic as L1/L2, so cutting allocation churn reduces it too. Removing it outright needs `cgroup_disable=memory` at the host level, which is a deployment choice, not a code change.
+
+## Mugration: barrier spin dominates the overhead
+
+Mugration does more real per-node work: exponentiating the country-state GTR transition matrix via OpenBLAS `dgemm`. Single-threaded-per-call BLAS (confirmed `SINGLE_THREADED` / `Sequential` via `treetime debug`), so there is **no BLAS-under-rayon oversubscription**.
+
+j=16 self-time (`mug-j16.data`, 51934 samples):
+
+| Category                          |     Share | Symbols                                                                                                              |
+| --------------------------------- | --------: | -------------------------------------------------------------------------------------------------------------------- |
+| Matrix exponential (real compute) |      ~28% | `dgemm_kernel_HASWELL`, `dgemm_itcopy`, `dgemm_otcopy`                                                               |
+| Work-stealing / rayon overhead    |      ~12% | `crossbeam_deque::Stealer::steal` (6.65%), `rayon bridge_producer_consumer` (3.76%), `WorkerThread::wait_until_cold` |
+| Kernel scheduler churn            |     ~9.5% | `try_to_wake_up`, `native_queued_spin_lock_slowpath`, `__schedule`, `pick_next_task_fair`                            |
+| Mutex                             |       ~2% | `pthread_mutex_lock`/`unlock`                                                                                        |
+| ndarray + math + misc             | remainder | `Zip::map_collect_owned`, `__ieee754_exp`, `count_transitions`                                                       |
+
+`Stealer::steal` at 6.65% is workers spinning to steal work that is not there; `try_to_wake_up` and the queued spin lock are the kernel waking and re-sleeping threads. This ~21% combined is pure parallelism machinery, paid because each of the 121 frontier levels is its own fork-join over a few dozen nodes. It explains the earlier observation of 6+ cores "busy" at only 1.3-2x speedup: much of that CPU time is spin-waiting, which `perf` counts as busy.
+
+## Recommendations
+
+Ordered by expected impact on sparse-mode scaling.
+
+- **R1. Parallelise sequence-compression setup.** `attach_seqs_to_graph` (`fitch.rs:55`) is a serial 17% of ancestral. Build the per-leaf `SparseNodePartition` values in parallel (`par_iter` over leaves, collect into the map). Removes a large chunk of the serial fraction directly.
+- **R2. Reduce fork-join count.** The per-level barrier is the shared root cause. Options: process independent subtrees (whose depth ranges do not interact) as one larger parallel region instead of one-level-at-a-time; or coarsen granularity so each rayon task covers a subtree, not a single node. Fewer, larger parallel regions means the barrier cost is amortised over more work.
+- **R3. Overlap I/O with compute.** Ancestral spends ~19% reading and decompressing the alignment and ~7.5% writing JSON, both serial and both currently outside any parallel region. Streaming the FASTA/xz read and pipelining output serialisation would shrink the serial fraction.
+- **R4. Parallelise across partitions** when multiple partitions exist (e.g. amino-acid partitions): `marginal_backward`/`marginal_forward` iterate partitions serially. No effect on the current single-nucleotide-partition runs, but relevant as soon as AA partitions land.
+
+R1 and R3 attack ancestral's serial fraction (the binding constraint there). R2 attacks the barrier overhead that limits every frontier-parallel pass, mugration included.
+
+## Reproduction
+
+```bash
+# build the profiling binary (release + debug symbols) in the container
+./dev/docker/run ./dev/dev bp treetime
+
+# record on host (kernel perf access required)
+perf record -F 1234 --call-graph dwarf -o tmp/profiling/anc-j1.data -- \
+  .build/docker/profiling/treetime ancestral --method-anc=marginal --dense=false \
+  --tree=data/mpox/clade-ii/2000/tree.nwk --aln=data/mpox/clade-ii/2000/aln.fasta.xz \
+  --output-all=tmp/profiling/anc-out -j 1 --silent
+
+perf report -i tmp/profiling/anc-j1.data --stdio --no-children -g none
+```


### PR DESCRIPTION


- Follow-up to: #831

The performance implementation needs reproducible evidence separated from its code review. This PR preserves the measured scaling reports, plots, report generator, and profiling helper used to inspect the graph-pass changes.

The reports distinguish wall-time improvement from aggregate CPU samples and retain the raw methodology needed to repeat the comparisons.

The benchmarked binary contains the cumulative graph-pass stack through `perf/clock-indexed-passes`. On the mpox-2000 workload, timetree scales from 34.9 s at one thread to 9.7 s at 16 threads, a 3.59x speedup.

![mpox-2000 speedup by command and thread count](https://raw.githubusercontent.com/neherlab/treetime/71b4bd6b6bdc9553006d732c91e9ddda37b04be0/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000_speedup.svg)

Profiles show the main sparse-mode limit: 25.6% of ancestral self-time is inside the parallel Fitch passes, while serial sparse setup accounts for 17.2%. See the [scaling report](https://github.com/neherlab/treetime/blob/71b4bd6b6bdc9553006d732c91e9ddda37b04be0/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000.md) and [profiling analysis](https://github.com/neherlab/treetime/blob/71b4bd6b6bdc9553006d732c91e9ddda37b04be0/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-findings.md).

### Work items

- [x] Add paired scaling reports and plots for representative workloads
- [x] Add the report generator for benchmark summaries
- [x] Preserve the profiling helper and interpretation guidance
- [x] Document remaining scheduler and serial-boundary observations in [kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-findings.md](https://github.com/neherlab/treetime/blob/71b4bd6b6bdc9553006d732c91e9ddda37b04be0/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-findings.md)

