### PR TITLE
chore: schedule nightly CLI releases

### DIFF
--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -1,0 +1,17 @@
+name: "Nightly CLI"
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    uses: neherlab/treetime/.github/workflows/nightly.yml@rust
+    with:
+      force: ${{ github.event_name == 'workflow_dispatch' }}
+    secrets: inherit


### PR DESCRIPTION
- Depends on: #836

GitHub only runs scheduled workflows from the repository's default branch, while the Rust release implementation lives on the rust branch.

Add a narrow default-branch dispatcher that invokes the reusable Rust workflow with repository release permission. Manual dispatch forces a build; scheduled runs let the Rust workflow skip unchanged revisions.

### Work items

- [x] Schedule the nightly CLI workflow from master.
- [x] Allow manual runs to force publication.
