### PR TITLE
refactor(distribution): move the log-to-probability bridge into the distribution layer

### DIFF
--- a/packages/treetime-distribution/src/distribution_ops/log_cost.rs
+++ b/packages/treetime-distribution/src/distribution_ops/log_cost.rs
@@ -1,0 +1,49 @@
+use crate::Distribution;
+use crate::policy::Plain;
+use eyre::Report;
+use ndarray::Array1;
+use treetime_utils::make_error;
+
+/// Multiplies a plain-probability distribution by `exp(-weight(t))`, where the
+/// caller supplies `weight` in negative-log space (a cost). The weight is
+/// evaluated on the distribution's own grid and the result is peak-normalized.
+///
+/// The product is formed with a log-sum-exp shift for numerical stability: each
+/// amplitude is scaled by `exp(min_j weight_j - weight_i)`, so the smallest
+/// weight maps to a unit factor and the exponential cannot overflow. The final
+/// `normalize()` divides by the peak.
+///
+/// Concrete distributions only: a `Formula` has no grid to evaluate on and is
+/// rejected. `Empty` passes through unchanged.
+pub fn distribution_apply_neg_log_weight<F>(
+  distribution: &Distribution<Plain>,
+  weight: F,
+) -> Result<Distribution<Plain>, Report>
+where
+  F: Fn(f64) -> Result<f64, Report>,
+{
+  match distribution {
+    Distribution::Empty => Ok(Distribution::Empty),
+    Distribution::Formula(_) => {
+      make_error!("distribution_apply_neg_log_weight requires a concrete Point, Range, or Function distribution")
+    },
+    Distribution::Point(_) | Distribution::Range(_) | Distribution::Function(_) => {
+      let times = distribution.t();
+      let weights = times
+        .iter()
+        .map(|&time| weight(time))
+        .collect::<Result<Vec<_>, Report>>()?;
+      let Some(minimum) = weights.iter().copied().reduce(f64::min).filter(|minimum| minimum.is_finite()) else {
+        return make_error!("distribution_apply_neg_log_weight found no finite weight over the distribution grid");
+      };
+      let amplitudes = Array1::from_iter(
+        distribution
+          .y()
+          .iter()
+          .zip(weights)
+          .map(|(&amplitude, weight)| amplitude * (minimum - weight).exp()),
+      );
+      Ok(Distribution::function(times, amplitudes)?.normalize())
+    },
+  }
+}

--- a/packages/treetime-distribution/src/distribution_ops/mod.rs
+++ b/packages/treetime-distribution/src/distribution_ops/mod.rs
@@ -1,5 +1,6 @@
 pub mod convolve;
 pub mod divide;
+pub mod log_cost;
 pub mod map;
 pub mod multiply;
 pub mod negate;

--- a/packages/treetime-distribution/src/lib.rs
+++ b/packages/treetime-distribution/src/lib.rs
@@ -12,6 +12,7 @@ pub use distribution_core::point::DistributionPoint;
 pub use distribution_core::range::DistributionRange;
 pub use distribution_ops::convolve::distribution_convolution;
 pub use distribution_ops::divide::distribution_division;
+pub use distribution_ops::log_cost::distribution_apply_neg_log_weight;
 pub use distribution_ops::map::distribution_map;
 pub use distribution_ops::multiply::distribution_multiplication;
 pub use distribution_ops::negate::{distribution_negation, distribution_negation_inplace};

