### PR TITLE
feat: publish nightly CLI builds

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,6 +11,22 @@ on:
   workflow_dispatch:
 
   workflow_call:
+    inputs:
+      source_ref:
+        description: "Immutable source commit to build"
+        required: false
+        type: string
+        default: ""
+      build_mode:
+        description: "CLI build version mode: dev, nightly, or release"
+        required: false
+        type: string
+        default: "dev"
+      version_suffix:
+        description: "Version suffix for TREETIME_VERSION_SUFFIX (e.g. nightly.20260714T043012Z+a1b2c3d)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: cli-${{ github.workflow }}-${{ github.ref_type }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
@@ -21,7 +37,8 @@ defaults:
     shell: bash -euo pipefail {0}
 
 env:
-  GITHUB_REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  TREETIME_BUILD_MODE: ${{ inputs.build_mode || 'dev' }}
+  TREETIME_VERSION_SUFFIX: ${{ inputs.version_suffix }}
   VERBOSE: 1
 
 
@@ -48,6 +65,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 1
           submodules: true
           lfs: true
@@ -107,6 +125,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 1
           submodules: true
           lfs: true
@@ -160,6 +179,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 1
           submodules: true
           lfs: true
@@ -238,6 +258,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 1
           submodules: true
           lfs: true
@@ -263,6 +284,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 1
           submodules: true
           lfs: true
@@ -371,6 +393,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.source_ref || github.sha }}
           fetch-depth: 1
           submodules: true
           lfs: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,82 @@
