### PR TITLE
docs: refresh CLI reference and record research questions

### DIFF
--- a/docs/docs/reference.md
+++ b/docs/docs/reference.md
@@ -50,7 +50,7 @@ Publication:   https://academic.oup.com/ve/article/4/1/vex042/4794731
 * `timetree` — Estimates time trees from an initial tree topology, a set of date constraints (e.g. tip dates), and an alignment (optional)
 * `optimize` — Optimizes the branch lengths and likelihood of a phylogenetic tree given aligned sequences
 * `prune` — Prunes short branches and/or branches without mutations from a phylogenetic tree
-* `ancestral` — Reconstructs ancestral sequences and maps mutations to the tree. The output consists of a file 'ancestral.fasta' with ancestral sequences and a tree 'annotated_tree.nexus' with mutations added as comments like A45G,G136T,..., number in SNPs used 1-based index by default. The inferred GTR model is written to stdout
+* `ancestral` — Reconstructs ancestral sequences and maps mutations to the tree. The output consists of a file 'ancestral.fasta' with ancestral sequences and a tree 'ancestral.nexus' with mutations added as comments like A45G,G136T,..., number in SNPs used 1-based index by default. The inferred GTR model is written to stdout
 * `clock` — Calculates the root-to-tip regression and quantifies the 'clock-i-ness' of the tree. It will reroot the tree to maximize the clock-like signal and recalculate branch length unless run with --keep_root
 * `homoplasy` — Reconstructs ancestral sequences and maps mutations to the tree. The tree is then scanned for homoplasies. An excess number of homoplasies might suggest contamination, recombination, culture adaptation or similar
 * `mugration` — Reconstructs discrete ancestral states, for example geographic location, host, or similar. In addition to ancestral states, a GTR model of state transitions is inferred
@@ -103,7 +103,7 @@ treetime completions bash > ~/.local/share/bash-completion/treetime
 
 Estimates time trees from an initial tree topology, a set of date constraints (e.g. tip dates), and an alignment (optional)
 
-**Usage:** `treetime timetree [OPTIONS] --outdir <OUTDIR>`
+**Usage:** `treetime timetree [OPTIONS]`
 
 ###### **Options:**
 
