### PR TITLE
fix(distribution): accumulate the coalescent factor in log space

### DIFF
--- a/kb/tests/distribution.md
+++ b/kb/tests/distribution.md
@@ -9,6 +9,7 @@
 | [Distribution core](#distribution-core)                                 | treetime-distribution | Unit |
 | [Distribution ops - multiply](#distribution-operations---multiply)      | treetime-distribution | Unit |
 | [Distribution ops - divide](#distribution-operations---divide)          | treetime-distribution | Unit |
+| [Distribution ops - log cost](#distribution-operations---log-cost)      | treetime-distribution | Unit |
 | [Distribution ops - convolve](#distribution-operations---convolve)      | treetime-distribution | Unit |
 | [Distribution ops - negation](#distribution-operations---negation)      | treetime-distribution | Unit |
 | [Distribution ops - scalar](#distribution-operations---scalar-multiply) | treetime-distribution | Unit |
@@ -95,6 +96,21 @@
 | `test_divide_range_by_function_no_overlap`         | Range / Function no overlap        |
 | `test_divide_function_by_function_same_grid`       | Same grid elementwise division     |
 | `test_divide_function_by_function_different_grids` | Different grids with interpolation |
+
+---
+
+### Distribution Operations - Log Cost
+
+**Test:** [`packages/treetime-distribution/src/distribution_ops/__tests__/test_log_cost.rs`](../../packages/treetime-distribution/src/distribution_ops/__tests__/test_log_cost.rs)
+
+**Impl:** [`packages/treetime-distribution/src/distribution_ops/log_cost.rs`](../../packages/treetime-distribution/src/distribution_ops/log_cost.rs)
+
+| Test                                                  | Purpose                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------- |
+| `test_log_cost_empty_passthrough`                     | Empty passes through unchanged                          |
+| `test_log_cost_rejects_formula`                       | Formula operand returns an error, not a panic           |
+| `test_log_cost_preserves_peak_under_wide_weight_span` | Peak survives a >700 weight span the naive shift zeroes |
+| `test_log_cost_zero_amplitude_stays_zero`             | Zero-amplitude grid points contribute no mass           |
 
 ---
 
@@ -329,8 +345,8 @@
 
 **Impl:** [`packages/treetime-distribution/src/distribution_core/distribution.rs`](../../packages/treetime-distribution/src/distribution_core/distribution.rs)
 
-| Test                                                            | Purpose                                                        |
-| --------------------------------------------------------------- | -------------------------------------------------------------- |
+| Test                                                           | Purpose                                                        |
+| -------------------------------------------------------------- | -------------------------------------------------------------- |
 | `test_gm_neglog_normalization_matches_v0_coalescent_underflow` | Stable relative likelihoods match v0 for large coalescent cost |
 
 **Test:** [`packages/treetime-distribution/src/__tests__/test_gaussian_product.rs`](../../packages/treetime-distribution/src/__tests__/test_gaussian_product.rs)

--- a/packages/treetime-distribution/src/distribution_ops/__tests__/mod.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/mod.rs
@@ -1,5 +1,6 @@
 mod test_convolve;
 mod test_divide;
+mod test_log_cost;
 mod test_multiply;
 mod test_negation;
 mod test_scalar_multiply;

--- a/packages/treetime-distribution/src/distribution_ops/__tests__/test_log_cost.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/test_log_cost.rs
@@ -1,0 +1,83 @@
+#[cfg(test)]
+mod tests {
+  use crate::DistributionPlain as Distribution;
+  use crate::distribution_ops::log_cost::distribution_apply_neg_log_weight;
+  use approx::assert_abs_diff_eq;
+  use ndarray::array;
+
+  /// Empty passes through unchanged.
+  #[test]
+  fn test_log_cost_empty_passthrough() {
+    let actual = distribution_apply_neg_log_weight(&Distribution::Empty, |_| Ok(1.0)).unwrap();
+    assert_eq!(Distribution::Empty, actual);
+  }
+
+  /// A Formula has no grid and is rejected.
+  #[test]
+  fn test_log_cost_rejects_formula() {
+    let formula = Distribution::Formula(crate::DistributionFormula::new(|_| Ok(1.0), 0.0, 10.0));
+    let error = distribution_apply_neg_log_weight(&formula, |_| Ok(1.0)).unwrap_err();
+    assert!(error.to_string().contains("concrete Point, Range, or Function"));
+  }
+
+  /// Log-space accumulation preserves the product peak when the weight spans
+  /// more than ~700 across the grid.
+  ///
+  /// The product peak sits at t=1, where the weight is largest (800) but the
+  /// message amplitude is largest too. A naive `amplitude * exp(min_weight -
+  /// weight)` shift evaluates `exp(-800)`, which underflows to exactly 0.0
+  /// before multiplication, destroying the peak. Shifting by the combined
+  /// minimum `weight - ln(amplitude)` keeps the peak at unit magnitude.
+  ///
+  /// Analytical oracle: the normalized product `amplitude_i * exp(-weight_i)`
+  /// peaks at t=1, and `product(0) / product(1) = exp((ln a0 - w0) - (ln a1 -
+  /// w1)) = exp((-405 - 0) - (405 - 800)) = exp(-10)`.
+  // Exact float equality is intentional: the naive shift underflows to exactly
+  // 0.0, and the normalized peak is exactly 1.0 by construction.
+  #[allow(clippy::float_cmp)]
+  #[test]
+  fn test_log_cost_preserves_peak_under_wide_weight_span() {
+    // Amplitudes e^-405, e^405, e^-405 are all finite, representable f64 values
+    // (e^405 ~ 8e175, e^-405 ~ 1e-176); their product with exp(-weight) is not.
+    let amplitudes = array![(-405.0_f64).exp(), (405.0_f64).exp(), (-405.0_f64).exp()];
+    let times = array![0.0, 1.0, 2.0];
+    let distribution = Distribution::function(times.clone(), amplitudes).unwrap();
+
+    let weight = |time: f64| Ok(if (time - 1.0).abs() < 1e-9 { 800.0 } else { 0.0 });
+    let actual = distribution_apply_neg_log_weight(&distribution, weight).unwrap();
+
+    // The naive cost-only shift zeroes the peak: exp(-800) underflows, so
+    // e^405 * exp(-800) = e^405 * 0.0 = 0.0.
+    let naive_peak = (405.0_f64).exp() * (0.0_f64 - 800.0).exp();
+    assert_eq!(0.0, naive_peak, "the naive shift must underflow the peak to zero");
+
+    // The log-space result keeps the grid, peaks at t=1, and stays finite.
+    assert_eq!(times, actual.t());
+    assert!(matches!(actual, Distribution::Function(_)));
+    let peak = actual.eval(1.0).unwrap();
+    assert_eq!(1.0, peak, "normalized peak must be 1.0 at t=1");
+    assert!(actual.eval(0.0).unwrap() < peak);
+    assert!(actual.eval(2.0).unwrap() < peak);
+
+    // Off-peak ratio matches the analytical value exp(-10). The tolerance
+    // absorbs the ln/exp round-trip on amplitudes of magnitude e^405.
+    assert_abs_diff_eq!((-10.0_f64).exp(), actual.eval(0.0).unwrap(), epsilon = 1e-15);
+    assert_abs_diff_eq!((-10.0_f64).exp(), actual.eval(2.0).unwrap(), epsilon = 1e-15);
+  }
+
+  /// Zero-amplitude grid points contribute no mass (their negative-log value is
+  /// +inf and is excluded from the shift).
+  // Exact float equality is intentional: a zero-amplitude point yields exactly 0.0.
+  #[allow(clippy::float_cmp)]
+  #[test]
+  fn test_log_cost_zero_amplitude_stays_zero() {
+    let amplitudes = array![0.0, 1.0, 0.5];
+    let times = array![0.0, 1.0, 2.0];
+    let distribution = Distribution::function(times, amplitudes).unwrap();
+
+    let actual = distribution_apply_neg_log_weight(&distribution, |_| Ok(0.0)).unwrap();
+
+    assert_eq!(0.0, actual.eval(0.0).unwrap());
+    assert!(actual.eval(1.0).unwrap() > 0.0);
+  }
+}

--- a/packages/treetime-distribution/src/distribution_ops/log_cost.rs
+++ b/packages/treetime-distribution/src/distribution_ops/log_cost.rs
@@ -8,10 +8,13 @@ use treetime_utils::make_error;
 /// caller supplies `weight` in negative-log space (a cost). The weight is
 /// evaluated on the distribution's own grid and the result is peak-normalized.
 ///
-/// The product is formed with a log-sum-exp shift for numerical stability: each
-/// amplitude is scaled by `exp(min_j weight_j - weight_i)`, so the smallest
-/// weight maps to a unit factor and the exponential cannot overflow. The final
-/// `normalize()` divides by the peak.
+/// The product is formed in negative-log space for numerical stability. Each
+/// grid point's combined value is `weight_i - ln(amplitude_i)`; amplitudes are
+/// then `exp(min_j(combined_j) - combined_i)`. Shifting by the minimum of the
+/// *combined* value, rather than the minimum of the weight alone, places the
+/// product peak at unit magnitude. A peak that sits at a high-weight grid point
+/// therefore survives, instead of underflowing `exp(min_weight - weight_i)` to
+/// zero when the weight spans more than ~700 across the grid.
 ///
 /// Concrete distributions only: a `Formula` has no grid to evaluate on and is
 /// rejected. `Empty` passes through unchanged.
@@ -29,21 +32,22 @@ where
     },
     Distribution::Point(_) | Distribution::Range(_) | Distribution::Function(_) => {
       let times = distribution.t();
-      let weights = times
+      let amplitudes = distribution.y();
+      let neg_log = amplitudes
         .iter()
-        .map(|&time| weight(time))
+        .zip(times.iter())
+        .map(|(&amplitude, &time)| Ok::<f64, Report>(weight(time)? - amplitude.ln()))
         .collect::<Result<Vec<_>, Report>>()?;
-      let Some(minimum) = weights.iter().copied().reduce(f64::min).filter(|minimum| minimum.is_finite()) else {
+      let Some(minimum) = neg_log
+        .iter()
+        .copied()
+        .reduce(f64::min)
+        .filter(|minimum| minimum.is_finite())
+      else {
         return make_error!("distribution_apply_neg_log_weight found no finite weight over the distribution grid");
       };
-      let amplitudes = Array1::from_iter(
-        distribution
-          .y()
-          .iter()
-          .zip(weights)
-          .map(|(&amplitude, weight)| amplitude * (minimum - weight).exp()),
-      );
-      Ok(Distribution::function(times, amplitudes)?.normalize())
+      let scaled = Array1::from_iter(neg_log.iter().map(|&value| (minimum - value).exp()));
+      Ok(Distribution::function(times, scaled)?.normalize())
     },
   }
 }


### PR DESCRIPTION
`fix/distribution-log-space-underflow` -> `refactor/distribution-log-cost-bridge`

- Depends on: `refactor/distribution-log-cost-bridge`

Update:

- [kb/tests/distribution.md](https://github.com/neherlab/treetime/blob/dcbb202accdf575964397de6b70ba696da12c132/kb/tests/distribution.md): add log-cost test entries

The bridge shifted amplitudes by `exp(min_weight - weight)`. When the weight spans more than about 700 across the grid, that exponential underflows to zero, losing the posterior peak if it sits at a high-weight grid point.

Shifting by the combined minimum `weight - ln(amplitude)` keeps the product peak at unit magnitude. Identical to the old computation in exact arithmetic, better near underflow, and consistent with v0's backward pass which already stays in log space.

### Work items

- [x] Shift by combined minimum `weight - ln(amplitude)` instead of `min(weight)` alone in `distribution_apply_neg_log_weight` [[src](https://github.com/neherlab/treetime/blob/dcbb202accdf575964397de6b70ba696da12c132/packages/treetime-distribution/src/distribution_ops/log_cost.rs#L21)].
- [x] Add `test_log_cost.rs` [[src](https://github.com/neherlab/treetime/blob/dcbb202accdf575964397de6b70ba696da12c132/packages/treetime-distribution/src/distribution_ops/__tests__/test_log_cost.rs)] with passthrough, formula-rejection, wide-span peak-preservation, and zero-amplitude tests.