--- a/packages/treetime/src/coalescent/__tests__/test_coalescent_model.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_coalescent_model.rs
@@ -8,7 +8,7 @@ mod tests {
   use eyre::Report;
   use ndarray::array;
   use proptest::prelude::*;
-  use treetime_distribution::{Distribution, DistributionFormula};
+  use treetime_distribution::{Distribution, DistributionFormula, distribution_apply_neg_log_weight};
   use treetime_grid::piecewise_constant_fn::PiecewiseConstantFn;
   use treetime_utils::prop_assert_abs_diff_eq;
 
@@ -32,7 +32,7 @@ mod tests {
     let model = model(array![0.0, 10.0], array![1.0, 2.0, 0.0], 2.0)?;
     let distribution = Distribution::range((0.0, 10.0), 1.0);
 
-    let actual = model.apply_leaf_cost(&distribution)?;
+    let actual = distribution_apply_neg_log_weight(&distribution, |time| Ok(model.leaf_contribution(time)))?;
 
     let expected_times = array![0.0, 10.0];
     assert_eq!(expected_times, actual.t());
@@ -46,7 +46,7 @@ mod tests {
     let model = model(array![0.0, 10.0], array![1.0, 2.0, 0.0], 2.0)?;
     let distribution = Distribution::point(5.0, 0.25);
 
-    let actual = model.apply_leaf_cost(&distribution)?;
+    let actual = distribution_apply_neg_log_weight(&distribution, |time| Ok(model.leaf_contribution(time)))?;
 
     // A one-point likelihood normalizes to unit peak without changing support.
     let expected = Distribution::point(5.0, 1.0);
@@ -58,7 +58,7 @@ mod tests {
   fn test_coalescent_model_leaf_application_preserves_empty() -> Result<(), Report> {
     let model = model(array![0.0, 10.0], array![1.0, 2.0, 0.0], 2.0)?;
 
-    let actual = model.apply_leaf_cost(&Distribution::Empty)?;
+    let actual = distribution_apply_neg_log_weight(&Distribution::Empty, |time| Ok(model.leaf_contribution(time)))?;
 
     assert_eq!(Distribution::Empty, actual);
     Ok(())
@@ -70,7 +70,7 @@ mod tests {
     let expected_times = array![0.0, 2.5, 5.0, 7.5, 10.0];
     let distribution = Distribution::function(expected_times.clone(), array![0.2, 0.5, 1.0, 0.5, 0.2])?;
 
-    let actual = model.apply_leaf_cost(&distribution)?;
+    let actual = distribution_apply_neg_log_weight(&distribution, |time| Ok(model.leaf_contribution(time)))?;
 
     assert_eq!(expected_times, actual.t());
     assert!(!matches!(actual, Distribution::Formula(_)));
@@ -82,7 +82,7 @@ mod tests {
     let model = model(array![0.0, 10.0], array![1.0, 2.0, 0.0], 2.0)?;
     let distribution = Distribution::Formula(DistributionFormula::new(|_| Ok(1.0), 0.0, 10.0));
 
-    let error = model.apply_leaf_cost(&distribution).unwrap_err();
+    let error = distribution_apply_neg_log_weight(&distribution, |time| Ok(model.leaf_contribution(time))).unwrap_err();
 
     assert!(error.to_string().contains("concrete Point, Range, or Function"));
     Ok(())

--- a/packages/treetime/src/coalescent/coalescent.rs
+++ b/packages/treetime/src/coalescent/coalescent.rs
@@ -3,7 +3,6 @@ use crate::coalescent::integration::{compute_integral_merger_rate, compute_merge
 use crate::coalescent::precomputed::CoalescentPrecomputed;
 use crate::payload::traits::TimetreeNode;
 use eyre::{Context, Report};
-use ndarray::Array1;
 use treetime_distribution::Distribution;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
@@ -82,22 +81,6 @@ impl CoalescentModel {
     Ok(survival_term - merger_credit)
   }
 
-  pub(crate) fn apply_leaf_cost(&self, distribution: &Distribution) -> Result<Distribution, Report> {
-    self.apply_cost(distribution, |time| Ok(self.leaf_contribution(time)))
-  }
-
-  pub(crate) fn apply_internal_cost(
-    &self,
-    distribution: &Distribution,
-    n_children: usize,
-  ) -> Result<Distribution, Report> {
-    self.apply_cost(distribution, |time| self.internal_contribution(time, n_children))
-  }
-
-  pub(crate) fn apply_root_cost(&self, distribution: &Distribution, n_children: usize) -> Result<Distribution, Report> {
-    self.apply_cost(distribution, |time| self.root_contribution(time, n_children))
-  }
-
   fn total_merger_rate(&self, time: f64) -> Result<f64, Report> {
     // Calendar right-continuity gives the number of lineages immediately on
     // the sampled-tree side of a merger, equivalent to TBP eval_left().
@@ -113,38 +96,5 @@ impl CoalescentModel {
       return make_error!("Coalescent Tc must be finite and positive at calendar time {time:.6e}, got {tc:.6e}");
     }
     Ok(compute_merger_rate_total_scalar(k, tc))
-  }
-
-  fn apply_cost<F>(&self, distribution: &Distribution, cost: F) -> Result<Distribution, Report>
-  where
-    F: Fn(f64) -> Result<f64, Report>,
-  {
-    match distribution {
-      Distribution::Empty => Ok(Distribution::Empty),
-      Distribution::Formula(_) => {
-        make_error!("Coalescent contributions require a concrete Point, Range, or Function distribution")
-      },
-      Distribution::Point(_) | Distribution::Range(_) | Distribution::Function(_) => {
-        let times = distribution.t();
-        let costs = times
-          .iter()
-          .map(|&time| cost(time))
-          .collect::<Result<Vec<_>, Report>>()?;
-        let minimum = costs
-          .iter()
-          .copied()
-          .reduce(f64::min)
-          .filter(|minimum| minimum.is_finite())
-          .ok_or_else(|| eyre::eyre!("Coalescent contribution has no finite cost"))?;
-        let amplitudes = Array1::from_iter(
-          distribution
-            .y()
-            .iter()
-            .zip(costs)
-            .map(|(&amplitude, cost)| amplitude * (minimum - cost).exp()),
-        );
-        Ok(Distribution::function(times, amplitudes)?.normalize())
-      },
-    }
   }
 }

--- a/packages/treetime/src/timetree/inference/backward_pass.rs
+++ b/packages/treetime/src/timetree/inference/backward_pass.rs
@@ -5,6 +5,7 @@ use eyre::Report;
 use rayon::prelude::*;
 use std::sync::Arc;
 use treetime_distribution::Distribution;
+use treetime_distribution::distribution_apply_neg_log_weight;
 use treetime_distribution::distribution_convolution;
 use treetime_distribution::distribution_multiplication;
 use treetime_graph::edge::GraphEdge;
@@ -84,9 +85,9 @@ where
 
   if let (Some(model), Some(distribution)) = (coalescent_model, result.as_ref()) {
     result = Some(if is_root {
-      model.apply_root_cost(distribution, n_children)?
+      distribution_apply_neg_log_weight(distribution, |time| model.root_contribution(time, n_children))?
     } else {
-      model.apply_internal_cost(distribution, n_children)?
+      distribution_apply_neg_log_weight(distribution, |time| model.internal_contribution(time, n_children))?
     });
   }
 
@@ -100,7 +101,10 @@ where
   let outgoing_distribution = if is_leaf {
     let distribution = slot.node.time_distribution();
     match (coalescent_model, distribution) {
-      (Some(model), Some(distribution)) => Some(Arc::new(model.apply_leaf_cost(distribution.as_ref())?)),
+      (Some(model), Some(distribution)) => Some(Arc::new(distribution_apply_neg_log_weight(
+        distribution.as_ref(),
+        |time| Ok(model.leaf_contribution(time)),
+      )?)),
       (_, distribution) => distribution.clone(),
     }
   } else {


### PR DESCRIPTION
`refactor/distribution-log-cost-bridge` -> `refactor/coalescent-contribution-names`

The coalescent model contained distribution-layer arithmetic: grid traversal, min-shifted exponentiation, function construction, and normalization.

This extracts it as `distribution_apply_neg_log_weight` [[src](https://github.com/neherlab/treetime/blob/cfdb8e2ca341317295b21056c954b32bd91632a5/packages/treetime-distribution/src/distribution_ops/log_cost.rs#L18)] in `treetime-distribution`; the model passes a per-time cost, and its four `apply_*` methods are gone. The same min-shifted exponential runs on the same grid, so golden masters do not move.

### Work items

- [x] Extract `distribution_apply_neg_log_weight` [[src](https://github.com/neherlab/treetime/blob/cfdb8e2ca341317295b21056c954b32bd91632a5/packages/treetime-distribution/src/distribution_ops/log_cost.rs#L18)] into `treetime-distribution`.
- [x] Remove `apply_*` methods from `CoalescentModel`.
- [x] Wire `backward_pass.rs` [[src](https://github.com/neherlab/treetime/blob/cfdb8e2ca341317295b21056c954b32bd91632a5/packages/treetime/src/timetree/inference/backward_pass.rs#L18)] to call `distribution_apply_neg_log_weight` directly.


