### PR TITLE
fix: align tree output mutations and confidence columns with augur

### DIFF
--- a/kb/issues/N-amino-acid-mutation-indel-representation-undecided.md
+++ b/kb/issues/N-amino-acid-mutation-indel-representation-undecided.md
@@ -1,0 +1,14 @@
+# Amino-acid mutation output indel representation is undecided
+
+The nucleotide mutation output is substitution-only, matching augur node-data. The amino-acid track still emits range-based insertion and deletion events, expanded to per-residue tokens. Whether the amino-acid track should be restricted to substitutions (as the nucleotide track is) is an open design question, not yet decided by the team.
+
+## Evidence
+
+- Amino-acid node-data chains substitutions with range-based indels [`packages/treetime/src/commands/ancestral/aa_node_data.rs#L270-L276`](../../packages/treetime/src/commands/ancestral/aa_node_data.rs#L270-L276); the substitution diff excludes gap positions [`packages/treetime/src/commands/ancestral/aa_node_data.rs#L326-L329`](../../packages/treetime/src/commands/ancestral/aa_node_data.rs#L326-L329), so gaps reach output only via the indel track.
+- The Auspice writer drops indels for the nucleotide track but not amino-acid tracks `fn group_mutations()` [`packages/treetime/src/commands/shared/tree_output.rs#L1473-L1502`](../../packages/treetime/src/commands/shared/tree_output.rs#L1473-L1502).
+
+## Open question
+
+augur represents amino-acid deletions as positional gap-substitutions (`K100-`), not as range events, so restricting the amino-acid track to substitutions would drop those tokens and diverge from augur; keeping range-based indels requires verifying that their coordinates match augur's alignment columns, especially for insertions. The decision and its options are analyzed in [kb/proposals/amino-acid-mutation-output-substitution-only.md](../proposals/amino-acid-mutation-output-substitution-only.md).
+
+Blocked on a team decision; no ticket until an option is selected.

--- a/kb/proposals/amino-acid-mutation-output-substitution-only.md
+++ b/kb/proposals/amino-acid-mutation-output-substitution-only.md
@@ -1,0 +1,76 @@
+# Restrict amino-acid mutation output to substitutions
+
+## Motivation
+
+TreeTime v1 emits amino-acid mutations as substitutions plus range-based insertion and deletion events. The nucleotide track was recently made substitution-only so that the Auspice `mutations.nuc` list matches the augur node-data contract, but the amino-acid track still carries indel tokens. This proposal records the question of whether the amino-acid track should likewise be restricted to substitutions, and the tension that decision has with reference parity.
+
+The two tracks are produced by different code:
+
+- Nucleotide node-data `muts` are substitution-only: `fn build_augur_node_data_json()` maps each `Sub` to its string and never emits indels [`packages/treetime/src/commands/ancestral/augur_node_data.rs#L71-L77`](../../packages/treetime/src/commands/ancestral/augur_node_data.rs#L71-L77).
+- Amino-acid node-data chains substitutions with range-based indels and serializes both: [`packages/treetime/src/commands/ancestral/aa_node_data.rs#L270-L276`](../../packages/treetime/src/commands/ancestral/aa_node_data.rs#L270-L276). The substitution diff excludes any position where either side is a gap, so gaps reach the output only through the indel track: `fn is_reportable_sub()` [`packages/treetime/src/commands/ancestral/aa_node_data.rs#L326-L329`](../../packages/treetime/src/commands/ancestral/aa_node_data.rs#L326-L329).
+- The Auspice writer groups whatever mutations it is given, per track: `fn group_mutations()` [`packages/treetime/src/commands/shared/tree_output.rs#L1473-L1502`](../../packages/treetime/src/commands/shared/tree_output.rs#L1473-L1502). It now drops indels for the nucleotide track only; amino-acid tracks pass through `fn mutation_event_strings()` [`packages/treetime/src/seq/mutation.rs#L57`](../../packages/treetime/src/seq/mutation.rs#L57), which expands a range-based indel into one positional token per residue (`{state}{pos}-` for a deletion, `-{pos}{state}` for an insertion).
+
+## Reference behavior (augur 34.0.0, 2026-07-07)
+
+augur does not model insertions or deletions as range events on either track. It compares aligned sequences position by position and writes each difference as a single `<from><pos><to>` string, allowing `-` on either side as an ordinary aligned character.
+
+Nucleotide muts come from the TreeTime substitution list, one string per differing site [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/ancestral.py#L218)] inside `def collect_mutations()` [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/ancestral.py#L185)].
+
+Amino-acid muts come from a direct column comparison of the translated reference against each node's translation, with no gap filtering [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/translate.py#L305)]:
+
+```python
+muts = [construct_mut(a, int(pos+1), d) for pos, (a,d) in enumerate(zip(ref, aln[n.name])) if a!=d]
+```
+
+`def construct_mut()` simply concatenates the three fields [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/translate.py#L206)], and translation renders in-frame gaps as `-` [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/translate.py#L67)]. A deleted residue therefore appears as `K100-`, and a gap-to-residue change as `-100A`, at fixed alignment-column coordinates.
+
+augur's Auspice export copies the node-data muts verbatim into the tree; `def create_branch_mutations()` [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/export_v2.py#L1062)] assigns `branch_attrs[...]["mutations"]["nuc"] = node_info["muts"]` [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/export_v2.py#L1070)]. Node-data and Auspice mutation lists are the same object by construction and cannot disagree.
+
+## The divergence question
+
+augur amino-acid muts are **not** substitution-only: a deletion is present as a `K100-` gap-substitution. TreeTime's token format matches (a range deletion expands to the same `K100-` strings), so for deletions the two representations are string-compatible when coordinates align. The mismatch risk is confined to:
+
+1. **Insertions.** augur has no insertion concept on a fixed-length alignment; an inserted residue relative to the reference is not a separate column. TreeTime's range-based insertions serialize as `-{pos}{state}`, whose position is a reference coordinate that may not correspond to any augur alignment column. Amino-acid sequences are translated from a fixed nucleotide MSA, so true insertions are not expected to arise, but the code path can emit them.
+2. **Coordinate correspondence.** Range indel coordinates are 1-based over the reference; augur coordinates are 1-based over the translated alignment column. Whether these coincide for every CDS has not been verified against augur output.
+
+Restricting the amino-acid track to substitutions removes both risks, but drops the deletion tokens that augur _does_ emit as gap-substitutions. It trades one divergence (possibly wrong indel coordinates) for another (missing deletions).
+
+## Design axes
+
+Two independent decisions.
+
+### A1. Amino-acid indel inclusion
+
+- **A1a. Substitutions only.** Drop amino-acid indels entirely, mirroring the nucleotide track. Simplest and internally consistent, avoids any coordinate mismatch, but omits deletions that augur represents.
+- **A1b. Keep range-based indels (current).** Retains deletion and insertion information but must prove coordinate correspondence with augur before it can claim parity.
+- **A1c. Emit amino-acid gaps as positional gap-substitutions.** Reproduce augur's model exactly: derive `K100-` / `-100A` from a per-column comparison of translated sequences rather than from range events. Closest reference parity; requires routing amino-acid gaps through the substitution path instead of the indel track.
+
+### A2. Scope of the change
+
+- **A2a. Both node-data and Auspice.** Keep the two outputs identical (augur's invariant). Any restriction applies at the amino-acid node-data source so every consumer agrees.
+- **A2b. Auspice only.** Filter in `fn group_mutations()`, leaving amino-acid node-data unchanged. This reintroduces exactly the node-data-vs-Auspice disagreement that the nucleotide fix removed and is not recommended.
+
+## Recommendation (open)
+
+Decision required from the team. The narrow request that motivated this proposal is A1a (amino-acid substitutions only), applied per A2a so node-data and Auspice stay identical. That is defensible as a consistency choice and is safe against the insertion-coordinate risk, but it is a deliberate divergence from augur, which surfaces amino-acid deletions. A1c is the only option that matches augur exactly. This proposal does not select an option; exact parity with augur remains the default until the team approves a divergence.
+
+## Impact
+
+- CLI outputs affected: `ancestral`, `optimize`, `timetree` amino-acid node-data and Auspice v2 `mutations` for CDS tracks. Datasets with amino-acid indels (translated from indel-bearing nucleotide alignments) change; substitution-only datasets are unaffected.
+- No nucleotide-track change; the nucleotide substitution-only contract already holds.
+
+## Validation plan
+
+- Golden-master comparison of amino-acid `muts` against `augur translate` node-data for an indel-bearing CDS, per option, to measure the actual divergence.
+- Unit coverage in `fn group_mutations()` and the amino-acid node-data builder asserting the chosen per-track policy.
+- Confirm node-data and Auspice amino-acid lists remain identical under A2a.
+
+## Non-goals
+
+- No change to the nucleotide track.
+- No change to PhyloXML or UShER MAT indel encoding, which have their own format contracts.
+
+## Related
+
+- [kb/issues/N-amino-acid-mutation-indel-representation-undecided.md](../issues/N-amino-acid-mutation-indel-representation-undecided.md)
+- [phyloxml-treetime-property-namespace.md](phyloxml-treetime-property-namespace.md)

--- a/packages/treetime/src/commands/shared/__tests__/test_tree_output.rs
+++ b/packages/treetime/src/commands/shared/__tests__/test_tree_output.rs
@@ -7,9 +7,8 @@ mod tests {
   use crate::commands::shared::tree_output::{
     ancestral_to_auspice, ancestral_to_mat, ancestral_to_phyloxml, clock_to_auspice, clock_to_mat, clock_to_phyloxml,
     format_number, group_mutations, mat_mutation, mugration_to_auspice, mugration_to_mat, mugration_to_phyloxml,
-    optimize_to_auspice,
-    optimize_to_mat, optimize_to_phyloxml, prune_to_auspice, prune_to_mat, prune_to_phyloxml, timetree_to_auspice,
-    timetree_to_mat, timetree_to_phyloxml, write_ancestral_tree_outputs,
+    optimize_to_auspice, optimize_to_mat, optimize_to_phyloxml, prune_to_auspice, prune_to_mat, prune_to_phyloxml,
+    timetree_to_auspice, timetree_to_mat, timetree_to_phyloxml, write_ancestral_tree_outputs,
   };
   use crate::gtr::get_gtr::GtrModelName;
   use crate::partition::fitch::PartitionFitch;
@@ -93,13 +92,13 @@ mod tests {
     assert!(properties.contains(&"nuc:del:2-3:CG"));
     assert!(properties.contains(&"aa:S%2F1%3Aweird:sub:A2T"));
 
+    // Nucleotide indels are dropped from the Auspice nuc mutation list, which mirrors the
+    // substitution-only augur node-data muts. A branch whose only nucleotide change is a
+    // deletion therefore has no `nuc` entry (phyloxml above still encodes it as `nuc:del:2-3:CG`).
     let graph = helpers::ancestral_graph(helpers::Mutations::Indel)?;
     let auspice = ancestral_to_auspice(&graph, "2026-07-19")?;
     let child = helpers::auspice_child(&auspice, "A");
-    assert_eq!(
-      vec!["C2-".to_owned(), "G3-".to_owned()],
-      child.branch_attrs.mutations["nuc"]
-    );
+    assert!(!child.branch_attrs.mutations.contains_key("nuc"));
 
     let graph = helpers::ancestral_graph(helpers::Mutations::AminoAcid)?;
     let auspice = ancestral_to_auspice(&graph, "2026-07-19")?;
@@ -362,13 +361,22 @@ mod tests {
     // for amino-acid tracks (aa node-data emits them). Deletion of range (1, 3) over "CG"
     // expands to per-position tokens "C2-", "G3-".
     let mutations = vec![
-      Mutation::substitution(MutationTrack::Nucleotide, Sub::new(helpers::c(b'A'), 0_usize, helpers::c(b'T'))?),
-      Mutation::indel(MutationTrack::Nucleotide, &InDel::del((1, 3), Seq::try_from_str("CG")?)?)?,
+      Mutation::substitution(
+        MutationTrack::Nucleotide,
+        Sub::new(helpers::c(b'A'), 0_usize, helpers::c(b'T'))?,
+      ),
+      Mutation::indel(
+        MutationTrack::Nucleotide,
+        &InDel::del((1, 3), Seq::try_from_str("CG")?)?,
+      )?,
       Mutation::substitution(
         MutationTrack::AminoAcid("GENE".to_owned()),
         Sub::new(helpers::c(b'K'), 4_usize, helpers::c(b'R'))?,
       ),
-      Mutation::indel(MutationTrack::AminoAcid("GENE".to_owned()), &InDel::del((1, 3), Seq::try_from_str("CG")?)?)?,
+      Mutation::indel(
+        MutationTrack::AminoAcid("GENE".to_owned()),
+        &InDel::del((1, 3), Seq::try_from_str("CG")?)?,
+      )?,
     ];
 
     let grouped = group_mutations(mutations)?;

--- a/packages/treetime/src/commands/shared/__tests__/test_tree_output.rs
+++ b/packages/treetime/src/commands/shared/__tests__/test_tree_output.rs
@@ -6,7 +6,8 @@ mod tests {
   use crate::commands::ancestral::result::AncestralGraphData;
   use crate::commands::shared::tree_output::{
     ancestral_to_auspice, ancestral_to_mat, ancestral_to_phyloxml, clock_to_auspice, clock_to_mat, clock_to_phyloxml,
-    format_number, mat_mutation, mugration_to_auspice, mugration_to_mat, mugration_to_phyloxml, optimize_to_auspice,
+    format_number, group_mutations, mat_mutation, mugration_to_auspice, mugration_to_mat, mugration_to_phyloxml,
+    optimize_to_auspice,
     optimize_to_mat, optimize_to_phyloxml, prune_to_auspice, prune_to_mat, prune_to_phyloxml, timetree_to_auspice,
     timetree_to_mat, timetree_to_phyloxml, write_ancestral_tree_outputs,
   };
@@ -352,6 +353,32 @@ mod tests {
     assert_ulps_eq!(123.456789, format_number(123.456789, 6), max_ulps = 0);
     assert_ulps_eq!(0.0, format_number(0.0, 6), max_ulps = 0);
     assert_ulps_eq!(2020.123, format_number(2020.1234567, 3), max_ulps = 0);
+  }
+
+  #[test]
+  fn test_tree_output_group_mutations_drops_nucleotide_indels_keeps_amino_acid_indels() -> Result<(), Report> {
+    // Auspice v2 mutation lists mirror the augur node-data `muts`: substitution-only for
+    // the nucleotide track (augur export copies node-data nuc muts verbatim), indels retained
+    // for amino-acid tracks (aa node-data emits them). Deletion of range (1, 3) over "CG"
+    // expands to per-position tokens "C2-", "G3-".
+    let mutations = vec![
+      Mutation::substitution(MutationTrack::Nucleotide, Sub::new(helpers::c(b'A'), 0_usize, helpers::c(b'T'))?),
+      Mutation::indel(MutationTrack::Nucleotide, &InDel::del((1, 3), Seq::try_from_str("CG")?)?)?,
+      Mutation::substitution(
+        MutationTrack::AminoAcid("GENE".to_owned()),
+        Sub::new(helpers::c(b'K'), 4_usize, helpers::c(b'R'))?,
+      ),
+      Mutation::indel(MutationTrack::AminoAcid("GENE".to_owned()), &InDel::del((1, 3), Seq::try_from_str("CG")?)?)?,
+    ];
+
+    let grouped = group_mutations(mutations)?;
+
+    let expected = btreemap! {
+      "GENE".to_owned() => vec!["K5R".to_owned(), "C2-".to_owned(), "G3-".to_owned()],
+      "nuc".to_owned() => vec!["A1T".to_owned()],
+    };
+    assert_eq!(expected, grouped);
+    Ok(())
   }
 
   mod helpers {

--- a/packages/treetime/src/commands/shared/tree_output.rs
+++ b/packages/treetime/src/commands/shared/tree_output.rs
@@ -1473,7 +1473,7 @@ fn timetree_date_is_inferred(
 fn group_mutations(mutations: Vec<Mutation>) -> Result<BTreeMap<String, Vec<String>>, Report> {
   let mut grouped = BTreeMap::new();
   for mutation in mutations {
-    let track = match mutation.track {
+    let track = match &mutation.track {
       MutationTrack::Nucleotide => NUC_TRACK.to_owned(),
       MutationTrack::AminoAcid(track) => {
         if track.is_empty()
@@ -1483,9 +1483,17 @@ fn group_mutations(mutations: Vec<Mutation>) -> Result<BTreeMap<String, Vec<Stri
         {
           return make_error!("Auspice v2 cannot represent amino-acid mutation track '{track}'");
         }
-        track
+        track.clone()
       },
     };
+    // The nucleotide auspice mutation list mirrors the augur node-data `muts`,
+    // which are substitution-only: augur export copies node-data muts verbatim
+    // into `branch_attrs.mutations.nuc`, so indels (a separate track) must not
+    // appear there. Amino-acid tracks keep indels to match their own node-data.
+    if matches!(mutation.track, MutationTrack::Nucleotide) && !matches!(mutation.event, MutationEvent::Substitution(_))
+    {
+      continue;
+    }
     grouped
       .entry(track)
       .or_insert_with(Vec::new)

--- a/packages/treetime/src/commands/shared/tree_output.rs
+++ b/packages/treetime/src/commands/shared/tree_output.rs
@@ -1470,7 +1470,7 @@ fn timetree_date_is_inferred(
   )
 }
 
-fn group_mutations(mutations: Vec<Mutation>) -> Result<BTreeMap<String, Vec<String>>, Report> {
+pub(crate) fn group_mutations(mutations: Vec<Mutation>) -> Result<BTreeMap<String, Vec<String>>, Report> {
   let mut grouped = BTreeMap::new();
   for mutation in mutations {
     let track = match &mutation.track {

--- a/packages/treetime/src/commands/timetree/output/__tests__/test_confidence_extract.rs
+++ b/packages/treetime/src/commands/timetree/output/__tests__/test_confidence_extract.rs
@@ -2,7 +2,7 @@
 mod tests {
   use crate::partition::timetree::GraphTimetree;
   use crate::payload::timetree::NodeTimetree;
-  use crate::timetree::confidence::extract_confidence_intervals;
+  use crate::timetree::confidence::{extract_confidence_intervals, write_confidence_intervals};
   use approx::assert_relative_eq;
   use helpers::{make_node, make_node_with_rate_dates};
   use ndarray::Array1;
@@ -231,6 +231,24 @@ mod tests {
     // Measured errors: lower=0.0, upper=3.9e-4.
     assert_relative_eq!(intervals[0].lower, hpd_lower, epsilon = 1e-3);
     assert_relative_eq!(intervals[0].upper, hpd_upper, epsilon = 1e-3);
+  }
+
+  #[test]
+  fn test_write_confidence_intervals_omits_internal_key_column() {
+    // The confidence TSV mirrors the augur node-data contract: columns are
+    // name, date, lower, upper. The graph node key is internal (serde-skipped)
+    // and must never leak as a serialized column.
+    let mut graph = GraphTimetree::new();
+    graph.add_node(make_node(Some("named"), Some(2020.0), None));
+    graph.build().unwrap();
+    let intervals = extract_confidence_intervals(&graph);
+
+    let mut buf = Vec::new();
+    write_confidence_intervals(&intervals, &mut buf).unwrap();
+    let output = String::from_utf8(buf).unwrap();
+
+    let header = output.lines().next().unwrap();
+    assert_eq!(header, "name\tdate\tlower\tupper");
   }
 
   mod helpers {

--- a/packages/treetime/src/timetree/confidence.rs
+++ b/packages/treetime/src/timetree/confidence.rs
@@ -233,6 +233,9 @@ pub fn extract_confidence_intervals(graph: &GraphTimetree) -> Vec<NodeConfidence
 #[derive(Debug, Clone, Serialize)]
 pub struct NodeConfidenceInterval {
   /// Graph node key for stable lookup across naming schemes.
+  /// Internal only: never serialized into the confidence TSV, whose columns are
+  /// `name, date, lower, upper`.
+  #[serde(skip)]
   pub key: GraphNodeKey,
   pub name: String,
   pub date: f64,


### PR DESCRIPTION
`fix/tree-output-augur-parity` -> `refactor/graph-io-single-source`

Create:

- [kb/proposals/amino-acid-mutation-output-substitution-only.md](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/kb/proposals/amino-acid-mutation-output-substitution-only.md): analyze restricting amino-acid mutation output to substitutions
- [kb/issues/N-amino-acid-mutation-indel-representation-undecided.md](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/kb/issues/N-amino-acid-mutation-indel-representation-undecided.md): track the undecided amino-acid indel representation

- Depends on: #858

Making the graph authoritative for tree output introduced two divergences from the augur node-data contract. The confidence TSV gained a leading `key` column when the internal graph node key was serialized, and the Auspice `mutations.nuc` list gained indel tokens absent from the substitution-only node data. augur's export copies the node-data `muts` verbatim into `branch_attrs.mutations.nuc` [[src](https://github.com/nextstrain/augur/blob/d8e38736037ba9474a809f9a5a63bc2b279d2407/augur/export_v2.py#L1070)], so node-data and Auspice mutation lists cannot disagree there.

Restore the internal-only marking on the confidence node key so the TSV columns return to `name, date, lower, upper` [[src](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/packages/treetime/src/timetree/confidence.rs#L239)], and restrict the Auspice nucleotide mutation list to substitutions [[src](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/packages/treetime/src/commands/shared/tree_output.rs#L1473)]. Amino-acid tracks keep indels because their node data also emits them.

The nucleotide correction restores exact parity: augur nucleotide `muts` are substitution-only, and the graph node key is an internal lookup handle, not an output column. The amino-acid track is left unchanged pending a team decision, since augur represents amino-acid deletions as positional gap-substitutions rather than dropping them.

### Work items

- [x] Keep the graph node key out of the confidence TSV via serde skip [[src](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/packages/treetime/src/timetree/confidence.rs#L239)]
- [x] Emit substitution-only nucleotide mutations in the Auspice writer [[src](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/packages/treetime/src/commands/shared/tree_output.rs#L1473)]
- [x] Add regression tests for the confidence columns and the nucleotide/amino-acid mutation split
- [x] Correct the Auspice regression test that had encoded the nucleotide-indel bug

### Possible improvements

- [ ] Decide whether amino-acid mutation output should be substitution-only ([kb/proposals/amino-acid-mutation-output-substitution-only.md](https://github.com/neherlab/treetime/blob/70aab5557626439e89228073aee22ffd56dd13a7/kb/proposals/amino-acid-mutation-output-substitution-only.md))
