### PR TITLE
perf: index informative Fitch positions

### DIFF
--- a/dev/bench-graph-pass-cli
+++ b/dev/bench-graph-pass-cli
@@ -15,6 +15,7 @@
 #   --runs N               Hyperfine measured runs (default: 3)
 #   --warmup N             Hyperfine warmup runs (default: 1)
 #   --output PATH          Output below the project root (default: tmp/graph-pass-cli-benchmark)
+#   --host                 Run measurements on the host; builds remain containerized
 #   --skip-output-check    Skip output equivalence runs
 #   -h, --help             Show this help
 #
@@ -40,6 +41,7 @@ RUNS=3
 WARMUP=1
 OUTPUT_DIR="tmp/graph-pass-cli-benchmark"
 CHECK_OUTPUT=true
+RUN_ON_HOST=false
 
 main() {
   show_help() {
@@ -59,6 +61,7 @@ main() {
       --runs) RUNS="${2}"; shift 2 ;;
       --warmup) WARMUP="${2}"; shift 2 ;;
       --output) OUTPUT_DIR="${2}"; shift 2 ;;
+      --host) RUN_ON_HOST=true; shift ;;
       --skip-output-check) CHECK_OUTPUT=false; shift ;;
       --) shift; break ;;
       -*) printf "Unknown option: %s\n" "${1}" >&2; exit 1 ;;
