### PR TITLE
fix: harden skyline solver inputs and convergence

### DIFF
--- a/packages/treetime/src/coalescent/__tests__/test_skyline.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_skyline.rs
@@ -9,6 +9,7 @@ mod tests {
   use maplit::btreemap;
   use treetime_io::dates_csv::{DateConstraint, DatesMap};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_utils::assert_error;
 
   const SMALL_TREE_NWK: &str = "((leaf1:1.0,leaf2:1.0)internal1:1.0,leaf3:1.0)root:1.0;";
 
@@ -176,6 +177,42 @@ mod tests {
       "skyline LL {} should be >= constant-Tc LL {}",
       result.log_likelihood,
       constant_tc.likelihood
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_optimize_skyline_rejects_nonpositive_stiffness() -> Result<(), Report> {
+    // A non-positive stiffness was previously treated as "no smoothing" silently;
+    // the parameter is documented positive, so a multi-segment fit now rejects it.
+    let graph = helpers::create_graph_with_dates(SMALL_TREE_NWK, &small_tree_dates())?;
+    let params = SkylineParams {
+      n_points: 2,
+      stiffness: -1.0,
+      ..SkylineParams::default()
+    };
+
+    assert_error!(
+      optimize_skyline(&graph, &params),
+      "Skyline smoothing stiffness must be finite and positive for a multi-segment fit, got -1"
+    );
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_optimize_skyline_rejects_nonfinite_stiffness() -> Result<(), Report> {
+    let graph = helpers::create_graph_with_dates(SMALL_TREE_NWK, &small_tree_dates())?;
+    let params = SkylineParams {
+      n_points: 2,
+      stiffness: f64::NAN,
+      ..SkylineParams::default()
+    };
+
+    assert_error!(
+      optimize_skyline(&graph, &params),
+      "Skyline smoothing stiffness must be finite and positive for a multi-segment fit, got NaN"
     );
 
     Ok(())

--- a/packages/treetime/src/coalescent/skyline.rs
+++ b/packages/treetime/src/coalescent/skyline.rs
@@ -4,8 +4,9 @@ use crate::coalescent::precomputed::CoalescentPrecomputed;
 use crate::make_error;
 use crate::payload::traits::TimetreeNode;
 use eyre::Report;
-use log::info;
+use log::{info, warn};
 use ndarray::Array1;
+use ordered_float::OrderedFloat;
 use treetime_distribution::{Distribution, DistributionFormula};
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
@@ -107,6 +108,16 @@ where
   let t_min = breakpoints[0];
   let t_max = breakpoints[breakpoints.len() - 1];
 
+  // Merger times drive the boundary quantiles; a non-finite time would make the
+  // grid meaningless and is rejected here rather than propagated into the sort.
+  if let Some(bad) = edges
+    .iter()
+    .map(|edge| edge.parent_time().value())
+    .find(|t| !t.is_finite())
+  {
+    return make_error!("Coalescent merger time must be finite, got {bad}");
+  }
+
   let boundaries = merger_quantile_boundaries(&edges, t_min, t_max, params.n_points);
 
   let (i_seg, m_seg) = accumulate_segment_terms(precomputed.lineage_counts(), &edges, &boundaries);
@@ -159,7 +170,7 @@ fn merger_quantile_boundaries(edges: &[CoalescentEdgeData], t_min: f64, t_max: f
   }
 
   let mut times: Vec<f64> = edges.iter().map(|e| e.parent_time().value()).collect();
-  times.sort_by(|a, b| a.partial_cmp(b).expect("merger times must be comparable"));
+  times.sort_by_key(|&t| OrderedFloat(t));
 
   let n = times.len();
   let mut boundaries = Vec::with_capacity(n_seg + 1);
@@ -264,11 +275,28 @@ fn solve_inverse_tc(
     })
     .collect();
 
-  // Single segment or no smoothing: the decoupled solution is already optimal.
-  if n == 1 || stiffness <= 0.0 {
+  // Single segment: the decoupled solution is already optimal, no smoothing applies.
+  if n == 1 {
     return Ok(x);
   }
 
+  // Multi-segment smoothing requires well-formed control parameters. A non-positive
+  // or non-finite stiffness was previously treated as "no smoothing" silently,
+  // masking misconfiguration; the parameter is documented as positive.
+  if !(stiffness.is_finite() && stiffness > 0.0) {
+    return make_error!(
+      "Skyline smoothing stiffness must be finite and positive for a multi-segment fit, got {stiffness}"
+    );
+  }
+  if !(tolerance.is_finite() && tolerance > 0.0) {
+    return make_error!("Skyline Newton tolerance must be finite and positive, got {tolerance}");
+  }
+  if max_iter == 0 {
+    return make_error!("Skyline Newton max_iter must be at least 1");
+  }
+
+  let mut converged = false;
+  let mut last_g_norm = f64::INFINITY;
   for _ in 0..max_iter {
     // Gradient and tridiagonal Hessian (diagonal `diag`, off-diagonal `off = -γ`).
     let mut g = vec![0.0; n];
@@ -288,7 +316,9 @@ fn solve_inverse_tc(
     }
 
     let g_norm = g.iter().fold(0.0_f64, |acc, &v| acc.max(v.abs()));
+    last_g_norm = g_norm;
     if g_norm < tolerance {
+      converged = true;
       break;
     }
 
@@ -316,6 +346,15 @@ fn solve_inverse_tc(
         break;
       }
     }
+  }
+
+  // A non-converged fit was previously indistinguishable from a converged one.
+  // Surface it so a returned iterate that failed the gradient tolerance is visible.
+  if !converged {
+    warn!(
+      "Skyline Newton did not reach gradient tolerance {tolerance:.3e} within {max_iter} iterations \
+       (final gradient infinity-norm {last_g_norm:.3e}); returning the last iterate"
+    );
   }
 
   Ok(x)

--- a/packages/treetime/src/commands/timetree/args.rs
+++ b/packages/treetime/src/commands/timetree/args.rs
@@ -122,7 +122,10 @@ pub struct TreetimeTimetreeArgs {
   ///
   /// When set, TreeTime will find the optimal Tc using Brent's method. This is similar
   /// to Python v0's `--coalescent=opt`, but uses a closed-form solution.
-  #[cfg_attr(feature = "clap", clap(long, conflicts_with = "coalescent", conflicts_with = "coalescent_skyline"))]
+  #[cfg_attr(
+    feature = "clap",
+    clap(long, conflicts_with = "coalescent", conflicts_with = "coalescent_skyline")
+  )]
   pub coalescent_opt: bool,
 
   /// Use skyline coalescent model instead of constant Tc.


### PR DESCRIPTION
`fix/coalescent-skyline-solver-robustness` -> `rust`

- Follow-up to: #856

The skyline optimizer had three robustness defects. Merger times were sorted with `partial_cmp().expect()`, which panics on a NaN time and departs from the project's `OrderedFloat` convention. A non-positive or non-finite stiffness was silently treated as no smoothing although the parameter is documented positive. And the Newton loop returned its last iterate whether or not the gradient tolerance was met, so a non-converged fit was indistinguishable from a converged one.

This sorts merger times with `OrderedFloat` and rejects non-finite times, rejects non-finite or non-positive stiffness, non-finite tolerance, and a zero iteration budget for multi-segment fits, and warns when Newton returns without reaching the gradient tolerance [[src](https://github.com/neherlab/treetime/blob/3da1622954186f9788ebc2df87795e305a330c34/packages/treetime/src/coalescent/skyline.rs)].

The input guards are hard errors because a non-finite or non-positive smoothing parameter has no valid interpretation and signals misconfiguration. Non-convergence is a warning rather than an error because the last iterate is still a usable estimate, and failing the run would discard an otherwise-progressing fit.

### Work items

- [x] Sort merger times with `OrderedFloat` and reject non-finite times [[src](https://github.com/neherlab/treetime/blob/3da1622954186f9788ebc2df87795e305a330c34/packages/treetime/src/coalescent/skyline.rs)]
- [x] Reject non-finite/non-positive stiffness, non-finite tolerance, and zero max-iter for multi-segment fits [[src](https://github.com/neherlab/treetime/blob/3da1622954186f9788ebc2df87795e305a330c34/packages/treetime/src/coalescent/skyline.rs)]
- [x] Warn when the Newton solve does not reach the gradient tolerance [[src](https://github.com/neherlab/treetime/blob/3da1622954186f9788ebc2df87795e305a330c34/packages/treetime/src/coalescent/skyline.rs)]
- [x] Add tests for the stiffness guards [[src](https://github.com/neherlab/treetime/blob/3da1622954186f9788ebc2df87795e305a330c34/packages/treetime/src/coalescent/__tests__/test_skyline.rs)]