+on:
+  workflow_call:
+    inputs:
+      force:
+        description: "Build even when rust has not changed since the latest nightly"
+        required: false
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  prepare:
+    name: "Resolve rust revision"
+    runs-on: ubuntu-24.04
+    outputs:
+      should_build: ${{ steps.prepare.outputs.should_build }}
+      source_sha: ${{ steps.prepare.outputs.source_sha }}
+      version_suffix: ${{ steps.prepare.outputs.version_suffix }}
+    steps:
+      - name: "Resolve version"
+        id: prepare
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          source_sha=$(gh api "repos/${GITHUB_REPOSITORY}/commits/rust" --jq '.sha')
+          short_sha="${source_sha:0:7}"
+          latest_tag=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 --json tagName --jq '[.[] | select(.tagName | contains("-nightly."))][0].tagName // ""')
+
+          should_build=true
+          if [[ "${{ inputs.force }}" != "true" && -n "${latest_tag}" && "${latest_tag}" == *"+${short_sha}" ]]; then
+            should_build=false
+          fi
+
+          timestamp=$(date -u "+%Y%m%dT%H%M%SZ")
+          version_suffix="nightly.${timestamp}+${short_sha}"
+
+          printf "Source: %s\nVersion suffix: %s\nBuild: %s\n" "${source_sha}" "${version_suffix}" "${should_build}"
+          printf "should_build=%s\nsource_sha=%s\nversion_suffix=%s\n" \
+            "${should_build}" "${source_sha}" "${version_suffix}" >> "${GITHUB_OUTPUT}"
+
+  build-and-test:
+    name: "Build and test"
+    needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
+    uses: neherlab/treetime/.github/workflows/cli.yml@rust
+    with:
+      source_ref: ${{ needs.prepare.outputs.source_sha }}
+      build_mode: nightly
+      version_suffix: ${{ needs.prepare.outputs.version_suffix }}
+    secrets: inherit
+
+  publish:
+    name: "Publish nightly release"
+    needs: [prepare, build-and-test]
+    if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Checkout rust revision"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          fetch-depth: 0
+
+      - name: "Download build artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "treetime-*"
+          merge-multiple: true
+          path: ".out"
+
+      - name: "Publish nightly release"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          chmod +x ./.out/*
+          ./dev/publish-nightly \
+            --artifacts_dir ".out" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --git_sha "${{ needs.prepare.outputs.source_sha }}"

--- a/dev/docker/run
+++ b/dev/docker/run
@@ -9,7 +9,6 @@ load_env "$(project_root)/.env.example"
 
 CROSS_COMPILE="${CROSS_COMPILE:-"native"}"
 PROJECT_DOCKER_REPO="${PROJECT_DOCKER_BUILDER_REPO:?}"
-
 USER="user"
 GROUP="user"
 
@@ -177,6 +176,11 @@ declare -A volumes=(
   ["${cache_dir}/jupyter"]="/home/${USER}/.jupyter"
 )
 
+git_common_dir=$(git rev-parse --path-format=absolute --git-common-dir)
+if [[ "${git_common_dir}" != "$(pwd)/.git" ]]; then
+  volumes["${git_common_dir}"]="${git_common_dir}"
+fi
+
 declare -A sccache_env=()
 if [[ "${SCCACHE_ENABLED:-true}" == "true" ]]; then
   sccache_env=(
@@ -199,6 +203,14 @@ if [[ "${SCCACHE_ENABLED:-true}" == "true" ]]; then
 fi
 
 mkdir -p "${!volumes[@]}"
+
+version_flags=()
+if [[ -n "${TREETIME_BUILD_MODE+x}" ]]; then
+  version_flags+=(--env="TREETIME_BUILD_MODE=${TREETIME_BUILD_MODE}")
+fi
+if [[ -n "${TREETIME_VERSION_SUFFIX+x}" ]]; then
+  version_flags+=(--env="TREETIME_VERSION_SUFFIX=${TREETIME_VERSION_SUFFIX}")
+fi
 
 x11_flags=()
 if [[ -n "${DISPLAY:-}" ]]; then
@@ -233,6 +245,7 @@ docker run --rm -i $(tty -s && echo "-t") \
   --env="TURBO_TELEMETRY_DISABLED=1" \
   --env="electron_config_cache=/workdir/.cache/electron" \
   $(for key in "${!sccache_env[@]}"; do echo "--env=${key}=${sccache_env[$key]}"; done) \
+  "${version_flags[@]}" \
   "${x11_flags[@]}" \
   --ulimit="core=0" \
   "${PROJECT_DOCKER_REPO}:${docker_image_tag}" \

--- a/dev/publish-nightly
+++ b/dev/publish-nightly
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# Usage: $0 [options]
+#
+# Upload CLI artifacts as a nightly pre-release in the source repository.
+# The release tag is read from the Linux binary so both versions are identical.
+#
+# Options:
+#   -h, --help                Show this help
+#   --artifacts_dir <dir>     Directory containing build artifacts
+#   --repo <owner/repo>       GitHub repository for the release
+#   --git_sha <sha>           Source commit SHA
+#
+# Environment:
+#   GITHUB_TOKEN    GitHub token with contents:write for the repository.
+#
+set -euo pipefail
+trap "exit" INT
+
+find_last_nightly_sha() {
+  local repo="${1}"
+  local last_tag
+  last_tag=$(gh release list --repo "${repo}" --limit 100 --json tagName --jq '[.[] | select(.tagName | contains("-nightly."))][0].tagName // ""')
+  [[ -n "${last_tag}" ]] || return
+
+  local abbreviated_sha="${last_tag##*+}"
+  [[ "${abbreviated_sha}" != "${last_tag}" ]] || return
+  if ! git rev-parse "${abbreviated_sha}^{commit}"; then
+    printf "Unable to resolve previous nightly source: %s\n" "${abbreviated_sha}" >&2
+    return 1
+  fi
+}
+
+generate_release_notes() {
+  local repo="${1}"
+  local git_sha="${2}"
+  local short_sha="${3}"
+  local last_sha="${4:-}"
+
+  cat <<EOF
+Nightly pre-release build of [treetime](https://github.com/${repo}).
+
+**Source**: [\`${short_sha}\`](https://github.com/${repo}/commit/${git_sha})
+
+> [!WARNING]
+> Automated nightly build for early testing. May contain bugs and breaking changes.
+EOF
+
+  [[ -n "${last_sha}" ]] || return
+
+  printf "\n**Compare**: [\`%s...%s\`](https://github.com/%s/compare/%s...%s)\n" \
+    "${last_sha:0:7}" "${short_sha}" "${repo}" "${last_sha}" "${git_sha}"
+
+  local last_commit_date
+  last_commit_date=$(git show -s --format='%aI' "${last_sha}")
+
+  local pr_json
+  pr_json=$(gh pr list --repo "${repo}" --state merged --base rust --limit 100 \
+    --json number,title,mergeCommit,mergedAt \
+    --jq "[.[] | select(.mergedAt > \"${last_commit_date}\")]")
+
+  if (( $(jq 'length' <<< "${pr_json}") > 0 )); then
+    printf "\n## Pull requests\n\n| PR | Title |\n|---|---|\n"
+    jq -r ".[] | \"| [#\\(.number)](https://github.com/${repo}/pull/\\(.number)) | \\(.title | gsub(\"[|]\"; \"\\\\|\")) |\"" <<< "${pr_json}"
+  fi
+
+  local pr_shas
+  pr_shas=$(jq -r '.[].mergeCommit.oid // empty' <<< "${pr_json}")
+  local all_commits
+  all_commits=$(git log --format='%H %s' "${last_sha}..${git_sha}")
+  local orphan_table=""
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    local commit_sha="${line%% *}"
+    local commit_msg="${line#* }"
+    if [[ -z "${pr_shas}" ]] || ! grep -qF "${commit_sha}" <<< "${pr_shas}"; then
+      orphan_table+="| [\`${commit_sha:0:7}\`](https://github.com/${repo}/commit/${commit_sha}) | ${commit_msg//|/\\|} |"$'\n'
+    fi
+  done <<< "${all_commits}"
+
+  if [[ -n "${orphan_table}" ]]; then
+    printf "\n## Commits not in any PR\n\n| Commit | Message |\n|---|---|\n%s" "${orphan_table}"
+  fi
+}
+
+main() {
+  show_help() {
+    sed -n '2,${/^#/!q; s/^# \?//p}' "${BASH_SOURCE[0]}" | sed "s|\$0|${0##*/}|g"
+  }
+
+  local artifacts_dir=""
+  local repo=""
+  local git_sha=""
+
+  # shfmt:off
+  while (( $# > 0 )); do
+    case "${1}" in
+      -h|--help) show_help; exit 0 ;;
+      --artifacts_dir) artifacts_dir="${2}"; shift 2 ;;
+      --repo) repo="${2}"; shift 2 ;;
+      --git_sha) git_sha="${2}"; shift 2 ;;
+      --) shift; break ;;
+      -*) printf "Unknown option: %s\n" "${1}" >&2; exit 1 ;;
+      *) break ;;
+    esac
+  done
+  # shfmt:on
+
+  local dependency
+  for dependency in gh git jq; do
+    command -v "${dependency}" >/dev/null || { printf "Required command not found: %s\n" "${dependency}" >&2; exit 1; }
+  done
+  : "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+  [[ -d "${artifacts_dir}" ]] || { printf "Artifact directory does not exist: %s\n" "${artifacts_dir}" >&2; exit 1; }
+  [[ -n "${repo}" ]] || { printf "--repo is required\n" >&2; exit 1; }
+  [[ -n "${git_sha}" ]] || { printf "--git_sha is required\n" >&2; exit 1; }
+
+  local artifacts=()
+  local artifact
+  for artifact in "${artifacts_dir}"/*; do
+    [[ -f "${artifact}" ]] && artifacts+=("${artifact}")
+  done
+  (( ${#artifacts[@]} > 0 )) || { printf "No artifacts found in: %s\n" "${artifacts_dir}" >&2; exit 1; }
+
+  local binary="${artifacts_dir}/treetime-x86_64-unknown-linux-gnu"
+  [[ -x "${binary}" ]] || { printf "Runnable Linux artifact not found: %s\n" "${binary}" >&2; exit 1; }
+  local version_output
+  version_output=$("${binary}" --version)
+  local version="${version_output#treetime }"
+  [[ "${version}" != "${version_output}" ]] || { printf "Unexpected version output: %s\n" "${version_output}" >&2; exit 1; }
+
+  local short_sha="${git_sha:0:7}"
+  [[ "${version}" == *"+${short_sha}" ]] || { printf "Version does not identify source %s: %s\n" "${short_sha}" "${version}" >&2; exit 1; }
+
+  local last_sha
+  last_sha=$(find_last_nightly_sha "${repo}")
+  printf "Creating nightly release: %s\n" "${version}"
+  generate_release_notes "${repo}" "${git_sha}" "${short_sha}" "${last_sha}" |
+    gh release create "${version}" \
+      --repo "${repo}" \
+      --target "${git_sha}" \
+      --title "${version}" \
+      --prerelease \
+      --notes-file - \
+      "${artifacts[@]}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/dev/trigger-nightly
+++ b/dev/trigger-nightly
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Usage: $0 [options]
+#
+# Trigger a nightly build and release via GitHub Actions.
+#
+# Dispatches the default-branch scheduler, which builds rust and publishes
+# binaries in the source repository.
+#
+# Options:
+#   -h, --help    Show this help
+#
+# Environment:
+#   GH_TOKEN or GITHUB_TOKEN must be set for gh authentication.
+#
+# Examples:
+#   $0
+#
+set -euo pipefail
+trap "exit" INT
+
+THIS_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
+main() {
+  show_help() {
+    sed -n '2,${/^#/!q; s/^# \?//p}' "${BASH_SOURCE[0]}" | sed "s|\$0|${0##*/}|g"
+  }
+
+  [[ "${1:-}" =~ ^(-h|--help)$ ]] && { show_help; exit 0; }
+
+  local source_repo
+  source_repo=$(git -C "${THIS_DIR}" remote get-url origin | sed 's|.*github\.com[:/]||; s|\.git$||')
+
+  command -v gh >/dev/null || { printf "Required command not found: gh\n" >&2; exit 1; }
+  command -v git >/dev/null || { printf "Required command not found: git\n" >&2; exit 1; }
+
+  printf "Triggering nightly workflow in %s\n" "${source_repo}"
+  gh workflow run schedule-nightly.yml --repo "${source_repo}"
+  printf "Workflow dispatched. Monitor at: https://github.com/%s/actions/workflows/schedule-nightly.yml\n" "${source_repo}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/docs/dev/developer_guide.md
+++ b/docs/dev/developer_guide.md
@@ -283,12 +283,46 @@ Note that dependency upgrades can cause breakage. The upgraded dependencies need
 
 ### Versioning
 
