### PR TITLE
refactor(coalescent): name cost functions by their contribution role

### DIFF
--- a/packages/treetime/examples/coalescent_validation.rs
+++ b/packages/treetime/examples/coalescent_validation.rs
@@ -313,9 +313,9 @@ fn run_coalescent_test(_snapshot_filename: &str, snapshot: Snapshot) -> Result<T
         .iter()
         .map(|&time| {
           if n_children == 0 {
-            Ok(model.leaf_cost(time))
+            Ok(model.leaf_contribution(time))
           } else {
-            model.internal_cost(time, n_children)
+            model.internal_contribution(time, n_children)
           }
         })
         .collect::<Result<Vec<_>, Report>>()?;

--- a/packages/treetime/src/coalescent/__tests__/test_coalescent_model.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_coalescent_model.rs
@@ -17,9 +17,13 @@ mod tests {
     let model = model(array![0.0, 5.0, 10.0], array![1.0, 2.0, 3.0, 0.0], 2.0)?;
 
     // Analytical oracle: κ=1/4 on [0,5], κ=1/2 on [5,10].
-    pretty_assert_ulps_eq!(-3.75, model.leaf_cost(0.0), max_ulps = 4);
-    pretty_assert_abs_diff_eq!(2.5 - 1.5_f64.ln(), model.internal_cost(5.0, 2)?, epsilon = 1e-10);
-    pretty_assert_abs_diff_eq!(7.5 - 0.5_f64.ln(), model.root_cost(0.0, 2)?, epsilon = 1e-10);
+    pretty_assert_ulps_eq!(-3.75, model.leaf_contribution(0.0), max_ulps = 4);
+    pretty_assert_abs_diff_eq!(
+      2.5 - 1.5_f64.ln(),
+      model.internal_contribution(5.0, 2)?,
+      epsilon = 1e-10
+    );
+    pretty_assert_abs_diff_eq!(7.5 - 0.5_f64.ln(), model.root_contribution(0.0, 2)?, epsilon = 1e-10);
     Ok(())
   }
 
@@ -104,9 +108,9 @@ mod tests {
         n_children as f64,
       );
 
-      let node_cost = model.root_cost(root_time, n_children).unwrap()
-        + n_children as f64 * model.leaf_cost(child_time);
-      let edge_cost = n_children as f64 * model.edge_cost(&edge).unwrap();
+      let node_cost = model.root_contribution(root_time, n_children).unwrap()
+        + n_children as f64 * model.leaf_contribution(child_time);
+      let edge_cost = n_children as f64 * model.edge_contribution(&edge).unwrap();
 
       // Algebraic oracle: telescoping branch survival leaves the grouped
       // leaf/internal/root objective exactly (Kingman 1982).

