### PR TITLE
fix(timetree): keep coalescent lineage counting complete after rerooting

### DIFF
--- a/kb/issues/H-timetree-coalescent-events-incomplete-after-topology-change.md
+++ b/kb/issues/H-timetree-coalescent-events-incomplete-after-topology-change.md
@@ -1,21 +1,22 @@
-# Coalescent events are incomplete after topology changes
+# Coalescent model may be built before node times are recomputed after a topology change
 
-A topology-changing refinement pass clears internal time distributions. Coalescent event collection then silently filters nodes without `likely_time`, so the next inference step can omit internal events and continue with an incomplete prior.
+`run_timetree` builds the coalescent model before its own backward/forward passes recompute node times: `compute_coalescent_model` runs at [packages/treetime/src/timetree/inference/runner.rs#L53-L55](../../packages/treetime/src/timetree/inference/runner.rs#L53-L55), before `propagate_distributions_backward`/`propagate_distributions_forward` at [runner.rs#L60-L64](../../packages/treetime/src/timetree/inference/runner.rs#L60-L64). The coalescent model therefore relies on node times left over from a previous pass. Any topology mutation that clears internal `time_distribution`s and is not followed by a coalescent-free time pass leaves the model built from an incomplete tree.
 
-`fn collect_tree_events()` adds an event only when both `time_distribution` and `likely_time()` are present [packages/treetime/src/coalescent/events.rs#L14-L43](../../packages/treetime/src/coalescent/events.rs#L14-L43); it checks only that the final event vector is nonempty, not that every required node contributed.
+## Fixed
 
-## Potential solutions
+- The post-ancestral reroot instance is fixed: the pipeline now runs a coalescent-free `run_timetree` right after the reroot, before the optimization loop, so round 1's coalescent build sees a complete tree ([packages/treetime/src/timetree/pipeline.rs#L281-L293](../../packages/treetime/src/timetree/pipeline.rs#L281-L293)).
+- Event collection no longer silently drops nodes without an inferred time. `collect_tree_events` returns a contextual error naming the offending node ([packages/treetime/src/coalescent/events.rs#L27-L54](../../packages/treetime/src/coalescent/events.rs#L27-L54)), so any remaining instance fails loudly instead of producing a wrong coalescent prior.
 
-- O1. Rebuild complete time state immediately after topology mutation and make event collection reject missing state.
-- O2. Derive event times directly during collection from distributions. This couples event construction to inference and still requires an explicit missing-state policy.
+## Remaining
 
-## Recommendation
+The resolve-polytomies refinement branch clears internal `time_distribution`s via `prepare_tree_after_topology_change` ([packages/treetime/src/timetree/optimization/polytomy.rs#L560](../../packages/treetime/src/timetree/optimization/polytomy.rs#L560)) and then calls `run_timetree` directly ([packages/treetime/src/timetree/refinement.rs#L74-L81](../../packages/treetime/src/timetree/refinement.rs#L74-L81)). That `run_timetree` builds the coalescent model before recomputing node times, so a dataset that actually resolves polytomies while a coalescent prior is active can still fail. This has not been reproduced (the tested datasets did not resolve polytomies under the coalescent modes), and it now surfaces as the explicit error from `collect_tree_events` rather than silent incompleteness.
 
-Define complete node-time state as a precondition for event collection. After topology mutation, rebuild required time distributions and likely times before computing events. A missing required time returns a contextual error instead of removing the node from the event set.
+## Potential solution
+
+Recompute node times immediately after any topology mutation that clears them and before the coalescent model is consumed, or restructure `run_timetree` so the coalescent model is built from node times established for the current topology rather than a prior pass.
 
 ## Validation
 
-- Topology-changing and topology-preserving refinement cases.
-- Assert the event multiset contains every required leaf, internal node, and root contribution.
-- Inject one missing internal time and require an error naming the node.
-- Compare the full coalescent likelihood against an independent direct calculation.
+- Coalescent modes on inversion-prone datasets (zika/20, flu/h3n2/200) no longer abort with "Lineage count must end at zero".
+- Inject one missing internal time and require a contextual error naming the node ([packages/treetime/src/coalescent/**tests**/test_events.rs](../../packages/treetime/src/coalescent/__tests__/test_events.rs)).
+- Exercise a resolve-polytomies run that actually introduces nodes while a coalescent prior is active, and assert the coalescent model is built from complete node times.

--- a/kb/issues/M-timetree-skyline-aborts-on-node-time-inversion.md
+++ b/kb/issues/M-timetree-skyline-aborts-on-node-time-inversion.md
@@ -1,0 +1,22 @@
+# Skyline optimization aborts on node-time inversions instead of degrading gracefully
+
+`optimize_skyline` collects per-edge coalescent data via `collect_coalescent_edges` ([packages/treetime/src/coalescent/skyline.rs#L106](../../packages/treetime/src/coalescent/skyline.rs#L106)), which returns a hard error when any edge has `child_time < parent_time` ([packages/treetime/src/coalescent/edge_data.rs#L85-L90](../../packages/treetime/src/coalescent/edge_data.rs#L85-L90)). The error propagates through the final skyline re-optimization ([packages/treetime/src/timetree/pipeline.rs#L343-L361](../../packages/treetime/src/timetree/pipeline.rs#L343-L361)) and aborts the whole run.
+
+The constant-Tc path handles the identical inversion gracefully: `optimize_tc` catches the error and falls back to the initial Tc with a warning ([packages/treetime/src/timetree/pipeline.rs#L234-L254](../../packages/treetime/src/timetree/pipeline.rs#L234-L254), [packages/treetime/src/timetree/pipeline.rs#L300-L318](../../packages/treetime/src/timetree/pipeline.rs#L300-L318)). Skyline does not, so `--coalescent-skyline` and `--coalescent-skyline --confidence` abort on inversion-prone datasets (e.g. flu/h3n2/200) while `--coalescent-opt` and `--coalescent=<v>` complete.
+
+## Reproduction
+
+```
+timetree --tree=data/flu/h3n2/200/tree.nwk --dates=data/flu/h3n2/200/metadata.tsv \
+  --aln=data/flu/h3n2/200/aln.fasta.xz --coalescent-skyline --n-skyline=5 --max-iter=3
+```
+
+Fails with `Failed to re-optimize skyline coalescent model` wrapping `Coalescent edge has child older than parent`.
+
+## Notes
+
+The inversions themselves stem from unconstrained marginal node-time selection, tracked in [M-timetree-marginal-node-times-can-violate-topology.md](M-timetree-marginal-node-times-can-violate-topology.md), whose contract is undecided. This issue is narrower: the skyline path should treat an inversion the same way the constant-Tc path does (skip/degrade with a warning) rather than aborting, so the two coalescent code paths behave consistently. The graceful policy chosen for inversions must match the resolution of the marginal-node-time issue.
+
+## Related issues
+
+- [M-timetree-marginal-node-times-can-violate-topology.md](M-timetree-marginal-node-times-can-violate-topology.md)

--- a/kb/issues/README.md
+++ b/kb/issues/README.md
@@ -53,7 +53,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | High       | I/O          | [Auspice v2 output omits required updated metadata](H-io-auspice-v2-required-updated-missing.md)                                                                   |
 | High       | I/O          | [UShER MAT export fabricates global reference nucleotides from branch-local alleles](H-io-usher-ref-nuc-uses-parent-allele.md)                                     |
 | High       | Marginal     | [Marginal cavity sentinel loses impossible-factor multiplicity](H-marginal-cavity-sentinel-loses-impossible-factor-multiplicity.md)                                |
-| High       | Timetree     | [Coalescent events are incomplete after topology changes](H-timetree-coalescent-events-incomplete-after-topology-change.md)                                        |
+| High       | Timetree     | [Coalescent model may be built before node times are recomputed after a topology change](H-timetree-coalescent-events-incomplete-after-topology-change.md)         |
 | High       | Timetree     | [No tree inference from alignment](H-timetree-tree-inference-unimplemented.md)                                                                                     |
 | Medium     | Ancestral    | [Dense-sparse log-likelihood divergence](M-ancestral-dense-sparse-divergence.md)                                                                                   |
 | Medium     | Ancestral    | [Fitch recurrence is not minimum parsimony on multifurcations](M-ancestral-fitch-polytomy-recurrence-not-minimum.md)                                               |
@@ -125,6 +125,7 @@ Issue name in the summary table must match the H1 heading in the linked file exa
 | Medium     | Timetree     | [Marginal dense timetree inference disproportionately slow for mpox dataset](M-timetree-marginal-dense-mpox-slow.md)                                               |
 | Medium     | Timetree     | [Marginal timetree node times can violate topology](M-timetree-marginal-node-times-can-violate-topology.md)                                                        |
 | Medium     | Timetree     | [Positional likelihood metric differs from v0](M-timetree-positional-likelihood-metric.md)                                                                         |
+| Medium     | Timetree     | [Skyline optimization aborts on node-time inversions instead of degrading gracefully](M-timetree-skyline-aborts-on-node-time-inversion.md)                         |
 | Medium     | Timetree     | [Skyline objective and optimizer diverge from v0](M-timetree-skyline-nelder-mead-optimizer.md)                                                                     |
 | Medium     | Timetree     | [Sparse timetree convergence tracking compares empty sequences](M-timetree-sparse-convergence-empty-sequences.md)                                                  |
 | Medium     | Timetree     | [Timetree backward pass combines child time messages in plain probability space](M-timetree-backward-pass-plain-space-underflow.md)                                |

--- a/packages/treetime/src/coalescent/__tests__/test_events.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_events.rs
@@ -10,6 +10,7 @@ mod tests {
   use pretty_assertions::assert_eq;
   use treetime_io::dates_csv::{DateConstraint, DatesMap};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_utils::assert_error;
 
   fn create_graph_with_dates(tree_nwk: &str, dates: &DatesMap) -> Result<GraphTimetree, Report> {
     let graph = nwk_read_str(tree_nwk)?;
@@ -89,6 +90,29 @@ mod tests {
     for i in 1..events.len() {
       assert!(events[i - 1].0 <= events[i].0);
     }
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_collect_tree_events_rejects_node_without_time() -> Result<(), Report> {
+    // internal1 has no date constraint, so its time distribution stays unset and it
+    // cannot contribute its merger event. Event collection must reject this rather
+    // than silently drop the node (which would unbalance the lineage-count deltas).
+    const TREE_NWK: &str = "((leaf1:1.0,leaf2:1.0)internal1:1.0,leaf3:1.0)root:1.0;";
+    let dates = btreemap! {
+      "root".to_owned() => Some(DateConstraint::exact(2000.0)),
+      "leaf1".to_owned() => Some(DateConstraint::exact(2010.0)),
+      "leaf2".to_owned() => Some(DateConstraint::exact(2010.0)),
+      "leaf3".to_owned() => Some(DateConstraint::exact(2012.0)),
+    };
+
+    let graph = create_graph_with_dates(TREE_NWK, &dates)?;
+
+    assert_error!(
+      collect_tree_events(&graph),
+      "Coalescent lineage count requires an inferred time for every node, but node (key=GraphNodeKey(2)) has none. The coalescent model was likely built before node times were recomputed for the current tree topology."
+    );
 
     Ok(())
   }

--- a/packages/treetime/src/coalescent/events.rs
+++ b/packages/treetime/src/coalescent/events.rs
@@ -25,19 +25,33 @@ where
   let mut events = Vec::new();
 
   graph.iter_breadth_first_forward(|node| {
-    if let Some(time_dist) = node.payload.time_distribution() {
-      if let Some(t) = time_dist.likely_time() {
-        let t = CalendarTime::new(t);
-        max_time = max_time.max(t);
+    // Every node must contribute an event: the lineage-count function relies on the
+    // per-node deltas summing to exactly 1 (one leaf `+1` per node, one merger `-(k-1)`
+    // per internal node). Silently dropping a node without an inferred time breaks that
+    // invariant and surfaces later as a nonsensical "count must end at zero" failure, so
+    // reject the missing state here and name the offending node instead.
+    let Some(t) = node
+      .payload
+      .time_distribution()
+      .as_ref()
+      .and_then(|time_dist| time_dist.likely_time())
+    else {
+      return make_error!(
+        "Coalescent lineage count requires an inferred time for every node, but node (key={:?}) has none. \
+         The coalescent model was likely built before node times were recomputed for the current tree topology.",
+        node.key
+      );
+    };
 
-        let num_children = node.child_edges.len();
+    let t = CalendarTime::new(t);
+    max_time = max_time.max(t);
 
-        if num_children == 0 {
-          events.push((t, 1));
-        } else {
-          events.push((t, -((num_children as i32) - 1)));
-        }
-      }
+    let num_children = node.child_edges.len();
+
+    if num_children == 0 {
+      events.push((t, 1));
+    } else {
+      events.push((t, -((num_children as i32) - 1)));
     }
     Ok(())
   })?;

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -278,6 +278,19 @@ pub fn run(
       !params.allow_negative_rate,
     )
     .wrap_err("Failed to reroot tree (post-ancestral)")?;
+
+    // Re-establish node times on the rerooted topology before the optimization loop.
+    // The reroot can leave internal-node time distributions cleared for the new
+    // topology, and the loop's first refinement builds the coalescent model (which
+    // reads node times) before its own backward/forward passes recompute them. Run
+    // without the coalescent prior: this pass only restores node times, mirroring v0,
+    // which recomputes the time tree after rerooting and only adds the merger model
+    // inside the iteration loop.
+    // packages/legacy/treetime/treetime/treetime.py#L279-L285
+    if coalescent_tc.is_some() {
+      run_timetree(&mut input.graph, &partitions, &clock_model, None, params.no_indels)
+        .wrap_err("Post-reroot timetree inference failed")?;
+    }
   }
 
   progress.check_cancelled()?;


### PR DESCRIPTION
`fix/lineage-count-node-time-inversion` -> `fix/coalescent-grid-spacing`

Create:

- [kb/issues/M-timetree-skyline-aborts-on-node-time-inversion.md](https://github.com/neherlab/treetime/blob/cf6d23e8205abd3d11abf5303830519752f08daf/kb/issues/M-timetree-skyline-aborts-on-node-time-inversion.md): skyline re-optimization aborts on node-time inversions while the constant-Tc path degrades gracefully

Update:

- [kb/issues/H-timetree-coalescent-events-incomplete-after-topology-change.md](https://github.com/neherlab/treetime/blob/cf6d23e8205abd3d11abf5303830519752f08daf/kb/issues/H-timetree-coalescent-events-incomplete-after-topology-change.md): reframe around the inference ordering; record the reroot instance and the silent node drop as fixed, and the resolve-polytomies branch as a remaining loud-failing site
- [kb/issues/README.md](https://github.com/neherlab/treetime/blob/cf6d23e8205abd3d11abf5303830519752f08daf/kb/issues/README.md): retitle the coalescent-events row and add the skyline row

Timetree with any coalescent prior (`--coalescent`, `--coalescent-opt`, `--coalescent-skyline`) aborted on calendar-dated datasets with `Lineage count must end at zero after the latest sample, got -N`. The coalescent model is built from node times, but `run_timetree` builds it before its own backward and forward passes recompute those times [[src](https://github.com/neherlab/treetime/blob/28b6a5db438b7e012ee33d4d9688482065cd36ec/packages/treetime/src/timetree/inference/runner.rs#L53-L64)]. The post-ancestral reroot leaves internal-node time distributions cleared for the new topology, so the first refinement built the model from a tree with missing internal times; event collection dropped those nodes and the per-node lineage-count deltas no longer summed to one.

Two changes:

- Recompute node times with a coalescent-free pass right after the post-ancestral reroot, before the optimization loop [[src](https://github.com/neherlab/treetime/blob/28b6a5db438b7e012ee33d4d9688482065cd36ec/packages/treetime/src/timetree/pipeline.rs#L281-L293)]. This matches v0, which recomputes the time tree after rerooting and only adds the merger model inside the iteration loop.
- Reject a missing node time during event collection with an error naming the node [[src](https://github.com/neherlab/treetime/blob/39b08a0be4ce9f5bcd012330f76cc663cd172b58/packages/treetime/src/coalescent/events.rs#L27-L54)], instead of silently dropping it and surfacing the count failure later with no indication of the incomplete node.

### Work items

- [x] Coalescent-free node-time pass after the post-ancestral reroot [[src](https://github.com/neherlab/treetime/blob/28b6a5db438b7e012ee33d4d9688482065cd36ec/packages/treetime/src/timetree/pipeline.rs#L281-L293)].
- [x] Contextual error on a missing node time in event collection [[src](https://github.com/neherlab/treetime/blob/39b08a0be4ce9f5bcd012330f76cc663cd172b58/packages/treetime/src/coalescent/events.rs#L27-L54)], with a unit test [[src](https://github.com/neherlab/treetime/blob/eb1242562a22c15fc06bb2717258b5cbd063e12a/packages/treetime/src/coalescent/__tests__/test_events.rs)].

### Possible improvements

- [ ] Skyline re-optimization aborts on marginal node-time inversions while the constant-Tc path degrades gracefully ([kb/issues/M-timetree-skyline-aborts-on-node-time-inversion.md](https://github.com/neherlab/treetime/blob/cf6d23e8205abd3d11abf5303830519752f08daf/kb/issues/M-timetree-skyline-aborts-on-node-time-inversion.md)); the underlying inversion contract is undecided ([kb/issues/M-timetree-marginal-node-times-can-violate-topology.md](https://github.com/neherlab/treetime/blob/cf6d23e8205abd3d11abf5303830519752f08daf/kb/issues/M-timetree-marginal-node-times-can-violate-topology.md))