@@ -241,7 +244,7 @@ run_benchmarks() {
       after_command="$(command_string "${WORKLOAD_ARGS[@]}")"
       hyperfine_json="${OUTPUT_DIR}/raw/${workload}-j${jobs}-hyperfine.json"
 
-      ./dev/docker/run hyperfine \
+      run_measured hyperfine \
         --warmup "${WARMUP}" \
         --runs "${RUNS}" \
         --prepare "rm -rf ${OUTPUT_DIR}/output/run-before ${OUTPUT_DIR}/output/run-after" \
@@ -260,7 +263,7 @@ run_benchmarks() {
         rss_json="${OUTPUT_DIR}/raw/${workload}-j${jobs}-${version}-rss.json"
         rm -rf -- "${OUTPUT_DIR}/output/rss-${version}"
         workload_args "${workload}" "${binary}" "${OUTPUT_DIR}/output/rss-${version}" "${jobs}"
-        ./dev/docker/run /usr/bin/time \
+        run_measured /usr/bin/time \
           -f '{"elapsed_seconds":%e,"peak_rss_kb":%M}' \
           -o "${rss_json}" \
           "${WORKLOAD_ARGS[@]}"
@@ -305,7 +308,7 @@ compare_outputs() {
         output="${OUTPUT_DIR}/output/check-${workload}-${version}-j${jobs}"
         rm -rf -- "${output}"
         workload_args "${workload}" "${binary}" "${output}" "${jobs}"
-        ./dev/docker/run "${WORKLOAD_ARGS[@]}"
+        run_measured "${WORKLOAD_ARGS[@]}"
       done
     done
 
@@ -352,6 +355,14 @@ compare_dirs() {
     >>"${OUTPUT_DIR}/comparisons.ndjson"
 }
 
+run_measured() {
+  if "${RUN_ON_HOST}"; then
+    "$@"
+  else
+    ./dev/docker/run "$@"
+  fi
+}
+
 write_summaries() {
   jq -s '.' "${OUTPUT_DIR}/results.ndjson" >"${OUTPUT_DIR}/results.json"
   jq -s '.' "${OUTPUT_DIR}/comparisons.ndjson" >"${OUTPUT_DIR}/comparisons.json"
@@ -376,6 +387,7 @@ write_summaries() {
     --arg after_sha256 "$(sha256sum "${AFTER_BIN}" | cut -d' ' -f1)" \
     --arg dataset "${DATA_DIR}" \
     --arg jobs "${JOBS_CSV}" \
+    --arg execution "$([[ "${RUN_ON_HOST}" == true ]] && printf 'host' || printf 'container')" \
     --argjson runs "${RUNS}" \
     --argjson warmup "${WARMUP}" \
     --slurpfile results "${OUTPUT_DIR}/results.json" \
@@ -389,6 +401,7 @@ write_summaries() {
         after_sha256: $after_sha256,
         dataset: $dataset,
         jobs: ($jobs | split(",") | map(tonumber)),
+        execution: $execution,
         runs: $runs,
         warmup: $warmup
       },

--- a/dev/dev
+++ b/dev/dev
@@ -58,7 +58,6 @@ _BUILD_RUSTFLAGS="-C linker-features=-lld ${RUSTFLAGS:-}"
 _TEST_RUSTFLAGS="${HOSTCC:+-C linker=${HOSTCC}} -C link-arg=-pthread -C link-arg=-lopenblas -C link-arg=-lgfortran -C link-arg=-static-libgfortran -C link-arg=-static-libgcc -C link-arg=-static-libstdc++ ${RUSTFLAGS:-}"
 _BUILD_ENV=(env "CARGO_TARGET_DIR=${_BUILD_DIR}" "RUSTFLAGS=${_BUILD_RUSTFLAGS}")
 _TEST_ENV=(env "CARGO_TARGET_DIR=${_TEST_DIR}" "RUSTFLAGS=${_TEST_RUSTFLAGS}")
-_BENCH_ENV=(env "CARGO_TARGET_DIR=${_BUILD_DIR}" "RUSTFLAGS=${_TEST_RUSTFLAGS}")
 
 function is_known_command() {
   local token="${1:-}"
@@ -240,10 +239,10 @@ function run_one() {
     nicely cargo -q fmt --check "$@"
     ;;
   "bench-all")
-    nicely "${_BENCH_ENV[@]}" cargo -q bench --workspace --benches "${_CI_ARGS[@]}" "$@"
+    nicely "${_BUILD_ENV[@]}" cargo -q bench --workspace --benches "${_CI_ARGS[@]}" "$@"
     ;;
   "bench-debug")
-    nicely "${_BENCH_ENV[@]}" cargo -q bench --workspace --benches --profile=profiling "${_CI_ARGS[@]}" "$@"
+    nicely "${_BUILD_ENV[@]}" cargo -q bench --workspace --benches --profile=profiling "${_CI_ARGS[@]}" "$@"
     ;;
   "upgrade-deps")
     nicely cargo -q upgrade --pinned --incompatible --verbose --recursive "${_CI_ARGS[@]}" "$@"

--- a/kb/algo/ancestral.md
+++ b/kb/algo/ancestral.md
@@ -13,13 +13,13 @@ v0: [`packages/legacy/treetime/treetime/treeanc.py#L575-L686`](../../packages/le
 
 Two-pass dynamic programming on a rooted tree:
 
-**Backward pass** (postorder, leaves to root): For each internal node, compute the set of possible states S from its children's state sets. If the children's sets intersect, S = intersection (no change needed). If they do not, S = union (at least one change occurred on the branches leading to this node). Each union operation increments the parsimony score by one.
+**Backward pass** (postorder, leaves to root): For each internal node, compute the set of possible states S from its children's state sets. On a binary node, a non-empty intersection needs no change; an empty intersection uses the union and adds one change. v1 preserves v0's all-child intersection/union recurrence at multifurcations, which is deterministic but does not encode the exact number of changes for arbitrary node degree. See [kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md](../issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md).
 
 **Forward pass** (preorder, root to leaves): Assign definite states top-down. At the root, pick one state from S_root. For each descendant, assign the parent's state if it appears in the child's state set; otherwise pick from the child's set.
 
 ### v1 extensions
 
-- Sparse representation: only variable positions (positions that differ from the reference) are stored and processed. Invariant positions carry no phylogenetic signal for parsimony and can be skipped.
+- Informative-position recurrence: the completed alignment is classified once into a full baseline sequence and sorted substitution-informative positions. Internal nodes clone the full baseline for reconstruction, while the child-state recurrence visits only columns with conflicting canonical leaf states or ambiguity. Gap and unknown ranges remain separate. Storage and baseline cloning therefore remain dense in alignment length.
 - Indel handling: insertions and deletions are tracked alongside substitutions, with majority rule for gap vs non-gap resolution at internal nodes.
 - `BitSet128` state sets: character state sets are represented as 128-bit bitmasks, enabling O(1) intersection and union via hardware AND/OR instructions.
 - Parallel BFS traversal: nodes at the same tree depth are processed in parallel using Rayon.
@@ -30,8 +30,9 @@ v1 uses deterministic `get_one()` (`#get_one`) for root state selection when the
 
 ### Key functions
 
-- `fitch_backward()` (`#fitch_backward`) and `run_fitch_backward()` (`#run_fitch_backward`): postorder pass computing state sets and parsimony score
-- `fitch_forward()` (`#fitch_forward`) and `run_fitch_forward()` (`#run_fitch_forward`): preorder pass resolving ambiguities
+- `FitchSiteIndex::new()` (`#new`): classifies graph-matched leaf columns into a baseline and informative positions
+- `fitch_backward()` (`#fitch_backward`) and `run_fitch_backward_indexed()` (`#run_fitch_backward_indexed`): postorder pass computing state sets
+- `fitch_forward()` (`#fitch_forward`) and `run_fitch_forward_indexed()` (`#run_fitch_forward_indexed`): preorder pass resolving ambiguities
 
 ### References
 

--- a/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md
+++ b/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md
@@ -1,0 +1,23 @@
+# Fitch polytomy recurrence does not minimize arbitrary-degree mutations
+
+## Problem
+
+The Fitch backward pass intersects every child state set at a multifurcation and takes their union when the common intersection is empty. This is exact for binary nodes. For three or more children, one union event does not encode how many child edges must change, so the retained state set can include assignments with different mutation costs.
+
+For three fixed children `A`, `A`, and `C`, the current recurrence returns `{A,C}`. Assigning the parent `A` costs one mutation, while assigning it `C` costs two. The forward pass can therefore select a non-minimum assignment depending on the parent state above the polytomy. TreeTime v0 uses the same all-child intersection/union rule, so correcting this changes parity and reconstructed ancestral states.
+
+## Impact
+
+- Binary trees remain exact under the standard unordered-character Fitch recurrence.
+- Multifurcating trees can receive non-minimal ancestral assignments and mutation placement.
+- Sparse marginal initialization inherits the selected Fitch assignment.
+
+## Evidence
+
+- v1 recurrence: [`packages/treetime/src/ancestral/fitch_sub.rs`](../../packages/treetime/src/ancestral/fitch_sub.rs) (`resolve_informative_positions_backward`)
+- v0 recurrence: [`packages/legacy/treetime/treetime/treeanc.py`](../../packages/legacy/treetime/treetime/treeanc.py) (`_fitch_ancestral`)
+- Existing multifurcation characterization: [`packages/treetime/src/ancestral/__tests__/test_fitch.rs`](../../packages/treetime/src/ancestral/__tests__/test_fitch.rs) (`test_fitch_polytomy`)
+
+## Required fix
+
+Use an exact finite-state cost recurrence for arbitrary node degree, retain every minimum-cost parent state, and validate the result against exhaustive assignments on generated multifurcating trees. This requires an approved scientific-output and v0-parity change.

--- a/kb/issues/N-ancestral-fitch-empty-transmission-state-set.md
+++ b/kb/issues/N-ancestral-fitch-empty-transmission-state-set.md
@@ -1,0 +1,17 @@
+# Fitch transmission filtering can produce an empty state set
+
+## Problem
+
+The Fitch backward recurrence excludes a child's substitution state when the position lies in that edge's `transmission` ranges. If every child is excluded at one candidate position, both the intersection and union of the remaining child profiles are empty. The empty set is stored as a variable Fitch state and a later forward pass calls `StateSet::get_one()`, which has no valid state to select.
+
+No production code currently assigns `SparseEdgePartition::transmission`, so the invalid state is dormant. Defining the correct result requires specifying whether a transmitted position contributes no evidence, inherits an external state, or should be excluded from the node entirely.
+
+## Evidence
+
+- Filtering and empty intersection/union: [`packages/treetime/src/ancestral/fitch_sub.rs`](../../packages/treetime/src/ancestral/fitch_sub.rs)
+- Forward state selection: [`packages/treetime/src/ancestral/fitch_sub.rs`](../../packages/treetime/src/ancestral/fitch_sub.rs) (`resolve_root_forward`, `resolve_nonroot_substitutions_forward`)
+- Transmission storage with no current writers: [`packages/treetime/src/partition/sparse.rs`](../../packages/treetime/src/partition/sparse.rs) (`SparseEdgePartition::transmission`)
+
+## Required decision
+
+Specify transmission semantics for Fitch substitution states, then reject or represent the all-children-filtered case without constructing an empty `StateSet`.

--- a/kb/issues/N-test-coverage-gaps.md
+++ b/kb/issues/N-test-coverage-gaps.md
@@ -102,7 +102,3 @@ Systematic test coverage gaps across major subsystems: timetree inference, clock
 `packages/treetime/src/payload/clock_set.rs:53-172:`
 
 `+`, `-`, `+=`, `-=`, `fn propagate_averages` lack property test coverage for algebraic identities (associativity, commutativity, identity element).
-
-### No property tests for Fitch parsimony invariants
-
-Score invariant under rerooting, state-set subset relation between parent and child Fitch sets.

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -52,6 +52,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Negligible | Clock        | [v1 clock regression produces all-negative rates where v0 finds positive](N-clock-regression-all-negative-rate.md)                                  |
 | Negligible | Clock        | [ClockSet::chisq() numerically unstable for near-zero determinant](N-clock-chisq-near-zero-determinant.md)                                          |
 | Medium     | Ancestral    | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                                    |
+| Medium     | Ancestral    | [Fitch polytomy recurrence does not minimize arbitrary-degree mutations](M-ancestral-fitch-polytomy-recurrence-not-minimum.md)                       |
 | Medium     | Ancestral    | [Marginal reconstruction uses plain probability space](M-ancestral-marginal-probability-space.md)                                                   |
 | Medium     | Ancestral    | [Sparse root invariance violation](M-ancestral-sparse-root-invariance.md)                                                                           |
 | Medium     | Ancestral    | [Sparse variable-site alphabet mismatch](M-ancestral-sparse-alphabet-mismatch.md)                                                                   |
@@ -91,6 +92,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Timetree     | [Marginal timetree node times can violate topology](M-timetree-marginal-node-times-can-violate-topology.md)                                         |
 | Medium     | Timetree     | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                                   |
 | Negligible | Ancestral    | [Ancestral command does not produce auspice JSON](N-ancestral-auspice-json-not-produced.md)                                                         |
+| Negligible | Ancestral    | [Fitch transmission filtering can produce an empty state set](N-ancestral-fitch-empty-transmission-state-set.md)                                   |
 | Negligible | Ancestral    | [Parallel sparse leaf setup has no defined error atomicity contract](N-ancestral-parallel-sparse-leaf-error-atomicity-unverified.md)                |
 | Negligible | Ancestral    | [Parallel sparse leaf setup may regress single-thread ancestral runtime](N-ancestral-parallel-sparse-leaf-single-thread-regression.md)              |
 | Negligible | Ancestral    | [Parallel sparse leaf setup validation covers only a narrow success path](N-ancestral-parallel-sparse-leaf-validation-coverage.md)                  |

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_cpu-utilization.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_cpu-utilization.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">CPU Utilization vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="306.3" x2="532" y2="306.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="310.3" fill="#898781" font-size="11" text-anchor="end">1</text>
+<line x1="72" y1="264.6" x2="532" y2="264.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="268.6" fill="#898781" font-size="11" text-anchor="end">2</text>
+<line x1="72" y1="222.9" x2="532" y2="222.9" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="226.9" fill="#898781" font-size="11" text-anchor="end">3</text>
+<line x1="72" y1="181.1" x2="532" y2="181.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="185.1" fill="#898781" font-size="11" text-anchor="end">4</text>
+<line x1="72" y1="139.4" x2="532" y2="139.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="143.4" fill="#898781" font-size="11" text-anchor="end">5</text>
+<line x1="72" y1="97.7" x2="532" y2="97.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="101.7" fill="#898781" font-size="11" text-anchor="end">6</text>
+<line x1="72" y1="56.0" x2="532" y2="56.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="60.0" fill="#898781" font-size="11" text-anchor="end">7</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">CPU cores utilized</text>
+<!-- Ideal utilization reference -->
+<polyline points="72.0,306.3 187.0,264.6 302.0,181.1 417.0,14.0 532.0,14.0" fill="none" stroke="#e1e0d9" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="310.0" y="175.1" fill="#898781" font-size="10">ideal</text>
+<!-- Timetree: 1.00, 1.70, 2.69, 3.80, 5.30 -->
+<polyline points="72.0,306.3 187.0,277.2 302.0,235.9 417.0,189.5 532.0,127.0" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="306.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="277.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="235.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="189.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="127.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Optimize: 1.00, 1.43, 1.96, 2.76, 4.70 -->
+<polyline points="72.0,306.3 187.0,288.4 302.0,266.3 417.0,233.0 532.0,152.2" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="306.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="288.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="266.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="233.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="152.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Ancestral: 1.00, 1.19, 1.35, 1.46, 1.85 -->
+<polyline points="72.0,306.3 187.0,298.4 302.0,291.7 417.0,287.1 532.0,270.9" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="306.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="298.4" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="291.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="287.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="270.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Mugration: 1.00, 1.63, 2.51, 3.92, 6.78 -->
+<polyline points="72.0,306.3 187.0,280.1 302.0,243.5 417.0,184.6 532.0,65.5" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="306.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="280.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="243.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="184.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="65.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Clock: 1.00, 1.16, 1.39, 1.91, 3.52 -->
+<polyline points="72.0,306.3 187.0,299.6 302.0,290.0 417.0,268.5 532.0,201.6" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="306.3" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="299.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="290.0" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="268.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="201.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Data labels at 16 threads -->
+<text x="540.0" y="131.0" fill="#52514e" font-size="9">5.30</text>
+<text x="540.0" y="156.2" fill="#52514e" font-size="9">4.70</text>
+<text x="540.0" y="274.9" fill="#52514e" font-size="9">1.85</text>
+<text x="540.0" y="69.5" fill="#52514e" font-size="9">6.78</text>
+<text x="540.0" y="205.6" fill="#52514e" font-size="9">3.52</text>
+<!-- Legend -->
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_efficiency.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_efficiency.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Efficiency vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0%</text>
+<line x1="72" y1="280.3" x2="532" y2="280.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="284.3" fill="#898781" font-size="11" text-anchor="end">25%</text>
+<line x1="72" y1="212.5" x2="532" y2="212.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="216.5" fill="#898781" font-size="11" text-anchor="end">50%</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="148.8" fill="#898781" font-size="11" text-anchor="end">75%</text>
+<line x1="72" y1="77.1" x2="532" y2="77.1" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="81.1" fill="#898781" font-size="11" text-anchor="end">100%</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Efficiency (%)</text>
+<line x1="72" y1="144.8" x2="532" y2="144.8" stroke="#c3c2b7" stroke-width="1" stroke-dasharray="4,3"/>
+<text x="536.0" y="148.8" fill="#898781" font-size="9">75%</text>
+<polyline points="72.0,77.1 187.0,121.2 302.0,174.1 417.0,230.8 532.0,282.1" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="121.2" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="174.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="230.8" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="282.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,176.9 302.0,243.6 417.0,290.6 532.0,320.4" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="176.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="243.6" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="290.6" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="320.4" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,191.5 302.0,264.1 417.0,303.7 532.0,325.7" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="191.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="264.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="303.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="325.7" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,154.3 302.0,223.5 417.0,284.5 532.0,313.1" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="154.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="223.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="284.5" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="313.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,77.1 187.0,219.9 302.0,279.1 417.0,315.3 532.0,332.5" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="77.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="219.9" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="279.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="315.3" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="332.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="58.6" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="69.2" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="80.0" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="90.8" fill="#52514e" font-size="9">100%</text>
+<text x="80.0" y="101.8" fill="#52514e" font-size="9">100%</text>
+<text x="195.0" y="124.2" fill="#52514e" font-size="9">84%</text>
+<text x="195.0" y="157.3" fill="#52514e" font-size="9">72%</text>
+<text x="195.0" y="179.9" fill="#52514e" font-size="9">63%</text>
+<text x="195.0" y="194.5" fill="#52514e" font-size="9">58%</text>
+<text x="195.0" y="222.9" fill="#52514e" font-size="9">47%</text>
+<text x="310.0" y="177.1" fill="#52514e" font-size="9">64%</text>
+<text x="310.0" y="226.5" fill="#52514e" font-size="9">46%</text>
+<text x="310.0" y="246.6" fill="#52514e" font-size="9">39%</text>
+<text x="310.0" y="267.1" fill="#52514e" font-size="9">31%</text>
+<text x="310.0" y="282.1" fill="#52514e" font-size="9">25%</text>
+<text x="425.0" y="233.8" fill="#52514e" font-size="9">43%</text>
+<text x="425.0" y="284.9" fill="#52514e" font-size="9">23%</text>
+<text x="425.0" y="295.9" fill="#52514e" font-size="9">21%</text>
+<text x="425.0" y="306.9" fill="#52514e" font-size="9">16%</text>
+<text x="425.0" y="318.3" fill="#52514e" font-size="9">12%</text>
+<text x="540.0" y="285.1" fill="#52514e" font-size="9">24%</text>
+<text x="540.0" y="309.4" fill="#52514e" font-size="9">13%</text>
+<text x="540.0" y="320.4" fill="#52514e" font-size="9">10%</text>
+<text x="540.0" y="331.4" fill="#52514e" font-size="9">8%</text>
+<text x="540.0" y="342.4" fill="#52514e" font-size="9">6%</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_paired-comparison.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_paired-comparison.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Paired Comparison vs Baseline</text>
+<text x="72" y="44" fill="#898781" font-size="11">Positive = regression, negative = improvement</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">-10%</text>
+<line x1="72" y1="310.4" x2="532" y2="310.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="314.4" fill="#898781" font-size="11" text-anchor="end">-5%</text>
+<line x1="72" y1="272.8" x2="532" y2="272.8" stroke="#c3c2b7" stroke-width="1.5"/>
+<text x="62" y="276.8" fill="#52514e" font-size="11" text-anchor="end" font-weight="600">0%</text>
+<line x1="72" y1="235.2" x2="532" y2="235.2" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="239.2" fill="#898781" font-size="11" text-anchor="end">+5%</text>
+<line x1="72" y1="197.6" x2="532" y2="197.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="201.6" fill="#898781" font-size="11" text-anchor="end">+10%</text>
+<line x1="72" y1="160.0" x2="532" y2="160.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="164.0" fill="#898781" font-size="11" text-anchor="end">+15%</text>
+<line x1="72" y1="122.4" x2="532" y2="122.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="126.4" fill="#898781" font-size="11" text-anchor="end">+20%</text>
+<line x1="72" y1="84.8" x2="532" y2="84.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="88.8" fill="#898781" font-size="11" text-anchor="end">+25%</text>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="216.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,216.0)">Change from baseline (%)</text>
+<!-- Shaded regions -->
+<rect x="72" y="55" width="460" height="217.8" fill="#c0392b" opacity="0.04"/>
+<rect x="72" y="272.8" width="460" height="75.2" fill="#27ae60" opacity="0.04"/>
+<!-- Timetree: +0.3, +3.4, +7.0, +9.6, +13.7 -->
+<polyline points="72.0,270.5 187.0,247.3 302.0,220.3 417.0,200.8 532.0,170.0" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="270.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="247.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="220.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="200.8" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="170.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Optimize: -4.1, +12.4, +18.9, +19.8, +23.9 -->
+<polyline points="72.0,303.6 187.0,179.8 302.0,131.1 417.0,124.3 532.0,93.6" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="303.6" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="179.8" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="131.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="124.3" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="93.6" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Ancestral: -3.6, +3.8, +5.4, +17.0, +16.1 -->
+<polyline points="72.0,299.8 187.0,244.3 302.0,232.3 417.0,145.3 532.0,152.0" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="299.8" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="244.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="232.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="145.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="152.0" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Mugration: +1.6, -0.9, +0.2, -4.9, -2.7 -->
+<polyline points="72.0,260.8 187.0,279.6 302.0,271.3 417.0,309.6 532.0,293.1" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="260.8" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="279.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="271.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="309.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="293.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Clock: +0.0, +5.2, +0.0, -3.6, -3.7 -->
+<polyline points="72.0,272.8 187.0,233.8 302.0,272.8 417.0,299.8 532.0,300.6" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="272.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="233.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="272.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="299.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="300.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<!-- Legend -->
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_peak-rss.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_peak-rss.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Peak Resident Memory vs Thread Count</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="298.3" x2="680" y2="298.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="302.3" fill="#898781" font-size="11" text-anchor="end">500</text>
+<line x1="72" y1="248.7" x2="680" y2="248.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="252.7" fill="#898781" font-size="11" text-anchor="end">1000</text>
+<line x1="72" y1="199.0" x2="680" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">1500</text>
+<line x1="72" y1="149.3" x2="680" y2="149.3" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="153.3" fill="#898781" font-size="11" text-anchor="end">2000</text>
+<line x1="72" y1="99.7" x2="680" y2="99.7" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="103.7" fill="#898781" font-size="11" text-anchor="end">2500</text>
+<line x1="72" y1="50.0" x2="680" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">3000</text>
+<line x1="72" y1="348.0" x2="680" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Peak RSS (MB)</text>
+<rect x="78.8" y="132.9" width="20.0" height="215.1" rx="2" fill="#2a78d6"/>
+<rect x="100.8" y="223.6" width="20.0" height="124.4" rx="2" fill="#1baf7a"/>
+<rect x="122.8" y="186.8" width="20.0" height="161.2" rx="2" fill="#eda100"/>
+<rect x="144.8" y="344.5" width="20.0" height="3.5" rx="2" fill="#008300"/>
+<rect x="166.8" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="132.8" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<rect x="200.4" y="134.0" width="20.0" height="214.0" rx="2" fill="#2a78d6"/>
+<rect x="222.4" y="223.1" width="20.0" height="124.9" rx="2" fill="#1baf7a"/>
+<rect x="244.4" y="160.1" width="20.0" height="187.9" rx="2" fill="#eda100"/>
+<rect x="266.4" y="344.4" width="20.0" height="3.6" rx="2" fill="#008300"/>
+<rect x="288.4" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="254.4" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<rect x="322.0" y="133.2" width="20.0" height="214.8" rx="2" fill="#2a78d6"/>
+<rect x="344.0" y="222.4" width="20.0" height="125.6" rx="2" fill="#1baf7a"/>
+<rect x="366.0" y="164.0" width="20.0" height="184.0" rx="2" fill="#eda100"/>
+<rect x="388.0" y="344.4" width="20.0" height="3.6" rx="2" fill="#008300"/>
+<rect x="410.0" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="376.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<rect x="443.6" y="130.9" width="20.0" height="217.1" rx="2" fill="#2a78d6"/>
+<rect x="465.6" y="220.6" width="20.0" height="127.4" rx="2" fill="#1baf7a"/>
+<rect x="487.6" y="165.3" width="20.0" height="182.7" rx="2" fill="#eda100"/>
+<rect x="509.6" y="344.4" width="20.0" height="3.6" rx="2" fill="#008300"/>
+<rect x="531.6" y="345.7" width="20.0" height="2.3" rx="2" fill="#4a3aa7"/>
+<text x="497.6" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<rect x="565.2" y="124.2" width="20.0" height="223.8" rx="2" fill="#2a78d6"/>
+<rect x="587.2" y="217.4" width="20.0" height="130.6" rx="2" fill="#1baf7a"/>
+<rect x="609.2" y="152.9" width="20.0" height="195.1" rx="2" fill="#eda100"/>
+<rect x="631.2" y="344.2" width="20.0" height="3.8" rx="2" fill="#008300"/>
+<rect x="653.2" y="345.5" width="20.0" height="2.5" rx="2" fill="#4a3aa7"/>
+<text x="619.2" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="376.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<rect x="615" y="47" width="10" height="10" rx="2" fill="#4a3aa7"/>
+<text x="629" y="56" fill="#0b0b0b" font-size="10">Clock</text>
+<rect x="532" y="47" width="10" height="10" rx="2" fill="#008300"/>
+<text x="546" y="56" fill="#0b0b0b" font-size="10">Mugration</text>
+<rect x="449" y="47" width="10" height="10" rx="2" fill="#eda100"/>
+<text x="463" y="56" fill="#0b0b0b" font-size="10">Ancestral</text>
+<rect x="373" y="47" width="10" height="10" rx="2" fill="#1baf7a"/>
+<text x="387" y="56" fill="#0b0b0b" font-size="10">Optimize</text>
+<rect x="297" y="47" width="10" height="10" rx="2" fill="#2a78d6"/>
+<text x="311" y="56" fill="#0b0b0b" font-size="10">Timetree</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_speedup.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_speedup.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Parallel Speedup vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0x</text>
+<line x1="72" y1="273.5" x2="532" y2="273.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="277.5" fill="#898781" font-size="11" text-anchor="end">5x</text>
+<line x1="72" y1="199.0" x2="532" y2="199.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="203.0" fill="#898781" font-size="11" text-anchor="end">10x</text>
+<line x1="72" y1="124.5" x2="532" y2="124.5" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="128.5" fill="#898781" font-size="11" text-anchor="end">15x</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">20x</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Speedup (x)</text>
+<polyline points="72.0,333.1 187.0,318.2 302.0,288.4 417.0,228.8 532.0,109.6" fill="none" stroke="#e1e0d9" stroke-width="1.5" stroke-dasharray="6,4"/>
+<text x="538.0" y="113.6" fill="#898781" font-size="10">ideal</text>
+<polyline points="72.0,333.1 187.0,323.1 302.0,309.7 417.0,296.4 532.0,290.0" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="323.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="309.7" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="296.4" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="290.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,329.2 302.0,325.0 417.0,322.7 532.0,323.7" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="329.2" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="325.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="322.7" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="323.7" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,330.8 302.0,329.5 417.0,328.5 532.0,328.3" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="330.8" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="329.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="328.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="328.3" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,326.7 302.0,320.6 417.0,320.1 532.0,317.3" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="326.7" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="320.6" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="320.1" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="317.3" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,333.1 187.0,333.9 302.0,332.8 417.0,333.6 532.0,334.4" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="72.0" cy="333.1" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="333.9" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="332.8" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="333.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="334.4" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="314.6" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="325.2" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="336.0" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="346.9" fill="#52514e" font-size="9">1x</text>
+<text x="80.0" y="357.9" fill="#52514e" font-size="9">1x</text>
+<text x="195.0" y="310.1" fill="#52514e" font-size="9">1.7x</text>
+<text x="195.0" y="320.8" fill="#52514e" font-size="9">1.4x</text>
+<text x="195.0" y="331.6" fill="#52514e" font-size="9">1.3x</text>
+<text x="195.0" y="342.5" fill="#52514e" font-size="9">1.2x</text>
+<text x="195.0" y="353.5" fill="#52514e" font-size="9">0.9x</text>
+<text x="310.0" y="304.8" fill="#52514e" font-size="9">2.6x</text>
+<text x="310.0" y="315.6" fill="#52514e" font-size="9">1.8x</text>
+<text x="310.0" y="326.5" fill="#52514e" font-size="9">1.5x</text>
+<text x="310.0" y="337.4" fill="#52514e" font-size="9">1.2x</text>
+<text x="310.0" y="348.4" fill="#52514e" font-size="9">1.0x</text>
+<text x="425.0" y="299.4" fill="#52514e" font-size="9">3.5x</text>
+<text x="425.0" y="312.7" fill="#52514e" font-size="9">1.9x</text>
+<text x="425.0" y="323.7" fill="#52514e" font-size="9">1.7x</text>
+<text x="425.0" y="334.7" fill="#52514e" font-size="9">1.3x</text>
+<text x="425.0" y="345.7" fill="#52514e" font-size="9">1.0x</text>
+<text x="540.0" y="293.0" fill="#52514e" font-size="9">3.9x</text>
+<text x="540.0" y="312.4" fill="#52514e" font-size="9">2.1x</text>
+<text x="540.0" y="323.4" fill="#52514e" font-size="9">1.6x</text>
+<text x="540.0" y="334.4" fill="#52514e" font-size="9">1.3x</text>
+<text x="540.0" y="345.4" fill="#52514e" font-size="9">0.9x</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_wall-time.svg
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_wall-time.svg
@@ -1,0 +1,169 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 400" font-family="system-ui,-apple-system,sans-serif">
+<rect width="700" height="400" fill="#fcfcfb"/>
+<text x="72" y="28" fill="#0b0b0b" font-size="15" font-weight="600">Wall-Clock Time vs Thread Count</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="352.0" fill="#898781" font-size="11" text-anchor="end">0</text>
+<line x1="72" y1="288.4" x2="532" y2="288.4" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="292.4" fill="#898781" font-size="11" text-anchor="end">10.0s</text>
+<line x1="72" y1="228.8" x2="532" y2="228.8" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="232.8" fill="#898781" font-size="11" text-anchor="end">20.0s</text>
+<line x1="72" y1="169.2" x2="532" y2="169.2" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="173.2" fill="#898781" font-size="11" text-anchor="end">30.0s</text>
+<line x1="72" y1="109.6" x2="532" y2="109.6" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="113.6" fill="#898781" font-size="11" text-anchor="end">40.0s</text>
+<line x1="72" y1="50.0" x2="532" y2="50.0" stroke="#e1e0d9" stroke-width="1"/>
+<text x="62" y="54.0" fill="#898781" font-size="11" text-anchor="end">50.0s</text>
+<line x1="72" y1="348.0" x2="532" y2="348.0" stroke="#c3c2b7" stroke-width="1"/>
+<text x="72.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">1</text>
+<text x="187.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">2</text>
+<text x="302.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">4</text>
+<text x="417.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">8</text>
+<text x="532.0" y="366.0" fill="#898781" font-size="11" text-anchor="middle">16</text>
+<text x="302.0" y="392.0" fill="#52514e" font-size="12" text-anchor="middle">Threads</text>
+<text x="14" y="199.0" fill="#52514e" font-size="12" text-anchor="middle" transform="rotate(-90,14,199.0)">Time (seconds)</text>
+<polyline points="72.0,137.9 187.0,222.5 302.0,266.1 417.0,287.3 532.0,294.0" fill="none" stroke="#2a78d6" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="138.2" x2="72.0" y2="137.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="138.2" x2="75.0" y2="138.2" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="137.1" x2="75.0" y2="137.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="223.5" x2="187.0" y2="221.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="223.5" x2="190.0" y2="223.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="221.5" x2="190.0" y2="221.5" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="267.4" x2="302.0" y2="265.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="267.4" x2="305.0" y2="267.4" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="265.0" x2="305.0" y2="265.0" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="287.9" x2="417.0" y2="286.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="287.9" x2="420.0" y2="287.9" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="286.1" x2="420.0" y2="286.1" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="294.8" x2="532.0" y2="293.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="294.8" x2="535.0" y2="294.8" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="293.3" x2="535.0" y2="293.3" stroke="#2a78d6" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="137.9" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="222.5" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="266.1" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="287.3" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="294.0" r="4" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,314.0 187.0,321.1 302.0,325.9 417.0,327.9 532.0,327.1" fill="none" stroke="#1baf7a" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="314.2" x2="72.0" y2="313.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="314.2" x2="75.0" y2="314.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="313.7" x2="75.0" y2="313.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="321.4" x2="187.0" y2="320.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="321.4" x2="190.0" y2="321.4" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="320.5" x2="190.0" y2="320.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="326.3" x2="302.0" y2="325.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="326.3" x2="305.0" y2="326.3" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="325.5" x2="305.0" y2="325.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="328.2" x2="417.0" y2="327.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="328.2" x2="420.0" y2="328.2" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="327.5" x2="420.0" y2="327.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="327.5" x2="532.0" y2="326.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="327.5" x2="535.0" y2="327.5" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="326.7" x2="535.0" y2="326.7" stroke="#1baf7a" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="314.0" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="321.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="325.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="327.9" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="327.1" r="4" fill="#1baf7a" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,313.9 187.0,318.5 302.0,320.5 417.0,321.9 532.0,322.1" fill="none" stroke="#eda100" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="314.0" x2="72.0" y2="313.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="314.0" x2="75.0" y2="314.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="313.7" x2="75.0" y2="313.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="318.7" x2="187.0" y2="318.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="318.7" x2="190.0" y2="318.7" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="318.1" x2="190.0" y2="318.1" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="321.6" x2="302.0" y2="318.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="321.6" x2="305.0" y2="321.6" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="318.3" x2="305.0" y2="318.3" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="322.8" x2="417.0" y2="320.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="322.8" x2="420.0" y2="322.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="320.8" x2="420.0" y2="320.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="322.8" x2="532.0" y2="321.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="322.8" x2="535.0" y2="322.8" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="321.0" x2="535.0" y2="321.0" stroke="#eda100" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="313.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="318.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="320.5" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="321.9" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="322.1" r="4" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,329.2 187.0,334.8 302.0,337.7 417.0,337.9 532.0,338.9" fill="none" stroke="#008300" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="329.4" x2="72.0" y2="329.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="329.4" x2="75.0" y2="329.4" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="329.0" x2="75.0" y2="329.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="335.1" x2="187.0" y2="334.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="335.1" x2="190.0" y2="335.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="334.5" x2="190.0" y2="334.5" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="338.0" x2="302.0" y2="337.4" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="338.0" x2="305.0" y2="338.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="337.4" x2="305.0" y2="337.4" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="338.1" x2="417.0" y2="337.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="338.1" x2="420.0" y2="338.1" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="337.8" x2="420.0" y2="337.8" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="339.0" x2="532.0" y2="338.7" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="339.0" x2="535.0" y2="339.0" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="338.7" x2="535.0" y2="338.7" stroke="#008300" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="329.2" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="334.8" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="337.7" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="337.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="338.9" r="4" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<polyline points="72.0,347.5 187.0,347.5 302.0,347.6 417.0,347.5 532.0,347.5" fill="none" stroke="#4a3aa7" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<line x1="72.0" y1="347.5" x2="72.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.5" x2="75.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="69.0" y1="347.5" x2="75.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="187.0" y1="347.5" x2="187.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.5" x2="190.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="184.0" y1="347.5" x2="190.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="302.0" y1="347.6" x2="302.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.6" x2="305.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="299.0" y1="347.6" x2="305.0" y2="347.6" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="417.0" y1="347.5" x2="417.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.5" x2="420.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="414.0" y1="347.5" x2="420.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="532.0" y1="347.5" x2="532.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.5" x2="535.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<line x1="529.0" y1="347.5" x2="535.0" y2="347.5" stroke="#4a3aa7" stroke-width="1" opacity="0.4"/>
+<circle cx="72.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="187.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="302.0" cy="347.6" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="417.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<circle cx="532.0" cy="347.5" r="4" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="2"/>
+<text x="80.0" y="140.9" fill="#52514e" font-size="9">35.3s</text>
+<text x="80.0" y="311.0" fill="#52514e" font-size="9">5.7s</text>
+<text x="80.0" y="322.0" fill="#52514e" font-size="9">5.7s</text>
+<text x="80.0" y="333.0" fill="#52514e" font-size="9">3.2s</text>
+<text x="80.0" y="350.5" fill="#52514e" font-size="9">76ms</text>
+<text x="195.0" y="225.5" fill="#52514e" font-size="9">21.1s</text>
+<text x="195.0" y="316.8" fill="#52514e" font-size="9">5.0s</text>
+<text x="195.0" y="327.8" fill="#52514e" font-size="9">4.5s</text>
+<text x="195.0" y="338.8" fill="#52514e" font-size="9">2.2s</text>
+<text x="195.0" y="350.5" fill="#52514e" font-size="9">81ms</text>
+<text x="310.0" y="269.1" fill="#52514e" font-size="9">13.7s</text>
+<text x="310.0" y="319.4" fill="#52514e" font-size="9">4.6s</text>
+<text x="310.0" y="330.4" fill="#52514e" font-size="9">3.7s</text>
+<text x="310.0" y="341.4" fill="#52514e" font-size="9">1.7s</text>
+<text x="310.0" y="352.4" fill="#52514e" font-size="9">75ms</text>
+<text x="425.0" y="290.3" fill="#52514e" font-size="9">10.2s</text>
+<text x="425.0" y="320.3" fill="#52514e" font-size="9">4.4s</text>
+<text x="425.0" y="331.3" fill="#52514e" font-size="9">3.4s</text>
+<text x="425.0" y="342.3" fill="#52514e" font-size="9">1.7s</text>
+<text x="425.0" y="353.3" fill="#52514e" font-size="9">79ms</text>
+<text x="540.0" y="297.0" fill="#52514e" font-size="9">9.1s</text>
+<text x="540.0" y="320.4" fill="#52514e" font-size="9">4.3s</text>
+<text x="540.0" y="331.4" fill="#52514e" font-size="9">3.5s</text>
+<text x="540.0" y="342.4" fill="#52514e" font-size="9">1.5s</text>
+<text x="540.0" y="353.4" fill="#52514e" font-size="9">83ms</text>
+<line x1="562" y1="60" x2="578" y2="60" stroke="#2a78d6" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="60" r="3.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="64" fill="#0b0b0b" font-size="12">Timetree</text>
+<line x1="562" y1="82" x2="578" y2="82" stroke="#1baf7a" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="82" r="3.5" fill="#1baf7a" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="86" fill="#0b0b0b" font-size="12">Optimize</text>
+<line x1="562" y1="104" x2="578" y2="104" stroke="#eda100" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="104" r="3.5" fill="#eda100" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="108" fill="#0b0b0b" font-size="12">Ancestral</text>
+<line x1="562" y1="126" x2="578" y2="126" stroke="#008300" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="126" r="3.5" fill="#008300" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="130" fill="#0b0b0b" font-size="12">Mugration</text>
+<line x1="562" y1="148" x2="578" y2="148" stroke="#4a3aa7" stroke-width="2" stroke-linecap="round"/>
+<circle cx="570" cy="148" r="3.5" fill="#4a3aa7" stroke="#fcfcfb" stroke-width="1.5"/>
+<text x="584" y="152" fill="#0b0b0b" font-size="12">Clock</text>
+</svg>

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-fitch-informative-positions.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-fitch-informative-positions.md
@@ -14,13 +14,15 @@ The change does not meet its performance objective on this dataset. Its one-thre
 
 ### Paired comparison
 
-| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
-|---|---:|---:|---:|---:|---:|
-| **Ancestral** | -3.6% | +3.8% | +5.4% | +17.0% | +16.1% |
-| **Optimize** | -4.1% | +12.4% | +18.9% | +19.8% | +23.9% |
-| **Timetree** | +0.3% | +3.4% | +7.0% | +9.6% | +13.7% |
-| **Mugration** | +1.6% | -0.9% | +0.2% | -4.9% | -2.7% |
-| **Clock** | +0.0% | +5.2% | +0.0% | -3.6% | -3.7% |
+![Paired comparison](assets/mpox-2000-fitch-informative-positions_paired-comparison.svg)
+
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Ancestral** |    -3.6% |     +3.8% |     +5.4% |    +17.0% |     +16.1% |
+| **Optimize**  |    -4.1% |    +12.4% |    +18.9% |    +19.8% |     +23.9% |
+| **Timetree**  |    +0.3% |     +3.4% |     +7.0% |     +9.6% |     +13.7% |
+| **Mugration** |    +1.6% |     -0.9% |     +0.2% |     -4.9% |      -2.7% |
+| **Clock**     |    +0.0% |     +5.2% |     +0.0% |     -3.6% |      -3.7% |
 
 Positive values are regressions. `mugration` and `clock` do not use the changed Fitch path and serve as controls; their small, non-monotonic differences indicate ordinary host variation rather than a systematic change.
 
@@ -37,13 +39,13 @@ The binaries were verified before measurement:
 
 ### Workloads
 
-| Subcommand | Description | Key parameters |
-|---|---|---|
+| Subcommand    | Description                                | Key parameters                        |
+| ------------- | ------------------------------------------ | ------------------------------------- |
 | **ancestral** | Marginal ancestral sequence reconstruction | `--method-anc=marginal --dense=false` |
-| **mugration** | Discrete trait reconstruction (country) | `--attribute=country --pc=1.0` |
-| **clock** | Molecular clock inference | default |
-| **optimize** | Branch length optimization | `--dense=false` |
-| **timetree** | Full time-scaled phylogeny | all output formats |
+| **mugration** | Discrete trait reconstruction (country)    | `--attribute=country --pc=1.0`        |
+| **clock**     | Molecular clock inference                  | default                               |
+| **optimize**  | Branch length optimization                 | `--dense=false`                       |
+| **timetree**  | Full time-scaled phylogeny                 | all output formats                    |
 
 ## Results
 
@@ -53,25 +55,25 @@ The tables and charts below show the changed implementation's absolute scaling. 
 
 ![Wall-clock time](assets/mpox-2000-fitch-informative-positions_wall-time.svg)
 
-| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
-|---|---:|---:|---:|---:|---:|
-| **Timetree** | 35.259 s | 21.057 s | 13.734 s | 10.185 s | 9.064 s |
-| **Optimize** | 5.711 s | 4.520 s | 3.704 s | 3.367 s | 3.499 s |
-| **Ancestral** | 5.728 s | 4.956 s | 4.622 s | 4.377 s | 4.341 s |
-| **Mugration** | 3.163 s | 2.211 s | 1.721 s | 1.687 s | 1.534 s |
-| **Clock** | 76.3 ms | 80.6 ms | 74.9 ms | 78.9 ms | 83.5 ms |
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  | 35.259 s |  21.057 s |  13.734 s |  10.185 s |    9.064 s |
+| **Optimize**  |  5.711 s |   4.520 s |   3.704 s |   3.367 s |    3.499 s |
+| **Ancestral** |  5.728 s |   4.956 s |   4.622 s |   4.377 s |    4.341 s |
+| **Mugration** |  3.163 s |   2.211 s |   1.721 s |   1.687 s |    1.534 s |
+| **Clock**     |  76.3 ms |   80.6 ms |   74.9 ms |   78.9 ms |    83.5 ms |
 
 ### Speedup
 
 ![Speedup](assets/mpox-2000-fitch-informative-positions_speedup.svg)
 
-| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
-|---|---:|---:|---:|---:|---:|
-| **Timetree** | 1.00x | 1.67x | 2.57x | 3.46x | 3.89x |
-| **Optimize** | 1.00x | 1.26x | 1.54x | 1.70x | 1.63x |
-| **Ancestral** | 1.00x | 1.16x | 1.24x | 1.31x | 1.32x |
-| **Mugration** | 1.00x | 1.43x | 1.84x | 1.87x | 2.06x |
-| **Clock** | 1.00x | 0.95x | 1.02x | 0.97x | 0.91x |
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |    1.00x |     1.67x |     2.57x |     3.46x |      3.89x |
+| **Optimize**  |    1.00x |     1.26x |     1.54x |     1.70x |      1.63x |
+| **Ancestral** |    1.00x |     1.16x |     1.24x |     1.31x |      1.32x |
+| **Mugration** |    1.00x |     1.43x |     1.84x |     1.87x |      2.06x |
+| **Clock**     |    1.00x |     0.95x |     1.02x |     0.97x |      0.91x |
 
 ### Parallel efficiency
 
@@ -79,37 +81,39 @@ The tables and charts below show the changed implementation's absolute scaling. 
 
 Efficiency = speedup / thread count.
 
-| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
-|---|---:|---:|---:|---:|---:|
-| **Timetree** | 100% | 84% | 64% | 43% | 24% |
-| **Optimize** | 100% | 63% | 39% | 21% | 10% |
-| **Ancestral** | 100% | 58% | 31% | 16% | 8% |
-| **Mugration** | 100% | 72% | 46% | 23% | 13% |
-| **Clock** | 100% | 47% | 25% | 12% | 6% |
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     100% |       84% |       64% |       43% |        24% |
+| **Optimize**  |     100% |       63% |       39% |       21% |        10% |
+| **Ancestral** |     100% |       58% |       31% |       16% |         8% |
+| **Mugration** |     100% |       72% |       46% |       23% |        13% |
+| **Clock**     |     100% |       47% |       25% |       12% |         6% |
 
 ### Peak resident memory
 
 ![Peak RSS](assets/mpox-2000-fitch-informative-positions_peak-rss.svg)
 
-| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
-|---|---:|---:|---:|---:|---:|
-| **Timetree** | 2165 MB | 2155 MB | 2163 MB | 2186 MB | 2253 MB |
-| **Optimize** | 1252 MB | 1257 MB | 1265 MB | 1282 MB | 1315 MB |
-| **Ancestral** | 1623 MB | 1892 MB | 1853 MB | 1839 MB | 1964 MB |
-| **Mugration** | 35 MB | 36 MB | 36 MB | 36 MB | 38 MB |
-| **Clock** | 23 MB | 24 MB | 23 MB | 23 MB | 26 MB |
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |  2165 MB |   2155 MB |   2163 MB |   2186 MB |    2253 MB |
+| **Optimize**  |  1252 MB |   1257 MB |   1265 MB |   1282 MB |    1315 MB |
+| **Ancestral** |  1623 MB |   1892 MB |   1853 MB |   1839 MB |    1964 MB |
+| **Mugration** |    35 MB |     36 MB |     36 MB |     36 MB |      38 MB |
+| **Clock**     |    23 MB |     24 MB |     23 MB |     23 MB |      26 MB |
 
 ### CPU utilization
 
+![CPU utilization](assets/mpox-2000-fitch-informative-positions_cpu-utilization.svg)
+
 User + system time / wall-clock time. Values above 1.0 indicate parallel CPU use.
 
-| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
-|---|---:|---:|---:|---:|---:|
-| **Timetree** | 1.00 | 1.70 | 2.69 | 3.80 | 5.30 |
-| **Optimize** | 1.00 | 1.43 | 1.96 | 2.76 | 4.70 |
-| **Ancestral** | 1.00 | 1.19 | 1.35 | 1.46 | 1.85 |
-| **Mugration** | 1.00 | 1.63 | 2.51 | 3.92 | 6.78 |
-| **Clock** | 1.00 | 1.16 | 1.39 | 1.91 | 3.52 |
+| Workload      | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+| ------------- | -------: | --------: | --------: | --------: | ---------: |
+| **Timetree**  |     1.00 |      1.70 |      2.69 |      3.80 |       5.30 |
+| **Optimize**  |     1.00 |      1.43 |      1.96 |      2.76 |       4.70 |
+| **Ancestral** |     1.00 |      1.19 |      1.35 |      1.46 |       1.85 |
+| **Mugration** |     1.00 |      1.63 |      2.51 |      3.92 |       6.78 |
+| **Clock**     |     1.00 |      1.16 |      1.39 |      1.91 |       3.52 |
 
 ## Output equivalence
 

--- a/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-fitch-informative-positions.md
+++ b/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-fitch-informative-positions.md
@@ -1,0 +1,128 @@
+# Informative Fitch Positions: mpox-2000
+
+**Baseline:** `e0601306b492bc425eac29c553cae24d37cc378a`
+**Changed:** `46e60670345c0f7bedff3289b2b27f384ff6f12f`
+**Dataset:** `data/mpox/clade-ii/2000`
+**Threads:** 1, 2, 4, 8, 16
+**Runs:** 3 measured + 1 warmup per configuration
+
+## Verdict
+
+Precomputing informative Fitch positions reduces single-threaded work, improving `ancestral` by 3.6% and `optimize` by 4.1% at one thread. It also introduces a serial pass before the parallel tree traversal. The changed implementation becomes slower as thread count increases: `ancestral` regresses by 3.8% at 2 threads and 16–17% at 8–16 threads. The regression propagates to `optimize` and `timetree`, reaching 23.9% and 13.7%, respectively, at 16 threads.
+
+The change does not meet its performance objective on this dataset. Its one-thread reduction in total work is outweighed by reduced parallel scaling.
+
+### Paired comparison
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Ancestral** | -3.6% | +3.8% | +5.4% | +17.0% | +16.1% |
+| **Optimize** | -4.1% | +12.4% | +18.9% | +19.8% | +23.9% |
+| **Timetree** | +0.3% | +3.4% | +7.0% | +9.6% | +13.7% |
+| **Mugration** | +1.6% | -0.9% | +0.2% | -4.9% | -2.7% |
+| **Clock** | +0.0% | +5.2% | +0.0% | -3.6% | -3.7% |
+
+Positive values are regressions. `mugration` and `clock` do not use the changed Fitch path and serve as controls; their small, non-monotonic differences indicate ordinary host variation rather than a systematic change.
+
+## Methodology
+
+Exact release binaries for the baseline and changed commits were built in Docker and benchmarked on the host with `dev/bench-graph-pass-cli`. Each of five CLI subcommands ran at thread counts 1, 2, 4, 8, and 16 using [hyperfine](https://github.com/sharkdp/hyperfine), with 3 measured runs after 1 warmup. Peak RSS was captured separately with `/usr/bin/time`.
+
+The `ancestral` 2-thread and 8-thread wall times use a confirmation run with 7 measurements after 3 warmups. The corresponding 4-thread and 16-thread confirmation samples exceeded the variance acceptance criterion, so those cells retain the complete primary matrix measurements. Peak RSS and CPU utilization come from the primary matrix for every configuration.
+
+The binaries were verified before measurement:
+
+- baseline SHA-256: `776c0a563c54f559ca7bb7fa7baaec136193d7cf17faeb70465dd4b7194d2e70`
+- changed SHA-256: `8609a1aa7b55bcd5ca929f6763bd5e9e4479c05d0a1cb4de1287a79a5d62c550`
+
+### Workloads
+
+| Subcommand | Description | Key parameters |
+|---|---|---|
+| **ancestral** | Marginal ancestral sequence reconstruction | `--method-anc=marginal --dense=false` |
+| **mugration** | Discrete trait reconstruction (country) | `--attribute=country --pc=1.0` |
+| **clock** | Molecular clock inference | default |
+| **optimize** | Branch length optimization | `--dense=false` |
+| **timetree** | Full time-scaled phylogeny | all output formats |
+
+## Results
+
+The tables and charts below show the changed implementation's absolute scaling. The paired comparison above is the appropriate measure of the change's effect.
+
+### Wall-clock time
+
+![Wall-clock time](assets/mpox-2000-fitch-informative-positions_wall-time.svg)
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 35.259 s | 21.057 s | 13.734 s | 10.185 s | 9.064 s |
+| **Optimize** | 5.711 s | 4.520 s | 3.704 s | 3.367 s | 3.499 s |
+| **Ancestral** | 5.728 s | 4.956 s | 4.622 s | 4.377 s | 4.341 s |
+| **Mugration** | 3.163 s | 2.211 s | 1.721 s | 1.687 s | 1.534 s |
+| **Clock** | 76.3 ms | 80.6 ms | 74.9 ms | 78.9 ms | 83.5 ms |
+
+### Speedup
+
+![Speedup](assets/mpox-2000-fitch-informative-positions_speedup.svg)
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 1.00x | 1.67x | 2.57x | 3.46x | 3.89x |
+| **Optimize** | 1.00x | 1.26x | 1.54x | 1.70x | 1.63x |
+| **Ancestral** | 1.00x | 1.16x | 1.24x | 1.31x | 1.32x |
+| **Mugration** | 1.00x | 1.43x | 1.84x | 1.87x | 2.06x |
+| **Clock** | 1.00x | 0.95x | 1.02x | 0.97x | 0.91x |
+
+### Parallel efficiency
+
+![Efficiency](assets/mpox-2000-fitch-informative-positions_efficiency.svg)
+
+Efficiency = speedup / thread count.
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 100% | 84% | 64% | 43% | 24% |
+| **Optimize** | 100% | 63% | 39% | 21% | 10% |
+| **Ancestral** | 100% | 58% | 31% | 16% | 8% |
+| **Mugration** | 100% | 72% | 46% | 23% | 13% |
+| **Clock** | 100% | 47% | 25% | 12% | 6% |
+
+### Peak resident memory
+
+![Peak RSS](assets/mpox-2000-fitch-informative-positions_peak-rss.svg)
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 2165 MB | 2155 MB | 2163 MB | 2186 MB | 2253 MB |
+| **Optimize** | 1252 MB | 1257 MB | 1265 MB | 1282 MB | 1315 MB |
+| **Ancestral** | 1623 MB | 1892 MB | 1853 MB | 1839 MB | 1964 MB |
+| **Mugration** | 35 MB | 36 MB | 36 MB | 36 MB | 38 MB |
+| **Clock** | 23 MB | 24 MB | 23 MB | 23 MB | 26 MB |
+
+### CPU utilization
+
+User + system time / wall-clock time. Values above 1.0 indicate parallel CPU use.
+
+| Workload | 1 thread | 2 threads | 4 threads | 8 threads | 16 threads |
+|---|---:|---:|---:|---:|---:|
+| **Timetree** | 1.00 | 1.70 | 2.69 | 3.80 | 5.30 |
+| **Optimize** | 1.00 | 1.43 | 1.96 | 2.76 | 4.70 |
+| **Ancestral** | 1.00 | 1.19 | 1.35 | 1.46 | 1.85 |
+| **Mugration** | 1.00 | 1.63 | 2.51 | 3.92 | 6.78 |
+| **Clock** | 1.00 | 1.16 | 1.39 | 1.91 | 3.52 |
+
+## Output equivalence
+
+`ancestral`, `mugration`, `optimize`, and `timetree` produced byte-identical output between the baseline and changed binaries at 1 and 16 threads. `clock` output differed at 16 threads both between binaries and between thread counts within each binary; this existing thread-dependent behavior is unrelated to the Fitch change.
+
+## Analysis
+
+The changed implementation moves site classification into the serial construction of [`FitchSiteIndex`](../../../packages/treetime/src/ancestral/fitch.rs#L34). Its nested leaf-by-site scan runs before the parallel backward traversal ([`fitch.rs#L55`](../../../packages/treetime/src/ancestral/fitch.rs#L55)), while the traversal subsequently restricts its recurrence to the resulting informative positions ([`fitch.rs#L262`](../../../packages/treetime/src/ancestral/fitch.rs#L262)).
+
+This trade changes where work occurs:
+
+- At one thread, skipping non-informative positions in the recurrence reduces elapsed time.
+- At higher thread counts, the serial classification pass limits the fraction of the workload available to Rayon. Changed `ancestral` CPU utilization reaches only 1.85 cores at 16 threads, and its speedup plateaus at 1.32x.
+- `optimize` invokes ancestral reconstruction and shows the same amplified regression. `timetree` contains more independently parallel work, so the regression is smaller but still increases monotonically with thread count.
+
+The implementation needs a parallel site-classification strategy, or a representation that derives informative positions without adding a serial full-alignment pass, before the optimization is performance-positive across supported thread counts.

--- a/kb/tests/ancestral.md
+++ b/kb/tests/ancestral.md
@@ -32,7 +32,7 @@ Support files (helpers only, no tests): [`packages/treetime/src/ancestral/__test
 
 ## Fitch Parsimony
 
-**Test:** [`packages/treetime/src/ancestral/__tests__/test_fitch.rs`](../../packages/treetime/src/ancestral/__tests__/test_fitch.rs)
+**Tests:** [`packages/treetime/src/ancestral/__tests__/test_fitch.rs`](../../packages/treetime/src/ancestral/__tests__/test_fitch.rs), [`packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs`](../../packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs), [`packages/treetime/src/ancestral/__tests__/test_prop_fitch_informative.rs`](../../packages/treetime/src/ancestral/__tests__/test_prop_fitch_informative.rs)
 
 **Impl:** [`packages/treetime/src/ancestral/fitch.rs`](../../packages/treetime/src/ancestral/fitch.rs)
 
@@ -48,6 +48,10 @@ Support files (helpers only, no tests): [`packages/treetime/src/ancestral/__test
 | `test_fitch_reroot_sparse_on_branch_ab_to_a`                 | Sparse partition consistency after reroot (no merge)         |
 | `test_fitch_reroot_sparse_with_trivial_root_removal`         | Reroot with edge merge: old root removed, edge composed      |
 | `test_fitch_reroot_sparse_forward_pass_nonzero_fixed_counts` | Marginal forward pass after reroot has non-zero multiplicity |
+| `test_fitch_site_index_classifies_leaf_columns`              | Baseline/candidate classification, including non-characters and extra records |
+| `test_fitch_invariant_columns_preserve_single_mutation`      | Invariant-dominated alignment preserves the sole substitution |
+
+Property coverage verifies the binary-tree score against exhaustive finite-state assignments, edge-reroot score invariance, column permutation, and insertion of invariant columns. The exact-score properties intentionally exclude multifurcations pending [kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md](../issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md).
 
 **Algorithm:** Fitch maximum parsimony (backward pass, forward pass, gap tracking)
 

--- a/kb/tickets/test-add-property-tests-for-clockset-algebraic-identities.md
+++ b/kb/tickets/test-add-property-tests-for-clockset-algebraic-identities.md
@@ -1,14 +1,10 @@
-# Add property tests for ClockSet algebraic identities and Fitch parsimony invariants
+# Add property tests for ClockSet algebraic identities
 
 ## No property tests for ClockSet algebraic identities
 
 `packages/treetime/src/payload/clock_set.rs:53-172:`
 
 `+`, `-`, `+=`, `-=`, `fn propagate_averages` lack property test coverage for algebraic identities (associativity, commutativity, identity element).
-
-## No property tests for Fitch parsimony invariants
-
-Score invariant under rerooting, state-set subset relation between parent and child Fitch sets.
 
 ## Related issues
 

--- a/packages/treetime/Cargo.toml
+++ b/packages/treetime/Cargo.toml
@@ -80,3 +80,7 @@ workspace = true
 [[bench]]
 name = "marginal_scaling"
 harness = false
+
+[[bench]]
+name = "fitch_scaling"
+harness = false

--- a/packages/treetime/benches/fitch_scaling.rs
+++ b/packages/treetime/benches/fitch_scaling.rs
@@ -1,0 +1,124 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ctor::ctor;
+use rayon::ThreadPoolBuilder;
+use std::hint::black_box;
+use treetime::alphabet::alphabet::Alphabet;
+use treetime::ancestral::fitch::create_fitch_partition;
+use treetime::payload::ancestral::GraphAncestral;
+use treetime_io::fasta::FastaRecord;
+use treetime_io::nwk::nwk_read_str;
+use treetime_primitives::{AsciiChar, Seq};
+use treetime_utils::init::global::global_init;
+
+#[ctor]
+fn init() {
+  global_init();
+}
+
+fn benchmark_fitch_scaling(criterion: &mut Criterion) {
+  let mut group = criterion.benchmark_group("fitch_informative_positions");
+  group.sample_size(10);
+  let pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+
+  for topology in [Topology::Balanced, Topology::Caterpillar, Topology::Star] {
+    for length in [1_000, 10_000] {
+      for (density, denominator) in [("invariant", None), ("one-percent", Some(100)), ("all", Some(1))] {
+        let (graph, alignment) = setup(topology, 16, length, denominator);
+        let benchmark = format!("{}-{density}", topology.name());
+        group.throughput(Throughput::Elements((alignment.len() * length) as u64));
+        group.bench_with_input(BenchmarkId::new(benchmark, length), &length, |bencher, _| {
+          bencher.iter(|| {
+            pool
+              .install(|| create_fitch_partition(black_box(&graph), 0, Alphabet::default(), black_box(&alignment)))
+              .unwrap();
+          });
+        });
+      }
+    }
+  }
+  group.finish();
+}
+
+#[derive(Clone, Copy)]
+enum Topology {
+  Balanced,
+  Caterpillar,
+  Star,
+}
+
+impl Topology {
+  fn name(self) -> &'static str {
+    match self {
+      Self::Balanced => "balanced",
+      Self::Caterpillar => "caterpillar",
+      Self::Star => "star",
+    }
+  }
+}
+
+fn setup(
+  topology: Topology,
+  tips: usize,
+  length: usize,
+  informative_denominator: Option<usize>,
+) -> (GraphAncestral, Vec<FastaRecord>) {
+  let names = (0..tips).map(|index| format!("T{index}")).collect::<Vec<_>>();
+  let newick = format!("{}root:0.0;", topology_newick(topology, &names));
+  let graph = nwk_read_str(&newick).unwrap();
+  let alignment = names
+    .into_iter()
+    .enumerate()
+    .map(|(taxon, seq_name)| FastaRecord {
+      seq_name,
+      seq: (0..length)
+        .map(|pos| {
+          if informative_denominator.is_some_and(|denominator| pos % denominator == 0) && taxon % 2 == 1 {
+            AsciiChar::from_byte_unchecked(b'C')
+          } else {
+            AsciiChar::from_byte_unchecked(b'A')
+          }
+        })
+        .collect::<Seq>(),
+      ..FastaRecord::default()
+    })
+    .collect();
+  (graph, alignment)
+}
+
+fn topology_newick(topology: Topology, names: &[String]) -> String {
+  match topology {
+    Topology::Balanced => balanced_newick(names),
+    Topology::Caterpillar => caterpillar_newick(names),
+    Topology::Star => format!(
+      "({})",
+      names
+        .iter()
+        .map(|name| format!("{name}:0.1"))
+        .collect::<Vec<_>>()
+        .join(",")
+    ),
+  }
+}
+
+fn balanced_newick(names: &[String]) -> String {
+  if names.len() == 1 {
+    return names[0].clone();
+  }
+  let middle = names.len() / 2;
+  format!(
+    "({}:0.1,{}:0.1)",
+    balanced_newick(&names[..middle]),
+    balanced_newick(&names[middle..])
+  )
+}
+
+fn caterpillar_newick(names: &[String]) -> String {
+  match names {
+    [name] => name.clone(),
+    [first, rest @ ..] => format!("({first}:0.1,{}:0.1)", caterpillar_newick(rest)),
+    [] => unreachable!(),
+  }
+}
+
+criterion_group!(benches, benchmark_fitch_scaling);
+criterion_main!(benches);

--- a/packages/treetime/src/ancestral/__tests__/mod.rs
+++ b/packages/treetime/src/ancestral/__tests__/mod.rs
@@ -21,6 +21,7 @@ mod test_marginal_stability;
 mod test_marginal_topology;
 mod test_mask;
 mod test_multi;
+mod test_prop_fitch_informative;
 mod test_python_parity;
 mod test_sample;
 mod test_sample_reconstruction;

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -2,7 +2,8 @@
 mod tests {
   use crate::alphabet::alphabet::{Alphabet, AlphabetName};
   use crate::ancestral::fitch::{
-    ancestral_reconstruction_fitch, attach_seqs_to_graph, compress_sequences, fitch_backward, fitch_forward,
+    FitchSiteIndex, ancestral_reconstruction_fitch, attach_seqs_to_graph, compress_sequences, create_fitch_partition,
+    fitch_backward, fitch_forward,
   };
   use crate::ancestral::marginal::update_marginal;
   use crate::gtr::get_gtr::{JC69Params, jc69};
@@ -20,6 +21,7 @@ mod tests {
   use maplit::btreemap;
   use parking_lot::RwLock;
   use pretty_assertions::assert_eq;
+  use rstest::rstest;
   use std::collections::BTreeMap;
   use std::sync::{Arc, LazyLock};
   use treetime_graph::node::GraphNodeKey;
@@ -171,6 +173,60 @@ mod tests {
   }
 
   static NUC_ALPHABET: LazyLock<Alphabet> = LazyLock::new(Alphabet::default);
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::invariant_canonical(">A\nACGT\n>B\nACGT\n",                         "ACGT", vec![])]
+  #[case::distinct_canonical( ">A\nACGT\n>B\nGCGT\n",                         "ACGT", vec![0])]
+  #[case::ambiguous_leaf(     ">A\nACGT\n>B\nRCGT\n",                         "ACGT", vec![0])]
+  #[case::non_character_only( ">A\nN-GT\n>B\n--GT\n",                         "  GT", vec![])]
+  #[case::extra_record_ignored(">A\nACGT\n>B\nACGT\n>extra\nGCGT\n",          "ACGT", vec![])]
+  #[trace]
+  fn test_fitch_site_index_classifies_leaf_columns(
+    #[case] fasta: &str,
+    #[case] expected_baseline: &str,
+    #[case] expected_positions: Vec<usize>,
+  ) -> Result<(), Report> {
+    let graph: GraphAncestral = nwk_read_str("(A:0.1,B:0.1)root:0.0;")?;
+    let aln = read_many_fasta_str(fasta, &*NUC_ALPHABET)?;
+
+    let actual = FitchSiteIndex::new(&graph, &NUC_ALPHABET, &aln)?;
+
+    // Fitch 1971: a canonical state shared by every observed leaf is substitution-invariant.
+    assert_eq!(expected_baseline, actual.baseline().as_str());
+    assert_eq!(expected_positions, actual.informative_positions());
+    Ok(())
+  }
+
+  #[test]
+  fn test_fitch_invariant_columns_preserve_single_mutation() -> Result<(), Report> {
+    let aln = read_many_fasta_str(
+      indoc! {r#"
+        >A
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        >B
+        AAAAAAAAAAAAAAACAAAAAAAAAAAAAAAA
+        >C
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        >D
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      "#},
+      &*NUC_ALPHABET,
+    )?;
+    let graph: GraphAncestral = nwk_read_str("((A:0.1,B:0.1)AB:0.1,(C:0.1,D:0.1)CD:0.1)root:0.0;")?;
+
+    let partition = create_fitch_partition(&graph, 0, Alphabet::default(), &aln)?;
+    let actual_score: usize = partition.edges.values().map(|edge| edge.fitch_subs().len()).sum();
+    let root_key = graph.get_exactly_one_root()?.read_arc().key();
+
+    // Fitch 1971: invariant columns contribute zero changes; only A16C is informative.
+    assert_eq!(1, actual_score);
+    assert_eq!(
+      "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      partition.nodes[&root_key].seq.sequence.as_str()
+    );
+    Ok(())
+  }
 
   /// Fitch maximum parsimony reconstruction on a balanced 4-taxon binary tree (Fitch 1971).
   ///
@@ -513,10 +569,9 @@ mod tests {
   ///
   /// Tree: ((A,B)AB,(C,D,E)CDE)root - node CDE has 3 children instead of 2.
   ///
-  /// Fitch's algorithm generalizes from binary to n-ary nodes: the backward pass computes
-  /// the intersection of all n child state sets. If the intersection is empty, it takes
-  /// the union (implying at least one state change). The forward pass resolves ambiguities
-  /// using the parent state when it is present in the child's state set.
+  /// This fixture preserves TreeTime's existing all-child intersection/union recurrence.
+  /// For multifurcations that recurrence is deterministic and v0-compatible, although an
+  /// exact arbitrary-degree minimum-mutation assignment requires a finite-state cost pass.
   ///
   /// Uses the same alignment as `test_fitch_complex_gaps` but with a different tree topology
   /// (D and E are direct children of CDE rather than grouped under a DE intermediate node).
@@ -637,7 +692,7 @@ mod tests {
 
     // Run backward pass only
     attach_seqs_to_graph(&graph, &partitions, &aln)?;
-    fitch_backward(&graph, &partitions)?;
+    fitch_backward(&graph, &partitions, &aln)?;
 
     {
       let partition = partitions[0].read_arc();

--- a/packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
-  use crate::alphabet::alphabet::{Alphabet, FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
+  use crate::alphabet::alphabet::{Alphabet, NON_CHAR, VARIABLE_CHAR};
   use crate::ancestral::fitch_sub::{
-    finalize_sequence_forward, resolve_fixed_positions_backward, resolve_nonroot_substitutions_forward,
-    resolve_root_forward, resolve_variable_positions_backward,
+    finalize_sequence_forward, resolve_informative_positions_backward, resolve_nonroot_substitutions_forward,
+    resolve_root_forward,
   };
   use crate::partition::sparse::{FitchSeqDistribution, SparseEdgePartition, SparseSeqInfo};
   use crate::seq::composition::Composition;
@@ -36,39 +36,39 @@ mod tests {
     SparseEdgePartition::default()
   }
 
-  // --- resolve_variable_positions_backward ---
-
   #[test]
-  fn test_fitch_sub_variable_backward_children_agree() {
+  fn test_fitch_sub_informative_backward_fixed_children_agree() {
     let child0 = make_seq_info("ACGT");
     let child1 = make_seq_info("ACGT");
     let edge0 = make_edge();
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    assert!(variable.is_empty(), "No variable positions when children agree");
+    assert!(variable.is_empty());
+    assert_eq!(sequence.as_str(), "ACGT");
   }
 
   #[test]
-  fn test_fitch_sub_variable_backward_children_disagree() {
+  fn test_fitch_sub_informative_backward_fixed_children_disagree() {
     let child0 = make_seq_info("ACGT");
     let child1 = make_seq_info("GCGT");
     let edge0 = make_edge();
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    assert!(variable.is_empty(), "Fixed-position disagreement is not handled here");
-    assert_eq!(sequence[1], FILL_CHAR, "Position 1 unchanged by variable pass");
+    let expected = btreemap! { 0_usize => stateset! {b'A', b'G'} };
+    assert_eq!(expected, variable);
+    assert_eq!(sequence[0], VARIABLE_CHAR);
   }
 
   #[test]
-  fn test_fitch_sub_variable_backward_intersection_ambiguous() {
+  fn test_fitch_sub_informative_backward_singleton_intersection() {
     let mut child0 = make_seq_info("ACGT");
     child0.fitch.variable.insert(0, stateset! {b'A', b'G'});
     let mut child1 = make_seq_info("ACGT");
@@ -77,16 +77,15 @@ mod tests {
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    // intersection {A,G} ∩ {A,C} = {A} is a singleton: resolved immediately, not stored as variable
     assert!(variable.is_empty());
     assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'A'));
   }
 
   #[test]
-  fn test_fitch_sub_variable_backward_intersection_multi_element() {
+  fn test_fitch_sub_informative_backward_multistate_intersection() {
     let mut child0 = make_seq_info("ACGT");
     child0.fitch.variable.insert(0, stateset! {b'A', b'G', b'C'});
     let mut child1 = make_seq_info("ACGT");
@@ -95,19 +94,16 @@ mod tests {
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    // intersection {A,G,C} ∩ {A,C} = {A,C}: ambiguous, stored as variable
-    assert_eq!(variable.len(), 1);
-    assert!(variable[&0].contains(b'A'));
-    assert!(variable[&0].contains(b'C'));
-    assert!(!variable[&0].contains(b'G'));
+    let expected = btreemap! { 0_usize => stateset! {b'A', b'C'} };
+    assert_eq!(expected, variable);
     assert_eq!(sequence[0], VARIABLE_CHAR);
   }
 
   #[test]
-  fn test_fitch_sub_variable_backward_intersection_empty_takes_union() {
+  fn test_fitch_sub_informative_backward_empty_intersection_uses_union() {
     let mut child0 = make_seq_info("ACGT");
     child0.fitch.variable.insert(0, stateset! {b'A'});
     let mut child1 = make_seq_info("GCGT");
@@ -116,34 +112,16 @@ mod tests {
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    assert_eq!(variable.len(), 1);
-    assert!(variable[&0].contains(b'A'));
-    assert!(variable[&0].contains(b'G'));
+    let expected = btreemap! { 0_usize => stateset! {b'A', b'G'} };
+    assert_eq!(expected, variable);
     assert_eq!(sequence[0], VARIABLE_CHAR);
   }
 
   #[test]
-  fn test_fitch_sub_variable_backward_singleton_intersection_resolved() {
-    let mut child0 = make_seq_info("ACGT");
-    child0.fitch.variable.insert(0, stateset! {b'A', b'G'});
-    let mut child1 = make_seq_info("ACGT");
-    child1.fitch.variable.insert(0, stateset! {b'A'});
-    let edge0 = make_edge();
-    let edge1 = make_edge();
-    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
-
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
-
-    assert!(variable.is_empty(), "Singleton intersection resolved immediately");
-    assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'A'));
-  }
-
-  #[test]
-  fn test_fitch_sub_variable_backward_skips_non_char_child() {
+  fn test_fitch_sub_informative_backward_ignores_non_char_child() {
     let mut child0 = make_seq_info("ACGT");
     child0.fitch.variable.insert(0, stateset! {b'A', b'G'});
     let mut child1 = make_seq_info("NCGT");
@@ -153,62 +131,47 @@ mod tests {
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    // child1 is in non_char at pos 0, so only child0's {A,G} contributes
-    assert_eq!(variable.len(), 1);
-    assert!(variable[&0].contains(b'A'));
-    assert!(variable[&0].contains(b'G'));
-  }
-
-  // --- resolve_fixed_positions_backward ---
-
-  #[test]
-  fn test_fitch_sub_fixed_backward_sets_fill_char() {
-    let child0 = make_seq_info("ACGT");
-    let edge0 = make_edge();
-    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0)];
-
-    let mut sequence = seq![FILL_CHAR; 4];
-    let mut variable = BTreeMap::new();
-    resolve_fixed_positions_backward(&children, &NUC_ALPHABET, &mut sequence, &mut variable);
-
-    assert_eq!(sequence.as_str(), "ACGT");
-    assert!(variable.is_empty());
+    let expected = btreemap! { 0_usize => stateset! {b'A', b'G'} };
+    assert_eq!(expected, variable);
   }
 
   #[test]
-  fn test_fitch_sub_fixed_backward_promotes_to_variable() {
+  fn test_fitch_sub_informative_backward_skips_local_non_char_position() {
     let child0 = make_seq_info("ACGT");
     let child1 = make_seq_info("GCGT");
     let edge0 = make_edge();
     let edge1 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![FILL_CHAR; 4];
-    let mut variable = BTreeMap::new();
-    resolve_fixed_positions_backward(&children, &NUC_ALPHABET, &mut sequence, &mut variable);
+    let mut sequence = seq![
+      NON_CHAR,
+      AsciiChar::from_byte_unchecked(b'C'),
+      AsciiChar::from_byte_unchecked(b'G'),
+      AsciiChar::from_byte_unchecked(b'T')
+    ];
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    assert_eq!(variable.len(), 1);
-    assert!(variable[&0].contains(b'A'));
-    assert!(variable[&0].contains(b'G'));
-    assert_eq!(sequence[0], VARIABLE_CHAR);
-    assert_eq!(sequence[1], AsciiChar::from_byte_unchecked(b'C'));
+    assert!(variable.is_empty());
+    assert_eq!(sequence[0], NON_CHAR);
   }
 
   #[test]
-  fn test_fitch_sub_fixed_backward_skips_non_char() {
+  fn test_fitch_sub_informative_backward_filters_transmission_child() {
     let child0 = make_seq_info("ACGT");
-    let edge0 = make_edge();
-    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0)];
+    let child1 = make_seq_info("GCGT");
+    let mut edge0 = make_edge();
+    edge0.transmission = Some(vec![(0, 1)]);
+    let edge1 = make_edge();
+    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
-    let mut sequence = seq![NON_CHAR; 4];
-    let mut variable = BTreeMap::new();
-    resolve_fixed_positions_backward(&children, &NUC_ALPHABET, &mut sequence, &mut variable);
+    let mut sequence = Seq::try_from_str("ACGT").unwrap();
+    let variable = resolve_informative_positions_backward(&children, &[0], &mut sequence);
 
-    assert_eq!(sequence[0], NON_CHAR, "NON_CHAR positions are skipped");
     assert!(variable.is_empty());
+    assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'G'));
   }
 
   // --- resolve_root_forward ---

--- a/packages/treetime/src/ancestral/__tests__/test_prop_fitch_informative.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_prop_fitch_informative.rs
@@ -1,0 +1,160 @@
+#[cfg(test)]
+mod tests {
+  use crate::alphabet::alphabet::Alphabet;
+  use crate::ancestral::__tests__::prop_generators::alignment::arb_alignment_no_gaps;
+  use crate::ancestral::fitch::create_fitch_partition;
+  use crate::partition::fitch::PartitionFitch;
+  use crate::payload::ancestral::GraphAncestral;
+  use eyre::Report;
+  use proptest::prelude::*;
+  use std::collections::BTreeMap;
+  use std::iter;
+  use treetime_graph::node::Named;
+  use treetime_io::fasta::FastaRecord;
+  use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::{AsciiChar, Seq};
+
+  const BALANCED: &str = "((A:0.1,B:0.1)AB:0.1,(C:0.1,D:0.1)CD:0.1)root:0.0;";
+  const ROOTED_AT_A: &str = "(A:0.05,(B:0.1,(C:0.1,D:0.1)CD:0.2)AB:0.05)root:0.0;";
+
+  proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Fitch 1971: on a binary tree, the backward/forward assignment attains
+    /// the minimum number of unordered character-state changes.
+    #[test]
+    fn test_prop_fitch_informative_score_matches_exhaustive_assignment(
+      alignment in arb_four_taxon_alignment(),
+    ) {
+      let actual = run_fitch(BALANCED, &alignment).unwrap();
+      let expected = exhaustive_balanced_score(&alignment);
+
+      prop_assert_eq!(expected, actual.score);
+    }
+
+    /// The minimum unordered-character score belongs to the unrooted binary
+    /// topology, so inserting the degree-two root on another edge preserves it.
+    #[test]
+    fn test_prop_fitch_informative_score_preserved_by_edge_reroot(
+      alignment in arb_four_taxon_alignment(),
+    ) {
+      let balanced = run_fitch(BALANCED, &alignment).unwrap();
+      let rerooted = run_fitch(ROOTED_AT_A, &alignment).unwrap();
+
+      prop_assert_eq!(balanced.score, rerooted.score);
+    }
+
+    #[test]
+    fn test_prop_fitch_informative_column_reversal_reverses_reconstruction(
+      alignment in arb_four_taxon_alignment(),
+    ) {
+      let original = run_fitch(BALANCED, &alignment).unwrap();
+      let reversed_alignment = alignment
+        .iter()
+        .cloned()
+        .map(|mut record| {
+          record.seq = record.seq.iter().copied().rev().collect();
+          record
+        })
+        .collect::<Vec<_>>();
+      let reversed = run_fitch(BALANCED, &reversed_alignment).unwrap();
+      let expected_sequences: BTreeMap<String, Seq> = original
+        .sequences
+        .into_iter()
+        .map(|(name, sequence)| (name, sequence.iter().copied().rev().collect::<Seq>()))
+        .collect();
+
+      prop_assert_eq!(original.score, reversed.score);
+      prop_assert_eq!(expected_sequences, reversed.sequences);
+    }
+
+    /// A column containing the same canonical state at every leaf has zero
+    /// parsimony cost and cannot alter assignments at independent columns.
+    #[test]
+    fn test_prop_fitch_informative_invariant_column_preserves_reconstruction(
+      alignment in arb_four_taxon_alignment(),
+    ) {
+      let original = run_fitch(BALANCED, &alignment).unwrap();
+      let with_invariant = alignment
+        .iter()
+        .cloned()
+        .map(|mut record| {
+          record.seq = iter::once(AsciiChar::from_byte_unchecked(b'A'))
+            .chain(record.seq.iter().copied())
+            .collect();
+          record
+        })
+        .collect::<Vec<_>>();
+      let actual = run_fitch(BALANCED, &with_invariant).unwrap();
+
+      prop_assert_eq!(original.score, actual.score);
+      for (name, expected) in original.sequences {
+        let sequence = &actual.sequences[&name];
+        prop_assert_eq!(Some(&AsciiChar::from_byte_unchecked(b'A')), sequence.first());
+        prop_assert_eq!(expected.as_slice(), &sequence.as_slice()[1..]);
+      }
+    }
+  }
+
+  fn arb_four_taxon_alignment() -> impl Strategy<Value = Vec<FastaRecord>> {
+    (1_usize..=8).prop_flat_map(|length| {
+      arb_alignment_no_gaps(
+        vec!["A".to_owned(), "B".to_owned(), "C".to_owned(), "D".to_owned()],
+        length,
+      )
+    })
+  }
+
+  fn run_fitch(newick: &str, alignment: &[FastaRecord]) -> Result<FitchResult, Report> {
+    let graph: GraphAncestral = nwk_read_str(newick)?;
+    let partition = create_fitch_partition(&graph, 0, Alphabet::default(), alignment)?;
+    let score = partition.edges.values().map(|edge| edge.fitch_subs().len()).sum();
+    let sequences = collect_sequences(&graph, &partition);
+    Ok(FitchResult { score, sequences })
+  }
+
+  struct FitchResult {
+    score: usize,
+    sequences: BTreeMap<String, Seq>,
+  }
+
+  fn collect_sequences(graph: &GraphAncestral, partition: &PartitionFitch) -> BTreeMap<String, Seq> {
+    graph
+      .get_nodes()
+      .iter()
+      .map(|node| {
+        let node = node.read_arc();
+        let name = node.payload().read_arc().name().unwrap().as_ref().to_owned();
+        (name, partition.nodes[&node.key()].seq.sequence.clone())
+      })
+      .collect()
+  }
+
+  fn exhaustive_balanced_score(alignment: &[FastaRecord]) -> usize {
+    let leaves = alignment
+      .iter()
+      .map(|record| (record.seq_name.as_str(), &record.seq))
+      .collect::<BTreeMap<_, _>>();
+    (0..alignment[0].seq.len())
+      .map(|pos| exhaustive_balanced_column([leaves["A"][pos], leaves["B"][pos], leaves["C"][pos], leaves["D"][pos]]))
+      .sum()
+  }
+
+  fn exhaustive_balanced_column(leaves: [AsciiChar; 4]) -> usize {
+    let canonical = [b'A', b'C', b'G', b'T'].map(AsciiChar::from_byte_unchecked);
+    canonical
+      .iter()
+      .flat_map(|&root| canonical.iter().map(move |&left| (root, left)))
+      .flat_map(|(root, left)| canonical.iter().map(move |&right| (root, left, right)))
+      .map(|(root, left, right)| {
+        usize::from(root != left)
+          + usize::from(root != right)
+          + usize::from(left != leaves[0])
+          + usize::from(left != leaves[1])
+          + usize::from(right != leaves[2])
+          + usize::from(right != leaves[3])
+      })
+      .min()
+      .unwrap()
+  }
+}

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -1,8 +1,8 @@
 use crate::alphabet::alphabet::{Alphabet, FILL_CHAR, NON_CHAR};
 use crate::ancestral::fitch_indel::{compute_node_ranges, resolve_indels_backward, resolve_indels_forward};
 use crate::ancestral::fitch_sub::{
-  finalize_sequence_forward, resolve_fixed_positions_backward, resolve_nonroot_substitutions_forward,
-  resolve_root_forward, resolve_variable_positions_backward,
+  finalize_sequence_forward, resolve_informative_positions_backward, resolve_nonroot_substitutions_forward,
+  resolve_root_forward,
 };
 use crate::make_report;
 use crate::partition::fitch::PartitionFitch;
@@ -24,11 +24,68 @@ use std::sync::Arc;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::GraphNodeForward;
-use treetime_graph::node::{GraphNode, NodeAncestralOps};
+use treetime_graph::node::{GraphNode, GraphNodeKey, NodeAncestralOps};
 use treetime_io::fasta::FastaRecord;
 use treetime_primitives::{AlphabetLike, Seq, seq};
 use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::sync::mutex::unwrap_arc_rwlock;
+
+#[derive(Clone, Debug)]
+pub(crate) struct FitchSiteIndex {
+  baseline: Seq,
+  informative_positions: Vec<usize>,
+}
+
+impl FitchSiteIndex {
+  /// Classify substitution-informative columns from the observed tree leaves.
+  ///
+  /// A column is informative when canonical leaf states disagree or any leaf
+  /// carries an ambiguity set. Gap and unknown states remain in the separate
+  /// non-character recurrence and therefore do not make a substitution candidate.
+  pub(crate) fn new<N, E>(graph: &Graph<N, E, ()>, alphabet: &Alphabet, aln: &[FastaRecord]) -> Result<Self, Report>
+  where
+    N: NodeAncestralOps,
+    E: GraphEdge,
+  {
+    let length = get_common_length(aln)?;
+    let leaf_records = leaf_records(graph, aln)?;
+    let mut baseline = seq![FILL_CHAR; length];
+    let mut informative = vec![false; length];
+
+    for (_, record) in leaf_records {
+      for (pos, &state) in record.seq.iter().enumerate() {
+        if alphabet.is_canonical(state) {
+          if baseline[pos] == FILL_CHAR {
+            baseline[pos] = state;
+          } else if baseline[pos] != state {
+            informative[pos] = true;
+          }
+        } else if alphabet.is_ambiguous(state) {
+          informative[pos] = true;
+        }
+      }
+    }
+
+    let informative_positions = informative
+      .into_iter()
+      .enumerate()
+      .filter_map(|(pos, is_informative)| is_informative.then_some(pos))
+      .collect();
+
+    Ok(Self {
+      baseline,
+      informative_positions,
+    })
+  }
+
+  pub(crate) fn baseline(&self) -> &Seq {
+    &self.baseline
+  }
+
+  pub(crate) fn informative_positions(&self) -> &[usize] {
+    &self.informative_positions
+  }
+}
 
 pub fn create_fitch_partition<N, E>(
   graph: &Graph<N, E, ()>,
@@ -62,33 +119,15 @@ where
   E: GraphEdge,
   P: PartitionCompressed,
 {
-  let aln_by_name = aln.iter().fold(BTreeMap::new(), |mut records, record| {
-    records.entry(record.seq_name.as_str()).or_insert(record);
-    records
-  });
-  let leaf_records = graph
-    .get_leaves()
-    .into_par_iter()
-    .map(|leaf| -> Result<_, Report> {
-      let leaf = leaf.read_arc();
-      let leaf_key = leaf.key();
-      let mut leaf_payload = leaf.payload().write_arc();
-      let leaf_name = leaf_payload
-        .name()
-        .ok_or_else(|| {
-          make_report!("Expected all leaf nodes to have names, such that they can be matched to their corresponding sequences. But found a leaf node that has no name.")
-        })?
-        .as_ref()
-        .to_owned();
-      let leaf_fasta = aln_by_name
-        .get(leaf_name.as_str())
-        .copied()
-        // Every leaf has a sequence record after alignment completion.
-        .ok_or_else(|| make_report!("Leaf sequence not found after alignment completion: '{leaf_name}'"))?;
-      leaf_payload.set_desc(leaf_fasta.desc.clone());
-      Ok((leaf_key, leaf_fasta))
-    })
-    .collect::<Result<Vec<_>, Report>>()?;
+  let leaf_records = leaf_records(graph, aln)?;
+
+  leaf_records.par_iter().try_for_each(|(leaf_key, leaf_fasta)| {
+    let leaf = graph
+      .get_node(*leaf_key)
+      .ok_or_else(|| make_report!("Leaf node {leaf_key} disappeared during sequence attachment"))?;
+    leaf.read_arc().payload().write_arc().set_desc(leaf_fasta.desc.clone());
+    Ok::<_, Report>(())
+  })?;
 
   for partition in partitions {
     let alphabet = partition.read_arc().alphabet().clone();
@@ -111,22 +150,60 @@ where
   Ok(())
 }
 
-pub(crate) fn fitch_backward<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<(), Report>
+fn leaf_records<'a, N, E>(
+  graph: &Graph<N, E, ()>,
+  aln: &'a [FastaRecord],
+) -> Result<Vec<(GraphNodeKey, &'a FastaRecord)>, Report>
 where
-  N: GraphNode,
+  N: NodeAncestralOps,
   E: GraphEdge,
-  P: PartitionCompressed,
+{
+  let aln_by_name = aln.iter().fold(BTreeMap::new(), |mut records, record| {
+    records.entry(record.seq_name.as_str()).or_insert(record);
+    records
+  });
+  graph
+    .get_leaves()
+    .into_par_iter()
+    .map(|leaf| -> Result<_, Report> {
+      let leaf = leaf.read_arc();
+      let leaf_key = leaf.key();
+      let leaf_payload = leaf.payload().read_arc();
+      let leaf_name = leaf_payload
+        .name()
+        .ok_or_else(|| {
+          make_report!("Expected all leaf nodes to have names, such that they can be matched to their corresponding sequences. But found a leaf node that has no name.")
+        })?;
+      let leaf_name = leaf_name.as_ref();
+      let leaf_fasta = aln_by_name
+        .get(leaf_name)
+        .copied()
+        .ok_or_else(|| make_report!("Leaf sequence not found after alignment completion: '{leaf_name}'"))?;
+      Ok((leaf_key, leaf_fasta))
+    })
+    .collect()
+}
+
+pub(crate) fn fitch_backward<N, E>(
+  graph: &Graph<N, E, ()>,
+  partitions: &[Arc<RwLock<PartitionFitch>>],
+  aln: &[FastaRecord],
+) -> Result<(), Report>
+where
+  N: NodeAncestralOps,
+  E: GraphEdge,
 {
   for partition in partitions {
     let mut partition = partition.write_arc();
     let alphabet = partition.alphabet().clone();
     let length = partition.length();
+    let site_index = FitchSiteIndex::new(graph, &alphabet, aln)?;
     let (nodes, edges) = partition.storage_mut();
     let mut pass = IndexedPass::new(graph, nodes, edges, |_| Ok(SparseNodePartition::empty(&alphabet)))?;
     let result = pass.try_for_each_backward_frontier(|node_indices, _, _, completed, frontier| {
-      frontier
-        .par_iter_mut()
-        .try_for_each(|slot| run_fitch_backward_indexed(graph, &alphabet, length, node_indices, completed, slot))
+      frontier.par_iter_mut().try_for_each(|slot| {
+        run_fitch_backward_indexed(graph, &alphabet, length, &site_index, node_indices, completed, slot)
+      })
     });
     let (nodes, edges) = pass.into_maps()?;
     *partition.nodes_mut() = nodes;
@@ -140,6 +217,7 @@ fn run_fitch_backward_indexed<N, E>(
   graph: &Graph<N, E, ()>,
   alphabet: &Alphabet,
   length: usize,
+  site_index: &FitchSiteIndex,
   node_indices: &[Option<usize>],
   completed: &[IndexedPassSlot<SparseNodePartition, SparseEdgePartition>],
   slot: &mut IndexedPassSlot<SparseNodePartition, SparseEdgePartition>,
@@ -176,13 +254,12 @@ where
   let non_char = ranges.non_char;
   let unknown = ranges.unknown;
 
-  let mut sequence = seq![FILL_CHAR; length];
+  let mut sequence = site_index.baseline().clone();
   for r in &non_char {
     sequence[r.0..r.1].fill(NON_CHAR);
   }
 
-  let mut variable = resolve_variable_positions_backward(&children, &non_char, &mut sequence);
-  resolve_fixed_positions_backward(&children, alphabet, &mut sequence, &mut variable);
+  let variable = resolve_informative_positions_backward(&children, site_index.informative_positions(), &mut sequence);
 
   let child_unknown: Vec<&Vec<(usize, usize)>> = children.iter().map(|(c, _)| &c.unknown).collect_vec();
   let child_variable_indels: Vec<&_> = children.iter().map(|(c, _)| &c.fitch.variable_indel).collect_vec();
@@ -330,18 +407,17 @@ where
   Ok(())
 }
 
-pub fn compress_sequences<N, E, P>(
+pub fn compress_sequences<N, E>(
   graph: &Graph<N, E, ()>,
-  partitions: &[Arc<RwLock<P>>],
+  partitions: &[Arc<RwLock<PartitionFitch>>],
   aln: &[FastaRecord],
 ) -> Result<(), Report>
 where
   N: NodeAncestralOps,
   E: GraphEdge,
-  P: PartitionCompressed,
 {
   attach_seqs_to_graph(graph, partitions, aln)?;
-  fitch_backward(graph, partitions)?;
+  fitch_backward(graph, partitions, aln)?;
   fitch_forward(graph, partitions)?;
   fitch_cleanup(graph, partitions)
 }

--- a/packages/treetime/src/ancestral/fitch_sub.rs
+++ b/packages/treetime/src/ancestral/fitch_sub.rs
@@ -1,45 +1,41 @@
-use crate::alphabet::alphabet::{Alphabet, FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
+use crate::alphabet::alphabet::{Alphabet, NON_CHAR, VARIABLE_CHAR};
 use crate::partition::sparse::{SparseEdgePartition, SparseSeqInfo};
 use crate::seq::composition::Composition;
 use crate::seq::mutation::Sub;
 use eyre::Report;
 use itertools::Itertools;
 use std::collections::BTreeMap;
-use treetime_primitives::{AlphabetLike, AsciiChar, BitSet128, Seq, StateSet, StateSetStatus, stateset};
+use treetime_primitives::{AlphabetLike, AsciiChar, Seq, StateSet, StateSetStatus};
 use treetime_utils::interval::range::range_contains;
 
-/// Backward pass: resolve variable positions using Fitch parsimony.
+/// Resolve substitution-informative positions during the Fitch backward pass.
 ///
-/// For each position that is variable in at least one child, collects the child
-/// state sets, computes the intersection (or union when the intersection is
-/// empty), and writes the result into `sequence` and the returned variable map.
-///
-/// Positions transmitted along an edge or in `non_char` ranges are skipped.
-pub fn resolve_variable_positions_backward(
+/// The candidate list is complete for substitutions because invariant canonical
+/// columns have one state across all leaves. At each candidate, intersect all
+/// informative child state sets; an empty intersection retains their union,
+/// preserving the existing unordered-character recurrence.
+pub fn resolve_informative_positions_backward(
   children: &[(&SparseSeqInfo, &SparseEdgePartition)],
-  non_char: &[(usize, usize)],
+  informative_positions: &[usize],
   sequence: &mut Seq,
 ) -> BTreeMap<usize, StateSet> {
-  let variable_positions = children
-    .iter()
-    .flat_map(|(c, _)| c.fitch.variable.keys().copied())
-    .unique()
-    .collect_vec();
-
   let mut variable = BTreeMap::new();
 
-  for pos in variable_positions {
-    // Collect child profiles (1D vectors)
+  for &pos in informative_positions {
+    if sequence[pos] == NON_CHAR {
+      continue;
+    }
+
     let child_profiles = children
       .iter()
       .filter_map(|(child, edge)| {
         if let Some(transmission) = &edge.transmission {
           if range_contains(transmission, pos) {
-            return None; // transmission field is not currently used
+            return None;
           }
         }
         if range_contains(&child.non_char, pos) {
-          return None; // this position does not have character state information
+          return None;
         }
         let state = match child.fitch.variable.get(&pos) {
           Some(var_pos) => *var_pos,
@@ -49,18 +45,13 @@ pub fn resolve_variable_positions_backward(
       })
       .collect_vec();
 
-    // Calculate Fitch parsimony.
-    // If we save the states of the children for each position that is variable in the node,
-    // then we would not need the full sequences in the forward pass.
     let intersection = StateSet::from_intersection(&child_profiles);
 
     match intersection.get() {
       StateSetStatus::Unambiguous(state) => {
-        // intersection has a single state, write it
         sequence[pos] = state;
       },
       StateSetStatus::Ambiguous(_) => {
-        // more than one possible states
         variable.insert(pos, intersection);
         sequence[pos] = VARIABLE_CHAR;
       },
@@ -73,37 +64,6 @@ pub fn resolve_variable_positions_backward(
   }
 
   variable
-}
-
-/// Backward pass: resolve fixed positions where children disagree with current parent state.
-///
-/// Scans each child's fixed sequence positions. When a child has a canonical state
-/// that differs from the current parent state, either sets the parent (if still
-/// FILL_CHAR) or promotes the position to variable.
-pub fn resolve_fixed_positions_backward(
-  children: &[(&SparseSeqInfo, &SparseEdgePartition)],
-  alphabet: &Alphabet,
-  sequence: &mut Seq,
-  variable: &mut BTreeMap<usize, StateSet>,
-) {
-  for &(child, _) in children {
-    for (pos, parent_state) in sequence.iter_mut().enumerate() {
-      let child_state = child.sequence[pos];
-      if *parent_state == child_state || *parent_state == NON_CHAR {
-        continue; // if parent is equal to child state or we know it's a non-char, skip
-      }
-      if alphabet.is_canonical(child_state) {
-        if *parent_state == FILL_CHAR {
-          // if child state is canonical and parent is still FILL_CHAR, set parent_state
-          *parent_state = child_state;
-        } else {
-          // otherwise set or update the variable state
-          *variable.entry(pos).or_insert_with(|| stateset! {*parent_state}) += child_state;
-          *parent_state = VARIABLE_CHAR;
-        }
-      }
-    }
-  }
 }
 
 /// Forward pass: resolve variable substitution states at the root.


### PR DESCRIPTION
Fitch maximum parsimony traverses every alignment column at every internal node, but most columns are invariant across all leaves and contribute no substitution signal. The backward and forward passes spend time intersecting identical singleton state sets at positions where the outcome is predetermined.

`FitchSiteIndex` classifies alignment columns once during partition construction by scanning graph-matched leaf states. Columns where all leaves share the same canonical state are captured in a dense baseline sequence. The Fitch recurrence then visits only the remaining informative positions -- those where leaf states disagree or carry ambiguity. Internal nodes clone the baseline and restrict child-state intersection/union to candidate columns only.

The optimization reduces single-threaded work but introduces a serial classification pass that limits parallel scaling. At one thread, `ancestral` improves by 3.6%. At 8+ threads, the serial fraction dominates and `ancestral` regresses by 16%, propagating to `optimize` and `timetree`. The implementation needs a parallel classification strategy before it is performance-positive across all thread counts. Full benchmark results in the [performance report](https://github.com/neherlab/treetime/blob/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/reports/2026-07-13_perf-report-parallel-scaling/mpox-2000-fitch-informative-positions.md).

### Paired comparison (baseline vs changed)

![Paired comparison](https://github.com/neherlab/treetime/raw/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_paired-comparison.svg)

### CPU utilization

![CPU utilization](https://github.com/neherlab/treetime/raw/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/reports/2026-07-13_perf-report-parallel-scaling/assets/mpox-2000-fitch-informative-positions_cpu-utilization.svg)

`ancestral` reaches only 1.85 cores at 16 threads, confirming the serial site-classification pass as the scaling bottleneck.

### Work items

- [x] Add `FitchSiteIndex` to classify baseline and informative positions from leaf states
- [x] Restrict `fitch_backward` / `fitch_forward` recurrence to informative columns, cloning baseline for internal nodes
- [x] Add property tests: exhaustive binary-tree score, column-permutation invariance, invariant-column insertion identity, reroot score stability
- [x] Add criterion benchmark for Fitch scaling across alignment length, informative-site density, and tree topology
- [x] Use standard build environment for benchmarks instead of test linker flags
- [x] Add `--host` flag to `dev/bench-graph-pass-cli` for host-kernel runtime measurements
- [x] File issue: [M-ancestral-fitch-polytomy-recurrence-not-minimum.md](https://github.com/neherlab/treetime/blob/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md): all-child intersection/union recurrence does not minimize mutations at multifurcations
- [x] File issue: [N-ancestral-fitch-empty-transmission-state-set.md](https://github.com/neherlab/treetime/blob/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/issues/N-ancestral-fitch-empty-transmission-state-set.md): transmission filtering can produce an empty state set (dormant)

### Possible improvements

- [ ] Parallelize site classification to eliminate the serial bottleneck ([M-ancestral-fitch-polytomy-recurrence-not-minimum.md](https://github.com/neherlab/treetime/blob/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md))
- [ ] Use exact finite-state cost recurrence for multifurcating nodes ([M-ancestral-fitch-polytomy-recurrence-not-minimum.md](https://github.com/neherlab/treetime/blob/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md))
- [ ] Define transmission semantics for Fitch substitution states ([N-ancestral-fitch-empty-transmission-state-set.md](https://github.com/neherlab/treetime/blob/20164657c95d853f15e1a5dc7d8955c6134798ce/kb/issues/N-ancestral-fitch-empty-transmission-state-set.md))