### PR TITLE
refactor(coalescent): retire the overloaded multiplicity

### DIFF
--- a/packages/treetime/src/coalescent/coalescent.rs
+++ b/packages/treetime/src/coalescent/coalescent.rs
@@ -46,9 +46,9 @@ impl CoalescentModel {
   }
 
   pub fn internal_cost(&self, time: f64, n_children: usize) -> Result<f64, Report> {
-    let multiplicity = n_children.saturating_sub(1) as f64;
+    let n_mergers = n_children.saturating_sub(1) as f64;
     let total_rate = self.total_rate(time)?;
-    Ok(multiplicity * (self.cumulative_branch_rate.eval(time) - total_rate.ln()))
+    Ok(n_mergers * (self.cumulative_branch_rate.eval(time) - total_rate.ln()))
   }
 
   pub fn root_cost(&self, time: f64, n_children: usize) -> Result<f64, Report> {
@@ -59,7 +59,8 @@ impl CoalescentModel {
     let parent_time = edge.parent_time().value();
     let child_time = edge.child_time().value();
     let survival_cost = self.cumulative_branch_rate.eval(parent_time) - self.cumulative_branch_rate.eval(child_time);
-    let merger_credit = self.total_rate(parent_time)?.ln() * (edge.multiplicity() - 1.0) / edge.multiplicity();
+    let n_children = edge.n_children();
+    let merger_credit = self.total_rate(parent_time)?.ln() * (n_children - 1.0) / n_children;
     Ok(survival_cost - merger_credit)
   }
 

--- a/packages/treetime/src/coalescent/edge_data.rs
+++ b/packages/treetime/src/coalescent/edge_data.rs
@@ -8,20 +8,20 @@ use treetime_graph::graph::Graph;
 use treetime_graph::node::GraphNode;
 use treetime_utils::make_error;
 
-/// Per-edge inferred calendar dates and parent merger multiplicity.
+/// Per-edge inferred calendar dates and the parent node's child count.
 #[derive(Clone, Debug)]
 pub struct CoalescentEdgeData {
   child_time: CalendarTime,
   parent_time: CalendarTime,
-  multiplicity: f64,
+  n_children: f64,
 }
 
 impl CoalescentEdgeData {
-  pub fn new(child_time: CalendarTime, parent_time: CalendarTime, multiplicity: f64) -> Self {
+  pub fn new(child_time: CalendarTime, parent_time: CalendarTime, n_children: f64) -> Self {
     Self {
       child_time,
       parent_time,
-      multiplicity,
+      n_children,
     }
   }
 
@@ -33,8 +33,9 @@ impl CoalescentEdgeData {
     self.parent_time
   }
 
-  pub fn multiplicity(&self) -> f64 {
-    self.multiplicity
+  /// Number of children of the edge's parent node (merger events = `n_children - 1`).
+  pub fn n_children(&self) -> f64 {
+    self.n_children
   }
 }
 
@@ -88,13 +89,13 @@ where
       );
     }
 
-    let multiplicity = graph
+    let n_children = graph
       .get_node(parent_node_key)
       .map_or(2.0, |parent| parent.read_arc().outbound().len() as f64);
     edges.push(CoalescentEdgeData::new(
       CalendarTime::new(child_time),
       CalendarTime::new(parent_time),
-      multiplicity,
+      n_children,
     ));
     Ok(())
   })?;


### PR DESCRIPTION
`refactor/coalescent-merger-count-name` -> `refactor/remove-unused-coalescent-merger-rates`

`multiplicity` meant child count on edges and merger count (children minus one) in per-node costs. In v0, the same variable serves both meanings.

Edges now expose `n_children` [[src](https://github.com/neherlab/treetime/blob/1c711afef96fba3181a9e2de0a975f3f4d041140/packages/treetime/src/coalescent/edge_data.rs#L37)], and per-node costs derive `n_mergers = n_children - 1` locally.

### Work items

- [x] Rename `multiplicity` to `n_children` in `CoalescentEdgeData` [[src](https://github.com/neherlab/treetime/blob/1c711afef96fba3181a9e2de0a975f3f4d041140/packages/treetime/src/coalescent/edge_data.rs#L13)] and its accessors.
- [x] Derive `n_mergers = n_children - 1` locally in per-node cost formulas.