-TODO
+The workspace version in `Cargo.toml` tracks the base release version (e.g. `1.0.0`). Nightly builds append a prerelease suffix: `1.0.0-nightly.20260714T043012Z+a1b2c3d`.
 
 ### Releases
 
-TODO
+#### Stable releases
+
+Not yet configured. The `dev/publish-github` script and the commented-out `publish-to-github-releases` job in `.github/workflows/cli.yml` are prepared for this.
+
+#### Nightly releases
+
+Automated pre-release builds are published in [neherlab/treetime](https://github.com/neherlab/treetime/releases) for early testing. Binaries for all 7 cross-compilation targets are attached to each release.
+
+**Schedule**: daily at 04:00 UTC via `.github/workflows/schedule-nightly.yml` on the default branch. The dispatcher calls `.github/workflows/nightly.yml` on `rust` and skips if no new Rust commits exist since the last nightly.
+
+**Manual trigger**:
+
+```bash
+./dev/trigger-nightly
+```
+
+This dispatches `schedule-nightly.yml` via `gh workflow run`. Requires `GH_TOKEN` or `gh auth login`.
+
+**Version format**: `<cargo-version>-nightly.<YYYYMMDD>T<HHMMSS>Z+<short-sha>` (e.g. `1.0.0-nightly.20260714T043012Z+a1b2c3d`). Always marked as prerelease.
+
+**How it works**:
+
+1. `schedule-nightly.yml` on `master` calls `nightly.yml` on `rust`
+2. `nightly.yml` resolves the current `rust` commit and calls `cli.yml` for the full build and validation matrix
+3. `dev/publish-nightly` creates a prerelease in `neherlab/treetime` with all binaries attached
+
+**Authentication**: the dispatcher grants `contents: write` to the repository's standard `GITHUB_TOKEN`. Nightly builds do not publish TreeTime Docker images; the reused CLI workflow retains its existing Docker builder-image cache.
 
 ### Continuous Integration (CI), Packaging, and Distribution
 
-TODO
+CI runs on every push to `rust` and on pull requests via `.github/workflows/cli.yml`:
+
+- Cross-compilation for 7 targets (Linux gnu/musl, macOS, Windows)
+- Unit tests
+- Clippy lints
+- Compatibility tests on native macOS, Windows, and Linux runners
+- CLI documentation freshness check
+
+The Rust nightly workflow (`.github/workflows/nightly.yml`) reuses `cli.yml` via `workflow_call` and adds a publish step.

--- a/packages/app-cli/build.rs
+++ b/packages/app-cli/build.rs
@@ -1,11 +1,91 @@
-use std::path::PathBuf;
+use std::env;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 use treetime_schema::{TreetimeSchemaFormat, generate_schema};
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
   println!("cargo:rerun-if-changed=../treetime/src");
 
   let out_dir = PathBuf::from("../app-contracts/src/generated");
   if let Err(err) = generate_schema(&TreetimeSchemaFormat::All, Some(&out_dir)) {
     eprintln!("cargo:warning=Schema generation failed: {err}");
   }
+
+  emit_long_version()?;
+  Ok(())
+}
+
+fn emit_long_version() -> Result<(), Box<dyn Error>> {
+  println!("cargo:rerun-if-env-changed=TREETIME_BUILD_MODE");
+  println!("cargo:rerun-if-env-changed=TREETIME_VERSION_SUFFIX");
+  emit_git_dependency("HEAD")?;
+  emit_git_dependency("index")?;
+
+  let symbolic_ref = git_output(&["symbolic-ref", "--quiet", "HEAD"])?;
+  if symbolic_ref.status.success() {
+    emit_git_dependency(&output_stdout(&symbolic_ref)?)?;
+  } else if symbolic_ref.status.code() != Some(1) {
+    return Err(command_error("git symbolic-ref --quiet HEAD", &symbolic_ref).into());
+  }
+
+  let base = env!("CARGO_PKG_VERSION");
+  let mode = env::var("TREETIME_BUILD_MODE").unwrap_or_else(|_| "dev".to_owned());
+  let suffix = env::var("TREETIME_VERSION_SUFFIX")
+    .ok()
+    .filter(|suffix| !suffix.is_empty());
+  let short_sha = git_stdout(&["rev-parse", "--short", "HEAD"])?;
+  let dirty = if git_stdout(&["status", "--porcelain"])?.is_empty() {
+    ""
+  } else {
+    ".dirty"
+  };
+
+  let long_version = match (mode.as_str(), suffix) {
+    ("dev", None) => format!("{base}-dev+{short_sha}{dirty}"),
+    ("nightly", Some(suffix)) => format!("{base}-{suffix}"),
+    ("release", None) => base.to_owned(),
+    ("dev" | "release", Some(_)) => {
+      return Err(format!("TREETIME_VERSION_SUFFIX is invalid for {mode} builds").into());
+    },
+    ("nightly", None) => {
+      return Err("TREETIME_VERSION_SUFFIX is required for nightly builds".into());
+    },
+    _ => return Err(format!("Unknown TREETIME_BUILD_MODE: {mode}").into()),
+  };
+
+  println!("cargo:rustc-env=TREETIME_LONG_VERSION={long_version}");
+  Ok(())
+}
+
+fn emit_git_dependency(path: &str) -> Result<(), Box<dyn Error>> {
+  let path = git_stdout(&["rev-parse", "--path-format=absolute", "--git-path", path])?;
+  if Path::new(&path).exists() {
+    println!("cargo:rerun-if-changed={path}");
+  }
+  Ok(())
+}
+
+fn git_stdout(args: &[&str]) -> Result<String, Box<dyn Error>> {
+  let output = git_output(args)?;
+  if !output.status.success() {
+    return Err(command_error(&format!("git {}", args.join(" ")), &output).into());
+  }
+  Ok(output_stdout(&output)?)
+}
+
+fn git_output(args: &[&str]) -> Result<Output, std::io::Error> {
+  Command::new("git").args(args).output()
+}
+
+fn output_stdout(output: &Output) -> Result<String, std::str::Utf8Error> {
+  Ok(std::str::from_utf8(&output.stdout)?.trim().to_owned())
+}
+
+fn command_error(command: &str, output: &Output) -> String {
+  format!(
+    "{command} failed with {}: {}",
+    output.status,
+    String::from_utf8_lossy(&output.stderr).trim()
+  )
 }


### PR DESCRIPTION
The Rust CLI has no automated prerelease channel. Scheduled workflows must originate from the default branch, while `master` must continue to serve Python TreeTime 0.x and Rust development remains on `rust`.

Add a reusable nightly implementation on `rust` that resolves one immutable source revision, runs the existing CLI build matrix, and publishes prereleases in the source repository with its standard token. Explicit build modes keep nightly identity separate from development and stable builds.

Use the version reported by the built Linux binary as the release tag. This keeps artifacts and GitHub releases tied to the same source and prevents partial publication when artifact or source validation fails.


### Work items

- [x] Embed explicit development, nightly, and release build identities.
- [x] Build every target from the resolved `rust` commit.
- [x] Publish same-repository prereleases with validated artifacts and release notes.
- [x] Support manual dispatch through the default-branch scheduler.
- [x] Document nightly operation and authentication.
