### PR TITLE
perf: parallelize sparse leaf construction

### DIFF
--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_efficiency.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_efficiency.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Efficiency vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0%</text>
+<line x1="72" y1="280.3" x2="532" y2="280.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="284.3" fill="#898781" font-size="11" text-anchor="end">25%</text>
+<line x1="72" y1="212.5" x2="532" y2="212.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="216.5" fill="#898781" font-size="11" text-anchor="end">50%</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="148.8" fill="#898781" font-size="11" text-anchor="end">75%</text>
+<line x1="72" y1="77.1" x2="532" y2="77.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="81.1" fill="#898781" font-size="11" text-anchor="end">100%</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Efficiency (%)</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#c3c2b7" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="536.0" y="148.8" fill="#898781" font-size="9">75%</text>
+<polyline points="72.0,77.1 187.0,112.2 302.0,159.4 417.0,217.9 532.0,273.2" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="112.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="159.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="217.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="273.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,144.2 302.0,217.1 417.0,273.4 532.0,310.4" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="144.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="217.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="273.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="310.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,162.3 302.0,240.4 417.0,289.3 532.0,318.7" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="162.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="240.4" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="289.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="318.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,135.2 302.0,210.9 417.0,268.5 532.0,309.0" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="135.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="210.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="268.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="309.0" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,209.3 302.0,279.0 417.0,312.2 532.0,332.0" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="209.3" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="279.0" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="312.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="332.0" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="58.6" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="69.2" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="80.0" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="90.8" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="101.8" fill="#52514e" font-size="9">100%</text>
+<text x="195.0" y="115.2" fill="#52514e" font-size="9">87%</text>
+<text x="195.0" y="137.2" fill="#52514e" font-size="9">79%</text>
+<text x="195.0" y="148.2" fill="#52514e" font-size="9">75%</text>
+<text x="195.0" y="165.3" fill="#52514e" font-size="9">69%</text>
+<text x="195.0" y="212.3" fill="#52514e" font-size="9">51%</text>
+<text x="310.0" y="162.4" fill="#52514e" font-size="9">70%</text>
+<text x="310.0" y="211.5" fill="#52514e" font-size="9">51%</text>
+<text x="310.0" y="222.5" fill="#52514e" font-size="9">48%</text>
+<text x="310.0" y="243.4" fill="#52514e" font-size="9">40%</text>
+<text x="310.0" y="282.0" fill="#52514e" font-size="9">25%</text>
+<text x="425.0" y="220.9" fill="#52514e" font-size="9">48%</text>
+<text x="425.0" y="268.5" fill="#52514e" font-size="9">29%</text>
+<text x="425.0" y="279.5" fill="#52514e" font-size="9">28%</text>
+<text x="425.0" y="292.3" fill="#52514e" font-size="9">22%</text>
+<text x="425.0" y="315.2" fill="#52514e" font-size="9">13%</text>
+<text x="540.0" y="276.2" fill="#52514e" font-size="9">28%</text>
+<text x="540.0" y="304.0" fill="#52514e" font-size="9">14%</text>
+<text x="540.0" y="315.0" fill="#52514e" font-size="9">14%</text>
+<text x="540.0" y="326.0" fill="#52514e" font-size="9">11%</text>
+<text x="540.0" y="337.0" fill="#52514e" font-size="9">6%</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_peak-rss.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_peak-rss.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Peak Resident Memory vs Thread Count</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="298.3" x2="680" y2="298.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="302.3" fill="#898781" font-size="11" text-anchor="end">500</text>
+<line x1="72" y1="248.7" x2="680" y2="248.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="252.7" fill="#898781" font-size="11" text-anchor="end">1000</text>
+<line x1="72" y1="199.0" x2="680" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">1500</text>
+<line x1="72" y1="149.3" x2="680" y2="149.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="153.3" fill="#898781" font-size="11" text-anchor="end">2000</text>
+<line x1="72" y1="99.7" x2="680" y2="99.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="103.7" fill="#898781" font-size="11" text-anchor="end">2500</text>
+<line x1="72" y1="50.0" x2="680" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">3000</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Peak RSS (MB)</text>
+<rect x="78.8" y="133.0" width="20.0" height="215.0" rx="2" fill="#2a78d6"/>
+<rect x="100.8" y="224.0" width="20.0" height="124.0" rx="2" fill="#1baf7a"/>
+<rect x="122.8" y="186.8" width="20.0" height="161.2" rx="2" fill="#eda100"/>
+<rect x="144.8" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="166.8" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="132.8" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<rect x="200.4" y="134.2" width="20.0" height="213.8" rx="2" fill="#2a78d6"/>
+<rect x="222.4" y="224.4" width="20.0" height="123.6" rx="2" fill="#1baf7a"/>
+<rect x="244.4" y="158.6" width="20.0" height="189.4" rx="2" fill="#eda100"/>
+<rect x="266.4" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="288.4" y="345.8" width="20.0" height="2.2" rx="2" fill="#4a3aa7"/>
+<text x="254.4" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<rect x="322.0" y="132.8" width="20.0" height="215.2" rx="2" fill="#2a78d6"/>
+<rect x="344.0" y="223.1" width="20.0" height="124.9" rx="2" fill="#1baf7a"/>
+<rect x="366.0" y="165.0" width="20.0" height="183.0" rx="2" fill="#eda100"/>
+<rect x="388.0" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="410.0" y="345.8" width="20.0" height="2.2" rx="2" fill="#4a3aa7"/>
+<text x="376.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<rect x="443.6" y="131.2" width="20.0" height="216.8" rx="2" fill="#2a78d6"/>
+<rect x="465.6" y="219.2" width="20.0" height="128.8" rx="2" fill="#1baf7a"/>
+<rect x="487.6" y="164.1" width="20.0" height="183.9" rx="2" fill="#eda100"/>
+<rect x="509.6" y="345.1" width="20.0" height="2.9" rx="2" fill="#008300"/>
+<rect x="531.6" y="345.8" width="20.0" height="2.2" rx="2" fill="#4a3aa7"/>
+<text x="497.6" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<rect x="565.2" y="121.3" width="20.0" height="226.7" rx="2" fill="#2a78d6"/>
+<rect x="587.2" y="216.4" width="20.0" height="131.6" rx="2" fill="#1baf7a"/>
+<rect x="609.2" y="151.8" width="20.0" height="196.2" rx="2" fill="#eda100"/>
+<rect x="631.2" y="344.9" width="20.0" height="3.1" rx="2" fill="#008300"/>
+<rect x="653.2" y="345.6" width="20.0" height="2.4" rx="2" fill="#4a3aa7"/>
+<text x="619.2" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="376.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<rect x="615" y="47" width="10" height="10" rx="2" fill="#4a3aa7"/>
+<text x="629" y="56" fill="#0b0b0b" font-size="10">Clock</text>
+<rect x="532" y="47" width="10" height="10" rx="2" fill="#008300"/>
+<text x="546" y="56" fill="#0b0b0b" font-size="10">Mugration</text>
+<rect x="449" y="47" width="10" height="10" rx="2" fill="#eda100"/>
+<text x="463" y="56" fill="#0b0b0b" font-size="10">Ancestral</text>
+<rect x="373" y="47" width="10" height="10" rx="2" fill="#1baf7a"/>
+<text x="387" y="56" fill="#0b0b0b" font-size="10">Optimize</text>
+<rect x="297" y="47" width="10" height="10" rx="2" fill="#2a78d6"/>
+<text x="311" y="56" fill="#0b0b0b" font-size="10">Timetree</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_speedup.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_speedup.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Speedup vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0x</text>
+<line x1="72" y1="273.5" x2="532" y2="273.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="277.5" fill="#898781" font-size="11" text-anchor="end">5x</text>
+<line x1="72" y1="199.0" x2="532" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">10x</text>
+<line x1="72" y1="124.5" x2="532" y2="124.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="128.5" fill="#898781" font-size="11" text-anchor="end">15x</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">20x</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Speedup (x)</text>
+<polyline points="72.0,333.1 187.0,318.2 302.0,288.4 417.0,228.8 532.0,109.6" fill="none" stroke="#e1e0d9" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="538.0" y="113.6" fill="#898781" font-size="10">ideal</text>
+<polyline points="72.0,333.1 187.0,322.1 302.0,306.5 417.0,290.8 532.0,282.2" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="322.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="306.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="290.8" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="282.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,325.6 302.0,319.2 417.0,315.2 532.0,314.9" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="325.6" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="319.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="315.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="314.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,327.6 302.0,324.3 417.0,322.2 532.0,322.2" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="327.6" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="324.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="322.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="322.2" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,324.6 302.0,317.8 417.0,313.0 532.0,313.6" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="324.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="317.8" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="313.0" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="313.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,332.7 302.0,332.8 417.0,332.2 532.0,333.9" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="332.7" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="332.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="332.2" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="333.9" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="314.6" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="325.2" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="336.0" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="346.9" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="357.9" fill="#52514e" font-size="9">1x</text>
+<text x="195.0" y="307.9" fill="#52514e" font-size="9">1.7x</text>
+<text x="195.0" y="318.6" fill="#52514e" font-size="9">1.6x</text>
+<text x="195.0" y="329.4" fill="#52514e" font-size="9">1.5x</text>
+<text x="195.0" y="340.3" fill="#52514e" font-size="9">1.4x</text>
+<text x="195.0" y="351.3" fill="#52514e" font-size="9">1.0x</text>
+<text x="310.0" y="301.4" fill="#52514e" font-size="9">2.8x</text>
+<text x="310.0" y="312.2" fill="#52514e" font-size="9">2.0x</text>
+<text x="310.0" y="323.1" fill="#52514e" font-size="9">1.9x</text>
+<text x="310.0" y="334.0" fill="#52514e" font-size="9">1.6x</text>
+<text x="310.0" y="345.0" fill="#52514e" font-size="9">1.0x</text>
+<text x="425.0" y="293.8" fill="#52514e" font-size="9">3.8x</text>
+<text x="425.0" y="307.2" fill="#52514e" font-size="9">2.3x</text>
+<text x="425.0" y="318.2" fill="#52514e" font-size="9">2.2x</text>
+<text x="425.0" y="329.1" fill="#52514e" font-size="9">1.7x</text>
+<text x="425.0" y="340.1" fill="#52514e" font-size="9">1.1x</text>
+<text x="540.0" y="285.2" fill="#52514e" font-size="9">4.4x</text>
+<text x="540.0" y="307.7" fill="#52514e" font-size="9">2.3x</text>
+<text x="540.0" y="318.7" fill="#52514e" font-size="9">2.2x</text>
+<text x="540.0" y="329.7" fill="#52514e" font-size="9">1.7x</text>
+<text x="540.0" y="340.7" fill="#52514e" font-size="9">0.9x</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_wall-time.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_wall-time.svg
@@ -1,0 +1,167 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Wall-Clock Time vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="273.5" x2="532" y2="273.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="277.5" fill="#898781" font-size="11" text-anchor="end">10.0s</text>
+<line x1="72" y1="199.0" x2="532" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">20.0s</text>
+<line x1="72" y1="124.5" x2="532" y2="124.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="128.5" fill="#898781" font-size="11" text-anchor="end">30.0s</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">40.0s</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Time (seconds)</text>
+<polyline points="72.0,90.1 187.0,199.9 302.0,255.4 417.0,280.9 532.0,289.6" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="91.6" x2="72.0" y2="89.4" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="91.6" x2="75.0" y2="91.6" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="89.4" x2="75.0" y2="89.4" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="200.5" x2="187.0" y2="199.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="200.5" x2="190.0" y2="200.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="199.3" x2="190.0" y2="199.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="255.5" x2="302.0" y2="255.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="255.5" x2="305.0" y2="255.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="255.3" x2="305.0" y2="255.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="281.4" x2="417.0" y2="280.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="281.4" x2="420.0" y2="281.4" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="280.2" x2="420.0" y2="280.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="290.8" x2="532.0" y2="288.7" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="290.8" x2="535.0" y2="290.8" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="288.7" x2="535.0" y2="288.7" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="90.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="199.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="255.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="280.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="289.6" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,303.4 187.0,318.4 302.0,324.9 417.0,327.8 532.0,327.9" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="304.3" x2="72.0" y2="302.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="304.3" x2="75.0" y2="304.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="302.2" x2="75.0" y2="302.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="318.7" x2="187.0" y2="318.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="318.7" x2="190.0" y2="318.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="318.0" x2="190.0" y2="318.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="325.5" x2="302.0" y2="324.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="325.5" x2="305.0" y2="325.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="324.0" x2="305.0" y2="324.0" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="328.2" x2="417.0" y2="327.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="328.2" x2="420.0" y2="328.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="327.3" x2="420.0" y2="327.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="328.1" x2="532.0" y2="327.8" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="328.1" x2="535.0" y2="328.1" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="327.8" x2="535.0" y2="327.8" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="303.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="318.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="324.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="327.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="327.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,302.9 187.0,315.1 302.0,319.6 417.0,322.0 532.0,322.0" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="305.0" x2="72.0" y2="301.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="305.0" x2="75.0" y2="305.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="301.1" x2="75.0" y2="301.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="315.2" x2="187.0" y2="314.9" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="315.2" x2="190.0" y2="315.2" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="314.9" x2="190.0" y2="314.9" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="319.9" x2="302.0" y2="319.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="319.9" x2="305.0" y2="319.9" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="319.3" x2="305.0" y2="319.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="322.7" x2="417.0" y2="321.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="322.7" x2="420.0" y2="322.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="321.3" x2="420.0" y2="321.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="323.0" x2="532.0" y2="320.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="323.0" x2="535.0" y2="323.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="320.0" x2="535.0" y2="320.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="302.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="315.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="319.6" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="322.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="322.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,322.9 187.0,332.0 302.0,335.6 417.0,337.3 532.0,337.1" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="324.0" x2="72.0" y2="322.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="324.0" x2="75.0" y2="324.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="322.3" x2="75.0" y2="322.3" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="332.2" x2="187.0" y2="331.9" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="332.2" x2="190.0" y2="332.2" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="331.9" x2="190.0" y2="331.9" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="335.6" x2="302.0" y2="335.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="335.6" x2="305.0" y2="335.6" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="335.5" x2="305.0" y2="335.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="337.5" x2="417.0" y2="337.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="337.5" x2="420.0" y2="337.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="337.1" x2="420.0" y2="337.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="337.6" x2="532.0" y2="336.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="337.6" x2="535.0" y2="337.6" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="336.8" x2="535.0" y2="336.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="322.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="332.0" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="335.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="337.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="337.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,347.5 187.0,347.5 302.0,347.5 417.0,347.5 532.0,347.4" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="347.5" x2="72.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.5" x2="75.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.4" x2="75.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="347.5" x2="187.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.5" x2="190.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.5" x2="190.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="347.5" x2="302.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.5" x2="305.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.4" x2="305.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="347.5" x2="417.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.5" x2="420.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.5" x2="420.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="347.4" x2="532.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.4" x2="535.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.4" x2="535.0" y2="347.4" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="347.4" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="93.1" fill="#52514e" font-size="9">34.6s</text>
+<text x="80.0" y="300.7" fill="#52514e" font-size="9">6.1s</text>
+<text x="80.0" y="311.7" fill="#52514e" font-size="9">6.0s</text>
+<text x="80.0" y="325.9" fill="#52514e" font-size="9">3.4s</text>
+<text x="80.0" y="350.5" fill="#52514e" font-size="9">73ms</text>
+<text x="195.0" y="202.9" fill="#52514e" font-size="9">19.9s</text>
+<text x="195.0" y="313.8" fill="#52514e" font-size="9">4.4s</text>
+<text x="195.0" y="324.8" fill="#52514e" font-size="9">4.0s</text>
+<text x="195.0" y="335.8" fill="#52514e" font-size="9">2.1s</text>
+<text x="195.0" y="350.5" fill="#52514e" font-size="9">71ms</text>
+<text x="310.0" y="258.4" fill="#52514e" font-size="9">12.4s</text>
+<text x="310.0" y="318.4" fill="#52514e" font-size="9">3.8s</text>
+<text x="310.0" y="329.4" fill="#52514e" font-size="9">3.1s</text>
+<text x="310.0" y="340.4" fill="#52514e" font-size="9">1.7s</text>
+<text x="310.0" y="351.4" fill="#52514e" font-size="9">72ms</text>
+<text x="425.0" y="283.9" fill="#52514e" font-size="9">9.0s</text>
+<text x="425.0" y="320.1" fill="#52514e" font-size="9">3.5s</text>
+<text x="425.0" y="331.1" fill="#52514e" font-size="9">2.7s</text>
+<text x="425.0" y="342.1" fill="#52514e" font-size="9">1.4s</text>
+<text x="425.0" y="353.1" fill="#52514e" font-size="9">69ms</text>
+<text x="540.0" y="292.6" fill="#52514e" font-size="9">7.8s</text>
+<text x="540.0" y="320.1" fill="#52514e" font-size="9">3.5s</text>
+<text x="540.0" y="331.1" fill="#52514e" font-size="9">2.7s</text>
+<text x="540.0" y="342.1" fill="#52514e" font-size="9">1.5s</text>
+<text x="540.0" y="353.1" fill="#52514e" font-size="9">77ms</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md
@@ -1,0 +1,109 @@
+# Parallel Sparse Leaf Setup: mpox-2000
+
+**Verdict:** parallel leaf construction materially improves multi-threaded sparse ancestral reconstruction, but the implementation does not fully meet the validation criterion of lower multi-thread wall time without a one-thread regression: `-j 1` regressed by 5.7%. At 2–16 threads, ancestral wall time improves by 12.9–21.2%. The affected outputs are byte-identical.
+
+- **Baseline:** `7e2a4e4b29322eba4a06d9a72fa0e3a5766f997d`
+- **Changed:** `ac1632682aa0e3c8444dc173d0112ded32491e91`
+- **Dataset:** `data/mpox/clade-ii/2000`
+- **Threads:** 1, 2, 4, 8, 16
+- **Runs:** 3 measured + 1 warmup per binary and configuration
+
+## Result
+
+### Ancestral before and after
+
+| Threads | Baseline | Changed | Wall-time change | Changed speedup | Changed CPU use | Changed peak RSS |
+| ------: | -------: | ------: | ---------------: | --------------: | --------------: | ---------------: |
+|       1 |  5.732 s | 6.057 s |            +5.7% |           1.00x |            1.00 |          1623 MB |
+|       2 |  5.072 s | 4.419 s |           -12.9% |           1.37x |            1.33 |          1907 MB |
+|       4 |  4.564 s | 3.814 s |           -16.4% |           1.59x |            1.62 |          1843 MB |
+|       8 |  4.372 s | 3.494 s |           -20.1% |           1.73x |            1.87 |          1852 MB |
+|      16 |  4.439 s | 3.496 s |           -21.2% |           1.73x |            2.47 |          1976 MB |
+
+The changed binary reaches its minimum at 8 threads. Sixteen threads add CPU work without reducing mean wall time, so 8 threads remains the useful limit for standalone ancestral reconstruction on this dataset.
+
+### Effect on all benchmarked commands
+
+Negative values are improvements. Optimize and timetree call sparse ancestral reconstruction and inherit the change; mugration and clock are unaffected controls.
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Ancestral** |    +5.7% |    -12.9% |    -16.4% |    -20.1% |     -21.2% |
+| **Optimize**  |    -0.5% |    -11.3% |    -21.1% |    -25.4% |     -26.3% |
+| **Timetree**  |    +0.2% |     -2.6% |     -7.3% |    -10.5% |     -12.3% |
+| **Mugration** |    +5.2% |     -0.0% |     +2.5% |     +1.1% |     -17.4% |
+| **Clock**     |    +2.7% |     +0.4% |     +4.1% |     -3.3% |      +4.1% |
+
+The mugration and clock fluctuations do not form a thread-dependent trend. Mugration's isolated 16-thread difference is paired with high baseline variance (standard deviation 0.226 s on a 1.770 s mean), so it is not evidence of an effect from code that mugration does not execute.
+
+## Changed-binary scaling
+
+### Wall-clock time
+
+![Wall-clock time](assets/mpox-2000-parallel-sparse-leaf-setup_wall-time.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  | 34.611 s |  19.885 s |  12.428 s |   9.011 s |    7.834 s |
+| **Optimize**  |  5.982 s |   3.975 s |   3.094 s |   2.715 s |    2.696 s |
+| **Ancestral** |  6.057 s |   4.419 s |   3.814 s |   3.494 s |    3.496 s |
+| **Mugration** |  3.371 s |   2.146 s |   1.665 s |   1.437 s |    1.462 s |
+| **Clock**     |  73.0 ms |   71.3 ms |   71.6 ms |   69.0 ms |    77.0 ms |
+
+### Speedup
+
+![Speedup](assets/mpox-2000-parallel-sparse-leaf-setup_speedup.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |    1.00x |     1.74x |     2.78x |     3.84x |      4.42x |
+| **Optimize**  |    1.00x |     1.50x |     1.93x |     2.20x |      2.22x |
+| **Ancestral** |    1.00x |     1.37x |     1.59x |     1.73x |      1.73x |
+| **Mugration** |    1.00x |     1.57x |     2.02x |     2.35x |      2.31x |
+| **Clock**     |    1.00x |     1.02x |     1.02x |     1.06x |      0.95x |
+
+### Parallel efficiency
+
+![Efficiency](assets/mpox-2000-parallel-sparse-leaf-setup_efficiency.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     100% |       87% |       70% |       48% |        28% |
+| **Optimize**  |     100% |       75% |       48% |       28% |        14% |
+| **Ancestral** |     100% |       69% |       40% |       22% |        11% |
+| **Mugration** |     100% |       79% |       51% |       29% |        14% |
+| **Clock**     |     100% |       51% |       25% |       13% |         6% |
+
+### Peak resident memory
+
+![Peak RSS](assets/mpox-2000-parallel-sparse-leaf-setup_peak-rss.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |  2164 MB |   2152 MB |   2167 MB |   2182 MB |    2282 MB |
+| **Optimize**  |  1248 MB |   1245 MB |   1257 MB |   1297 MB |    1325 MB |
+| **Ancestral** |  1623 MB |   1907 MB |   1843 MB |   1852 MB |    1976 MB |
+| **Mugration** |    29 MB |     29 MB |     29 MB |     30 MB |      31 MB |
+| **Clock**     |    23 MB |     22 MB |     22 MB |     22 MB |      24 MB |
+
+Ancestral peak RSS is within 55 MB of baseline at 1, 4, 8, and 16 threads. The changed 2-thread run is 109 MB higher; peak RSS is a separate single run, and the non-monotonic series does not show persistent memory growth from the parallel collection.
+
+## Output equivalence
+
+Ancestral, optimize, timetree, and mugration outputs are byte-identical:
+
+- between baseline and changed binaries at 1 and 16 threads;
+- between 1 and 16 threads within each binary.
+
+Clock is identical between binaries at one thread. Its 16-thread output differs both between binaries and between thread counts within each binary. Because the baseline shows the same thread-dependent behavior and the changed code is outside clock, this is an existing clock determinism issue rather than a result of sparse leaf construction.
+
+## Methodology
+
+`dev/bench-graph-pass-cli` alternated two release binaries in each hyperfine configuration. Each binary received one warmup and three measured runs at 1, 2, 4, 8, and 16 threads. Peak RSS was measured separately with `/usr/bin/time`; output directories were compared after the timing runs.
+
+| Binary   | Commit                                     | SHA-256                                                            |
+| -------- | ------------------------------------------ | ------------------------------------------------------------------ |
+| Baseline | `7e2a4e4b29322eba4a06d9a72fa0e3a5766f997d` | `02c0167c255f83ffd3a1fa6194b418320c0cdfe0c228cf9fa5e978c2e0561ada` |
+| Changed  | `ac1632682aa0e3c8444dc173d0112ded32491e91` | `9f4a35d3f4c4ac659ca1995a0b55d32b93634d37a63f3aecc06c34c93afc7a11` |
+
+The workload definitions and dataset are identical to [mpox-2000.md](mpox-2000.md). The charts show the changed binary only; the before/after tables use the direct paired benchmark results.

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-parallel-sparse-leaf-setup.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-parallel-sparse-leaf-setup.md
@@ -1,0 +1,77 @@
+# Profiling Parallel Sparse Leaf Setup
+
+**Verdict:** the intended setup work is now distributed across Rayon workers. `SparseNodePartition::new` remains a large share of aggregate CPU samples because the same construction work still exists, but it is no longer a serial wall-time component at multi-thread settings. The next ancestral compute target is the dense fixed-position backward scan.
+
+- **Commit:** `ac1632682aa0e3c8444dc173d0112ded32491e91`
+- **Dataset:** `data/mpox/clade-ii/2000`
+- **Method:** `perf record -F 1234 --call-graph dwarf` on a profiling build, with the process pinned to CPUs 2–17
+
+## Finding: setup parallelization is active
+
+At `-j 8`, `SparseNodePartition::new` accounts for 16.97% of aggregate self samples. Its samples are balanced across all eight Rayon worker threads:
+
+| Worker TID | Self share |
+| ---------: | ---------: |
+|     129254 |      2.11% |
+|     129255 |      2.09% |
+|     129256 |      2.05% |
+|     129257 |      2.10% |
+|     129258 |      2.17% |
+|     129259 |      2.16% |
+|     129260 |      2.17% |
+|     129261 |      2.11% |
+
+The implementation first resolves leaf records in parallel, then constructs a partition-local map with `par_iter`, and finally acquires the partition write lock once to extend the node map. See [`packages/treetime/src/ancestral/fitch.rs`](../../../packages/treetime/src/ancestral/fitch.rs#L55).
+
+The one-thread profile still attributes 18.04% to `SparseNodePartition::new`, close to the 17.2% reported before the change in [profiling-findings.md](profiling-findings.md). This is expected: parallelization changes when the work completes, not the CPU instructions required to build each sparse node. At eight threads, the aggregate 16.97% is concurrent worker time and must not be interpreted as a 16.97% serial fraction.
+
+The wall-time measurements corroborate the thread attribution. Ancestral improves by 20.1% at 8 threads and 21.2% at 16 threads, while CPU utilization rises from 1.38 to 1.87 at 8 threads and from 1.66 to 2.47 at 16 threads. Full measurements are in [mpox-2000-parallel-sparse-leaf-setup.md](mpox-2000-parallel-sparse-leaf-setup.md).
+
+## Current ancestral profile
+
+| Symbol or activity                                              | `-j 1` | `-j 8` | Interpretation                                  |
+| --------------------------------------------------------------- | ------: | ------: | ----------------------------------------------- |
+| `resolve_fixed_positions_backward`                              |  18.24% |  18.45% | Parallel dense alignment scan                   |
+| `SparseNodePartition::new`                                      |  18.04% |  16.97% | Parallel at `-j 8`; balanced over eight workers |
+| `FastaReader::read`                                             |  14.16% |  12.41% | Main-thread input                               |
+| `lzma_crc64` + `lzma_decode`                                    |   5.05% |   4.60% | Main-thread xz decompression                    |
+| `__memmove_avx_unaligned_erms`                                  |   7.65% |   9.69% | Cross-cutting memory movement                   |
+| `write_augur_node_data_json_with_aa` + `format_escaped_str`     |   9.37% |   8.63% | Serial output formatting                        |
+| `run_fitch_forward_indexed`                                     |   2.34% |   2.24% | Parallel forward pass                           |
+
+The captures contain 7,058 samples at `-j 1` and 7,969 samples at `-j 8`, with zero lost samples. Percentages are self samples across all threads, so overlapping functions are not double-counted in the table.
+
+## What to try next
+
+### Ancestral: reduce the fixed-position work domain
+
+`resolve_fixed_positions_backward` is now the largest named compute symbol at 18.45%. It scans every child sequence position for every internal node even though variable Fitch states are sparse. See [`packages/treetime/src/ancestral/fitch_sub.rs`](../../../packages/treetime/src/ancestral/fitch_sub.rs#L83).
+
+The next ancestral experiment should compress repeated invariant alignment patterns while retaining one entry per genuinely variable position, then run substitution Fitch on that compressed domain. A lower-risk kernel comparison can first seed a parent sequence from one child and scan only the remaining children. Both target useful work rather than adding scheduling around an already parallel kernel.
+
+### Shared graph passes: retain frontier coarsening as a separate target
+
+The original mugration profile found substantial work-stealing and scheduler churn from one fork-join per tree frontier. That mechanism remains in [`packages/treetime/src/partition/indexed_pass.rs`](../../../packages/treetime/src/partition/indexed_pass.rs#L185). This follow-up profile covers ancestral only and therefore does not supersede the mugration evidence in [profiling-findings.md](profiling-findings.md). Dependency-aware subtree tasks or another coarsened scheduling unit remain the next shared traversal experiment.
+
+### Serial boundary work
+
+FASTA reading plus xz decoding accounts for about 17.0% of `-j 8` self samples on the main thread, and output formatting accounts for 8.6%. The completed zstd experiment in [mpox-2000-zstd.md](mpox-2000-zstd.md) found no measurable end-to-end one-thread gain from codec replacement alone, so the remaining I/O hypothesis is overlap or reduced data movement rather than another compression-format substitution.
+
+## Reproduction
+
+```bash
+./dev/docker/run taskset -c 2-17 ./dev/dev bp treetime
+
+taskset -c 2-17 perf record -F 1234 --call-graph dwarf \
+  -o tmp/parallel-sparse-leaf-setup/profiling/ancestral-j8.data -- \
+  .build/docker/profiling/treetime ancestral \
+  --method-anc=marginal --dense=false \
+  --tree=data/mpox/clade-ii/2000/tree.nwk \
+  --aln=data/mpox/clade-ii/2000/aln.fasta.xz \
+  --output-all=tmp/parallel-sparse-leaf-setup/profiling/output-j8 \
+  -j 8 --silent
+
+perf report \
+  -i tmp/parallel-sparse-leaf-setup/profiling/ancestral-j8.data \
+  --stdio --no-children -g none
+```

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs
@@ -541,11 +541,11 @@ mod tests {
   }
 
   #[test]
-  fn test_marginal_sparse_parallel_frontiers_are_thread_count_deterministic() -> Result<(), Report> {
+  fn test_marginal_sparse_parallel_pipeline_is_thread_count_deterministic() -> Result<(), Report> {
     let expected = helpers::run_thread_determinism_case(1)?;
     let actual = helpers::run_thread_determinism_case(4)?;
 
-    // Independent frontier scheduling must not affect sum-product messages or MAP state.
+    // Parallel sequence compression and frontier scheduling must not affect messages or MAP state.
     assert_eq!(expected, actual);
     Ok(())
   }

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -66,32 +66,37 @@ where
     records.entry(record.seq_name.as_str()).or_insert(record);
     records
   });
-  for leaf in graph.get_leaves() {
-    let leaf_key = leaf.read_arc().key();
-    let mut leaf = leaf.read_arc().payload().write_arc();
+  let leaf_records = graph
+    .get_leaves()
+    .into_par_iter()
+    .map(|leaf| -> Result<_, Report> {
+      let leaf = leaf.read_arc();
+      let leaf_key = leaf.key();
+      let mut leaf_payload = leaf.payload().write_arc();
+      let leaf_name = leaf_payload
+        .name()
+        .ok_or_else(|| {
+          make_report!("Expected all leaf nodes to have names, such that they can be matched to their corresponding sequences. But found a leaf node that has no name.")
+        })?
+        .as_ref()
+        .to_owned();
+      let leaf_fasta = aln_by_name
+        .get(leaf_name.as_str())
+        .copied()
+        // Every leaf has a sequence record after alignment completion.
+        .ok_or_else(|| make_report!("Leaf sequence not found after alignment completion: '{leaf_name}'"))?;
+      leaf_payload.set_desc(leaf_fasta.desc.clone());
+      Ok((leaf_key, leaf_fasta))
+    })
+    .collect::<Result<Vec<_>, Report>>()?;
 
-    let leaf_name = leaf.name().ok_or_else(|| {
-      make_report!("Expected all leaf nodes to have names, such that they can be matched to their corresponding sequences. But found a leaf node that has no name.")
-    })?.as_ref().to_owned();
-
-    let leaf_fasta = aln_by_name
-      .get(leaf_name.as_str())
-      .copied()
-      // Every leaf has a sequence record after alignment completion.
-      .ok_or_else(|| make_report!("Leaf sequence not found after alignment completion: '{leaf_name}'"))?;
-
-    leaf.set_desc(leaf_fasta.desc.clone());
-
-    partitions.iter().try_for_each(|partition| -> Result<(), Report> {
-      let mut partition = partition.write_arc();
-      let alphabet = &partition.alphabet().clone(); // TODO: avoid clone
-
-      partition
-        .nodes_mut()
-        .insert(leaf_key, SparseNodePartition::new(&leaf_fasta.seq, alphabet)?);
-
-      Ok(())
-    })?;
+  for partition in partitions {
+    let alphabet = partition.read_arc().alphabet().clone();
+    let nodes = leaf_records
+      .par_iter()
+      .map(|(leaf_key, leaf_fasta)| SparseNodePartition::new(&leaf_fasta.seq, &alphabet).map(|node| (*leaf_key, node)))
+      .collect::<Result<BTreeMap<_, _>, Report>>()?;
+    partition.write_arc().nodes_mut().extend(nodes);
   }
 
   for edge in graph.get_edges() {


### PR DESCRIPTION


- Follow-up to: #828

Sparse leaf construction still held partition write locks while building every leaf node. That setup remained serial before the indexed ancestral passes could begin.

This PR resolves leaf records in parallel, builds each partition-local node map outside its write lock, and commits the completed map once. The accompanying report records deterministic outputs for the exercised workloads and a multi-thread wall-time improvement, while also retaining the measured one-thread regression.

Source: `pub(crate) fn attach_seqs_to_graph()` [[src](https://github.com/neherlab/treetime/blob/7d7ea7351e2adbeaa6d3bbdc036d42c8a9def539/packages/treetime/src/ancestral/fitch.rs#L55-L111)]

The paired mpox-2000 comparison isolates this PR against `docs/parallel-scaling-reports`. Sparse ancestral wall time improves at every multi-thread setting, with the best mean at eight threads. The one-thread regression remains a known issue.

| Threads | Baseline | This PR | Change |
| ------: | -------: | ------: | -----: |
|       1 |  5.732 s | 6.057 s |  +5.7% |
|       2 |  5.072 s | 4.419 s | -12.9% |
|       8 |  4.372 s | 3.494 s | -20.1% |
|      16 |  4.439 s | 3.496 s | -21.2% |

![scaling after parallel sparse leaf construction](https://raw.githubusercontent.com/neherlab/treetime/7d7ea7351e2adbeaa6d3bbdc036d42c8a9def539/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-parallel-sparse-leaf-setup_speedup.svg)

Profiling at eight threads attributes balanced `SparseNodePartition::new` samples to all eight Rayon workers, confirming that the targeted setup work is distributed. Ancestral, optimize, timetree, and mugration outputs are byte-identical in the exercised before/after and thread-count comparisons. See the [paired benchmark](https://github.com/neherlab/treetime/blob/7d7ea7351e2adbeaa6d3bbdc036d42c8a9def539/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md) and [follow-up profile](https://github.com/neherlab/treetime/blob/7d7ea7351e2adbeaa6d3bbdc036d42c8a9def539/kb/reports/2026-07-13_perf-report-parallel-scaling/profiling-parallel-sparse-leaf-setup.md).

### Work items

- [x] Resolve leaf records with Rayon
- [x] Build sparse partition nodes outside write locks
- [x] Compare one-thread and four-thread pipeline results
- [x] Report scaling, output equivalence, memory, and profiling evidence in [kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md](https://github.com/neherlab/treetime/blob/7d7ea7351e2adbeaa6d3bbdc036d42c8a9def539/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md)