@@ -181,12 +181,13 @@ Estimates time trees from an initial tree topology, a set of date constraints (e
 
   Default value: `3.0`
 * `--n-iqd <N_IQD>` — Number of IQD (interquartile distance) for clock filter outlier detection
-* `--reroot <REROOT>` — Reroot the tree using root-to-tip regression. Valid choices are 'min_dev', 'least-squares', and 'oldest'. 'least-squares' adjusts the root to minimize residuals of the root-to-tip vs sampling time regression, 'min_dev' minimizes variance of root-to-tip distances. 'least- squares' can be combined with --covariation to account for shared ancestry. Alternatively, you can specify a node name or a list of node names to be used as outgroup or use 'oldest' to reroot to the oldest node. By default, TreeTime will reroot using 'least-squares'. Use --keep- root to keep the current root
+* `--reroot <REROOT>` — Reroot the tree by temporal-signal optimization.
 
-  Default value: `least-squares`
+   Defaults to least-squares when rerooting is enabled. Use --keep-root to keep the input root.
 
-  Possible values: `least-squares`, `min-dev`, `oldest`, `clock-filter`, `mrca`
+  Possible values: `least-squares`, `min-dev`, `oldest`, `clock-filter`
 
+* `--reroot-tips <REROOT_TIPS>` — Reroot on the branch leading to a tip or the MRCA of a comma-separated tip list
 * `--keep-root` — don't reroot the tree. Otherwise, reroot to minimize the residual of the regression of root-to-tip distance and sampling time
 * `--allow-negative-rate` — By default, rates are forced to be positive. For trees with little temporal signal it is advisable to remove this restriction to achieve essentially mid-point rooting
 * `--tip-slack <TIP_SLACK>` — excess variance associated with terminal nodes accounting for overdispersion of the molecular clock
@@ -243,12 +244,131 @@ Estimates time trees from an initial tree topology, a set of date constraints (e
 * `--no-indels` — Disable indel (insertion/deletion) contributions to branch-length optimization and branch-length distributions.
 
    When set, branch-length optimization uses substitution-only likelihood and timetree branch distributions exclude the Poisson indel term. Matches standard phylogenetic tools (RAxML, IQ-TREE, PhyML, BEAST) and enables v0 parity testing. Default: indels enabled.
-* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Write augur-compatible node data JSON to this path
+* `--divergence-units <DIVERGENCE_UNITS>` — Units for divergence values in augur node data JSON and auspice output.
 
-   Contains per-node dates, branch lengths, clock model parameters, confidence intervals, and divergence metrics. The output is compatible with augur export v2 --node-data for Nextstrain pipeline integration. Defaults to `<outdir>/timetree.augur-node-data.json`.
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
-* `--tracelog <TRACELOG>` — Write iteration statistics to tracelog CSV file for monitoring convergence
-* `--seed <SEED>` — Random seed
+   `mutations-per-site` (default): branch divergence as substitutions per site. `mutations`: absolute count of reconstructed substitutions per branch, excluding ambiguous and gap positions. Requires ancestral reconstruction (incompatible with `--branch-length-mode=input`).
+
+  Default value: `mutations-per-site`
+
+  Possible values: `mutations-per-site`, `mutations`
+
+* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Path to output augur-compatible node data JSON.
+
+   Contains per-node dates, branch lengths, clock model parameters, confidence intervals, and divergence metrics. The output is compatible with augur export v2 --node-data for Nextstrain pipeline integration.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-gtr <OUTPUT_GTR>` — Path to output GTR model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-clock-model <OUTPUT_CLOCK_MODEL>` — Path to output clock model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-confidence-tsv <OUTPUT_CONFIDENCE_TSV>` — Path to output date-confidence-interval TSV.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-tracelog <OUTPUT_TRACELOG>` [alias: `tracelog`] — Path to output iteration-statistics tracelog CSV (monitors convergence).
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
+
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `augur-node-data`, `gtr`, `clock-model`, `confidence-tsv`, `tracelog`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
+* `--seed <SEED>` [alias: `rng-seed`] — Random seed
 
 
 
@@ -256,7 +376,7 @@ Estimates time trees from an initial tree topology, a set of date constraints (e
 
 Optimizes the branch lengths and likelihood of a phylogenetic tree given aligned sequences
 
-**Usage:** `treetime optimize [OPTIONS] --tree <TREE> --outdir <OUTDIR>`
+**Usage:** `treetime optimize [OPTIONS] --tree <TREE>`
 
 ###### **Options:**
 
@@ -304,10 +424,121 @@ Optimizes the branch lengths and likelihood of a phylogenetic tree given aligned
 
   Possible values: `true`, `false`
 
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
-* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Write augur-compatible node data JSON to this path
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
 
-   Contains per-node optimized branch lengths (divergence, substitutions per site) and the input alignment and tree paths. The output is compatible with augur export v2 --node-data, equivalent to `augur refine` run without `--timetree` (no clock or date fields). Defaults to `<outdir>/optimize.augur-node-data.json`.
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--divergence-units <DIVERGENCE_UNITS>` — Units for divergence values in augur node data JSON output.
+
+   `mutations-per-site` (default): branch divergence as substitutions per site. `mutations`: absolute count of reconstructed substitutions per branch, excluding ambiguous and gap positions.
+
+  Default value: `mutations-per-site`
+
+  Possible values: `mutations-per-site`, `mutations`
+
+* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Path to output augur-compatible node data JSON.
+
+   Contains per-node optimized branch lengths (divergence, substitutions per site) and the input alignment and tree paths. The output is compatible with augur export v2 --node-data.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-gtr <OUTPUT_GTR>` — Path to output GTR model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `augur-node-data`, `gtr`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
 * `--max-iter <MAX_ITER>` — Maximum number of iterations
 
   Default value: `10`
@@ -358,6 +589,16 @@ Optimizes the branch lengths and likelihood of a phylogenetic tree given aligned
 * `--no-indels` — Disable indel (insertion/deletion) contributions to branch-length optimization.
 
    When set, the optimizer uses substitution-only likelihood, matching standard phylogenetic tools (RAxML, IQ-TREE, PhyML, BEAST) and enabling v0 parity testing. Default: indels enabled.
+* `--reroot <REROOT>` — Reroot the tree by minimizing root-to-tip divergence variance.
+
+   By default, optimize keeps the input root. Pass --reroot or --reroot=min-dev to enable divergence-based rerooting. Date-dependent methods (least-squares, oldest, clock-filter) are available in the timetree and clock commands.
+
+  Possible values: `min-dev`
+
+* `--reroot-tips <REROOT_TIPS>` — Reroot on the branch leading to a tip or the MRCA of a comma-separated tip list
+* `--keep-root` — Keep the input tree root instead of rerooting.
+
+   Optimize keeps the input root by default; this flag is the explicit form and is mutually exclusive with the reroot options.
 * `--gap-fill <GAP_FILL>` — How to handle gap characters in input sequences
 
    'only-terminal': replace leading and trailing gap characters with the ambiguous character (default, matches v0). 'all': replace all gap characters with the ambiguous character. 'none': leave all gap characters unchanged.
@@ -373,7 +614,7 @@ Optimizes the branch lengths and likelihood of a phylogenetic tree given aligned
 
 Prunes short branches and/or branches without mutations from a phylogenetic tree
 
-**Usage:** `treetime prune [OPTIONS] --tree <TREE> --outdir <OUTDIR>`
+**Usage:** `treetime prune [OPTIONS] --tree <TREE>`
 
 ###### **Options:**
 
@@ -391,7 +632,108 @@ Prunes short branches and/or branches without mutations from a phylogenetic tree
 
   Possible values: `nuc`, `aa`, `aa-no-stop`
 
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
+
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-gtr <OUTPUT_GTR>` — Path to output GTR model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `gtr`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
 * `-s`, `--prune-short <THRESHOLD>` — Threshold value for pruning of branches
 
    If set, prune branches with a length below this value
@@ -433,9 +775,9 @@ Prunes short branches and/or branches without mutations from a phylogenetic tree
 
 ## `treetime ancestral`
 
-Reconstructs ancestral sequences and maps mutations to the tree. The output consists of a file 'ancestral.fasta' with ancestral sequences and a tree 'annotated_tree.nexus' with mutations added as comments like A45G,G136T,..., number in SNPs used 1-based index by default. The inferred GTR model is written to stdout
+Reconstructs ancestral sequences and maps mutations to the tree. The output consists of a file 'ancestral.fasta' with ancestral sequences and a tree 'ancestral.nexus' with mutations added as comments like A45G,G136T,..., number in SNPs used 1-based index by default. The inferred GTR model is written to stdout
 
-**Usage:** `treetime ancestral [OPTIONS] --tree <TREE> --outdir <OUTDIR>`
+**Usage:** `treetime ancestral [OPTIONS] --tree <TREE>`
 
 ###### **Options:**
 
@@ -501,16 +843,150 @@ Reconstructs ancestral sequences and maps mutations to the tree. The output cons
 * `--zero-based` — Zero-based mutation indexing
 * `--reconstruct-tip-states` — Overwrite ambiguous states on tips with the most likely inferred state
 * `--report-ambiguous` — Include transitions involving ambiguous states
-* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Write augur-compatible node data JSON to this path.
+* `--ignore-missing-alns` — Treat tree tips that have no sequence in the alignment as fully ambiguous (missing data) instead of aborting.
+
+   Without this flag the run aborts when more than one third of the tips lack a sequence, matching TreeTime v0. Useful when consuming per-CDS translations where some samples have no peptide for a given CDS.
+* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Path to output augur-compatible node data JSON.
 
    Contains per-node nucleotide mutations, reconstructed sequences, the alignment mask, genome annotations, and the reference (root) sequence. The output is compatible with augur export v2 --node-data for Nextstrain pipeline integration.
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-gtr <OUTPUT_GTR>` — Path to output GTR model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-reconstructed-nuc-fasta <OUTPUT_RECONSTRUCTED_NUC_FASTA>` — Path to output reconstructed nucleotide FASTA.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--translations <TRANSLATIONS>` — Path template for per-CDS amino-acid FASTA alignments.
+
+   The template must contain a CDS placeholder, replaced with each value from `--cdses` (or each CDS in `--annotation` when `--cdses` is omitted). Both `{cds}` (Nextclade `--output-translations`) and `%GENE` (augur) placeholders are accepted.
+* `--cdses <CDS>` [alias: `genes`] — Comma-separated CDS names to reconstruct from `--translations`.
+
+   When omitted, the CDS set is derived from `--annotation`.
+* `--annotation <ANNOTATION>` — GFF3 file with CDS coordinates for Augur node data annotations.
+
+   Also supplies the CDS set when `--cdses` is omitted.
+* `--aa-root-sequence <AA_ROOT_SEQUENCE>` — FASTA file with one amino-acid root/reference sequence per CDS
+* `--aa-model <AA_MODEL>` — Amino-acid substitution model. Mirrors the nucleotide `--model`; default `infer` matches augur
+
+  Default value: `infer`
+
+  Possible values:
+  - `infer`:
+    Infer an amino-acid GTR from the data over the stop-inclusive alphabet. Matches augur
+  - `jtt92`:
+    Jones-Taylor-Thornton 1992 empirical 20-amino-acid model (no stop codon). Stop codons and any other out-of-alphabet characters in the input are mapped to the unknown state `X`
+
+* `--output-reconstructed-aa-fasta <OUTPUT_RECONSTRUCTED_AA_FASTA>` — Path template for per-CDS reconstructed amino-acid FASTA output (including internal nodes).
+
+   Off by default. When set, the reconstructed sequence of every node is written per CDS. Accepts the same `{cds}`/`%GENE` placeholders as `--translations`.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
+
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `augur-node-data`, `gtr`, `reconstructed-nuc-fasta`, `reconstructed-aa-fasta`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
 * `--gtr-iterations <GTR_ITERATIONS>` — Number of outer GTR refinement iterations.
 
    Re-estimates the rate matrix from marginal posterior profiles after each reconstruction pass. Only effective with `--model infer`. Default 0 preserves the current single-pass behavior. Mugration uses 5 by default.
 
   Default value: `0`
-* `--seed <SEED>` — Random seed
+* `--seed <SEED>` [alias: `rng-seed`] — Random seed
 * `--sample-from-profile <SAMPLE_FROM_PROFILE>` — How to pick ancestral states from the marginal posterior profile.
 
    'argmax': most likely state at every node (deterministic, default). 'root': sample from the posterior at the root only, argmax elsewhere (matches augur's `sample_from_profile='root'`). Use `--seed` for reproducible draws. 'all': sample from the posterior at every node.
@@ -528,7 +1004,7 @@ Reconstructs ancestral sequences and maps mutations to the tree. The output cons
 
 Calculates the root-to-tip regression and quantifies the 'clock-i-ness' of the tree. It will reroot the tree to maximize the clock-like signal and recalculate branch length unless run with --keep_root
 
-**Usage:** `treetime clock [OPTIONS] --metadata <METADATA> --outdir <OUTDIR>`
+**Usage:** `treetime clock [OPTIONS] --metadata <METADATA>`
 
 ###### **Options:**
 
@@ -596,19 +1072,124 @@ Calculates the root-to-tip regression and quantifies the 'clock-i-ness' of the t
 * `--clock-filter <CLOCK_FILTER>` — ignore tips that don't follow a loose clock, 'clock-filter=number of interquartile ranges from regression'. Default=3.0, set to 0 to switch off
 
   Default value: `3.0`
-* `--reroot <REROOT>` — Reroot the tree using root-to-tip regression. Valid choices are 'min_dev', 'least-squares', and 'oldest'. 'least-squares' adjusts the root to minimize residuals of the root-to-tip vs sampling time regression, 'min_dev' minimizes variance of root-to-tip distances. 'least- squares' can be combined with --covariation to account for shared ancestry. Alternatively, you can specify a node name or a list of node names to be used as outgroup or use 'oldest' to reroot to the oldest node. By default, TreeTime will reroot using 'least-squares'. Use --keep- root to keep the current root
+* `--reroot <REROOT>` — Reroot the tree by temporal-signal optimization.
 
-  Default value: `least-squares`
+   Defaults to least-squares when rerooting is enabled. Use --keep-root to keep the input root.
 
-  Possible values: `least-squares`, `min-dev`, `oldest`, `clock-filter`, `mrca`
+  Possible values: `least-squares`, `min-dev`, `oldest`, `clock-filter`
 
+* `--reroot-tips <REROOT_TIPS>` — Reroot on the branch leading to a tip or the MRCA of a comma-separated tip list
 * `--keep-root` — don't reroot the tree. Otherwise, reroot to minimize the residual of the regression of root-to-tip distance and sampling time
 * `--prune-short`
 * `--tip-slack <TIP_SLACK>` — excess variance associated with terminal nodes accounting for overdispersion of the molecular clock
 * `--covariation` — Account for covariation when estimating rates or rerooting using root-to-tip regression
 * `--allow-negative-rate` — By default, rates are forced to be positive. For trees with little temporal signal it is advisable to remove this restriction to achieve essentially mid-point rooting
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
-* `--seed <SEED>` — Random seed
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
+
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-clock-model <OUTPUT_CLOCK_MODEL>` — Path to output clock model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-clock-csv <OUTPUT_CLOCK_CSV>` — Path to output clock regression CSV.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `clock-model`, `clock-csv`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
+* `--seed <SEED>` [alias: `rng-seed`] — Random seed
 * `--branch-split-method <METHOD>` — Optimization method to use for finding the best root position
 
   Default value: `grid`
@@ -652,7 +1233,7 @@ Calculates the root-to-tip regression and quantifies the 'clock-i-ness' of the t
 
 Reconstructs ancestral sequences and maps mutations to the tree. The tree is then scanned for homoplasies. An excess number of homoplasies might suggest contamination, recombination, culture adaptation or similar
 
-**Usage:** `treetime homoplasy [OPTIONS] --tree <TREE> --outdir <OUTDIR>`
+**Usage:** `treetime homoplasy [OPTIONS] --tree <TREE>`
 
 ###### **Options:**
 
@@ -718,16 +1299,150 @@ Reconstructs ancestral sequences and maps mutations to the tree. The tree is the
 * `--zero-based` — Zero-based mutation indexing
 * `--reconstruct-tip-states` — Overwrite ambiguous states on tips with the most likely inferred state
 * `--report-ambiguous` — Include transitions involving ambiguous states
-* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Write augur-compatible node data JSON to this path.
+* `--ignore-missing-alns` — Treat tree tips that have no sequence in the alignment as fully ambiguous (missing data) instead of aborting.
+
+   Without this flag the run aborts when more than one third of the tips lack a sequence, matching TreeTime v0. Useful when consuming per-CDS translations where some samples have no peptide for a given CDS.
+* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Path to output augur-compatible node data JSON.
 
    Contains per-node nucleotide mutations, reconstructed sequences, the alignment mask, genome annotations, and the reference (root) sequence. The output is compatible with augur export v2 --node-data for Nextstrain pipeline integration.
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-gtr <OUTPUT_GTR>` — Path to output GTR model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-reconstructed-nuc-fasta <OUTPUT_RECONSTRUCTED_NUC_FASTA>` — Path to output reconstructed nucleotide FASTA.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--translations <TRANSLATIONS>` — Path template for per-CDS amino-acid FASTA alignments.
+
+   The template must contain a CDS placeholder, replaced with each value from `--cdses` (or each CDS in `--annotation` when `--cdses` is omitted). Both `{cds}` (Nextclade `--output-translations`) and `%GENE` (augur) placeholders are accepted.
+* `--cdses <CDS>` [alias: `genes`] — Comma-separated CDS names to reconstruct from `--translations`.
+
+   When omitted, the CDS set is derived from `--annotation`.
+* `--annotation <ANNOTATION>` — GFF3 file with CDS coordinates for Augur node data annotations.
+
+   Also supplies the CDS set when `--cdses` is omitted.
+* `--aa-root-sequence <AA_ROOT_SEQUENCE>` — FASTA file with one amino-acid root/reference sequence per CDS
+* `--aa-model <AA_MODEL>` — Amino-acid substitution model. Mirrors the nucleotide `--model`; default `infer` matches augur
+
+  Default value: `infer`
+
+  Possible values:
+  - `infer`:
+    Infer an amino-acid GTR from the data over the stop-inclusive alphabet. Matches augur
+  - `jtt92`:
+    Jones-Taylor-Thornton 1992 empirical 20-amino-acid model (no stop codon). Stop codons and any other out-of-alphabet characters in the input are mapped to the unknown state `X`
+
+* `--output-reconstructed-aa-fasta <OUTPUT_RECONSTRUCTED_AA_FASTA>` — Path template for per-CDS reconstructed amino-acid FASTA output (including internal nodes).
+
+   Off by default. When set, the reconstructed sequence of every node is written per CDS. Accepts the same `{cds}`/`%GENE` placeholders as `--translations`.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
+
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `augur-node-data`, `gtr`, `reconstructed-nuc-fasta`, `reconstructed-aa-fasta`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
 * `--gtr-iterations <GTR_ITERATIONS>` — Number of outer GTR refinement iterations.
 
    Re-estimates the rate matrix from marginal posterior profiles after each reconstruction pass. Only effective with `--model infer`. Default 0 preserves the current single-pass behavior. Mugration uses 5 by default.
 
   Default value: `0`
-* `--seed <SEED>` — Random seed
+* `--seed <SEED>` [alias: `rng-seed`] — Random seed
 * `--sample-from-profile <SAMPLE_FROM_PROFILE>` — How to pick ancestral states from the marginal posterior profile.
 
    'argmax': most likely state at every node (deterministic, default). 'root': sample from the posterior at the root only, argmax elsewhere (matches augur's `sample_from_profile='root'`). Use `--seed` for reproducible draws. 'all': sample from the posterior at every node.
@@ -752,7 +1467,7 @@ Reconstructs ancestral sequences and maps mutations to the tree. The tree is the
 
 Reconstructs discrete ancestral states, for example geographic location, host, or similar. In addition to ancestral states, a GTR model of state transitions is inferred
 
-**Usage:** `treetime mugration [OPTIONS] --attribute <ATTRIBUTE> --metadata <METADATA> --outdir <OUTDIR>`
+**Usage:** `treetime mugration [OPTIONS] --attribute <ATTRIBUTE> --metadata <METADATA>`
 
 ###### **Options:**
 
@@ -772,7 +1487,9 @@ Reconstructs discrete ancestral states, for example geographic location, host, o
    The delimiter actually present in the file is used. Defaults to comma and tab.
 
   Default values: `,`, `	`
-* `--output-confidence <OUTPUT_CONFIDENCE>` — Write confidence profile of mugration inference to this path
+* `--output-confidence-csv <OUTPUT_CONFIDENCE_CSV>` [alias: `confidence`] — Path to output state-probability-profile CSV.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
 * `--pc <PC>` — Pseudo-counts. Higher numbers results in 'flatter' models. Default: 1.0
 * `--missing-data <MISSING_DATA>` — String indicating missing data
 
@@ -784,10 +1501,123 @@ Reconstructs discrete ancestral states, for example geographic location, host, o
 
   Default value: `5`
 * `--sampling-bias-correction <SAMPLING_BIAS_CORRECTION>` — Rough estimate of how many more events would have been observed if sequences represented an even sample
-* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Write augur-compatible node data JSON to this path.
+* `--smooth-initial-pi` — Smooth the initial equilibrium frequencies with the pseudo-count before the first reconstruction pass.
+
+   Off by default (TreeTime v0 builds the initial model from raw frequencies and applies the pseudo-count only as infer_gtr regularization). Enabling this flattens the prior for the first pass; it only affects weighted models.
+* `--filter-uninformative-root` — Exclude near-uniform root positions from the equilibrium-frequency prior.
+
+   Off by default (TreeTime v0 always folds the root's most-likely state into the prior). Enabling this drops root positions whose posterior carries no phylogenetic signal, removing a state-order-dependent bias at ambiguous roots.
+* `--output-augur-node-data <OUTPUT_AUGUR_NODE_DATA>` — Path to output augur-compatible node data JSON.
 
    Contains per-node discrete trait assignments, confidence profiles, entropy, the inferred substitution model, and branch state-change labels. The output is compatible with augur export v2 --node-data for Nextstrain pipeline integration.
-* `-O`, `--outdir <OUTDIR>` — Directory to write the standard set of output files to
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-gtr <OUTPUT_GTR>` — Path to output GTR model JSON.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--output-traits-csv <OUTPUT_TRAITS_CSV>` — Path to output traits CSV.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+* `--seed <SEED>` [alias: `rng-seed`] — Random seed
+* `-O`, `--output-all <OUTPUT_ALL>` — Write all default output files into this directory.
+
+   Produces the default set of tree and non-tree outputs for the command, using `<dir>/<command>.<ext>` paths. Combine with `--output-selection` to restrict which outputs are written.
+
+   Per-file flags (`--output-tree-nwk`, `--output-augur-node-data`, etc.) override or supplement the files produced by `--output-all`.
+* `--output-nwk-style <OUTPUT_NWK_STYLE>` — NWK/Nexus annotation styles to write (comma-separated): `plain`, `beast`, `nhx`.
+
+   Applies to every NWK and Nexus output. With more than one style, files are distinguished by a secondary extension (`.annotated` for beast, `.nhx` for nhx). Default: `plain`.
+
+  Possible values: `plain`, `beast`, `nhx`
+
+* `--output-tree-nwk <OUTPUT_TREE_NWK>` — Path to output Newick tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-nexus <OUTPUT_TREE_NEXUS>` — Path to output Nexus tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`. With multiple `--output-nwk-style` values, a secondary extension is inserted per style.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-auspice <OUTPUT_TREE_AUSPICE>` — Path to output Auspice v2 JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml <OUTPUT_TREE_PHYLOXML>` — Path to output PhyloXML tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-phyloxml-json <OUTPUT_TREE_PHYLOXML_JSON>` — Path to output PhyloXML-JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-pb <OUTPUT_TREE_MAT_PB>` — Path to output UShER MAT protobuf tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-mat-json <OUTPUT_TREE_MAT_JSON>` — Path to output UShER MAT JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-graph-json <OUTPUT_TREE_GRAPH_JSON>` — Path to output internal graph JSON tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-tree-dot <OUTPUT_TREE_DOT>` — Path to output Graphviz DOT tree file.
+
+   Takes precedence over paths configured with `--output-all` and `--output-selection`.
+
+   Compression: path ending in `.gz`, `.bz2`, `.xz`, `.zst` writes compressed output. Use `-` to write uncompressed to stdout.
+
+   Parent directories are created if missing.
+* `--output-selection <OUTPUT_SELECTION>` — Comma-separated list of outputs to produce with `--output-all`.
+
+   Restricts which outputs `--output-all` writes. Special value `all` expands to every output available for this command. Requires `--output-all`. Per-file flags are always honored regardless of this selection.
+
+  Possible values: `all`, `nwk`, `nexus`, `auspice`, `phyloxml`, `phyloxml-json`, `mat-pb`, `mat-json`, `graph-json`, `dot`, `augur-node-data`, `gtr`, `confidence-csv`, `traits-csv`
+
+* `--ladderize <LADDERIZE>` — Order tree topology before writing output files
+
+  Possible values: `none`, `ascending`, `descending`
+
+* `--topology-order <TOPOLOGY_ORDER>` — Canonical topology ordering preset
+
+  Possible values: `keep`, `descendant-count`, `descendant-count-reverse`, `height`, `height-reverse`, `divergence`, `divergence-reverse`, `label`, `label-reverse`, `target-order`, `target-order-reverse`
+
+* `--topology-order-target-source <TOPOLOGY_ORDER_TARGET_SOURCE>` — Source for target-order topology sorting
+
+  Possible values: `input`, `reference-topology`, `list`
+
+* `--topology-order-target-file <TOPOLOGY_ORDER_TARGET_FILE>` — File used by list or reference-topology target-order sources
+* `--topology-order-target-aggregate <TOPOLOGY_ORDER_TARGET_AGGREGATE>` — Aggregate used to map a subtree to a target-order position
+
+  Default value: `mean`
+
+  Possible values: `mean`, `median`
+
 
 
 

--- a/kb/issues/M-timetree-coalescent-multiplication-ordering-diverges-from-v0.md
+++ b/kb/issues/M-timetree-coalescent-multiplication-ordering-diverges-from-v0.md
@@ -1,21 +1,24 @@
 # Coalescent multiplication ordering diverges from v0 without empirical validation
 
+> [!IMPORTANT]
+> **Research and discussion required.** This issue records an unapproved parity divergence. Empirical comparison and an explicit decision are required before implementation work is ready.
+
 The v0 and v1 backward passes apply the coalescent contribution at different points. Because the implementations also reconstruct grids differently, the two paths do not merely reassociate exact arithmetic: they evaluate and interpolate on different grids.
 
 ## Reference behavior
 
-In v0 [`ClockTree._ml_t_marginal()`](../../packages/legacy/treetime/treetime/clock_tree.py), the backward pass:
+In v0 `def ClockTree._ml_t_marginal()` [packages/legacy/treetime/treetime/clock_tree.py](../../packages/legacy/treetime/treetime/clock_tree.py), the backward pass:
 
 1. collects all child messages;
 2. multiplies them into `product_of_child_messages`;
 3. evaluates `merger_model.node_contribution()` on that final product grid; and
 4. multiplies the evaluated contribution into the child product.
 
-In v1 [`propagate_distributions_backward_single_node()`](../../packages/treetime/src/timetree/inference/backward_pass.rs), `result` is seeded with the plain coalescent `Formula`, then each child message is multiplied into it sequentially. The first `Formula x Function` operation fixes a grid before the remaining children are known, and later products interpolate again.
+In v1 `fn propagate_distributions_backward_single_node()` [packages/treetime/src/timetree/inference/backward_pass.rs](../../packages/treetime/src/timetree/inference/backward_pass.rs), `result` is seeded with the plain coalescent `Formula`, then each child message is multiplied into it sequentially. The first `Formula x Function` operation fixes a grid before the remaining children are known, and later products interpolate again.
 
 ## Unverified decision
 
-[`kb/decisions/coalescent-multiplication-ordering.md`](../decisions/coalescent-multiplication-ordering.md) classifies this as the same mathematical result within floating-point precision and calls the interpolation error negligible because the coalescent contribution is smooth. The entry contains no v0/v1 empirical comparison demonstrating the claimed bound across binary trees, polytomies, Tc values, skyline histories, or grids with non-aligned knots.
+[kb/decisions/coalescent-multiplication-ordering.md](../decisions/coalescent-multiplication-ordering.md) classifies this as the same mathematical result within floating-point precision and calls the interpolation error negligible because the coalescent contribution is smooth. The entry contains no v0/v1 empirical comparison demonstrating the claimed bound across binary trees, polytomies, $T_c$ values, skyline histories, or grids with non-aligned knots, where $T_c$ is the coalescent time scale.
 
 The project parity rule treats an unverified divergence as a bug. Peak-relative negative-log multiplication preserves the likelihood shape, but it does not establish that the two application orders construct equivalent grids.
 

--- a/kb/issues/N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md
+++ b/kb/issues/N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md
@@ -1,0 +1,28 @@
+# Parallel sparse leaf setup has no defined error atomicity contract
+
+> [!IMPORTANT]
+> **Investigation and discussion required.** This is an unverified failure-state contract, not a confirmed regression. Define the required atomicity before preparing an implementation ticket.
+
+## Problem
+
+`pub(crate) fn attach_seqs_to_graph()` [packages/treetime/src/ancestral/fitch.rs#L55](../../packages/treetime/src/ancestral/fitch.rs#L55) mutates leaf descriptions while resolving alignment records in parallel. If another leaf has no name or matching record, the function returns an error after an execution-dependent subset of descriptions may already have changed.
+
+Partition construction collects a complete node map before extending each partition, which prevents partial insertion within one partition. Multiple partitions are still processed sequentially, so an error in a later partition can leave earlier partitions populated. The pre-parallel implementation also mutated state incrementally, but the parallel schedule changes which leaf-description mutations can precede an error.
+
+Callers currently discard setup state when construction fails, which may make transactional rollback unnecessary. That ownership assumption is not stated or tested.
+
+## Research required
+
+- Trace every caller to establish whether a failed graph or partition set can remain observable.
+- Exercise missing-name, missing-record, invalid-sequence, and multi-partition failures under multiple thread counts.
+- Decide whether setup must be transactional, must leave a documented partial state, or may rely on callers discarding the state.
+
+## Locations
+
+- `pub(crate) fn attach_seqs_to_graph()` [packages/treetime/src/ancestral/fitch.rs#L55](../../packages/treetime/src/ancestral/fitch.rs#L55)
+- Sparse marginal tests [packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs](../../packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs)
+
+## Related issues
+
+- [N-ancestral-parallel-sparse-leaf-validation-coverage.md](N-ancestral-parallel-sparse-leaf-validation-coverage.md)
+- [N-ancestral-parallel-sparse-leaf-single-thread-regression.md](N-ancestral-parallel-sparse-leaf-single-thread-regression.md)

--- a/kb/issues/N-ancestral-parallel-sparse-leaf-single-thread-regression.md
+++ b/kb/issues/N-ancestral-parallel-sparse-leaf-single-thread-regression.md
@@ -1,0 +1,26 @@
+# Parallel sparse leaf setup may regress single-thread ancestral runtime
+
+> [!IMPORTANT]
+> **More performance research is required.** The available measurement covers one dataset and does not establish whether the regression is systematic or noise.
+
+## Observation
+
+The mpox-2000 comparison reports ancestral wall time increasing from 5.732 seconds to 6.057 seconds at `-j 1`, a 5.7% regression. The same change improves ancestral wall time at 2-16 threads. Optimize and timetree do not show a comparable one-thread regression in that run.
+
+The benchmark used one warmup and three measured runs per binary and configuration. That supports the recorded observation but is insufficient to choose a sequential fast path or accept a general one-thread tradeoff.
+
+## Research required
+
+- Repeat paired measurements across representative datasets and compression ratios.
+- Separate Rayon collection overhead from changed allocation and map-construction behavior.
+- Establish whether the regression exceeds normal run-to-run variation and affects end-to-end commands.
+- Compare any proposed one-thread path for output and error-state equivalence before implementation.
+
+## Evidence
+
+- [kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md](../reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md)
+
+## Related issues
+
+- [N-ancestral-parallel-sparse-leaf-validation-coverage.md](N-ancestral-parallel-sparse-leaf-validation-coverage.md)
+- [N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md](N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md)

--- a/kb/issues/N-ancestral-parallel-sparse-leaf-validation-coverage.md
+++ b/kb/issues/N-ancestral-parallel-sparse-leaf-validation-coverage.md
@@ -1,0 +1,29 @@
+# Parallel sparse leaf setup validation covers only a narrow success path
+
+> [!IMPORTANT]
+> **Investigation required.** Current evidence supports deterministic success on the exercised inputs, but broader correctness and failure behavior remain unverified.
+
+## Current evidence
+
+`fn test_marginal_sparse_parallel_pipeline_is_thread_count_deterministic()` [packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs#L544](../../packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs#L544) compares one-thread and four-thread results for a four-leaf tree with one nucleotide partition. It compares likelihood state and reconstructed node and edge data, so it exercises the parallel setup and indexed passes together.
+
+The mpox-2000 performance report additionally records byte-identical ancestral, optimize, timetree, and mugration outputs between the baseline and changed binaries at selected thread counts. That practical check is retained as a report rather than an automated regression test.
+
+## Missing coverage
+
+- Multiple partitions and larger leaf sets are not exercised directly.
+- Setup failures and partial mutation are not tested.
+- The report's real-dataset output equivalence is not represented by a stable automated oracle.
+- Existing dense-sparse and sparse root-invariance defects limit the strength of broader representation properties.
+
+## Research required
+
+Define the intended validation contract before adding tests. The contract should distinguish deterministic parallel execution from existing sparse-model divergences, then select unit, property, and golden-master coverage for each observable signal.
+
+## Related issues
+
+- [N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md](N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md)
+- [M-ancestral-dense-sparse-divergence.md](M-ancestral-dense-sparse-divergence.md)
+- [M-ancestral-sparse-root-invariance.md](M-ancestral-sparse-root-invariance.md)
+- [N-ancestral-parallel-sparse-leaf-single-thread-regression.md](N-ancestral-parallel-sparse-leaf-single-thread-regression.md)
+- [kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md](../reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-parallel-sparse-leaf-setup.md)

--- a/kb/issues/N-io-auspice-number-formatting-missing-augur-golden-master.md
+++ b/kb/issues/N-io-auspice-number-formatting-missing-augur-golden-master.md
@@ -1,0 +1,28 @@
+# Auspice number formatting lacks an independent Augur golden master
+
+> [!IMPORTANT]
+> **More research is required.** Current examples support the intended formatting rule, but the claimed Augur parity has not been verified against an independent Augur execution.
+
+## Problem
+
+`pub fn format_number()` [packages/treetime-io/src/tree_ir/auspice.rs#L38](../../packages/treetime-io/src/tree_ir/auspice.rs#L38) reimplements Augur's significant-digit behavior for divergence and numeric dates. Its unit tests use manually written expected values attributed to `augur export_v2.format_number`; they do not capture outputs from a pinned Augur revision.
+
+This leaves boundary behavior unverified for negative values, powers of ten, values crossing an integer-digit boundary after rounding, very small magnitudes, and ties affected by Python and Rust formatting differences. TreeIR round-trip tests cannot serve as an independent oracle because they read output produced by the same adapter.
+
+## Research required
+
+- Identify and pin the Augur revision that defines the compatibility contract.
+- Capture representative and boundary outputs directly from Augur without reimplementing its formatter in the capture path.
+- Compare both numeric values and serialized Auspice JSON, including divergence and date precision.
+- Decide whether exact Augur formatting is required or whether a documented numeric-equivalence contract is sufficient.
+
+## Locations
+
+- `pub fn format_number()` [packages/treetime-io/src/tree_ir/auspice.rs#L38](../../packages/treetime-io/src/tree_ir/auspice.rs#L38)
+- Unit tests [packages/treetime-io/src/tree_ir/__tests__/test_auspice.rs](../../packages/treetime-io/src/tree_ir/__tests__/test_auspice.rs)
+
+## Related KB items
+
+- [kb/decisions/multi-format-tree-io.md](../decisions/multi-format-tree-io.md)
+- [kb/proposals/output-format-selection.md](../proposals/output-format-selection.md)
+- [kb/issues/N-io-tree-ir-architecture-unapproved.md](N-io-tree-ir-architecture-unapproved.md)

--- a/kb/issues/N-io-tree-ir-architecture-unapproved.md
+++ b/kb/issues/N-io-tree-ir-architecture-unapproved.md
@@ -1,0 +1,31 @@
+# Shared TreeIR architecture has not received an explicit design decision
+
+> [!IMPORTANT]
+> **Research and discussion required.** TreeIR is implemented, but its status as an accepted v1 architecture is unresolved. No decision entry may be added without explicit approval.
+
+## Problem
+
+TreeIR provides one format-neutral graph for PhyloXML, Auspice v2, and UShER MAT serialization. Commands project domain graphs and analysis results into this representation before dispatching format-specific writers. This is a new v1 architecture rather than direct parity with a v0 abstraction.
+
+The implementation defines a shared loss and ownership boundary: domain-specific data must be projected into `TreeIrNode`, `TreeIrEdge`, and `TreeIrData`, while formats outside TreeIR serialize directly from the domain graph. [kb/decisions/multi-format-tree-io.md](../decisions/multi-format-tree-io.md) describes a common graph intermediate representation, but it predates the concrete TreeIR boundary, refers to the former `ConverterGraph`, and does not define TreeIR's preservation or loss invariants. The decision also requires a consent audit under the current project rule that architecture decisions must have explicit approval.
+
+## Research required
+
+- Compare the data requirements and loss behavior of each TreeIR-backed format.
+- Establish invariants for node identity, topology order, branch data, mutations, dates, traits, and round trips.
+- Decide whether TreeIR is an internal implementation detail or a project-level architectural commitment.
+- If the architecture is accepted, obtain explicit approval before adding a `kb/decisions/` entry. If it is not accepted, specify the replacement boundary before implementation work.
+
+## Locations
+
+- `type TreeIrGraph` [packages/treetime-io/src/graph.rs#L23](../../packages/treetime-io/src/graph.rs#L23)
+- `pub fn write_tree_outputs()` [packages/treetime-io/src/graph.rs#L61](../../packages/treetime-io/src/graph.rs#L61)
+- TreeIR adapters [packages/treetime-io/src/tree_ir/mod.rs](../../packages/treetime-io/src/tree_ir/mod.rs)
+- Command projection [packages/treetime/src/commands/shared/ir_projection.rs](../../packages/treetime/src/commands/shared/ir_projection.rs)
+
+## Related KB items
+
+- [kb/decisions/multi-format-tree-io.md](../decisions/multi-format-tree-io.md)
+- [kb/proposals/output-format-selection.md](../proposals/output-format-selection.md)
+- [kb/proposals/tree-format-model-embedding.md](../proposals/tree-format-model-embedding.md)
+- [kb/issues/N-io-auspice-number-formatting-missing-augur-golden-master.md](N-io-auspice-number-formatting-missing-augur-golden-master.md)

--- a/kb/issues/N-reroot-duplicated-tip-name-resolution.md
+++ b/kb/issues/N-reroot-duplicated-tip-name-resolution.md
@@ -1,6 +1,9 @@
 # Tip-name resolution duplicated between optimize and clock reroot
 
-Two reroot call sites implement the same graph-node-by-name lookup independently. Optimize's `resolve_tip_keys` and clock's `find_node_key_by_name` both scan the graph for a node whose name matches a string, using the identical predicate.
+> [!IMPORTANT]
+> **Discussion required.** The shared lookup contract and duplicate-name semantics need agreement before the two implementations are consolidated.
+
+Two reroot call sites implement the same graph-node-by-name lookup independently. Optimize's `fn resolve_tip_keys()` [packages/treetime/src/optimize/pipeline.rs#L251](../../packages/treetime/src/optimize/pipeline.rs#L251) and clock's `fn find_node_key_by_name()` [packages/treetime/src/clock/reroot.rs#L270](../../packages/treetime/src/clock/reroot.rs#L270) both scan the graph for a node whose name matches a string, using the identical predicate.
 
 ## Duplication
 
@@ -36,5 +39,7 @@ Extract a single name-to-node-key lookup (generic over `GraphNode + Named`), pla
 
 ## Locations
 
-- `packages/treetime/src/optimize/pipeline.rs:251-260`
-- `packages/treetime/src/clock/reroot.rs:274-281`
+- `fn resolve_tip_keys()` [packages/treetime/src/optimize/pipeline.rs#L251](../../packages/treetime/src/optimize/pipeline.rs#L251)
+- `fn find_node_key_by_name()` [packages/treetime/src/clock/reroot.rs#L270](../../packages/treetime/src/clock/reroot.rs#L270)
+- [kb/proposals/reroot-generic-scoring-architecture.md](../proposals/reroot-generic-scoring-architecture.md)
+- [kb/issues/N-reroot-tip-resolution-untested-errors.md](N-reroot-tip-resolution-untested-errors.md)

--- a/kb/issues/N-reroot-leaf-variance-offset-diverges-from-v0.md
+++ b/kb/issues/N-reroot-leaf-variance-offset-diverges-from-v0.md
@@ -1,8 +1,11 @@
 # Leaf variance offset convention diverges from v0 on terminal edges
 
+> [!IMPORTANT]
+> **Research and discussion required.** The v1 behavior is not an approved divergence. Compare both conventions empirically and obtain an explicit decision before changing or retaining it.
+
 ## Problem
 
-v1's `EdgeCostFn::evaluate` at `packages/treetime/src/reroot/cost_function.rs:34` computes leaf-edge variance as:
+v1's `pub fn EdgeCostFn::evaluate()` [packages/treetime/src/reroot/cost_function.rs#L29](../../packages/treetime/src/reroot/cost_function.rs#L29) computes leaf-edge variance as:
 
 ```rust
 self.branch_variance * (1.0 - x) + self.variance_offset_leaf
@@ -10,7 +13,7 @@ self.branch_variance * (1.0 - x) + self.variance_offset_leaf
 
 With the default `VarianceModel` (`variance_factor=0, variance_offset=0, variance_offset_leaf=1`), `branch_variance = 0` and the effective leaf variance is `0*(1-x) + 1 = 1` for all split fractions `x`. The leaf measurement noise is constant, not scaled by the split position.
 
-v0's `_optimal_root_along_branch` at `packages/legacy/treetime/treetime/treeregression.py:389` passes `var*x` and `var*(1-x)` to `propagate_averages`, where `var = self.branch_variance(n)`. For v0's `min_dev` default (`branch_variance = lambda x: 1.0 if x.is_terminal() else 0.0`), the full `1.0` is scaled by the split fraction: child-side variance is `1.0*(1-x)`, parent-side is `1.0*x`.
+v0's `def TreeRegression._optimal_root_along_branch()` [packages/legacy/treetime/treetime/treeregression.py#L385](../../packages/legacy/treetime/treetime/treeregression.py#L385) passes `var*x` and `var*(1-x)` to `propagate_averages`, where `var = self.branch_variance(n)`. For v0's `min_dev` default [packages/legacy/treetime/treetime/clock_tree.py#L287](../../packages/legacy/treetime/treetime/clock_tree.py#L287), the full `1.0` is scaled by the split fraction: child-side variance is `1.0*(1-x)`, parent-side is `1.0*x`.
 
 ## Impact
 
@@ -25,7 +28,12 @@ v1's treatment (fixed tip measurement noise, not split-proportional) is more pri
 
 ## Code references
 
-- v1 cost function: `packages/treetime/src/reroot/cost_function.rs:30-40`
-- v1 variance model: `packages/treetime/src/reroot/variance.rs:11-24`
-- v0 split: `packages/legacy/treetime/treetime/treeregression.py:389-392`
-- v0 default branch_variance: `packages/legacy/treetime/treetime/clock_tree.py:287`
+- `pub fn EdgeCostFn::evaluate()` [packages/treetime/src/reroot/cost_function.rs#L29](../../packages/treetime/src/reroot/cost_function.rs#L29)
+- `struct VarianceModel` [packages/treetime/src/reroot/variance.rs#L12](../../packages/treetime/src/reroot/variance.rs#L12)
+- `def TreeRegression._optimal_root_along_branch()` [packages/legacy/treetime/treetime/treeregression.py#L385](../../packages/legacy/treetime/treetime/treeregression.py#L385)
+- v0 `min_dev` default [packages/legacy/treetime/treetime/clock_tree.py#L287](../../packages/legacy/treetime/treetime/clock_tree.py#L287)
+
+## Related KB items
+
+- [kb/proposals/reroot-generic-scoring-architecture.md](../proposals/reroot-generic-scoring-architecture.md)
+- [kb/proposals/optimize-reroot-support.md](../proposals/optimize-reroot-support.md)

--- a/kb/issues/N-reroot-missing-v0-golden-master.md
+++ b/kb/issues/N-reroot-missing-v0-golden-master.md
@@ -1,12 +1,15 @@
 # No v0 golden master test for min-dev reroot
 
+> [!IMPORTANT]
+> **Investigation required.** End-to-end parity remains unverified until an independent v0 golden master covers edge selection and split position.
+
 There is no test comparing the v1 min-dev root position against a v0 oracle. The min-dev objective (minimize root-to-tip divergence variance) exists in v0, so a golden master is feasible, but none is captured.
 
 ## Background
 
-v0 implements min-dev rerooting in `TreeRegression.optimal_reroot` with `slope=0`, which minimizes the variance of root-to-tip distances (`packages/legacy/treetime/treetime/treeregression.py`, `_optimal_root_along_branch`). v1 reproduces this with `DivStats` divergence-only scoring in the generic reroot module. The optimize-reroot proposal lists as a validation criterion that the root from `optimize --reroot=min-dev` matches the root from v0 min-dev rerooting on the same tree.
+v0 implements min-dev rerooting in `def TreeRegression.optimal_reroot()` [packages/legacy/treetime/treetime/treeregression.py](../../packages/legacy/treetime/treetime/treeregression.py) with `slope=0`, which minimizes the variance of root-to-tip distances. v1 reproduces this with `struct DivStats` divergence-only scoring in the generic reroot module. [kb/proposals/optimize-reroot-support.md](../proposals/optimize-reroot-support.md) lists as a validation criterion that the root from `optimize --reroot=min-dev` matches the root from v0 min-dev rerooting on the same tree.
 
-Current coverage validates the scoring algebra in isolation: `DivStats` is cross-checked against `ClockSet::propagate_averages` in unit tests (`packages/treetime/src/reroot/__tests__/test_div_stats.rs`). No end-to-end test confirms that the selected root edge and split position match v0 on a real dataset.
+Current coverage validates the scoring algebra in isolation: `struct DivStats` is cross-checked against `fn ClockSet::propagate_averages()` in unit tests [packages/treetime/src/reroot/__tests__/test_div_stats.rs](../../packages/treetime/src/reroot/__tests__/test_div_stats.rs). No end-to-end test confirms that the selected root edge and split position match v0 on a real dataset.
 
 ## Impact
 
@@ -18,6 +21,8 @@ Capture the v0 min-dev root on a small dataset (e.g. flu/h3n2/20) by running v0 
 
 ## Locations
 
-- `packages/treetime/src/reroot/` (min-dev scoring and search under test)
-- `packages/treetime/src/reroot/__tests__/test_div_stats.rs` (existing algebra cross-check)
-- v0 reference: `packages/legacy/treetime/treetime/treeregression.py`
+- Generic reroot implementation [packages/treetime/src/reroot/mod.rs](../../packages/treetime/src/reroot/mod.rs)
+- Existing algebra cross-check [packages/treetime/src/reroot/__tests__/test_div_stats.rs](../../packages/treetime/src/reroot/__tests__/test_div_stats.rs)
+- v0 reference [packages/legacy/treetime/treetime/treeregression.py](../../packages/legacy/treetime/treetime/treeregression.py)
+- [kb/proposals/reroot-generic-scoring-architecture.md](../proposals/reroot-generic-scoring-architecture.md)
+- [kb/proposals/optimize-reroot-support.md](../proposals/optimize-reroot-support.md)

--- a/kb/issues/N-reroot-tip-resolution-untested-errors.md
+++ b/kb/issues/N-reroot-tip-resolution-untested-errors.md
@@ -1,3 +1,12 @@
 # resolve_tip_keys error and ambiguity paths untested
 
-`packages/treetime/src/optimize/pipeline.rs:255` `resolve_tip_keys` is only tested with valid leaf names. Missing coverage for: missing tip name error, empty tip list, duplicate names in the tree, internal-node name matches. Also duplicated with `packages/treetime/src/clock/reroot.rs` (`find_node_key_by_name`), tracked in `kb/issues/N-reroot-duplicated-tip-name-resolution.md`.
+> [!IMPORTANT]
+> **Investigation required.** Expected behavior for empty input, duplicate names, and internal-node matches must be established before complete tests or a shared resolver can be specified.
+
+`fn resolve_tip_keys()` [packages/treetime/src/optimize/pipeline.rs#L251](../../packages/treetime/src/optimize/pipeline.rs#L251) is only tested with valid leaf names. Missing coverage includes a missing tip name, an empty tip list, duplicate names in the tree, and internal-node name matches. The lookup is duplicated by `fn find_node_key_by_name()` [packages/treetime/src/clock/reroot.rs#L270](../../packages/treetime/src/clock/reroot.rs#L270), tracked in [kb/issues/N-reroot-duplicated-tip-name-resolution.md](N-reroot-duplicated-tip-name-resolution.md).
+
+## Related KB items
+
+- [kb/issues/N-reroot-duplicated-tip-name-resolution.md](N-reroot-duplicated-tip-name-resolution.md)
+- [kb/proposals/reroot-generic-scoring-architecture.md](../proposals/reroot-generic-scoring-architecture.md)
+- [kb/proposals/optimize-reroot-support.md](../proposals/optimize-reroot-support.md)

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -91,6 +91,9 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Timetree     | [Marginal timetree node times can violate topology](M-timetree-marginal-node-times-can-violate-topology.md)                                         |
 | Medium     | Timetree     | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                                   |
 | Negligible | Ancestral    | [Ancestral command does not produce auspice JSON](N-ancestral-auspice-json-not-produced.md)                                                         |
+| Negligible | Ancestral    | [Parallel sparse leaf setup has no defined error atomicity contract](N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md)                |
+| Negligible | Ancestral    | [Parallel sparse leaf setup may regress single-thread ancestral runtime](N-ancestral-parallel-sparse-leaf-single-thread-regression.md)              |
+| Negligible | Ancestral    | [Parallel sparse leaf setup validation covers only a narrow success path](N-ancestral-parallel-sparse-leaf-validation-coverage.md)                  |
 | Negligible | Ancestral    | [Sparse marginal passes still use remove/insert pattern](N-ancestral-sparse-remove-insert-pattern.md)                                               |
 | Negligible | Core         | [Zero branch length clamping](N-core-branch-length-clamping.md)                                                                                     |
 | Negligible | Dates        | [Imprecise date upper bound not capped at present](N-dates-imprecise-upper-bound-not-capped.md)                                                     |
@@ -100,6 +103,8 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | I/O          | [Multi-segment genome input not wired](N-io-multi-segment-genome-input.md)                                                                          |
 | Negligible | I/O          | [Newick writer defaults to 3 significant digits, truncating branch lengths](N-io-nwk-writer-3-sigfig-default-truncates-precision.md)                |
 | Negligible | I/O          | [Graphviz DOT writer uses Newick precision defaults for edge labels](N-io-graphviz-dot-branch-length-precision.md)                                  |
+| Negligible | I/O          | [Auspice number formatting lacks an independent Augur golden master](N-io-auspice-number-formatting-missing-augur-golden-master.md)                 |
+| Negligible | I/O          | [Shared TreeIR architecture has not received an explicit design decision](N-io-tree-ir-architecture-unapproved.md)                                 |
 | Negligible | I/O          | [Name reconciliation logic duplicated across subsystems](N-io-name-reconciliation-duplicated.md)                                                    |
 | Negligible | I/O          | [Edge annotations from Newick not wired into EdgeFromNwk](N-io-edge-annotation-wiring-not-implemented.md)                                           |
 | Negligible | Optimize     | [update_marginal traverses graph twice for mixed partitions](N-optimize-double-graph-traversal-update-marginal.md)                                  |


### PR DESCRIPTION


Several open questions are recorded as if they were implementation-ready defects or accepted behavior. That presentation obscures where empirical work, design agreement, or explicit approval is still required. The generated CLI reference also lags behind the accumulated command changes.

This PR regenerates the command reference, marks those entries prominently, and files the missing sparse-leaf and TreeIR questions. It makes no code or scientific-behavior decision.

### Work items

- [x] Refresh the generated [docs/docs/reference.md](https://github.com/neherlab/treetime/blob/7d4ea0266daf42a739e7d80e490881bd0cc881d2/docs/docs/reference.md) from the current CLI definitions
- [x] Mark the coalescent ordering question as unapproved and research-dependent: [kb/issues/M-timetree-coalescent-multiplication-ordering-diverges-from-v0.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/M-timetree-coalescent-multiplication-ordering-diverges-from-v0.md)
- [x] Mark reroot parity and tip-resolution questions as requiring investigation or agreement: [kb/issues/N-reroot-leaf-variance-offset-diverges-from-v0.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-reroot-leaf-variance-offset-diverges-from-v0.md), [kb/issues/N-reroot-missing-v0-golden-master.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-reroot-missing-v0-golden-master.md), [kb/issues/N-reroot-duplicated-tip-name-resolution.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-reroot-duplicated-tip-name-resolution.md), and [kb/issues/N-reroot-tip-resolution-untested-errors.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-reroot-tip-resolution-untested-errors.md)
- [x] File sparse-leaf research issues: [kb/issues/N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md), [kb/issues/N-ancestral-parallel-sparse-leaf-single-thread-regression.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-ancestral-parallel-sparse-leaf-single-thread-regression.md), and [kb/issues/N-ancestral-parallel-sparse-leaf-validation-coverage.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-ancestral-parallel-sparse-leaf-validation-coverage.md)
- [x] File TreeIR research issues: [kb/issues/N-io-auspice-number-formatting-missing-augur-golden-master.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-io-auspice-number-formatting-missing-augur-golden-master.md) and [kb/issues/N-io-tree-ir-architecture-unapproved.md](https://github.com/neherlab/treetime/blob/e0601306b492bc425eac29c553cae24d37cc378a/kb/issues/N-io-tree-ir-architecture-unapproved.md)
