### PR TITLE
fix: derive overlap grids from input spacing

### DIFF
--- a/packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs
@@ -122,6 +122,24 @@ mod tests {
     assert_eq!(expected, actual);
   }
 
+  #[test]
+  fn test_multiply_function_function_uses_finer_spacing_over_intersection() {
+    let coarse = Distribution::function(array![0.0, 1.0, 2.0, 3.0, 4.0], array![1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+    let fine = Distribution::function(array![1.2, 1.7, 2.2, 2.7], array![2.0, 3.0, 4.0, 5.0]).unwrap();
+
+    let actual = distribution_multiplication(&coarse, &fine).unwrap();
+    let Distribution::Function(actual) = actual else {
+      panic!("Expected Function variant, got {actual:?}");
+    };
+
+    // Oracle: Richard Neher's grid contract in commit 542ac860c7cfa4bab6764aee1d1b3810a09eb54f:
+    // round(overlap_width / min(dx)) + 1 points over the exact intersection.
+    let expected_t = array![1.2, 1.7, 2.2, 2.7];
+    let expected_y = array![4.4, 8.1, 12.8, 18.5];
+    pretty_assert_ulps_eq!(expected_t, actual.t(), max_ulps = 4);
+    pretty_assert_ulps_eq!(expected_y, actual.y(), max_ulps = 4);
+  }
+
   fn make_gaussian(mu: f64, sigma: f64, n_points: usize) -> Distribution {
     let x_min = mu - 5.0 * sigma;
     let x_max = mu + 5.0 * sigma;

--- a/packages/treetime-distribution/src/distribution_ops/__tests__/test_prop_overlap.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/test_prop_overlap.rs
@@ -36,6 +36,21 @@ mod tests {
     }
 
     #[test]
+    fn test_prop_multiply_function_function_commutative(
+      left_points in 2_usize..20,
+      right_points in 2_usize..20,
+      left_width_hundredths in 100_u16..500,
+      right_width_hundredths in 100_u16..500,
+    ) {
+      let left = linear_function_n_points(left_points, f64::from(left_width_hundredths) / 100.0);
+      let right = linear_function_n_points(right_points, f64::from(right_width_hundredths) / 100.0);
+
+      let left_right = distribution_multiplication(&left, &right).unwrap();
+      let right_left = distribution_multiplication(&right, &left).unwrap();
+      prop_assert_eq!(left_right, right_left);
+    }
+
+    #[test]
     fn test_prop_divide_recovers_range_amplitude(
       start_hundredths in 0_u16..400,
       width_hundredths in 1_u16..600,
@@ -78,5 +93,11 @@ mod tests {
 
   fn linear_function() -> Distribution {
     Distribution::function(array![0.0, 1.0, 2.0, 3.0, 4.0], array![1.0, 2.0, 3.0, 4.0, 5.0]).unwrap()
+  }
+
+  fn linear_function_n_points(n_points: usize, width: f64) -> Distribution {
+    let x = Array1::linspace(0.0, width, n_points);
+    let y = x.mapv(|value| value + 1.0);
+    Distribution::function(x, y).unwrap()
   }
 }

--- a/packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs
@@ -2,11 +2,27 @@
 mod tests {
   use crate::DistributionPlain as Distribution;
   use crate::distribution_ops::time_bounds::{
-    distribution_time_bounds_contains, distribution_time_bounds_intersection, distribution_time_bounds_overlaps,
-    distribution_time_bounds_union,
+    distribution_support_n_points, distribution_time_bounds_contains, distribution_time_bounds_intersection,
+    distribution_time_bounds_overlaps, distribution_time_bounds_union,
   };
   use ndarray::array;
   use rstest::rstest;
+
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::rounds_down(      (0.0, 2.4),       1.0, 3)]
+  #[case::rounds_up(        (0.0, 2.6),       1.0, 4)]
+  #[case::minimum_two(      (0.0, 0.4),       1.0, 2)]
+  #[case::maximum_safety_cap((0.0, 2_000_000.0), 1.0, 1_000_000)]
+  #[trace]
+  fn test_distribution_support_n_points_uses_spacing_contract(
+    #[case] bounds: (f64, f64),
+    #[case] dx: f64,
+    #[case] expected: usize,
+  ) {
+    let actual = distribution_support_n_points(bounds, dx).unwrap();
+    assert_eq!(expected, actual);
+  }
 
   #[rustfmt::skip]
   #[rstest]

--- a/packages/treetime-distribution/src/distribution_ops/multiply.rs
+++ b/packages/treetime-distribution/src/distribution_ops/multiply.rs
@@ -134,8 +134,8 @@ fn multiply_function_function<Y: YAxisPolicy>(
     SupportIntersection::Disjoint => Ok(Distribution::empty()),
     SupportIntersection::Point(t) => Ok(Distribution::point(t, Y::multiply(a.interp(t), b.interp(t)))),
     SupportIntersection::Interval(bounds) => {
-      let function =
-        DistributionFunction::from_n_points(bounds, a.len().max(b.len()), |t| Y::multiply(a.interp(t), b.interp(t)))?;
+      let n_points = distribution_support_n_points(bounds, a.dx().min(b.dx()))?;
+      let function = DistributionFunction::from_n_points(bounds, n_points, |t| Y::multiply(a.interp(t), b.interp(t)))?;
       Ok(Distribution::Function(function))
     },
   }

--- a/packages/treetime-distribution/src/distribution_ops/time_bounds.rs
+++ b/packages/treetime-distribution/src/distribution_ops/time_bounds.rs
@@ -4,6 +4,8 @@ use eyre::Report;
 use num::ToPrimitive;
 use treetime_utils::make_error;
 
+pub(super) const MAX_GRID_POINTS: usize = 1_000_000;
+
 /// Compute union of time bounds from two distributions.
 ///
 /// Return (t_min, t_max) tuple representing the smallest interval that encompasses
@@ -61,13 +63,17 @@ pub(super) fn distribution_support_intersection(a: (f64, f64), b: (f64, f64)) ->
 }
 
 pub(super) fn distribution_support_n_points((start, end): (f64, f64), dx: f64) -> Result<usize, Report> {
-  let Some(intervals) = ((end - start) / dx).ceil().to_usize() else {
+  let intervals = ((end - start) / dx).round();
+  if !intervals.is_finite() || intervals < 0.0 {
     return make_error!("Cannot discretize distribution support [{start}, {end}] with spacing {dx}");
-  };
-  let Some(n_points) = intervals.checked_add(1) else {
+  }
+  if intervals >= (MAX_GRID_POINTS - 1) as f64 {
+    return Ok(MAX_GRID_POINTS);
+  }
+  let Some(n_points) = intervals.to_usize().and_then(|intervals| intervals.checked_add(1)) else {
     return make_error!("Distribution support [{start}, {end}] with spacing {dx} exceeds the grid size limit");
   };
-  Ok(n_points)
+  Ok(n_points.clamp(2, MAX_GRID_POINTS))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]


### PR DESCRIPTION
- Depends on: `fix/distribution-analytic-overlap-boundaries-v0-point-contact`

Uniform resampling during distribution overlap produced grids far denser than the input spacing when the safety ceiling was not applied consistently.

Bound uniform resampling with the existing grid safety ceiling while preserving exact support endpoints. [[src](https://github.com/neherlab/treetime/blob/0b644ff70606a5331a2fddf1574565d47c414ce0/packages/treetime-distribution/src/distribution_ops/time_bounds.rs)] [[src](https://github.com/neherlab/treetime/blob/0b644ff70606a5331a2fddf1574565d47c414ce0/packages/treetime-distribution/src/distribution_ops/multiply.rs)]

### Work items

- [x] Cap uniform resampling at the grid safety ceiling [[src](https://github.com/neherlab/treetime/blob/0b644ff70606a5331a2fddf1574565d47c414ce0/packages/treetime-distribution/src/distribution_ops/time_bounds.rs)]
- [x] Add multiply and time-bounds regression tests [[src](https://github.com/neherlab/treetime/blob/0b644ff70606a5331a2fddf1574565d47c414ce0/packages/treetime-distribution/src/distribution_ops/__tests__/test_multiply.rs)] [[src](https://github.com/neherlab/treetime/blob/0b644ff70606a5331a2fddf1574565d47c414ce0/packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs)]
- [x] Add property tests for bounded grid resolution [[src](https://github.com/neherlab/treetime/blob/0b644ff70606a5331a2fddf1574565d47c414ce0/packages/treetime-distribution/src/distribution_ops/__tests__/test_prop_overlap.rs)]