### PR TITLE
fix: allow --coalescent to seed --coalescent-opt

### DIFF
--- a/packages/treetime/src/commands/timetree/args.rs
+++ b/packages/treetime/src/commands/timetree/args.rs
@@ -122,7 +122,10 @@ pub struct TreetimeTimetreeArgs {
   ///
   /// When set, TreeTime will find the optimal Tc using Brent's method. This is similar
   /// to Python v0's `--coalescent=opt`, but uses a closed-form solution.
-  #[cfg_attr(feature = "clap", clap(long, conflicts_with = "coalescent", conflicts_with = "coalescent_skyline"))]
+  // `--coalescent` is not a conflict: when both are given, its value seeds the
+  // `CoalescentMode::Constant { seed }` fallback used if the analytic optimization
+  // fails on a degenerate tree.
+  #[cfg_attr(feature = "clap", clap(long, conflicts_with = "coalescent_skyline"))]
   pub coalescent_opt: bool,
 
   /// Use skyline coalescent model instead of constant Tc.


### PR DESCRIPTION
`fix/timetree-coalescent-opt-seed-reachable` -> `rust`

- Follow-up to: #856

`--coalescent-opt` declared `conflicts_with = "coalescent"`, so the two flags could not be supplied together. The documented `CoalescentMode::Constant { seed }` fallback for a failed analytic optimization (the previous round's $T_c$, then the user-supplied `--coalescent`, then no prior) was therefore unreachable from the CLI, and a unit case even constructed a seeded state the CLI could not produce.

This drops that conflict so `--coalescent` seeds the optimizer's failure fallback [[src](https://github.com/neherlab/treetime/blob/2505cb39ebecb7757296b5b65014ccc7df156566/packages/treetime/src/commands/timetree/args.rs)].

Making the fallback reachable is preferable to deleting the `seed` field: on a degenerate tree, recovery to a user-supplied timescale is desirable, and it is already documented behavior.

### Work items

- [x] Remove `conflicts_with = "coalescent"` from `--coalescent-opt` [[src](https://github.com/neherlab/treetime/blob/2505cb39ebecb7757296b5b65014ccc7df156566/packages/treetime/src/commands/timetree/args.rs)]

