### PR TITLE
fix: ignore bad branches in when collecting coalescent edges

### DIFF
--- a/kb/issues/M-coalescent-bad-branch-handling-inconsistent.md
+++ b/kb/issues/M-coalescent-bad-branch-handling-inconsistent.md
@@ -10,8 +10,8 @@ Bad branches are excluded from some coalescent computations but included in othe
 | Backward pass: outgoing message to parent | Excluded (guarded)                | `backward_pass.rs:114` |
 | Forward pass: leaf early return           | No check (returns for all leaves) | `forward_pass.rs:73`   |
 | Lineage event collection                  | **Included** (no filter)          | `events.rs:27-43`      |
-| Edge data collection                      | **Included** (no filter)          | `edge_data.rs:50-101`  |
-| Total log-likelihood                      | **Included** (via edge data)      | `total_lh.rs:24-35`    |
+| Edge data collection                      | Excluded (guarded, PR#851)        | `edge_data.rs:55-62`   |
+| Total log-likelihood                      | Excluded (via edge data, PR#851)  | `total_lh.rs:24-35`    |
 
 ## V0 behavior
 
@@ -25,9 +25,13 @@ When bad branches exist in the tree:
 - Bad-branch edges contribute to the total log-likelihood even though their time messages were excluded from the backward pass
 - The Tc optimizer sees an objective function that mixes filtered and unfiltered tree structure
 
-## Decision required
+## Partial fix
 
-Choose one of: (a) exclude bad branches from lineage events and edge collection, matching v0; (b) approve a coherent alternative contract and document the divergence.
+[PR#851](https://github.com/neherlab/treetime/pull/851) added a `bad_branch()` guard to `collect_coalescent_edges`, fixing edge data collection and total log-likelihood. Lineage event collection (`events.rs`) remains unguarded -- bad-branch nodes still inflate $k(t)$.
+
+## Remaining decision
+
+Exclude bad branches from lineage events (`collect_tree_events`), matching v0. The lineage-count invariant (deltas sum to zero) needs adjustment to account for skipped subtrees.
 
 ## Related issues
 

--- a/kb/issues/N-coalescent-initial-tc-hardcoded-fallback.md
+++ b/kb/issues/N-coalescent-initial-tc-hardcoded-fallback.md
@@ -1,0 +1,13 @@
+# Initial coalescent Tc is a hardcoded constant instead of data-derived
+
+`INITIAL_COALESCENT_TC` is a fixed constant (`5.0` after [PR#851](https://github.com/neherlab/treetime/pull/851), previously `0.001`) used as the fallback coalescent timescale when Brent optimization fails. The value only affects the error-recovery path -- the optimizer searches its full bracket `[-20, 2]` in log space regardless of starting point.
+
+A data-derived initial value (e.g., root-to-tip time span from the clock regression) would adapt to dataset timescale automatically. Datasets with timescales far from 5 years (sub-annual outbreaks, deep evolutionary trees) get a poor fallback when optimization fails.
+
+## Location
+
+[`packages/treetime/src/timetree/pipeline.rs`](../../packages/treetime/src/timetree/pipeline.rs): `INITIAL_COALESCENT_TC` constant and its use in `CoalescentInitialization::Optimize`.
+
+## Impact
+
+Low. The Brent optimizer succeeds for most datasets. The fallback path matters only when the tree's coalescent structure is too degenerate for optimization to converge.

--- a/packages/treetime/src/coalescent/edge_data.rs
+++ b/packages/treetime/src/coalescent/edge_data.rs
@@ -52,6 +52,13 @@ where
     if node.parent_keys.is_empty() {
       return Ok(());
     }
+    if node.payload.bad_branch() {
+      warn!(
+        "Coalescent edge data: skipping node (key={:?}) with a bad branch",
+        node.key
+      );
+      return Ok(());
+    }
 
     let Some(child_time) = node
       .payload

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -515,16 +515,16 @@ fn optimize_branch_lengths_pre_step(
 
 #[cfg(test)]
 mod tests {
-  use super::{CoalescentInitialization, coalescent_initialization};
+  use super::{CoalescentInitialization, INITIAL_COALESCENT_TC, coalescent_initialization};
   use rstest::rstest;
 
   #[rustfmt::skip]
   #[rstest]
   #[case::disabled(       None,       false, false, CoalescentInitialization::None)]
   #[case::fixed(          Some(0.25), false, false, CoalescentInitialization::Fixed(0.25))]
-  #[case::opt_default(    None,       true,  false, CoalescentInitialization::Optimize(0.001))]
+  #[case::opt_default(    None,       true,  false, CoalescentInitialization::Optimize(INITIAL_COALESCENT_TC))]
   #[case::opt_configured( Some(0.25), true,  false, CoalescentInitialization::Optimize(0.25))]
-  #[case::skyline_default(None,       false, true,  CoalescentInitialization::Optimize(0.001))]
+  #[case::skyline_default(None,       false, true,  CoalescentInitialization::Optimize(INITIAL_COALESCENT_TC))]
   #[trace]
   fn test_pipeline_coalescent_initialization(
     #[case] coalescent: Option<f64>,
@@ -534,9 +534,6 @@ mod tests {
   ) {
     let actual = coalescent_initialization(coalescent, coalescent_opt, coalescent_skyline);
 
-    // v0 creates Coalescent with Tc=0.001 before optimizing it in the first iteration:
-    // packages/legacy/treetime/treetime/merger_models.py#L25
-    // packages/legacy/treetime/treetime/treetime.py#L307-L317
     assert_eq!(expected, actual);
   }
 }

--- a/packages/treetime/src/timetree/pipeline.rs
+++ b/packages/treetime/src/timetree/pipeline.rs
@@ -41,7 +41,7 @@ use treetime_io::fasta::FastaRecord;
 use treetime_utils::make_report;
 
 const TIMETREE_PRE_STEP_DAMPING: f64 = 0.75;
-const INITIAL_COALESCENT_TC: f64 = 0.001;
+const INITIAL_COALESCENT_TC: f64 = 5.0;
 
 pub struct TimetreeParams {
   pub model: GtrModelName,


### PR DESCRIPTION
The `INITIAL_COALESCENT_TC` would be better set as the time difference between the initial estimate of the root age and the latest tip. This should give us a time scale on the right scale. The previous value was measuring things in substitutions, not years. 

skyline optimization still errors with children before parents. we probably need to enforce this strictly. 