### PR TITLE
docs: correct skyline quadrature self-consistency claim

### DIFF
--- a/kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md
+++ b/kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md
@@ -1,17 +1,30 @@
 # Skyline merger-rate quadrature lacks an accuracy contract
 
-> **Scope narrowed.** The skyline is now piecewise-*constant*, and its optimizer
-> attributes each lineage-count interval wholly to the segment of its midpoint —
-> the same midpoint convention the model uses — so the midpoint rule is *exact* for
-> the piecewise-constant skyline (no quadrature error, and the analytic optimum
-> matches the model-evaluated likelihood). See
+> **Scope narrowed.** The skyline is now piecewise-_constant_, and its optimizer
+> attributes each lineage-count interval wholly to the segment of its midpoint,
+> the same midpoint convention the model uses. This makes fitting and evaluation
+> _self-consistent_: the analytic optimum is the true maximizer of the
+> model-evaluated likelihood, and the reported LH matches
+> `compute_coalescent_total_lh`. Self-consistency is not exactness. For the segment
+> boundaries the tool reports (merger-time midpoints, which fall off the
+> lineage-count grid), the midpoint rule is exact on every lineage-count interval
+> that contains no skyline boundary, but at most `n_points - 1` intervals straddle
+> a boundary, and each contributes an error bounded by its exposure times the
+> inter-segment $T_c$ contrast. Two checks quantify the straddle error: interval
+> $[0,2]$, $k=3$, $T_c$ jumping $1\to10$ at $0.5$ gives exact $0.65$ versus computed
+> $0.2$; interval $[0,10]$, $k=2$, $T_c$ jumping $1\to100$ at $1$ gives exact
+> $0.545$ versus computed $0.05$. The smoothing penalty keeps per-boundary contrasts
+> small, so the practical bias on real trees is expected to be small relative to the
+> $T_c(t)$ uncertainty, but it is currently unquantified beyond the single
+> continuous-$T_c$ measurement below. See
 > [decisions/coalescent-skyline-convex-inverse-tc.md](../decisions/coalescent-skyline-convex-inverse-tc.md).
-> The contract below still applies to genuinely continuous $T_c(t)$ (e.g. a
-> `Formula` distribution), which the ignored smooth-$T_c$ test exercises.
+> The contract below applies both to these off-grid boundaries and to genuinely
+> continuous $T_c(t)$ (e.g. a `Formula` distribution), which the ignored smooth-$T_c$
+> test exercises.
 
 `fn compute_integral_merger_rate()` evaluates $T_c(t)$ once at each lineage-count interval midpoint [packages/treetime/src/coalescent/integration.rs#L44-L71](../../packages/treetime/src/coalescent/integration.rs#L44-L71). The approximation has no stated convergence order, refinement rule, or error bound for a varying skyline.
 
-The ignored analytical test integrates $1/(0.01+0.004t)$ on $[0,10]$ and observes an error of approximately $1.6\times10^{-4}$ [packages/treetime/src/coalescent/__tests__/test_integration.rs#L157-L164](../../packages/treetime/src/coalescent/__tests__/test_integration.rs#L157-L164). V0 uses a different numerical integration rule, so the selected algorithm also requires an explicit parity disposition.
+The ignored analytical test integrates $1/(0.01+0.004t)$ on $[0,10]$ and observes an error of approximately $1.6\times10^{-4}$ [packages/treetime/src/coalescent/**tests**/test_integration.rs#L157-L164](../../packages/treetime/src/coalescent/__tests__/test_integration.rs#L157-L164). V0 uses a different numerical integration rule, so the selected algorithm also requires an explicit parity disposition.
 
 Let $\kappa(t)$ be the per-branch merger rate and let $I(t)$ be its cumulative integral:
 


### PR DESCRIPTION
`docs/coalescent-skyline-quadrature-contract` -> `rust`

Update:

- [kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md](https://github.com/neherlab/treetime/blob/5ff243d06fee3747a748d0bb21d640be9fc98443/kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md): replace the "no quadrature error" claim with self-consistency and record the off-grid error bound

- Follow-up to: #856

The quadrature issue claimed the midpoint rule is exact for the piecewise-constant skyline, with no quadrature error. That holds only if the operative demographic function is taken to be the midpoint-snapped one. For the merger-time-midpoint boundaries the tool actually reports, the rule is self-consistent, not exact.

This corrects the wording to self-consistency and records the off-grid error characterization: the midpoint rule is exact on every lineage-count interval that contains no skyline boundary, while at most $n-1$ intervals straddle a boundary and each contributes an error bounded by its exposure times the inter-segment $T_c$ contrast [[src](https://github.com/neherlab/treetime/blob/5ff243d06fee3747a748d0bb21d640be9fc98443/kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md)].

### Work items

- [x] Replace the "no quadrature error" claim with self-consistency and record the off-grid error bound [[src](https://github.com/neherlab/treetime/blob/5ff243d06fee3747a748d0bb21d640be9fc98443/kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md)]

### Possible improvements

- [ ] Implement the exact interval integral, splitting each inter-event interval at the skyline breakpoints (option O3) ([kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md](https://github.com/neherlab/treetime/blob/5ff243d06fee3747a748d0bb21d640be9fc98443/kb/issues/N-coalescent-skyline-quadrature-contract-undecided.md))