--- a/packages/treetime/src/coalescent/__tests__/test_gm_coalescent.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_gm_coalescent.rs
@@ -65,9 +65,9 @@ mod tests {
           .iter()
           .map(|&time| {
             if n_children == 0 {
-              Ok(model.leaf_cost(time))
+              Ok(model.leaf_contribution(time))
             } else {
-              model.internal_cost(time, n_children)
+              model.internal_contribution(time, n_children)
             }
           })
           .collect::<Result<Vec<_>, Report>>()?;

--- a/packages/treetime/src/coalescent/__tests__/test_total_lh.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_total_lh.rs
@@ -93,7 +93,7 @@ mod tests {
 
   #[test]
   fn test_total_lh_matches_optimize_tc_likelihood() -> Result<(), Report> {
-    // Both code paths call sum_coalescent_cost() with identical inputs for
+    // Both code paths call coalescent_log_likelihood() with identical inputs for
     // constant Tc. Results should agree to machine precision.
     let graph = setup_graph()?;
     let opt = optimize_tc(&graph, 1.0)?;

--- a/packages/treetime/src/coalescent/coalescent.rs
+++ b/packages/treetime/src/coalescent/coalescent.rs
@@ -54,31 +54,36 @@ impl CoalescentModel {
     })
   }
 
-  pub fn leaf_cost(&self, time: f64) -> f64 {
+  // Per-node and per-edge additive terms of the Kingman coalescent objective,
+  // matching v0's signed `node_contribution`. Each is the term's contribution to
+  // the coalescent cost (negative log-likelihood); a value can be negative, as a
+  // leaf's branch-survival credit is. `coalescent_log_likelihood` sums the edge
+  // contributions and negates the total.
+  pub fn leaf_contribution(&self, time: f64) -> f64 {
     -self.expected_mergers.eval(time)
   }
 
-  pub fn internal_cost(&self, time: f64, n_children: usize) -> Result<f64, Report> {
+  pub fn internal_contribution(&self, time: f64, n_children: usize) -> Result<f64, Report> {
     let n_mergers = n_children.saturating_sub(1) as f64;
     let total_merger_rate = self.total_merger_rate(time)?;
     Ok(n_mergers * (self.expected_mergers.eval(time) - total_merger_rate.ln()))
   }
 
-  pub fn root_cost(&self, time: f64, n_children: usize) -> Result<f64, Report> {
-    Ok(self.internal_cost(time, n_children)? + self.expected_mergers.eval(time))
+  pub fn root_contribution(&self, time: f64, n_children: usize) -> Result<f64, Report> {
+    Ok(self.internal_contribution(time, n_children)? + self.expected_mergers.eval(time))
   }
 
-  pub(crate) fn edge_cost(&self, edge: &CoalescentEdgeData) -> Result<f64, Report> {
+  pub(crate) fn edge_contribution(&self, edge: &CoalescentEdgeData) -> Result<f64, Report> {
     let parent_time = edge.parent_time().value();
     let child_time = edge.child_time().value();
-    let survival_cost = self.expected_mergers.eval(parent_time) - self.expected_mergers.eval(child_time);
+    let survival_term = self.expected_mergers.eval(parent_time) - self.expected_mergers.eval(child_time);
     let n_children = edge.n_children();
     let merger_credit = self.total_merger_rate(parent_time)?.ln() * (n_children - 1.0) / n_children;
-    Ok(survival_cost - merger_credit)
+    Ok(survival_term - merger_credit)
   }
 
   pub(crate) fn apply_leaf_cost(&self, distribution: &Distribution) -> Result<Distribution, Report> {
-    self.apply_cost(distribution, |time| Ok(self.leaf_cost(time)))
+    self.apply_cost(distribution, |time| Ok(self.leaf_contribution(time)))
   }
 
   pub(crate) fn apply_internal_cost(
@@ -86,11 +91,11 @@ impl CoalescentModel {
     distribution: &Distribution,
     n_children: usize,
   ) -> Result<Distribution, Report> {
-    self.apply_cost(distribution, |time| self.internal_cost(time, n_children))
+    self.apply_cost(distribution, |time| self.internal_contribution(time, n_children))
   }
 
   pub(crate) fn apply_root_cost(&self, distribution: &Distribution, n_children: usize) -> Result<Distribution, Report> {
-    self.apply_cost(distribution, |time| self.root_cost(time, n_children))
+    self.apply_cost(distribution, |time| self.root_contribution(time, n_children))
   }
 
   fn total_merger_rate(&self, time: f64) -> Result<f64, Report> {

--- a/packages/treetime/src/coalescent/edge_data.rs
+++ b/packages/treetime/src/coalescent/edge_data.rs
@@ -103,11 +103,12 @@ where
   Ok(edges)
 }
 
-/// Sums the shared model's endpoint-derived edge costs and returns log-likelihood.
-pub fn sum_coalescent_cost(edges: &[CoalescentEdgeData], model: &CoalescentModel) -> Result<f64, Report> {
-  let total_cost = edges
+/// Sums the shared model's endpoint-derived edge contributions and negates to
+/// return the coalescent log-likelihood (higher is more likely).
+pub fn coalescent_log_likelihood(edges: &[CoalescentEdgeData], model: &CoalescentModel) -> Result<f64, Report> {
+  let total_contribution = edges
     .iter()
-    .map(|edge| model.edge_cost(edge))
+    .map(|edge| model.edge_contribution(edge))
     .sum::<Result<f64, Report>>()?;
-  Ok(-total_cost)
+  Ok(-total_contribution)
 }

--- a/packages/treetime/src/coalescent/optimize_tc.rs
+++ b/packages/treetime/src/coalescent/optimize_tc.rs
@@ -1,5 +1,5 @@
 use crate::coalescent::coalescent::CoalescentModel;
-use crate::coalescent::edge_data::{CoalescentEdgeData, collect_coalescent_edges, sum_coalescent_cost};
+use crate::coalescent::edge_data::{CoalescentEdgeData, coalescent_log_likelihood, collect_coalescent_edges};
 use crate::coalescent::precomputed::CoalescentPrecomputed;
 use crate::make_report;
 use crate::optimize::observer::OptimizationObserver;
@@ -118,7 +118,7 @@ impl TcCostFunction {
   fn compute_total_lh(&self, tc: f64) -> Result<f64, Report> {
     let tc_dist = Distribution::constant(tc);
     let model = CoalescentModel::new(&self.precomputed, &tc_dist)?;
-    sum_coalescent_cost(&self.edges, &model)
+    coalescent_log_likelihood(&self.edges, &model)
   }
 }
 

--- a/packages/treetime/src/coalescent/skyline.rs
+++ b/packages/treetime/src/coalescent/skyline.rs
@@ -1,5 +1,5 @@
 use crate::coalescent::coalescent::CoalescentModel;
-use crate::coalescent::edge_data::{CoalescentEdgeData, collect_coalescent_edges, sum_coalescent_cost};
+use crate::coalescent::edge_data::{CoalescentEdgeData, coalescent_log_likelihood, collect_coalescent_edges};
 use crate::coalescent::precomputed::CoalescentPrecomputed;
 use crate::optimize::observer::OptimizationObserver;
 use crate::payload::traits::TimetreeNode;
@@ -136,7 +136,7 @@ where
   let opt_log_tc_clamped = Array1::from_iter(opt_log_tc.iter().map(|&x| x.clamp(-200.0, 100.0)));
   let tc_distribution = build_tc_distribution(&time_grid, &opt_log_tc_clamped)?;
   let model = CoalescentModel::new(&cost_fn.precomputed, &tc_distribution)?;
-  let log_likelihood = sum_coalescent_cost(&cost_fn.edges, &model)?;
+  let log_likelihood = coalescent_log_likelihood(&cost_fn.edges, &model)?;
 
   info!(
     "Skyline optimization completed: final_cost={:.4}, log_likelihood={log_likelihood:.4}",
@@ -174,7 +174,7 @@ impl CostFunction for &SkylineCostFunction {
 
     let model = CoalescentModel::new(&self.precomputed, &tc_dist)
       .map_err(|e| Error::msg(format!("Failed to construct coalescent model: {e}")))?;
-    let neg_log_lh = -sum_coalescent_cost(&self.edges, &model)
+    let neg_log_lh = -coalescent_log_likelihood(&self.edges, &model)
       .map_err(|e| Error::msg(format!("Failed to compute coalescent likelihood: {e}")))?;
 
     // Add smoothness penalty: stiffness * sum(diff(logTc)^2)

--- a/packages/treetime/src/coalescent/total_lh.rs
+++ b/packages/treetime/src/coalescent/total_lh.rs
@@ -1,5 +1,5 @@
 use crate::coalescent::coalescent::CoalescentModel;
-use crate::coalescent::edge_data::{collect_coalescent_edges, sum_coalescent_cost};
+use crate::coalescent::edge_data::{coalescent_log_likelihood, collect_coalescent_edges};
 use crate::coalescent::precomputed::CoalescentPrecomputed;
 use crate::payload::traits::TimetreeNode;
 use eyre::Report;
@@ -31,5 +31,5 @@ where
   let model = CoalescentModel::new(&pre, tc_dist)?;
   let edges = collect_coalescent_edges(graph)?;
 
-  sum_coalescent_cost(&edges, &model)
+  coalescent_log_likelihood(&edges, &model)
 }


### PR DESCRIPTION
`refactor/coalescent-contribution-names` -> `refactor/coalescent-quantity-names`

`leaf_cost` returned a survival credit (negative) and `sum_coalescent_cost` returned a log-likelihood. Neither was a cost.

The per-node and per-edge functions become `*_contribution` [[src](https://github.com/neherlab/treetime/blob/40f7e0ebad44d9a361997f574879cedf4c906c58/packages/treetime/src/coalescent/coalescent.rs#L62-L72)] (matching v0's `node_contribution`), and the sum becomes `coalescent_log_likelihood` [[src](https://github.com/neherlab/treetime/blob/40f7e0ebad44d9a361997f574879cedf4c906c58/packages/treetime/src/coalescent/edge_data.rs#L108)]. A one-line doc states the sign convention. The rename reaches the callers (skyline, the Tc optimizer, total-LH) and their tests.

### Work items

- [x] Rename per-node cost methods to `*_contribution` and `survival_cost` to `survival_term` on `CoalescentModel`.
- [x] Rename `sum_coalescent_cost` to `coalescent_log_likelihood`.
- [x] Update callers in `optimize_tc.rs`, `skyline.rs`, `total_lh.rs`, tests, and `coalescent_validation.rs`.


