### PR TITLE
test: add failing repro for unvalidated non-positive skyline stiffness

### DIFF
--- a/packages/treetime/src/coalescent/__tests__/mod.rs
+++ b/packages/treetime/src/coalescent/__tests__/mod.rs
@@ -7,4 +7,5 @@ mod test_integration;
 mod test_lineage_dynamics;
 mod test_optimize_tc;
 mod test_skyline;
+mod test_skyline_repro_stiffness_validation;
 mod test_total_lh;

--- a/packages/treetime/src/coalescent/__tests__/test_skyline_repro_stiffness_validation.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_skyline_repro_stiffness_validation.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests {
+  use crate::clock::date_constraints::load_date_constraints;
+  use crate::coalescent::skyline::{SkylineParams, optimize_skyline};
+  use crate::partition::timetree::GraphTimetree;
+  use eyre::Report;
+  use maplit::btreemap;
+  use treetime_io::dates_csv::{DateConstraint, DatesMap};
+  use treetime_io::nwk::nwk_read_str;
+
+  const SMALL_TREE_NWK: &str = "((leaf1:1.0,leaf2:1.0)internal1:1.0,leaf3:1.0)root:1.0;";
+
+  fn small_tree_dates() -> DatesMap {
+    btreemap! {
+      "root".to_owned() => Some(DateConstraint::exact(2000.0)),
+      "internal1".to_owned() => Some(DateConstraint::exact(2005.0)),
+      "leaf1".to_owned() => Some(DateConstraint::exact(2010.0)),
+      "leaf2".to_owned() => Some(DateConstraint::exact(2010.0)),
+      "leaf3".to_owned() => Some(DateConstraint::exact(2012.0)),
+    }
+  }
+
+  fn small_tree() -> Result<GraphTimetree, Report> {
+    let graph = nwk_read_str(SMALL_TREE_NWK)?;
+    load_date_constraints(&small_tree_dates(), &graph)?;
+    Ok(graph)
+  }
+
+  // Counterexample for the unenforced `stiffness > 0` precondition.
+  //
+  // `SkylineParams::stiffness` is documented "Must be positive for more than one
+  // segment", but `optimize_skyline` validates only `n_points` and the CLI accepts
+  // any `f64`. This branch also removed the previous `stiffness <= 0` short-circuit
+  // in `solve_log_tc`. A negative stiffness turns the smoothing penalty into
+  // `-(|s|/2) * sum (ln(Tc_{i+1}/Tc_i))^2`, which is unbounded below, so the
+  // objective is no longer convex and the Thomas solve loses the positive-definite
+  // Hessian it assumes (no pivoting).
+  //
+  // Expected: multi-segment optimization rejects a non-positive stiffness with a
+  // typed error. Once the guard is restored, tighten this to
+  // `assert_err!(result, "<message>")`.
+  #[test]
+  fn test_skyline_negative_stiffness_is_rejected() -> Result<(), Report> {
+    let params = SkylineParams {
+      n_points: 5,
+      stiffness: -1.0,
+      ..SkylineParams::default()
+    };
+
+    let result = optimize_skyline(&small_tree()?, &params);
+
+    assert!(
+      result.is_err(),
+      "multi-segment optimize_skyline must reject negative stiffness, but returned Ok"
+    );
+    Ok(())
+  }
+}


### PR DESCRIPTION
- Related to: #869
- Reviewed in: [#869 review comment](https://github.com/neherlab/treetime/pull/869#issuecomment-5064308569)

Red counterexample for #869, base is the PR head branch so CI shows it failing against the code under review. Not intended to merge as-is: the author decides the fix, then adapts or removes the test.

`SkylineParams::stiffness` is documented "Must be positive for more than one segment", but `optimize_skyline` validates only `n_points`, the CLI exposes `--skyline-stiffness` as a bare `f64` with no `value_parser`, and this branch removed the previous `stiffness <= 0` short-circuit in `solve_log_tc`. A negative stiffness makes the smoothing penalty unbounded below, so the objective is non-convex and the Thomas solve loses the positive-definite Hessian it assumes.

The test drives a five-segment skyline with `stiffness = -1.0` and asserts the call is rejected. On the current head it returns `Ok`: the solver degrades to the decoupled warm start (the Armijo line search rejects the indefinite Newton step) rather than raising an error. The output stays finite on this tree, so the concern is an unenforced precondition and a latent non-convex solve, not an observed `NaN`.

### Work items

- [x] Assert a multi-segment `optimize_skyline` with negative stiffness returns an error

### Possible improvements

- [ ] Once a guard is restored, tighten to `assert_err!` with the real message and add `stiffness = 0` (behavior-preserving) and `NaN`/`inf` cases