### PR TITLE
feat: type aggregate log-likelihood values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4767,6 +4767,7 @@ dependencies = [
 name = "treetime-primitives"
 version = "1.0.0"
 dependencies = [
+ "approx",
  "auto_ops",
  "ctor 0.5.0",
  "eyre",

--- a/packages/treetime-primitives/Cargo.toml
+++ b/packages/treetime-primitives/Cargo.toml
@@ -21,6 +21,7 @@ itertools = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]
+approx = { workspace = true }
 ctor = { workspace = true }
 pretty_assertions = { workspace = true }
 rayon = { workspace = true }

--- a/packages/treetime-primitives/src/__tests__/mod.rs
+++ b/packages/treetime-primitives/src/__tests__/mod.rs
@@ -1,3 +1,4 @@
 mod test_ascii_char;
 mod test_bitset128;
+mod test_log_lh;
 mod test_seq;

--- a/packages/treetime-primitives/src/__tests__/test_log_lh.rs
+++ b/packages/treetime-primitives/src/__tests__/test_log_lh.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+mod tests {
+  use crate::LogLh;
+  use std::mem::{align_of, size_of};
+  use treetime_utils::io::json::{JsonPretty, json_read_str, json_write_str};
+  use treetime_utils::pretty_assert_ulps_eq;
+
+  #[test]
+  fn test_log_lh_construction_and_extraction() {
+    let log_lh = LogLh::new(-12.5);
+
+    pretty_assert_ulps_eq!(-12.5, log_lh.value(), max_ulps = 1);
+  }
+
+  #[test]
+  fn test_log_lh_constants() {
+    pretty_assert_ulps_eq!(0.0, LogLh::ZERO.value(), max_ulps = 1);
+    assert!(LogLh::IMPOSSIBLE.value().is_infinite());
+    assert!(LogLh::IMPOSSIBLE.value().is_sign_negative());
+  }
+
+  #[test]
+  fn test_log_lh_addition_and_assignment() {
+    let mut actual = LogLh::new(-2.0) + LogLh::new(-3.5);
+    actual += LogLh::new(1.0);
+
+    pretty_assert_ulps_eq!(-4.5, actual.value(), max_ulps = 1);
+  }
+
+  #[test]
+  fn test_log_lh_owned_and_borrowed_sums() {
+    let values = [LogLh::new(-1.0), LogLh::new(-2.0), LogLh::new(-3.0)];
+
+    let owned: LogLh = values.into_iter().sum();
+    let borrowed: LogLh = values.iter().sum();
+
+    pretty_assert_ulps_eq!(-6.0, owned.value(), max_ulps = 1);
+    pretty_assert_ulps_eq!(-6.0, borrowed.value(), max_ulps = 1);
+  }
+
+  #[test]
+  fn test_log_lh_subtraction_returns_difference() {
+    let difference = LogLh::new(-2.0) - LogLh::new(-5.5);
+
+    pretty_assert_ulps_eq!(3.5, difference, max_ulps = 1);
+  }
+
+  #[test]
+  fn test_log_lh_negation_returns_optimizer_cost() {
+    let cost = -LogLh::new(-2.5);
+
+    pretty_assert_ulps_eq!(2.5, cost, max_ulps = 1);
+  }
+
+  #[test]
+  fn test_log_lh_comparison() {
+    assert!(LogLh::new(-2.0) > LogLh::new(-3.0));
+  }
+
+  #[test]
+  fn test_log_lh_layout_matches_f64() {
+    assert_eq!(size_of::<f64>(), size_of::<LogLh>());
+    assert_eq!(align_of::<f64>(), align_of::<LogLh>());
+  }
+
+  #[test]
+  fn test_log_lh_json_is_transparent() {
+    let expected = "-12.5";
+
+    let actual = json_write_str(&LogLh::new(-12.5), JsonPretty(false)).expect("LogLh serialization should succeed");
+    let roundtrip: LogLh = json_read_str(&actual).expect("LogLh deserialization should succeed");
+
+    assert_eq!(expected, actual);
+    pretty_assert_ulps_eq!(-12.5, roundtrip.value(), max_ulps = 1);
+  }
+}

--- a/packages/treetime-primitives/src/lib.rs
+++ b/packages/treetime-primitives/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod bitset128;
+pub mod log_lh;
 pub mod seq;
 pub mod seq_char;
 
 pub use bitset128::{BitSet128, BitSet128Status};
+pub use log_lh::LogLh;
 pub use seq::Seq;
 pub use seq_char::AsciiChar;
 

--- a/packages/treetime-primitives/src/log_lh.rs
+++ b/packages/treetime-primitives/src/log_lh.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use std::iter::Sum;
+use std::ops::{Add, AddAssign, Neg, Sub};
+
+/// Aggregate log-likelihood in natural-log space.
+///
+/// The wrapper distinguishes complete and component log-likelihoods from raw
+/// probabilities, branch lengths, dates, and optimizer coordinates while
+/// retaining the layout of `f64`.
+///
+/// Raw floats cannot be mixed into log-likelihood arithmetic implicitly:
+///
+/// ```compile_fail
+/// use treetime_primitives::LogLh;
+///
+/// let _ = LogLh::new(-2.0) + 1.0;
+/// ```
+///
+/// ```compile_fail
+/// use treetime_primitives::LogLh;
+///
+/// let _ = 1.0 + LogLh::new(-2.0);
+/// ```
+///
+/// ```compile_fail
+/// use treetime_primitives::LogLh;
+///
+/// let _: LogLh = -2.0;
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[repr(transparent)]
+#[serde(transparent)]
+pub struct LogLh(f64);
+
+impl LogLh {
+  /// Additive identity for independent log-likelihood components.
+  pub const ZERO: Self = Self(0.0);
+
+  /// Log-likelihood of an impossible event.
+  pub const IMPOSSIBLE: Self = Self(f64::NEG_INFINITY);
+
+  pub const fn new(value: f64) -> Self {
+    Self(value)
+  }
+
+  pub const fn value(self) -> f64 {
+    self.0
+  }
+}
+
+impl Default for LogLh {
+  fn default() -> Self {
+    Self::ZERO
+  }
+}
+
+impl Add for LogLh {
+  type Output = Self;
+
+  fn add(self, rhs: Self) -> Self::Output {
+    Self(self.0 + rhs.0)
+  }
+}
+
+impl AddAssign for LogLh {
+  fn add_assign(&mut self, rhs: Self) {
+    self.0 += rhs.0;
+  }
+}
+
+impl Sum for LogLh {
+  fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+    iter.fold(Self::ZERO, Add::add)
+  }
+}
+
+impl<'a> Sum<&'a LogLh> for LogLh {
+  fn sum<I: Iterator<Item = &'a LogLh>>(iter: I) -> Self {
+    iter.copied().sum()
+  }
+}
+
+impl Sub for LogLh {
+  type Output = f64;
+
+  fn sub(self, rhs: Self) -> Self::Output {
+    self.0 - rhs.0
+  }
+}
+
+impl Neg for LogLh {
+  type Output = f64;
+
+  fn neg(self) -> Self::Output {
+    -self.0
+  }
+}

--- a/packages/treetime/src/ancestral/__tests__/prop_marginal_support.rs
+++ b/packages/treetime/src/ancestral/__tests__/prop_marginal_support.rs
@@ -50,7 +50,7 @@ pub mod tests {
       length,
     )))];
 
-    let log_lh = initialize_marginal(&graph, &partitions, &input.alignment)?;
+    let log_lh = initialize_marginal(&graph, &partitions, &input.alignment)?.value();
     Ok((log_lh, partitions))
   }
 
@@ -83,7 +83,7 @@ pub mod tests {
     let partitions = [Arc::new(RwLock::new(
       fitch.into_marginal_sparse(input.gtr.clone(), &graph)?,
     ))];
-    let log_lh = update_marginal(&graph, &partitions)?;
+    let log_lh = update_marginal(&graph, &partitions)?.value();
     Ok((log_lh, partitions))
   }
 }

--- a/packages/treetime/src/ancestral/__tests__/test_dense_completeness.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_dense_completeness.rs
@@ -43,7 +43,7 @@ NNGTACGTAC
       length,
     )));
 
-    initialize_marginal(&graph, std::slice::from_ref(&partition), &aln)?;
+    initialize_marginal(&graph, std::slice::from_ref(&partition), &aln)?.value();
     Ok((graph, partition))
   }
 
@@ -68,7 +68,7 @@ NNGTACGTAC
     let partition = Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ));
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    update_marginal(&graph, std::slice::from_ref(&partition))?.value();
     Ok((graph, partition))
   }
 
@@ -170,7 +170,7 @@ ACGTACGTAC
       length,
     )));
 
-    initialize_marginal(&graph, std::slice::from_ref(&partition), &aln)?;
+    initialize_marginal(&graph, std::slice::from_ref(&partition), &aln)?.value();
     Ok((graph, partition))
   }
 
@@ -236,7 +236,7 @@ ACGTACGTAC
     let partition = Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ));
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    update_marginal(&graph, std::slice::from_ref(&partition))?.value();
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -1132,7 +1132,7 @@ mod tests {
 
     // Run initial marginal pass before reroot
     let partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>> = vec![Arc::new(RwLock::new(sparse))];
-    update_marginal(&graph, &partitions)?;
+    update_marginal(&graph, &partitions)?.value();
 
     // Reroot on AB->A
     let old_root_key = graph.get_exactly_one_root()?.read_arc().key();
@@ -1162,7 +1162,7 @@ mod tests {
     partitions[0].write_arc().apply_reroot(&changes)?;
 
     // Run marginal pass after reroot
-    update_marginal(&graph, &partitions)?;
+    update_marginal(&graph, &partitions)?.value();
 
     let partition = partitions[0].read_arc();
     let root_edge_totals: Vec<(_, usize)> = graph

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_analytical/test_marginal_analytical_support.rs
@@ -108,7 +108,7 @@ pub mod tests {
       get_common_length(&aln)?,
     )))];
 
-    let log_lh = initialize_marginal(&graph, &partitions, &aln)?;
+    let log_lh = initialize_marginal(&graph, &partitions, &aln)?.value();
     Ok(log_lh)
   }
 }

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_consistency.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_consistency.rs
@@ -100,7 +100,7 @@ mod tests {
     )));
     let partitions = [Arc::clone(&partition)];
 
-    let log_lh = initialize_marginal(graph, &partitions, aln)?;
+    let log_lh = initialize_marginal(graph, &partitions, aln)?.value();
     Ok((log_lh, partition))
   }
 
@@ -127,7 +127,7 @@ mod tests {
     let partition = Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, graph)?));
     let partitions = [Arc::clone(&partition)];
 
-    let log_lh = update_marginal(graph, &partitions)?;
+    let log_lh = update_marginal(graph, &partitions)?.value();
     Ok((log_lh, partition))
   }
 
@@ -272,9 +272,9 @@ mod tests {
 
     for node_data in sparse.nodes.values() {
       assert!(
-        node_data.profile.log_lh.is_finite(),
+        node_data.profile.log_lh.value().is_finite(),
         "Sparse node profile log_lh is not finite: {}",
-        node_data.profile.log_lh
+        node_data.profile.log_lh.value()
       );
 
       for (pos, var_pos) in &node_data.profile.variable {
@@ -450,7 +450,7 @@ mod tests {
     )));
     let partitions = [Arc::clone(&partition)];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     // Verify all marginal posterior rows sum to 1.0
     let partition = partition.read_arc();

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_dense.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_dense.rs
@@ -89,7 +89,7 @@ mod tests {
       get_common_length(aln)?,
     )))];
 
-    let log_lh = initialize_marginal(graph, &partitions, aln)?;
+    let log_lh = initialize_marginal(graph, &partitions, aln)?.value();
     Ok((log_lh, partitions))
   }
 
@@ -262,8 +262,8 @@ mod tests {
 
     let (log_lh_init, partitions) = run_dense_marginal(&graph, &ALN_7_TAXON, gtr)?;
 
-    let log_lh_first = update_marginal(&graph, &partitions)?;
-    let log_lh_second = update_marginal(&graph, &partitions)?;
+    let log_lh_first = update_marginal(&graph, &partitions)?.value();
+    let log_lh_second = update_marginal(&graph, &partitions)?.value();
 
     // Repeated updates must produce identical log-likelihood to initialization
     pretty_assert_ulps_eq!(log_lh_init, log_lh_first, epsilon = 1e-10);

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_idempotency_example.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_idempotency_example.rs
@@ -79,8 +79,8 @@ TCGGCCGTGTRTTG--
     let graph: GraphAncestral = nwk_read_str(&input.newick)?;
     let (_, partitions) = run_dense_marginal(&input)?;
 
-    let log_lh_first = update_marginal(&graph, &partitions)?;
-    let log_lh_second = update_marginal(&graph, &partitions)?;
+    let log_lh_first = update_marginal(&graph, &partitions)?.value();
+    let log_lh_second = update_marginal(&graph, &partitions)?.value();
     pretty_assert_ulps_eq!(log_lh_first, log_lh_second, epsilon = 1e-10);
 
     Ok(())
@@ -106,8 +106,8 @@ TCGGCCGTGTRTTG--
     let graph: GraphAncestral = nwk_read_str(&input.newick)?;
     let (_, partitions) = run_sparse_marginal(&input)?;
 
-    let log_lh_first = update_marginal(&graph, &partitions)?;
-    let log_lh_second = update_marginal(&graph, &partitions)?;
+    let log_lh_first = update_marginal(&graph, &partitions)?.value();
+    let log_lh_second = update_marginal(&graph, &partitions)?.value();
     pretty_assert_ulps_eq!(log_lh_first, log_lh_second, epsilon = 1e-10);
 
     Ok(())

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_idempotency_prop.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_idempotency_prop.rs
@@ -46,8 +46,8 @@ mod tests {
       let graph: GraphAncestral = nwk_read_str(&input.newick).unwrap();
       let (_, partitions) = run_dense_marginal(&input).unwrap();
 
-      let log_lh_first = update_marginal(&graph, &partitions).unwrap();
-      let log_lh_second = update_marginal(&graph, &partitions).unwrap();
+      let log_lh_first = update_marginal(&graph, &partitions).unwrap().value();
+      let log_lh_second = update_marginal(&graph, &partitions).unwrap().value();
 
       prop_assert_abs_diff_eq!(log_lh_first, log_lh_second, epsilon = 1e-10);
     }
@@ -76,8 +76,8 @@ mod tests {
       let graph: GraphAncestral = nwk_read_str(&input.newick).unwrap();
       let (_, partitions) = run_sparse_marginal(&input).unwrap();
 
-      let log_lh_first = update_marginal(&graph, &partitions).unwrap();
-      let log_lh_second = update_marginal(&graph, &partitions).unwrap();
+      let log_lh_first = update_marginal(&graph, &partitions).unwrap().value();
+      let log_lh_second = update_marginal(&graph, &partitions).unwrap().value();
 
       prop_assert_abs_diff_eq!(log_lh_first, log_lh_second, epsilon = 1e-10);
     }

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_normalization_example.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_normalization_example.rs
@@ -152,9 +152,9 @@ ACGTACGC
     for node_data in partition.nodes.values() {
       let profile = &node_data.profile;
       assert!(
-        profile.log_lh.is_finite(),
+        profile.log_lh.value().is_finite(),
         "Sparse node profile log-lh is not finite: {}",
-        profile.log_lh
+        profile.log_lh.value()
       );
       for var_pos in profile.variable.values() {
         pretty_assert_array_finite!(var_pos.dis);
@@ -170,9 +170,9 @@ ACGTACGC
     for edge_data in partition.edges.values() {
       let profile = &edge_data.msg_to_child;
       assert!(
-        profile.log_lh.is_finite(),
+        profile.log_lh.value().is_finite(),
         "Sparse edge message log-lh is not finite: {}",
-        profile.log_lh
+        profile.log_lh.value()
       );
       for var_pos in profile.variable.values() {
         pretty_assert_array_finite!(var_pos.dis);

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_normalization_prop.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_normalization_prop.rs
@@ -46,9 +46,9 @@ mod tests {
   /// Returns a proptest-compatible `TestCaseError` on failure to support shrinking.
   fn assert_sparse_profile_normalized(profile: &SparseSeqDistribution) -> Result<(), TestCaseError> {
     prop_assert!(
-      profile.log_lh.is_finite(),
+      profile.log_lh.value().is_finite(),
       "Profile log_lh non-finite: {}",
-      profile.log_lh
+      profile.log_lh.value()
     );
 
     for (pos, var_pos) in &profile.variable {

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_sparse.rs
@@ -45,9 +45,9 @@ mod tests {
   /// Kolmogorov axioms: P(s) >= 0 for all states s, and sum_s P(s) = 1.
   fn assert_sparse_profile_normalized(profile: &SparseSeqDistribution, max_ulps: u32) {
     assert!(
-      profile.log_lh.is_finite(),
+      profile.log_lh.value().is_finite(),
       "Profile log_lh is not finite: {}",
-      profile.log_lh
+      profile.log_lh.value()
     );
 
     for (pos, var_pos) in &profile.variable {
@@ -122,7 +122,7 @@ mod tests {
     let alphabet = Alphabet::default();
     let fitch = create_fitch_partition(graph, 0, alphabet, aln)?;
     let partitions = [Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, graph)?))];
-    let log_lh = update_marginal(graph, &partitions)?;
+    let log_lh = update_marginal(graph, &partitions)?.value();
     Ok((log_lh, partitions))
   }
 
@@ -188,7 +188,7 @@ mod tests {
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ))];
 
-    let log_lh = update_marginal(&graph, &partitions_marginal_sparse)?;
+    let log_lh = update_marginal(&graph, &partitions_marginal_sparse)?.value();
 
     // generate ancestral reconstruction and test against expectation
     let mut actual = BTreeMap::new();
@@ -298,8 +298,8 @@ mod tests {
     let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
     let partitions = [Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, &graph)?))];
 
-    let log_lh_first = update_marginal(&graph, &partitions)?;
-    let log_lh_second = update_marginal(&graph, &partitions)?;
+    let log_lh_first = update_marginal(&graph, &partitions)?.value();
+    let log_lh_second = update_marginal(&graph, &partitions)?.value();
 
     // Verify log-likelihood value matches expected (same tree/alignment as normalization test)
     pretty_assert_ulps_eq!(-55.33813399214274, log_lh_first, epsilon = 1e-6);
@@ -460,7 +460,7 @@ mod tests {
           let fitch = create_fitch_partition(&graph, 0, alphabet.clone(), &aln)?;
           let partitions_marginal_sparse = [Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr.clone(), &graph)?))];
 
-          let log_lh = update_marginal(&graph, &partitions_marginal_sparse)?;
+          let log_lh = update_marginal(&graph, &partitions_marginal_sparse)?.value();
           total_lh += log_lh.exp();
         }
       }
@@ -500,7 +500,7 @@ mod tests {
     let partitions = [Arc::new(RwLock::new(
       fitch.into_marginal_sparse(make_nonuniform_gtr()?, &graph)?,
     ))];
-    update_marginal(&graph, &partitions)?;
+    update_marginal(&graph, &partitions)?.value();
 
     let actual_by_edge = {
       let partition = partitions[0].read_arc();
@@ -577,6 +577,7 @@ mod tests {
           partition.nodes[&graph.get_exactly_one_root()?.read_arc().key()]
             .profile
             .log_lh
+            .value()
             .to_bits(),
           json_write_str(&partition.nodes, JsonPretty(false))?,
           json_write_str(&partition.edges, JsonPretty(false))?,

--- a/packages/treetime/src/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_marginal_stability/test_marginal_stability_support.rs
@@ -24,9 +24,9 @@ pub mod tests {
   /// Assert that a dense marginal profile is numerically stable.
   pub fn assert_dense_profile_stable(profile: &DenseSeqDistribution, max_ulps: u32) {
     assert!(
-      profile.log_lh.is_finite(),
+      profile.log_lh.value().is_finite(),
       "Profile log_lh is not finite: {}",
-      profile.log_lh
+      profile.log_lh.value()
     );
     pretty_assert_array_finite!(profile.dis);
     pretty_assert_array_nonneg!(profile.dis, epsilon = 1e-15);
@@ -38,9 +38,9 @@ pub mod tests {
   /// Assert that a sparse marginal profile is numerically stable.
   pub fn assert_sparse_profile_stable(profile: &SparseSeqDistribution, max_ulps: u32) {
     assert!(
-      profile.log_lh.is_finite(),
+      profile.log_lh.value().is_finite(),
       "Profile log_lh is not finite: {}",
-      profile.log_lh
+      profile.log_lh.value()
     );
 
     for var_pos in profile.variable.values() {
@@ -73,7 +73,7 @@ pub mod tests {
       get_common_length(&aln)?,
     )))];
 
-    let log_lh = initialize_marginal(&graph, &partitions, &aln)?;
+    let log_lh = initialize_marginal(&graph, &partitions, &aln)?.value();
     Ok((log_lh, partitions))
   }
 
@@ -89,7 +89,7 @@ pub mod tests {
 
     let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
     let partitions = [Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, &graph)?))];
-    let log_lh = update_marginal(&graph, &partitions)?;
+    let log_lh = update_marginal(&graph, &partitions)?.value();
     Ok((log_lh, partitions))
   }
 }

--- a/packages/treetime/src/ancestral/__tests__/test_python_parity.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_python_parity.rs
@@ -78,7 +78,7 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     let mut root_seq = String::new();
     ancestral_reconstruction_marginal(
@@ -190,7 +190,7 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     // Find node AB and check profile at position 0
     let ab_key = find_node_key_by_name(&graph, "AB").ok_or_else(|| make_report!("Node AB not found"))?;
@@ -236,7 +236,7 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     // Find root node
     let root_key = find_node_key_by_name(&graph, "root").ok_or_else(|| make_report!("Node root not found"))?;
@@ -278,7 +278,7 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     let cd_key = find_node_key_by_name(&graph, "CD").ok_or_else(|| make_report!("Node CD not found"))?;
     let partition = partitions[0].read_arc();
@@ -321,7 +321,7 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     let partition = partitions[0].read_arc();
 
@@ -372,7 +372,7 @@ mod tests {
 
     let partitions = [Arc::clone(&partition1), Arc::clone(&partition2)];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
     let root_key = find_node_key_by_name(&graph, "root").ok_or_else(|| make_report!("Node root not found"))?;
 
     let p1 = partition1.read_arc();
@@ -434,7 +434,7 @@ mod tests {
 
     let partitions = [Arc::clone(&partition1), Arc::clone(&partition2)];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     let ab_key = find_node_key_by_name(&graph, "AB").ok_or_else(|| make_report!("Node AB not found"))?;
 
@@ -490,12 +490,12 @@ mod tests {
       length,
     )));
 
-    let dense_log_lh = initialize_marginal(&graph, from_ref(&dense_partition), &aln)?;
+    let dense_log_lh = initialize_marginal(&graph, from_ref(&dense_partition), &aln)?.value();
 
     // Sparse partition
     let fitch = create_fitch_partition(&graph, 0, alphabet, &aln)?;
     let sparse_partition = Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, &graph)?));
-    let sparse_log_lh = update_marginal(&graph, from_ref(&sparse_partition))?;
+    let sparse_log_lh = update_marginal(&graph, from_ref(&sparse_partition))?.value();
 
     // Log-likelihoods should match for clean sequences
     pretty_assert_ulps_eq!(dense_log_lh, sparse_log_lh, epsilon = 1e-10);

--- a/packages/treetime/src/ancestral/__tests__/test_sample_reconstruction.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_sample_reconstruction.rs
@@ -102,7 +102,7 @@ mod tests {
         fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
       ))];
 
-      update_marginal(&graph, &partitions)?;
+      update_marginal(&graph, &partitions)?.value();
 
       let mut rng = StdRng::seed_from_u64(seed);
       let mut out = BTreeMap::new();

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -26,7 +26,7 @@ use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::GraphNodeForward;
 use treetime_graph::node::{GraphNode, NodeAncestralOps};
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::{AlphabetLike, Seq, seq};
+use treetime_primitives::{AlphabetLike, LogLh, Seq, seq};
 use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::sync::mutex::unwrap_arc_rwlock;
 
@@ -207,7 +207,7 @@ where
       variable_indel: BTreeSet::new(),
       fixed: btreemap! {},
       fixed_counts: Composition::new(alphabet.chars(), alphabet.gap()),
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     },
   };
   Ok(())

--- a/packages/treetime/src/ancestral/marginal.rs
+++ b/packages/treetime/src/ancestral/marginal.rs
@@ -9,13 +9,13 @@ use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::{Seq, seq};
+use treetime_primitives::{LogLh, Seq, seq};
 
 pub fn initialize_marginal<N, E, P>(
   graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
   aln: &[FastaRecord],
-) -> Result<f64, Report>
+) -> Result<LogLh, Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -27,7 +27,7 @@ where
   update_marginal(graph, partitions)
 }
 
-pub fn update_marginal<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<f64, Report>
+pub fn update_marginal<N, E, P>(graph: &Graph<N, E, ()>, partitions: &[Arc<RwLock<P>>]) -> Result<LogLh, Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -35,7 +35,7 @@ where
 {
   marginal_backward(graph, partitions)?;
   let log_lh = graph_log_lh(graph, partitions)?;
-  trace!("Marginal log likelihood (substitution): {log_lh}");
+  trace!("Marginal log likelihood (substitution): {}", log_lh.value());
   marginal_forward(graph, partitions)?;
   Ok(log_lh)
 }

--- a/packages/treetime/src/coalescent/__tests__/test_gm_total_lh.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_gm_total_lh.rs
@@ -51,7 +51,7 @@ mod tests {
   #[trace]
   fn test_gm_total_lh_binary(#[case] tc: f64, #[case] expected: f64) -> Result<(), Report> {
     let graph = setup_graph()?;
-    let actual = compute_coalescent_total_lh(&graph, &Distribution::constant(tc))?;
+    let actual = compute_coalescent_total_lh(&graph, &Distribution::constant(tc))?.value();
     assert_abs_diff_eq!(expected, actual, epsilon = 1e-8);
     Ok(())
   }
@@ -68,7 +68,7 @@ mod tests {
   #[trace]
   fn test_gm_total_lh_polytomy(#[case] tc: f64, #[case] expected: f64) -> Result<(), Report> {
     let graph = setup_polytomy_graph()?;
-    let actual = compute_coalescent_total_lh(&graph, &Distribution::constant(tc))?;
+    let actual = compute_coalescent_total_lh(&graph, &Distribution::constant(tc))?.value();
     assert_abs_diff_eq!(expected, actual, epsilon = 1e-8);
     Ok(())
   }

--- a/packages/treetime/src/coalescent/__tests__/test_optimize_tc.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_optimize_tc.rs
@@ -46,7 +46,7 @@ mod tests {
 
     assert!(result.tc > 0.0, "Optimized Tc should be positive");
     assert!(result.tc.is_finite(), "Optimized Tc should be finite");
-    assert!(result.likelihood.is_finite(), "Likelihood should be finite");
+    assert!(result.likelihood.value().is_finite(), "Likelihood should be finite");
 
     Ok(())
   }
@@ -61,7 +61,7 @@ mod tests {
     let b = optimize_tc(&graph)?;
 
     assert_eq!(a.tc, b.tc);
-    assert_eq!(a.likelihood, b.likelihood);
+    assert_eq!(a.likelihood.value(), b.likelihood.value());
 
     Ok(())
   }

--- a/packages/treetime/src/coalescent/__tests__/test_skyline.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_skyline.rs
@@ -42,7 +42,7 @@ mod tests {
 
     assert_eq!(result.segment_boundaries.len(), 6);
     assert_eq!(result.tc_values.len(), 5);
-    assert!(result.log_likelihood.is_finite());
+    assert!(result.log_likelihood.value().is_finite());
 
     Ok(())
   }
@@ -118,7 +118,7 @@ mod tests {
     let result = optimize_skyline(&graph, &params)?;
 
     assert_eq!(result.tc_values.len(), 10);
-    assert!(result.log_likelihood.is_finite());
+    assert!(result.log_likelihood.value().is_finite());
 
     Ok(())
   }
@@ -134,9 +134,9 @@ mod tests {
     };
 
     let result = optimize_skyline(&graph, &params)?;
-    let expected = compute_coalescent_total_lh(&graph, &result.tc_distribution)?;
+    let expected = compute_coalescent_total_lh(&graph, &result.tc_distribution)?.value();
 
-    pretty_assert_ulps_eq!(expected, result.log_likelihood, max_ulps = 10);
+    pretty_assert_ulps_eq!(expected, result.log_likelihood.value(), max_ulps = 10);
     Ok(())
   }
 
@@ -157,11 +157,11 @@ mod tests {
     };
 
     let result = optimize_skyline(&graph, &params)?;
-    let expected = compute_coalescent_total_lh(&graph, &result.tc_distribution)?;
+    let expected = compute_coalescent_total_lh(&graph, &result.tc_distribution)?.value();
 
     // Oracle: the canonical per-edge Kingman cost assigns m - 1 merger-rate
     // factors to an m-child polytomy (Kingman 1982, doi:10.1016/0304-4149(82)90011-4).
-    pretty_assert_ulps_eq!(expected, result.log_likelihood, max_ulps = 10);
+    pretty_assert_ulps_eq!(expected, result.log_likelihood.value(), max_ulps = 10);
     Ok(())
   }
 
@@ -183,10 +183,10 @@ mod tests {
     // The constant Tc is a feasible skyline (all segments equal), so the skyline
     // optimum can only match or beat its likelihood; the slack is solver noise.
     assert!(
-      result.log_likelihood >= constant_tc.likelihood - 1e-10,
+      result.log_likelihood.value() >= constant_tc.likelihood.value() - 1e-10,
       "skyline LL {} should be >= constant-Tc LL {}",
-      result.log_likelihood,
-      constant_tc.likelihood
+      result.log_likelihood.value(),
+      constant_tc.likelihood.value()
     );
 
     Ok(())

--- a/packages/treetime/src/coalescent/__tests__/test_total_lh.rs
+++ b/packages/treetime/src/coalescent/__tests__/test_total_lh.rs
@@ -16,7 +16,7 @@ mod tests {
     let graph = setup_graph()?;
     let tc = Distribution::constant(1.0);
 
-    let lh = compute_coalescent_total_lh(&graph, &tc)?;
+    let lh = compute_coalescent_total_lh(&graph, &tc)?.value();
 
     assert!(lh.is_finite(), "Total coalescent LH should be finite, got {lh}");
     Ok(())
@@ -29,7 +29,7 @@ mod tests {
     let graph = setup_graph()?;
     let tc = Distribution::constant(1.0);
 
-    let lh = compute_coalescent_total_lh(&graph, &tc)?;
+    let lh = compute_coalescent_total_lh(&graph, &tc)?.value();
 
     assert!(lh < 0.0, "Coalescent log-likelihood should be negative, got {lh}");
     Ok(())
@@ -46,7 +46,7 @@ mod tests {
     let graph = setup_graph()?;
     let tc = Distribution::constant(tc_value);
 
-    let lh = compute_coalescent_total_lh(&graph, &tc)?;
+    let lh = compute_coalescent_total_lh(&graph, &tc)?.value();
 
     assert!(lh.is_finite(), "LH should be finite for Tc={tc_value}");
     Ok(())
@@ -57,8 +57,8 @@ mod tests {
     // The coalescent LH depends on Tc. Different Tc values produce different LH.
     let graph = setup_graph()?;
 
-    let lh_small = compute_coalescent_total_lh(&graph, &Distribution::constant(0.1))?;
-    let lh_large = compute_coalescent_total_lh(&graph, &Distribution::constant(100.0))?;
+    let lh_small = compute_coalescent_total_lh(&graph, &Distribution::constant(0.1))?.value();
+    let lh_large = compute_coalescent_total_lh(&graph, &Distribution::constant(100.0))?.value();
 
     assert!(
       (lh_small - lh_large).abs() > 1e-6,
@@ -74,9 +74,9 @@ mod tests {
     let opt = optimize_tc(&graph)?;
 
     let tc_opt = opt.tc;
-    let lh_opt = compute_coalescent_total_lh(&graph, &Distribution::constant(tc_opt))?;
-    let lh_low = compute_coalescent_total_lh(&graph, &Distribution::constant(tc_opt * 0.01))?;
-    let lh_high = compute_coalescent_total_lh(&graph, &Distribution::constant(tc_opt * 100.0))?;
+    let lh_opt = compute_coalescent_total_lh(&graph, &Distribution::constant(tc_opt))?.value();
+    let lh_low = compute_coalescent_total_lh(&graph, &Distribution::constant(tc_opt * 0.01))?.value();
+    let lh_high = compute_coalescent_total_lh(&graph, &Distribution::constant(tc_opt * 100.0))?.value();
 
     assert!(
       lh_opt >= lh_low,
@@ -97,9 +97,9 @@ mod tests {
     let graph = setup_graph()?;
     let opt = optimize_tc(&graph)?;
 
-    let lh = compute_coalescent_total_lh(&graph, &Distribution::constant(opt.tc))?;
+    let lh = compute_coalescent_total_lh(&graph, &Distribution::constant(opt.tc))?.value();
 
-    pretty_assert_ulps_eq!(opt.likelihood, lh, max_ulps = 10);
+    pretty_assert_ulps_eq!(opt.likelihood.value(), lh, max_ulps = 10);
 
     Ok(())
   }
@@ -116,8 +116,8 @@ mod tests {
       1000.0,
     ));
 
-    let lh_const = compute_coalescent_total_lh(&graph, &tc_const)?;
-    let lh_formula = compute_coalescent_total_lh(&graph, &tc_formula)?;
+    let lh_const = compute_coalescent_total_lh(&graph, &tc_const)?.value();
+    let lh_formula = compute_coalescent_total_lh(&graph, &tc_formula)?.value();
 
     pretty_assert_ulps_eq!(lh_const, lh_formula, max_ulps = 10);
 

--- a/packages/treetime/src/coalescent/edge_data.rs
+++ b/packages/treetime/src/coalescent/edge_data.rs
@@ -6,6 +6,7 @@ use log::warn;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::GraphNode;
+use treetime_primitives::LogLh;
 use treetime_utils::make_error;
 
 /// Per-edge inferred calendar dates and the parent node's child count.
@@ -116,10 +117,10 @@ where
 
 /// Sums the shared model's endpoint-derived edge contributions and negates to
 /// return the coalescent log-likelihood (higher is more likely).
-pub fn coalescent_log_likelihood(edges: &[CoalescentEdgeData], model: &CoalescentModel) -> Result<f64, Report> {
+pub fn coalescent_log_likelihood(edges: &[CoalescentEdgeData], model: &CoalescentModel) -> Result<LogLh, Report> {
   let total_contribution = edges
     .iter()
     .map(|edge| model.edge_contribution(edge))
     .sum::<Result<f64, Report>>()?;
-  Ok(-total_contribution)
+  Ok(LogLh::new(-total_contribution))
 }

--- a/packages/treetime/src/coalescent/optimize_tc.rs
+++ b/packages/treetime/src/coalescent/optimize_tc.rs
@@ -4,13 +4,14 @@ use eyre::Report;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
+use treetime_primitives::LogLh;
 
 /// Result of Tc optimization.
 pub struct OptimizeTcResult {
   /// Optimized coalescence time scale.
   pub tc: f64,
   /// Total coalescent likelihood at optimized Tc.
-  pub likelihood: f64,
+  pub likelihood: LogLh,
 }
 
 /// Computes the constant coalescence time scale Tc that maximizes the coalescent

--- a/packages/treetime/src/coalescent/skyline.rs
+++ b/packages/treetime/src/coalescent/skyline.rs
@@ -11,6 +11,7 @@ use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
 use treetime_grid::piecewise_constant_fn::PiecewiseConstantFn;
+use treetime_primitives::LogLh;
 
 /// Parameters for skyline (piecewise-constant Tc) optimization.
 #[derive(Debug, Clone)]
@@ -48,7 +49,7 @@ pub struct SkylineResult {
   /// Optimized Tc value per segment (length `n_points`).
   pub tc_values: Array1<f64>,
   /// Coalescent log-likelihood at the optimized Tc(t).
-  pub log_likelihood: f64,
+  pub log_likelihood: LogLh,
 }
 
 /// Optimizes a piecewise-constant Tc(t) trajectory that maximizes the coalescent
@@ -140,7 +141,10 @@ where
   let model = CoalescentModel::new(&precomputed, &tc_distribution)?;
   let log_likelihood = coalescent_log_likelihood(&edges, &model)?;
 
-  info!("Skyline optimization completed: log_likelihood={log_likelihood:.4}");
+  info!(
+    "Skyline optimization completed: log_likelihood={:.4}",
+    log_likelihood.value()
+  );
   info!("Skyline Tc(t) trajectory ({} segments):", tc_values.len());
   for (i, &tc) in tc_values.iter().enumerate() {
     info!(

--- a/packages/treetime/src/coalescent/total_lh.rs
+++ b/packages/treetime/src/coalescent/total_lh.rs
@@ -7,6 +7,7 @@ use treetime_distribution::Distribution;
 use treetime_graph::edge::GraphEdge;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::GraphNode;
+use treetime_primitives::LogLh;
 
 /// Computes the total coalescent log-likelihood of the tree under the given Tc.
 ///
@@ -21,7 +22,7 @@ use treetime_graph::node::GraphNode;
 ///
 /// Accepts any `Distribution` for Tc (constant, skyline, or formula-based).
 /// Nonconstant distributions are evaluated in decimal calendar years.
-pub fn compute_coalescent_total_lh<N, E, D>(graph: &Graph<N, E, D>, tc_dist: &Distribution) -> Result<f64, Report>
+pub fn compute_coalescent_total_lh<N, E, D>(graph: &Graph<N, E, D>, tc_dist: &Distribution) -> Result<LogLh, Report>
 where
   N: GraphNode + TimetreeNode,
   E: GraphEdge,

--- a/packages/treetime/src/commands/mugration/__tests__/test_discrete_marginal.rs
+++ b/packages/treetime/src/commands/mugration/__tests__/test_discrete_marginal.rs
@@ -120,7 +120,7 @@ mod tests {
     partition.attach_traits(&graph, &traits)?;
 
     let partition = Arc::new(RwLock::new(partition));
-    let actual_log_lh = update_marginal(&graph, std::slice::from_ref(&partition))?;
+    let actual_log_lh = update_marginal(&graph, std::slice::from_ref(&partition))?.value();
 
     assert!(actual_log_lh.is_finite());
     assert!(

--- a/packages/treetime/src/commands/shared/__tests__/test_tree_output.rs
+++ b/packages/treetime/src/commands/shared/__tests__/test_tree_output.rs
@@ -29,7 +29,7 @@ mod tests {
   use treetime_graph::node::{GraphNodeKey, Named};
   use treetime_io::graph::TreeWriteKind;
   use treetime_io::nwk::{CommentProviders, NwkStyle, nwk_read_str};
-  use treetime_primitives::{AsciiChar, Seq};
+  use treetime_primitives::{AsciiChar, LogLh, Seq};
   use treetime_utils::io::json::{JsonPretty, json_read_file, json_read_str, json_write_str};
 
   #[test]
@@ -710,12 +710,12 @@ mod tests {
             key,
             DenseNodePartition {
               seq: DenseSeqInfo::default(),
-              profile: DenseSeqDistribution::new(profile, 0.0),
+              profile: DenseSeqDistribution::new(profile, LogLh::ZERO),
             },
           )
         })
         .collect();
-      Ok(MugrationResult::new(graph, partition, "country", 0.0).graph)
+      Ok(MugrationResult::new(graph, partition, "country", LogLh::ZERO).graph)
     }
 
     fn timetree_graph() -> Result<GraphTimetree<TimetreeGraphData>, Report> {

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract.rs
@@ -64,7 +64,7 @@ mod tests {
       alphabet,
       get_common_length(aln)?,
     )));
-    initialize_marginal(&graph, from_ref(&partition), aln)?;
+    initialize_marginal(&graph, from_ref(&partition), aln)?.value();
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_contract_dense_sparse_real.rs
@@ -131,7 +131,7 @@ mod tests {
         DENSE_NUC_ALPHABET.clone(),
         get_common_length(&aln)?,
       )));
-      initialize_marginal(&graph, from_ref(&partition), &aln)?;
+      initialize_marginal(&graph, from_ref(&partition), &aln)?.value();
       let counts = partition.read_arc().count_transitions(&graph)?;
       let InferGtrResult { W, pi, mu } = infer_gtr_impl(&counts, &InferGtrOptions::default())?;
       let n_states = partition.read_arc().alphabet.n_canonical();

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_dense.rs
@@ -50,7 +50,7 @@ mod tests {
       get_common_length(aln)?,
     )));
 
-    initialize_marginal(&graph, from_ref(&partition), aln)?;
+    initialize_marginal(&graph, from_ref(&partition), aln)?.value();
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs
+++ b/packages/treetime/src/gtr/infer_gtr/__tests__/test_gm_infer_gtr_dense.rs
@@ -144,7 +144,7 @@ mod tests {
       get_common_length(aln)?,
     )));
 
-    initialize_marginal(&graph, from_ref(&partition), aln)?;
+    initialize_marginal(&graph, from_ref(&partition), aln)?.value();
     Ok((graph, partition))
   }
 
@@ -170,7 +170,7 @@ mod tests {
       get_common_length(&aln)?,
     )));
 
-    initialize_marginal(&graph, from_ref(&partition), &aln)?;
+    initialize_marginal(&graph, from_ref(&partition), &aln)?.value();
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/gtr/refinement.rs
+++ b/packages/treetime/src/gtr/refinement.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
+use treetime_primitives::LogLh;
 
 pub fn refine_gtr_iterative<N, E, P>(
   graph: &Graph<N, E, ()>,
@@ -22,7 +23,7 @@ pub fn refine_gtr_iterative<N, E, P>(
   pc: f64,
   sampling_bias_correction: Option<f64>,
   optimize_rate: bool,
-) -> Result<f64, Report>
+) -> Result<LogLh, Report>
 where
   N: GraphNode + Named,
   E: EdgeOptimizeOps,
@@ -79,8 +80,10 @@ where
   let guard = partition.read_arc();
   let gtr = guard.gtr();
   info!(
-    "GTR refinement: final log likelihood = {log_lh:.4}, mu = {:.6}, pi = {:?}",
-    gtr.mu, gtr.pi
+    "GTR refinement: final log likelihood = {:.4}, mu = {:.6}, pi = {:?}",
+    log_lh.value(),
+    gtr.mu,
+    gtr.pi
   );
 
   Ok(log_lh)

--- a/packages/treetime/src/mugration/mugration.rs
+++ b/packages/treetime/src/mugration/mugration.rs
@@ -162,7 +162,7 @@ pub fn execute_mugration(
   let partition = Arc::new(RwLock::new(partition));
 
   let log_lh = update_marginal(&graph, std::slice::from_ref(&partition))?;
-  info!("Mugration: initial log likelihood = {log_lh:.4}");
+  info!("Mugration: initial log likelihood = {:.4}", log_lh.value());
 
   let log_lh = refine_gtr_iterative(
     &graph,

--- a/packages/treetime/src/mugration/result.rs
+++ b/packages/treetime/src/mugration/result.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fmt::Write;
 use treetime_graph::node::Named;
+use treetime_primitives::LogLh;
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfidenceRow {
   /// Node name.
@@ -110,7 +111,7 @@ impl MugrationTraitsOutput {
 pub struct MugrationGraphData {
   pub traits: MugrationTraitsOutput,
   pub confidence: MugrationConfidenceOutput,
-  pub log_lh: f64,
+  pub log_lh: LogLh,
   pub partition: PartitionMarginalDiscrete,
 }
 
@@ -129,7 +130,7 @@ impl std::ops::Deref for MugrationResult {
 }
 
 impl MugrationResult {
-  pub fn new(graph: GraphAncestral, partition: PartitionMarginalDiscrete, attribute: &str, log_lh: f64) -> Self {
+  pub fn new(graph: GraphAncestral, partition: PartitionMarginalDiscrete, attribute: &str, log_lh: LogLh) -> Self {
     let assignments = extract_trait_assignments(&graph, &partition);
     let traits = MugrationTraitsOutput::new(attribute, assignments);
     let confidence = MugrationConfidenceOutput::new(&graph, &partition);

--- a/packages/treetime/src/optimize/__tests__/test_branch_length_validation.rs
+++ b/packages/treetime/src/optimize/__tests__/test_branch_length_validation.rs
@@ -64,7 +64,7 @@ mod tests {
   #[test]
   fn test_branch_length_validation_poisson_zero_boundary_depends_on_indel_count() {
     let no_indels = poisson_indel_log_lh(0, 1.0, 0.0).expect("zero is valid without indels");
-    assert_abs_diff_eq!(0.0, no_indels.log_lh, epsilon = 1e-15);
+    assert_abs_diff_eq!(0.0, no_indels.log_lh.value(), epsilon = 1e-15);
 
     let error = poisson_indel_log_lh(1, 1.0, 0.0).expect_err("zero is invalid with observed indels");
     assert!(error.to_string().contains("positive branch length"));

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_basic.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_basic.rs
@@ -33,7 +33,7 @@ mod tests {
 
     // Verify via evaluate function
     let metrics = evaluate_dense_contribution(&contribution, 0.0).expect("valid branch length");
-    pretty_assert_ulps_eq!(metrics.log_lh, 0.25_f64.ln(), max_ulps = 100);
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), 0.25_f64.ln(), max_ulps = 100);
   }
 
   #[test]
@@ -83,7 +83,10 @@ mod tests {
 
     // At branch_length=0, likelihood should be high (states match)
     let metrics = evaluate_dense_contribution(&contribution, 0.0).expect("valid branch length");
-    assert!(metrics.log_lh > -1.0, "log-LH should be high for matching states");
+    assert!(
+      metrics.log_lh.value() > -1.0,
+      "log-LH should be high for matching states"
+    );
   }
 
   #[test]
@@ -101,7 +104,7 @@ mod tests {
     // At branch_length=0, likelihood should be zero (mismatch with no time for substitution)
     let metrics = evaluate_dense_contribution(&contribution, 0.0).expect("valid branch length");
     assert!(
-      metrics.log_lh < -10.0 || metrics.log_lh == f64::NEG_INFINITY,
+      metrics.log_lh.value() < -10.0 || metrics.log_lh.value() == f64::NEG_INFINITY,
       "log-LH should be very low for mismatched states at zero branch length"
     );
   }

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_invariants.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_invariants.rs
@@ -96,7 +96,7 @@ mod tests {
     };
     let multi_metrics = evaluate_sparse_contribution(&multi, branch_length).expect("valid branch length");
 
-    assert_abs_diff_eq!(multi_metrics.log_lh, multiplicity * single_metrics.log_lh, epsilon = 1e-12);
+    assert_abs_diff_eq!(multi_metrics.log_lh.value(), multiplicity * single_metrics.log_lh.value(), epsilon = 1e-12);
     assert_abs_diff_eq!(multi_metrics.derivative, multiplicity * single_metrics.derivative, epsilon = 1e-12);
     assert_abs_diff_eq!(multi_metrics.second_derivative, multiplicity * single_metrics.second_derivative, epsilon = 1e-12);
   }
@@ -137,7 +137,7 @@ mod tests {
     };
     let sparse_metrics = evaluate_sparse_contribution(&sparse_contrib, branch_length).expect("valid branch length");
 
-    assert_abs_diff_eq!(dense_metrics.log_lh, sparse_metrics.log_lh, epsilon = 1e-10);
+    assert_abs_diff_eq!(dense_metrics.log_lh.value(), sparse_metrics.log_lh.value(), epsilon = 1e-10);
     assert_abs_diff_eq!(dense_metrics.derivative, sparse_metrics.derivative, epsilon = 1e-10);
     assert_abs_diff_eq!(dense_metrics.second_derivative, sparse_metrics.second_derivative, epsilon = 1e-10);
   }
@@ -182,8 +182,8 @@ mod tests {
     let metrics_combined = evaluate_dense_contribution(&contrib_combined, branch_length).expect("valid branch length");
 
     assert_abs_diff_eq!(
-      metrics_combined.log_lh,
-      metrics_a.log_lh + metrics_b.log_lh,
+      metrics_combined.log_lh.value(),
+      metrics_a.log_lh.value() + metrics_b.log_lh.value(),
       epsilon = 1e-12
     );
     assert_abs_diff_eq!(

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_prop_invariants.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_prop_invariants.rs
@@ -40,7 +40,7 @@ mod tests {
     // (transition matrix allows state changes)
     let metrics = evaluate_dense_contribution(&contribution, 0.1).expect("valid branch length");
     assert!(
-      metrics.log_lh.is_finite(),
+      metrics.log_lh.value().is_finite(),
       "At t>0, disjoint support should have finite log-lh"
     );
     assert!(metrics.derivative.is_finite(), "At t>0, derivative should be finite");
@@ -138,7 +138,7 @@ mod tests {
         };
         let multi_metrics = evaluate_sparse_contribution(&multi, branch_length).expect("valid branch length");
 
-        prop_assert_abs_diff_eq!(multi_metrics.log_lh, multiplicity * single_metrics.log_lh, epsilon = 1e-9);
+        prop_assert_abs_diff_eq!(multi_metrics.log_lh.value(), multiplicity * single_metrics.log_lh.value(), epsilon = 1e-9);
         prop_assert_abs_diff_eq!(multi_metrics.derivative, multiplicity * single_metrics.derivative, epsilon = 1e-9);
         prop_assert_abs_diff_eq!(multi_metrics.second_derivative, multiplicity * single_metrics.second_derivative, epsilon = 1e-9);
       }
@@ -171,7 +171,7 @@ mod tests {
         };
         let sparse_metrics = evaluate_sparse_contribution(&sparse_contrib, branch_length).expect("valid branch length");
 
-        prop_assert_abs_diff_eq!(dense_metrics.log_lh, sparse_metrics.log_lh, epsilon = 1e-8);
+        prop_assert_abs_diff_eq!(dense_metrics.log_lh.value(), sparse_metrics.log_lh.value(), epsilon = 1e-8);
         prop_assert_abs_diff_eq!(dense_metrics.derivative, sparse_metrics.derivative, epsilon = 1e-8);
         prop_assert_abs_diff_eq!(dense_metrics.second_derivative, sparse_metrics.second_derivative, epsilon = 1e-8);
       }
@@ -206,7 +206,7 @@ mod tests {
         let contrib_combined = get_coefficients(&make_dense_seq_dis(parents), &make_dense_seq_dis(children), &gtr);
         let metrics_combined = evaluate_dense_contribution(&contrib_combined, branch_length).expect("valid branch length");
 
-        prop_assert_abs_diff_eq!(metrics_combined.log_lh, metrics_a.log_lh + metrics_b.log_lh, epsilon = 1e-9);
+        prop_assert_abs_diff_eq!(metrics_combined.log_lh.value(), metrics_a.log_lh.value() + metrics_b.log_lh.value(), epsilon = 1e-9);
         prop_assert_abs_diff_eq!(metrics_combined.derivative, metrics_a.derivative + metrics_b.derivative, epsilon = 1e-9);
         prop_assert_abs_diff_eq!(metrics_combined.second_derivative, metrics_a.second_derivative + metrics_b.second_derivative, epsilon = 1e-9);
       }
@@ -227,8 +227,8 @@ mod tests {
         let metrics = evaluate_dense_contribution(&contribution, branch_length).expect("valid branch length");
 
         let h = f64::max(branch_length * 1e-4, 1e-5);
-        let lh_plus = evaluate_dense_contribution(&contribution, branch_length + h).expect("valid branch length").log_lh;
-        let lh_minus = evaluate_dense_contribution(&contribution, branch_length - h).expect("valid branch length").log_lh;
+        let lh_plus = evaluate_dense_contribution(&contribution, branch_length + h).expect("valid branch length").log_lh.value();
+        let lh_minus = evaluate_dense_contribution(&contribution, branch_length - h).expect("valid branch length").log_lh.value();
         let numerical_derivative = (lh_plus - lh_minus) / (2.0 * h);
 
         prop_assert_relative_eq!(metrics.derivative, numerical_derivative, max_relative = 1e-4);

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_properties.rs
@@ -25,7 +25,7 @@ mod tests {
     let metrics = evaluate_dense_contribution(&contribution, 0.0).expect("valid branch length");
 
     // Log-LH should be finite for valid probability distributions
-    assert!(metrics.log_lh.is_finite(), "log-LH should be finite");
+    assert!(metrics.log_lh.value().is_finite(), "log-LH should be finite");
   }
 
   #[test]
@@ -54,7 +54,7 @@ mod tests {
     let mismatch_metrics = evaluate_dense_contribution(&mismatch_contribution, 0.0).expect("valid branch length");
 
     assert!(
-      match_metrics.log_lh > mismatch_metrics.log_lh,
+      match_metrics.log_lh.value() > mismatch_metrics.log_lh.value(),
       "matching states should have higher log-LH at zero branch length"
     );
   }
@@ -77,7 +77,7 @@ mod tests {
     let contribution = get_coefficients(&msg_to_parent, &msg_to_child, &gtr);
 
     let metrics = evaluate_dense_contribution(&contribution, branch_length).expect("valid branch length");
-    assert!(metrics.log_lh.is_finite(), "log-LH should be finite");
+    assert!(metrics.log_lh.value().is_finite(), "log-LH should be finite");
     assert!(metrics.derivative.is_finite(), "derivative should be finite");
     assert!(metrics.second_derivative.is_finite(), "second_derivative should be finite");
   }

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_support.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_dense/test_coefficient_extraction_dense_support.rs
@@ -2,8 +2,9 @@
 pub mod tests {
   use crate::partition::dense::DenseSeqDistribution;
   use ndarray::Array2;
+  use treetime_primitives::LogLh;
 
   pub fn make_dense_seq_dis(dis: Array2<f64>) -> DenseSeqDistribution {
-    DenseSeqDistribution::new(dis, 0.0)
+    DenseSeqDistribution::new(dis, LogLh::ZERO)
   }
 }

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_coefficients.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_coefficients.rs
@@ -63,7 +63,10 @@ mod tests {
     let metrics = evaluate_sparse_contribution(&contribution, 0.0).expect("valid branch length");
 
     // Matching states at zero branch length should have high likelihood
-    assert!(metrics.log_lh > -1.0, "log-LH should be high for matching states");
+    assert!(
+      metrics.log_lh.value() > -1.0,
+      "log-LH should be high for matching states"
+    );
   }
 
   #[test]
@@ -93,7 +96,7 @@ mod tests {
 
     // Mismatched states at zero branch length should have very low likelihood
     assert!(
-      metrics.log_lh < -10.0 || metrics.log_lh == f64::NEG_INFINITY,
+      metrics.log_lh.value() < -10.0 || metrics.log_lh.value() == f64::NEG_INFINITY,
       "log-LH should be very low for mismatched states at zero branch length"
     );
   }

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_derivatives.rs
@@ -36,7 +36,7 @@ mod tests {
     // Numerical first derivative: (f(t+h) - f(t-h)) / 2h
     let metrics_plus = evaluate_sparse_contribution(&contribution, branch_length + h).expect("valid branch length");
     let metrics_minus = evaluate_sparse_contribution(&contribution, branch_length - h).expect("valid branch length");
-    let numerical_d1 = (metrics_plus.log_lh - metrics_minus.log_lh) / (2.0 * h);
+    let numerical_d1 = (metrics_plus.log_lh.value() - metrics_minus.log_lh.value()) / (2.0 * h);
 
     assert_abs_diff_eq!(metrics.derivative, numerical_d1, epsilon = 1e-9);
   }
@@ -133,7 +133,7 @@ mod tests {
 
     // All three quantities scale linearly with multiplicity:
     // ℓ(t) = m * ln(L), ℓ'(t) = m * d1, ℓ''(t) = m * (d2 - d1^2)
-    pretty_assert_ulps_eq!(metrics3.log_lh, 3.0 * metrics1.log_lh, max_ulps = 100);
+    pretty_assert_ulps_eq!(metrics3.log_lh.value(), 3.0 * metrics1.log_lh.value(), max_ulps = 100);
     pretty_assert_ulps_eq!(metrics3.derivative, 3.0 * metrics1.derivative, max_ulps = 100);
     pretty_assert_ulps_eq!(
       metrics3.second_derivative,
@@ -185,7 +185,7 @@ mod tests {
     let sparse_metrics = evaluate_sparse_contribution(&sparse_contribution, branch_length).expect("valid branch length");
     let dense_metrics = evaluate_dense_contribution(&dense_contribution, branch_length).expect("valid branch length");
 
-    pretty_assert_ulps_eq!(sparse_metrics.log_lh, dense_metrics.log_lh, max_ulps = 10);
+    pretty_assert_ulps_eq!(sparse_metrics.log_lh.value(), dense_metrics.log_lh.value(), max_ulps = 10);
     pretty_assert_ulps_eq!(sparse_metrics.derivative, dense_metrics.derivative, max_ulps = 10);
     pretty_assert_ulps_eq!(
       sparse_metrics.second_derivative,

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_eigenvalues.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_eigenvalues.rs
@@ -25,7 +25,7 @@ mod tests {
 
     // Log-LH should differ at different branch lengths
     assert!(
-      (metrics_short.log_lh - metrics_long.log_lh).abs() > 1e-6,
+      (metrics_short.log_lh.value() - metrics_long.log_lh.value()).abs() > 1e-6,
       "log-LH should differ at different branch lengths"
     );
   }

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_evaluate.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_evaluate.rs
@@ -26,7 +26,7 @@ mod tests {
     // At branch_length=0, exp(λt) = 1 for all eigenvalues
     // log-LH = ln(sum of coefficients) = ln(1.0) = 0.0
     let coeff_sum: f64 = 0.5 + 0.2 + 0.2 + 0.1;
-    pretty_assert_ulps_eq!(metrics.log_lh, coeff_sum.ln(), max_ulps = 100);
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), coeff_sum.ln(), max_ulps = 100);
   }
 
   #[test]
@@ -49,7 +49,7 @@ mod tests {
     // log-LH = multiplicity * ln(sum of coefficients) = 10 * ln(1.0) = 0.0
     let coeff_sum: f64 = 0.5 + 0.2 + 0.2 + 0.1;
     let expected_log_lh = 10.0 * coeff_sum.ln();
-    pretty_assert_ulps_eq!(metrics.log_lh, expected_log_lh, max_ulps = 100);
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), expected_log_lh, max_ulps = 100);
   }
 
   #[test]
@@ -82,7 +82,7 @@ mod tests {
     let metrics5 = evaluate_sparse_contribution(&contribution5, 0.1).expect("valid branch length");
 
     // log-LH should scale with multiplicity
-    pretty_assert_ulps_eq!(metrics5.log_lh, 5.0 * metrics1.log_lh, max_ulps = 100);
+    pretty_assert_ulps_eq!(metrics5.log_lh.value(), 5.0 * metrics1.log_lh.value(), max_ulps = 100);
   }
 
   #[test]
@@ -128,6 +128,10 @@ mod tests {
     let metrics_both = evaluate_sparse_contribution(&contribution_both, 0.1).expect("valid branch length");
 
     // log-LH should be sum of individual contributions
-    pretty_assert_ulps_eq!(metrics_both.log_lh, metrics_a.log_lh + metrics_b.log_lh, max_ulps = 100);
+    pretty_assert_ulps_eq!(
+      metrics_both.log_lh.value(),
+      metrics_a.log_lh.value() + metrics_b.log_lh.value(),
+      max_ulps = 100
+    );
   }
 }

--- a/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_mixed_sites.rs
+++ b/packages/treetime/src/optimize/__tests__/test_coefficient_extraction_sparse/test_coefficient_extraction_sparse_mixed_sites.rs
@@ -53,8 +53,8 @@ mod tests {
     let fixed_metrics = evaluate_sparse_contribution(&fixed_contribution, branch_length).expect("valid branch length");
 
     // Total log-LH equals sum of individual contributions
-    let expected_log_lh = variable_metrics.log_lh + fixed_metrics.log_lh;
-    pretty_assert_ulps_eq!(metrics.log_lh, expected_log_lh, max_ulps = 100);
+    let expected_log_lh = variable_metrics.log_lh.value() + fixed_metrics.log_lh.value();
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), expected_log_lh, max_ulps = 100);
 
     // Total derivative equals sum of individual derivatives
     let expected_derivative = variable_metrics.derivative + fixed_metrics.derivative;
@@ -88,12 +88,12 @@ mod tests {
     // variable: 1.0 * ln(0.4) ≈ -0.916
     // fixed: 1000.0 * ln(1.0) = 0.0
     // Total ≈ -0.916, but fixed sites with high LH reduce total magnitude
-    assert!(metrics.log_lh.is_finite());
+    assert!(metrics.log_lh.value().is_finite());
     // The fixed site with sum ~1.0 contributes 0 to log-LH per multiplicity
     // The variable site with sum ~0.4 contributes negative value
     let fixed_coeff_sum: f64 = 0.9 + 0.03 + 0.03 + 0.04;
     let variable_coeff_sum: f64 = 0.1 + 0.1 + 0.1 + 0.1;
     let expected = 1.0 * variable_coeff_sum.ln() + 1000.0 * fixed_coeff_sum.ln();
-    pretty_assert_ulps_eq!(metrics.log_lh, expected, max_ulps = 100);
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), expected, max_ulps = 100);
   }
 }

--- a/packages/treetime/src/optimize/__tests__/test_convergence/test_convergence_idempotence.rs
+++ b/packages/treetime/src/optimize/__tests__/test_convergence/test_convergence_idempotence.rs
@@ -34,7 +34,7 @@ mod tests {
     // Run optimization iterations
     for i in 0..20 {
       run_optimize_mixed(&graph, &mixed_partitions, method)?;
-      let lh = update_marginal(&graph, &dense_partitions)? + update_marginal(&graph, &sparse_partitions)?;
+      let lh = update_marginal(&graph, &dense_partitions)?.value() + update_marginal(&graph, &sparse_partitions)?.value();
 
       lh_history.push(lh);
 
@@ -83,8 +83,8 @@ mod tests {
 
     for _ in 0..10 {
       run_optimize_mixed(&graph1, &mixed_partitions1, method)?;
-      update_marginal(&graph1, &dense_partitions1)?;
-      update_marginal(&graph1, &sparse_partitions1)?;
+      update_marginal(&graph1, &dense_partitions1)?.value();
+      update_marginal(&graph1, &sparse_partitions1)?.value();
     }
 
     let lh1 = compute_total_lh(&graph1, &dense_partitions1, &sparse_partitions1)?;
@@ -95,8 +95,8 @@ mod tests {
 
     for _ in 0..10 {
       run_optimize_mixed(&graph2, &mixed_partitions2, method)?;
-      update_marginal(&graph2, &dense_partitions2)?;
-      update_marginal(&graph2, &sparse_partitions2)?;
+      update_marginal(&graph2, &dense_partitions2)?.value();
+      update_marginal(&graph2, &sparse_partitions2)?.value();
     }
 
     let lh2 = compute_total_lh(&graph2, &dense_partitions2, &sparse_partitions2)?;

--- a/packages/treetime/src/optimize/__tests__/test_convergence/test_convergence_iterations.rs
+++ b/packages/treetime/src/optimize/__tests__/test_convergence/test_convergence_iterations.rs
@@ -126,8 +126,8 @@ mod tests {
     // Run several optimization iterations
     for _ in 0..10 {
       run_optimize_mixed(&graph, &mixed_partitions, method)?;
-      update_marginal(&graph, &dense_partitions)?;
-      update_marginal(&graph, &sparse_partitions)?;
+      update_marginal(&graph, &dense_partitions)?.value();
+      update_marginal(&graph, &sparse_partitions)?.value();
     }
 
     // Verify all branch lengths are in valid range

--- a/packages/treetime/src/optimize/__tests__/test_convergence/test_convergence_support.rs
+++ b/packages/treetime/src/optimize/__tests__/test_convergence/test_convergence_support.rs
@@ -64,8 +64,8 @@ pub mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, graph)?,
     ))];
-    initialize_marginal(graph, &dense_partitions, aln)?;
-    update_marginal(graph, &sparse_partitions)?;
+    initialize_marginal(graph, &dense_partitions, aln)?.value();
+    update_marginal(graph, &sparse_partitions)?.value();
 
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
     initial_guess_mixed(graph, &mixed_partitions, true, false)?;
@@ -78,8 +78,8 @@ pub mod tests {
     dense_partitions: &[Arc<RwLock<PartitionMarginalDense>>],
     sparse_partitions: &[Arc<RwLock<PartitionMarginalSparse>>],
   ) -> Result<f64, Report> {
-    let dense_lh = update_marginal(graph, dense_partitions)?;
-    let sparse_lh = update_marginal(graph, sparse_partitions)?;
+    let dense_lh = update_marginal(graph, dense_partitions)?.value();
+    let sparse_lh = update_marginal(graph, sparse_partitions)?.value();
     Ok(dense_lh + sparse_lh)
   }
 }

--- a/packages/treetime/src/optimize/__tests__/test_convergence_conditions.rs
+++ b/packages/treetime/src/optimize/__tests__/test_convergence_conditions.rs
@@ -154,9 +154,13 @@ mod tests {
         assert!(iter >= 2, "Worsened should not fire before iteration 2, got {iter}");
         // The best LH should be the maximum in the history (the worsened condition
         // restores branch lengths from the best iteration).
-        let best_lh = result.lh_history.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let best_lh = result
+          .lh_history
+          .iter()
+          .map(|log_lh| log_lh.value())
+          .fold(f64::NEG_INFINITY, f64::max);
         // The iteration that triggered worsened must have a lower LH than the best.
-        let trigger_lh = result.lh_history[iter];
+        let trigger_lh = result.lh_history[iter].value();
         assert!(
           trigger_lh < best_lh,
           "Trigger LH ({trigger_lh:.6}) should be less than best LH ({best_lh:.6})"

--- a/packages/treetime/src/optimize/__tests__/test_convergence_sc2.rs
+++ b/packages/treetime/src/optimize/__tests__/test_convergence_sc2.rs
@@ -41,7 +41,7 @@ mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ))];
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let dense_partitions = vec![];
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
@@ -90,7 +90,7 @@ mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ))];
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let dense_partitions = vec![];
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);

--- a/packages/treetime/src/optimize/__tests__/test_dense_edge_subs.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dense_edge_subs.rs
@@ -21,6 +21,7 @@ mod tests {
   use std::sync::Arc;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::LogLh;
 
   /// Regression test: uniform outgroup message must not create false substitutions.
   ///
@@ -56,17 +57,17 @@ mod tests {
         nodes: btreemap! {
           parent_key => DenseNodePartition {
             seq: DenseSeqInfo::default(),
-            profile: DenseSeqDistribution::new(parent_posterior, 0.0),
+            profile: DenseSeqDistribution::new(parent_posterior, LogLh::ZERO),
           },
           child_key => DenseNodePartition {
             seq: DenseSeqInfo::default(),
-            profile: DenseSeqDistribution::new(child_posterior, 0.0),
+            profile: DenseSeqDistribution::new(child_posterior, LogLh::ZERO),
           },
         },
         edges: btreemap! {
           edge_key => DenseEdgePartition {
-            msg_to_parent: DenseSeqDistribution::new(msg_to_parent, 0.0),
-            msg_to_child: DenseSeqDistribution::new(msg_to_child, 0.0),
+            msg_to_parent: DenseSeqDistribution::new(msg_to_parent, LogLh::ZERO),
+            msg_to_child: DenseSeqDistribution::new(msg_to_child, LogLh::ZERO),
             ..Default::default()
           },
         },
@@ -117,17 +118,17 @@ mod tests {
         nodes: btreemap! {
           parent_key => DenseNodePartition {
             seq: DenseSeqInfo::default(),
-            profile: DenseSeqDistribution::new(parent_posterior, 0.0),
+            profile: DenseSeqDistribution::new(parent_posterior, LogLh::ZERO),
           },
           child_key => DenseNodePartition {
             seq: DenseSeqInfo::default(),
-            profile: DenseSeqDistribution::new(child_posterior, 0.0),
+            profile: DenseSeqDistribution::new(child_posterior, LogLh::ZERO),
           },
         },
         edges: btreemap! {
           edge_key => DenseEdgePartition {
-            msg_to_parent: DenseSeqDistribution::new(msg_to_parent, 0.0),
-            msg_to_child: DenseSeqDistribution::new(msg_to_child, 0.0),
+            msg_to_parent: DenseSeqDistribution::new(msg_to_parent, LogLh::ZERO),
+            msg_to_child: DenseSeqDistribution::new(msg_to_child, LogLh::ZERO),
             ..Default::default()
           },
         },
@@ -169,8 +170,8 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
-    update_marginal(&graph, &partitions)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
+    update_marginal(&graph, &partitions)?.value();
 
     let partition = partitions[0].read_arc();
 
@@ -249,11 +250,11 @@ mod tests {
         nodes: btreemap! {
           parent_key => DenseNodePartition {
             seq: DenseSeqInfo::default(),
-            profile: DenseSeqDistribution::new(parent_posterior, 0.0),
+            profile: DenseSeqDistribution::new(parent_posterior, LogLh::ZERO),
           },
           child_key => DenseNodePartition {
             seq: DenseSeqInfo { gaps: vec![(1, 3)], non_char: vec![(1, 3)], ..Default::default() },
-            profile: DenseSeqDistribution::new(child_posterior, 0.0),
+            profile: DenseSeqDistribution::new(child_posterior, LogLh::ZERO),
           },
         },
         edges: btreemap! {
@@ -293,8 +294,8 @@ mod tests {
       get_common_length(&aln)?,
     )))];
 
-    initialize_marginal(&graph, &partitions, &aln)?;
-    update_marginal(&graph, &partitions)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
+    update_marginal(&graph, &partitions)?.value();
 
     let partition = partitions[0].read_arc();
     for edge_ref in graph.get_edges() {

--- a/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_bounds.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_bounds.rs
@@ -30,10 +30,10 @@ mod tests {
 
     for _ in 0..10 {
       run_optimize_mixed(&graph_dense, &dense_partitions, method)?;
-      update_marginal(&graph_dense, &dense_partitions)?;
+      update_marginal(&graph_dense, &dense_partitions)?.value();
     }
 
-    let log_lh_dense = update_marginal(&graph_dense, &dense_partitions)?;
+    let log_lh_dense = update_marginal(&graph_dense, &dense_partitions)?.value();
 
     // Run sparse-only optimization
     let graph_sparse: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
@@ -41,10 +41,10 @@ mod tests {
 
     for _ in 0..10 {
       run_optimize_mixed(&graph_sparse, &sparse_partitions, method)?;
-      update_marginal(&graph_sparse, &sparse_partitions)?;
+      update_marginal(&graph_sparse, &sparse_partitions)?.value();
     }
 
-    let log_lh_sparse = update_marginal(&graph_sparse, &sparse_partitions)?;
+    let log_lh_sparse = update_marginal(&graph_sparse, &sparse_partitions)?.value();
 
     // Both modes should produce finite log-LH in expected range
     assert!(
@@ -86,7 +86,7 @@ mod tests {
 
     for _ in 0..10 {
       run_optimize_mixed(&graph_dense, &dense_partitions, method)?;
-      update_marginal(&graph_dense, &dense_partitions)?;
+      update_marginal(&graph_dense, &dense_partitions)?.value();
     }
 
     let branch_lengths_dense = get_branch_lengths(&graph_dense);
@@ -97,7 +97,7 @@ mod tests {
 
     for _ in 0..10 {
       run_optimize_mixed(&graph_sparse, &sparse_partitions, method)?;
-      update_marginal(&graph_sparse, &sparse_partitions)?;
+      update_marginal(&graph_sparse, &sparse_partitions)?.value();
     }
 
     let branch_lengths_sparse = get_branch_lengths(&graph_sparse);

--- a/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_convergence.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_convergence.rs
@@ -26,12 +26,12 @@ mod tests {
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions = setup_dense_only(&graph, &aln)?;
 
-    let initial_lh = update_marginal(&graph, &partitions)?;
+    let initial_lh = update_marginal(&graph, &partitions)?.value();
     let mut lh_history = vec![initial_lh];
 
     for _ in 0..50 {
       run_optimize_mixed(&graph, &partitions, method)?;
-      let lh = update_marginal(&graph, &partitions)?;
+      let lh = update_marginal(&graph, &partitions)?.value();
       lh_history.push(lh);
     }
 
@@ -78,12 +78,12 @@ mod tests {
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions = setup_sparse_only(&graph, &aln)?;
 
-    let initial_lh = update_marginal(&graph, &partitions)?;
+    let initial_lh = update_marginal(&graph, &partitions)?.value();
     let mut lh_history = vec![initial_lh];
 
     for _ in 0..50 {
       run_optimize_mixed(&graph, &partitions, method)?;
-      let lh = update_marginal(&graph, &partitions)?;
+      let lh = update_marginal(&graph, &partitions)?.value();
       lh_history.push(lh);
     }
 

--- a/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_initial.rs
@@ -19,12 +19,12 @@ mod tests {
     // Initialize dense
     let graph_dense: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let dense_partitions = setup_dense_only(&graph_dense, &aln)?;
-    let log_lh_dense = update_marginal(&graph_dense, &dense_partitions)?;
+    let log_lh_dense = update_marginal(&graph_dense, &dense_partitions)?.value();
 
     // Initialize sparse
     let graph_sparse: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let sparse_partitions = setup_sparse_only(&graph_sparse, &aln)?;
-    let log_lh_sparse = update_marginal(&graph_sparse, &sparse_partitions)?;
+    let log_lh_sparse = update_marginal(&graph_sparse, &sparse_partitions)?.value();
 
     // Initial log-LH should be equivalent (before any optimization)
     pretty_assert_ulps_eq!(log_lh_dense, log_lh_sparse, max_ulps = 100);
@@ -52,12 +52,12 @@ mod tests {
     // Initialize dense
     let graph_dense: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let dense_partitions = setup_dense_only(&graph_dense, &aln)?;
-    let log_lh_dense = update_marginal(&graph_dense, &dense_partitions)?;
+    let log_lh_dense = update_marginal(&graph_dense, &dense_partitions)?.value();
 
     // Initialize sparse
     let graph_sparse: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let sparse_partitions = setup_sparse_only(&graph_sparse, &aln)?;
-    let log_lh_sparse = update_marginal(&graph_sparse, &sparse_partitions)?;
+    let log_lh_sparse = update_marginal(&graph_sparse, &sparse_partitions)?.value();
 
     // Initial log-LH should be equivalent
     pretty_assert_ulps_eq!(log_lh_dense, log_lh_sparse, max_ulps = 100);

--- a/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_support.rs
@@ -61,7 +61,7 @@ pub mod tests {
       get_common_length(aln)?,
     )))];
 
-    initialize_marginal(graph, &partitions, aln)?;
+    initialize_marginal(graph, &partitions, aln)?.value();
 
     Ok(partitions)
   }
@@ -75,7 +75,7 @@ pub mod tests {
     let partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, graph)?,
     ))];
-    update_marginal(graph, &partitions)?;
+    update_marginal(graph, &partitions)?.value();
 
     Ok(partitions)
   }

--- a/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_validity.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dense_sparse_equivalence/test_dense_sparse_equivalence_validity.rs
@@ -27,16 +27,16 @@ mod tests {
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions = setup_dense_only(&graph, &aln)?;
 
-    let initial_lh = update_marginal(&graph, &partitions)?;
+    let initial_lh = update_marginal(&graph, &partitions)?.value();
     assert!(initial_lh.is_finite(), "Initial log-LH should be finite");
 
     for _ in 0..10 {
       run_optimize_mixed(&graph, &partitions, method)?;
-      let lh = update_marginal(&graph, &partitions)?;
+      let lh = update_marginal(&graph, &partitions)?.value();
       assert!(lh.is_finite(), "Log-LH should remain finite during optimization");
     }
 
-    let final_lh = update_marginal(&graph, &partitions)?;
+    let final_lh = update_marginal(&graph, &partitions)?.value();
 
     // Final log-LH should be in expected range for this simple tree
     // 16 sites, 4 leaves, mostly identical sequences -> log-LH between -100 and -10
@@ -81,16 +81,16 @@ mod tests {
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions = setup_sparse_only(&graph, &aln)?;
 
-    let initial_lh = update_marginal(&graph, &partitions)?;
+    let initial_lh = update_marginal(&graph, &partitions)?.value();
     assert!(initial_lh.is_finite(), "Initial log-LH should be finite");
 
     for _ in 0..10 {
       run_optimize_mixed(&graph, &partitions, method)?;
-      let lh = update_marginal(&graph, &partitions)?;
+      let lh = update_marginal(&graph, &partitions)?.value();
       assert!(lh.is_finite(), "Log-LH should remain finite during optimization");
     }
 
-    let final_lh = update_marginal(&graph, &partitions)?;
+    let final_lh = update_marginal(&graph, &partitions)?.value();
 
     // Final log-LH should be in expected range for this simple tree
     // 16 sites, 4 leaves, mostly identical sequences -> log-LH between -100 and -10

--- a/packages/treetime/src/optimize/__tests__/test_dispatch_zero_boundary.rs
+++ b/packages/treetime/src/optimize/__tests__/test_dispatch_zero_boundary.rs
@@ -79,8 +79,8 @@ mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(get_gtr_by_name(model)?, graph)?,
     ))];
-    initialize_marginal(graph, &dense_partitions, &aln)?;
-    update_marginal(graph, &sparse_partitions)?;
+    initialize_marginal(graph, &dense_partitions, &aln)?.value();
+    update_marginal(graph, &sparse_partitions)?.value();
 
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
     initial_guess_mixed(graph, &mixed_partitions, false, false)?;
@@ -277,10 +277,18 @@ mod tests {
   #[test]
   fn test_dispatch_zero_boundary_reconcile_positive_candidate_finds_positive_mode() {
     let contributions = [make_dinh_matsen_k80_contribution()];
-    let lh_zero = evaluate_mixed_log_lh_only(&contributions, 0.0).expect("valid branch length");
-    let lh_near_peak = evaluate_mixed_log_lh_only(&contributions, 0.2).expect("valid branch length");
-    let lh_at_dip = evaluate_mixed_log_lh_only(&contributions, 1.0).expect("valid branch length");
-    let lh_recovery = evaluate_mixed_log_lh_only(&contributions, 5.0).expect("valid branch length");
+    let lh_zero = evaluate_mixed_log_lh_only(&contributions, 0.0)
+      .expect("valid branch length")
+      .value();
+    let lh_near_peak = evaluate_mixed_log_lh_only(&contributions, 0.2)
+      .expect("valid branch length")
+      .value();
+    let lh_at_dip = evaluate_mixed_log_lh_only(&contributions, 1.0)
+      .expect("valid branch length")
+      .value();
+    let lh_recovery = evaluate_mixed_log_lh_only(&contributions, 5.0)
+      .expect("valid branch length")
+      .value();
 
     assert!(
       lh_near_peak > lh_zero,
@@ -302,7 +310,9 @@ mod tests {
     // $t \approx 0.2$ is better than both the dip and zero. The helper
     // must delegate to `grid_search_inner` and return the local max.
     let candidate = 1.0;
-    let lh_candidate = evaluate_mixed_log_lh_only(&contributions, candidate).expect("valid branch length");
+    let lh_candidate = evaluate_mixed_log_lh_only(&contributions, candidate)
+      .expect("valid branch length")
+      .value();
     assert!(
       lh_candidate < lh_zero,
       "precondition: candidate log_lh({candidate})={lh_candidate} must be worse than log_lh(0)={lh_zero}"
@@ -319,7 +329,9 @@ mod tests {
       result > 0.0,
       "reconcile_zero_boundary must return a positive mode, not zero, got {result}"
     );
-    let lh_result = evaluate_mixed_log_lh_only(&contributions, result).expect("valid branch length");
+    let lh_result = evaluate_mixed_log_lh_only(&contributions, result)
+      .expect("valid branch length")
+      .value();
     assert!(
       lh_result > lh_zero,
       "reconciled result must beat zero: log_lh(result)={lh_result} vs log_lh(0)={lh_zero}"
@@ -608,8 +620,12 @@ mod tests {
   #[test]
   fn test_dispatch_zero_boundary_reconcile_exact_zero_finds_positive_mode() {
     let contributions = [make_dinh_matsen_k80_contribution()];
-    let lh_zero = evaluate_mixed_log_lh_only(&contributions, 0.0).expect("valid branch length");
-    let lh_near_peak = evaluate_mixed_log_lh_only(&contributions, 0.2).expect("valid branch length");
+    let lh_zero = evaluate_mixed_log_lh_only(&contributions, 0.0)
+      .expect("valid branch length")
+      .value();
+    let lh_near_peak = evaluate_mixed_log_lh_only(&contributions, 0.2)
+      .expect("valid branch length")
+      .value();
     assert!(
       lh_near_peak > lh_zero,
       "precondition: log_lh(0.2)={lh_near_peak} > log_lh(0)={lh_zero}"
@@ -630,7 +646,9 @@ mod tests {
       result > 0.0,
       "reconcile_zero_boundary must reject exact-zero and return a positive mode on a multi-modal surface, got {result}"
     );
-    let lh_result = evaluate_mixed_log_lh_only(&contributions, result).expect("valid branch length");
+    let lh_result = evaluate_mixed_log_lh_only(&contributions, result)
+      .expect("valid branch length")
+      .value();
     assert!(
       lh_result > lh_zero,
       "reconciled result must beat zero: log_lh(result)={lh_result} vs log_lh(0)={lh_zero}"

--- a/packages/treetime/src/optimize/__tests__/test_eval_zero_branch_mismatch.rs
+++ b/packages/treetime/src/optimize/__tests__/test_eval_zero_branch_mismatch.rs
@@ -60,8 +60,8 @@ mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ))];
-    initialize_marginal(&graph, &dense_partitions, &aln)?;
-    update_marginal(&graph, &sparse_partitions)?;
+    initialize_marginal(&graph, &dense_partitions, &aln)?.value();
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
 

--- a/packages/treetime/src/optimize/__tests__/test_gm_optimize.rs
+++ b/packages/treetime/src/optimize/__tests__/test_gm_optimize.rs
@@ -183,6 +183,7 @@ mod tests {
 
     use crate::payload::ancestral::GraphAncestral;
     use eyre::Report;
+    use itertools::Itertools;
 
     use parking_lot::RwLock;
     use serde::Deserialize;
@@ -192,6 +193,7 @@ mod tests {
     use std::sync::Arc;
     use treetime_io::fasta::read_many_fasta;
     use treetime_io::nwk::nwk_read_file;
+    use treetime_primitives::LogLh;
 
     #[derive(Clone, Deserialize)]
     pub struct GmOptimizeCase {
@@ -253,9 +255,9 @@ mod tests {
         length,
       )))];
 
-      initialize_marginal(&graph, &dense_partitions, &aln)?;
-      update_marginal(&graph, &sparse_partitions)?;
-      update_marginal(&graph, &dense_partitions)?;
+      initialize_marginal(&graph, &dense_partitions, &aln)?.value();
+      update_marginal(&graph, &sparse_partitions)?.value();
+      update_marginal(&graph, &dense_partitions)?.value();
 
       let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
       initial_guess_mixed(&graph, &mixed_partitions, true, false)?;
@@ -276,9 +278,9 @@ mod tests {
       // Append a trailing likelihood measurement so `lh_history.last()` reflects the state
       // AFTER the final in-loop branch-length update (`run_optimize_loop` records the LH
       // at the START of each iteration, before that iteration's update).
-      let mut lh_history = result.lh_history;
-      let sparse_lh = update_marginal(&graph, &sparse_partitions)?;
-      let dense_lh = update_marginal(&graph, &dense_partitions)?;
+      let mut lh_history = result.lh_history.into_iter().map(LogLh::value).collect_vec();
+      let sparse_lh = update_marginal(&graph, &sparse_partitions)?.value();
+      let dense_lh = update_marginal(&graph, &dense_partitions)?.value();
       lh_history.push(sparse_lh + dense_lh);
 
       Ok(OptimizeResult {

--- a/packages/treetime/src/optimize/__tests__/test_grid_search/test_grid_search_basic.rs
+++ b/packages/treetime/src/optimize/__tests__/test_grid_search/test_grid_search_basic.rs
@@ -22,10 +22,14 @@ mod tests {
     let branch_lengths = grid_search_branch_lengths(branch_length, one_mutation).unwrap();
     let best_log_lh = evaluate_mixed(&contributions, best_bl)
       .expect("valid branch length")
-      .log_lh;
+      .log_lh
+      .value();
 
     for &bl in &branch_lengths {
-      let log_lh = evaluate_mixed(&contributions, bl).expect("valid branch length").log_lh;
+      let log_lh = evaluate_mixed(&contributions, bl)
+        .expect("valid branch length")
+        .log_lh
+        .value();
       assert!(
         log_lh <= best_log_lh + 1e-10,
         "Found bl={bl} with log_lh={log_lh} > best_log_lh={best_log_lh}"

--- a/packages/treetime/src/optimize/__tests__/test_grid_search/test_grid_search_partitions.rs
+++ b/packages/treetime/src/optimize/__tests__/test_grid_search/test_grid_search_partitions.rs
@@ -24,10 +24,14 @@ mod tests {
     let branch_lengths = grid_search_branch_lengths(branch_length, one_mutation).unwrap();
     let best_log_lh = evaluate_mixed(&contributions, best_bl)
       .expect("valid branch length")
-      .log_lh;
+      .log_lh
+      .value();
 
     for &bl in &branch_lengths {
-      let log_lh = evaluate_mixed(&contributions, bl).expect("valid branch length").log_lh;
+      let log_lh = evaluate_mixed(&contributions, bl)
+        .expect("valid branch length")
+        .log_lh
+        .value();
       assert!(log_lh <= best_log_lh + 1e-10);
     }
   }

--- a/packages/treetime/src/optimize/__tests__/test_grid_search/test_grid_search_support.rs
+++ b/packages/treetime/src/optimize/__tests__/test_grid_search/test_grid_search_support.rs
@@ -20,7 +20,7 @@ pub mod tests {
       .iter()
       .max_by_key(|&&bl| {
         let metrics = evaluate_mixed(contributions, bl).expect("valid branch length");
-        OrderedFloat(metrics.log_lh)
+        OrderedFloat(metrics.log_lh.value())
       })
       .copied()
       .unwrap_or(branch_length)

--- a/packages/treetime/src/optimize/__tests__/test_initial_guess_formula.rs
+++ b/packages/treetime/src/optimize/__tests__/test_initial_guess_formula.rs
@@ -171,7 +171,7 @@ mod tests {
     let partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, graph)?,
     ))];
-    update_marginal(graph, &partitions)?;
+    update_marginal(graph, &partitions)?.value();
 
     Ok(partitions)
   }
@@ -188,7 +188,7 @@ mod tests {
       get_common_length(aln)?,
     )))];
 
-    initialize_marginal(graph, &partitions, aln)?;
+    initialize_marginal(graph, &partitions, aln)?.value();
 
     Ok(partitions)
   }
@@ -243,7 +243,7 @@ mod tests {
           .expect("valid branch length");
         Ok((
           child_name,
-          (metrics.log_lh, metrics.derivative, metrics.second_derivative),
+          (metrics.log_lh.value(), metrics.derivative, metrics.second_derivative),
         ))
       })
       .collect()

--- a/packages/treetime/src/optimize/__tests__/test_initial_guess_gaps.rs
+++ b/packages/treetime/src/optimize/__tests__/test_initial_guess_gaps.rs
@@ -86,7 +86,7 @@ mod tests {
     let partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, graph)?,
     ))];
-    update_marginal(graph, &partitions)?;
+    update_marginal(graph, &partitions)?.value();
 
     Ok(partitions)
   }
@@ -103,7 +103,7 @@ mod tests {
       get_common_length(aln)?,
     )))];
 
-    initialize_marginal(graph, &partitions, aln)?;
+    initialize_marginal(graph, &partitions, aln)?.value();
 
     Ok(partitions)
   }

--- a/packages/treetime/src/optimize/__tests__/test_initial_guess_gtr_messages.rs
+++ b/packages/treetime/src/optimize/__tests__/test_initial_guess_gtr_messages.rs
@@ -50,7 +50,7 @@ mod tests {
       alphabet,
       get_common_length(aln)?,
     )))];
-    initialize_marginal(graph, &partitions, aln)?;
+    initialize_marginal(graph, &partitions, aln)?.value();
     Ok(partitions)
   }
 
@@ -78,7 +78,7 @@ mod tests {
     // Replace GTR but do NOT re-run update_marginal.
     let graph_stale: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions_stale = setup_dense_jc69(&graph_stale, &aln)?;
-    update_marginal(&graph_stale, &partitions_stale)?;
+    update_marginal(&graph_stale, &partitions_stale)?.value();
     partitions_stale[0].write_arc().data.gtr = f81_gtr.clone();
     initial_guess_mixed(&graph_stale, &partitions_stale, true, false)?;
     let bl_stale = get_branch_lengths(&graph_stale);
@@ -87,9 +87,9 @@ mod tests {
     // Replace GTR AND re-run update_marginal.
     let graph_fresh: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions_fresh = setup_dense_jc69(&graph_fresh, &aln)?;
-    update_marginal(&graph_fresh, &partitions_fresh)?;
+    update_marginal(&graph_fresh, &partitions_fresh)?.value();
     partitions_fresh[0].write_arc().data.gtr = f81_gtr;
-    update_marginal(&graph_fresh, &partitions_fresh)?;
+    update_marginal(&graph_fresh, &partitions_fresh)?.value();
     initial_guess_mixed(&graph_fresh, &partitions_fresh, true, false)?;
     let bl_fresh = get_branch_lengths(&graph_fresh);
 
@@ -115,9 +115,9 @@ mod tests {
     // Run full initialization with the fix: JC69, update, replace, update, guess
     let graph: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions = setup_dense_jc69(&graph, &aln)?;
-    update_marginal(&graph, &partitions)?;
+    update_marginal(&graph, &partitions)?.value();
     partitions[0].write_arc().data.gtr = f81_gtr.clone();
-    update_marginal(&graph, &partitions)?;
+    update_marginal(&graph, &partitions)?.value();
     initial_guess_mixed(&graph, &partitions, true, false)?;
     let bl_first = get_branch_lengths(&graph);
 
@@ -129,9 +129,9 @@ mod tests {
     // produce the same result.
     let graph2: GraphAncestral = nwk_read_str(TREE_NEWICK)?;
     let partitions2 = setup_dense_jc69(&graph2, &aln)?;
-    update_marginal(&graph2, &partitions2)?;
+    update_marginal(&graph2, &partitions2)?.value();
     partitions2[0].write_arc().data.gtr = f81_gtr;
-    update_marginal(&graph2, &partitions2)?;
+    update_marginal(&graph2, &partitions2)?.value();
     initial_guess_mixed(&graph2, &partitions2, true, false)?;
     let bl_second = get_branch_lengths(&graph2);
 

--- a/packages/treetime/src/optimize/__tests__/test_initial_guess_indel_zero_bl.rs
+++ b/packages/treetime/src/optimize/__tests__/test_initial_guess_indel_zero_bl.rs
@@ -112,8 +112,8 @@ mod tests {
         get_common_length(&aln)?,
       )))];
 
-      initialize_marginal(&graph, &partitions, &aln)?;
-      update_marginal(&graph, &partitions)?;
+      initialize_marginal(&graph, &partitions, &aln)?.value();
+      update_marginal(&graph, &partitions)?.value();
 
       Ok((graph, partitions))
     }

--- a/packages/treetime/src/optimize/__tests__/test_initial_guess_mode.rs
+++ b/packages/treetime/src/optimize/__tests__/test_initial_guess_mode.rs
@@ -375,8 +375,8 @@ pub mod tests {
         get_common_length(&aln)?,
       )))];
 
-      initialize_marginal(&graph, &partitions, &aln)?;
-      update_marginal(&graph, &partitions)?;
+      initialize_marginal(&graph, &partitions, &aln)?.value();
+      update_marginal(&graph, &partitions)?.value();
 
       Ok((graph, partitions))
     }

--- a/packages/treetime/src/optimize/__tests__/test_is_zero_branch_optimal.rs
+++ b/packages/treetime/src/optimize/__tests__/test_is_zero_branch_optimal.rs
@@ -478,7 +478,11 @@ mod tests {
     // a local min near t=1, and a global max at equilibrium (t -> infinity).
     // This non-monotonic shape -- rise, dip, recovery -- is the hallmark of
     // multimodality that JC69/F81 cannot exhibit.
-    let lh = |t: f64| evaluate_mixed_log_lh_only(&contributions, t).expect("valid branch length");
+    let lh = |t: f64| {
+      evaluate_mixed_log_lh_only(&contributions, t)
+        .expect("valid branch length")
+        .value()
+    };
 
     let log_lh_near_peak = lh(0.2);
     let log_lh_at_dip = lh(1.0);

--- a/packages/treetime/src/optimize/__tests__/test_newton_convergence/test_newton_convergence_evaluate_mixed.rs
+++ b/packages/treetime/src/optimize/__tests__/test_newton_convergence/test_newton_convergence_evaluate_mixed.rs
@@ -14,7 +14,7 @@ mod tests {
 
     let metrics = evaluate_mixed(&contributions, 0.1).expect("valid branch length");
 
-    assert!(metrics.log_lh.is_finite());
+    assert!(metrics.log_lh.value().is_finite());
     assert!(metrics.derivative.is_finite());
     assert!(metrics.second_derivative.is_finite());
   }
@@ -29,7 +29,7 @@ mod tests {
     let metrics = evaluate_mixed(&contributions, 0.1).expect("valid branch length");
 
     // Log of a probability is negative or zero
-    assert!(metrics.log_lh <= 0.0);
+    assert!(metrics.log_lh.value() <= 0.0);
   }
 
   #[test]
@@ -42,7 +42,7 @@ mod tests {
     let branch_lengths = [0.001, 0.01, 0.1, 0.5, 1.0];
     for &bl in &branch_lengths {
       let metrics = evaluate_mixed(&contributions, bl).expect("valid branch length");
-      assert!(metrics.log_lh.is_finite(), "log_lh should be finite at bl={bl}");
+      assert!(metrics.log_lh.value().is_finite(), "log_lh should be finite at bl={bl}");
       assert!(metrics.derivative.is_finite(), "derivative should be finite at bl={bl}");
       assert!(
         metrics.second_derivative.is_finite(),

--- a/packages/treetime/src/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs
+++ b/packages/treetime/src/optimize/__tests__/test_newton_convergence/test_newton_convergence_iteration.rs
@@ -36,7 +36,7 @@ mod tests {
       "precondition: second_derivative at branch_length=0.1 must be negative for Newton to run, got {}",
       metrics.second_derivative
     );
-    let initial_lh = metrics.log_lh;
+    let initial_lh = metrics.log_lh.value();
 
     let mut new_branch_length =
       (branch_length - clamp(metrics.derivative / metrics.second_derivative, -1.0, branch_length)).max(min_bl);
@@ -72,9 +72,9 @@ mod tests {
     let final_metrics =
       evaluate_with_indels(&contributions, indel_count, indel_rate, branch_length).expect("valid branch length");
     assert!(
-      final_metrics.log_lh >= initial_lh - 1e-10,
+      final_metrics.log_lh.value() >= initial_lh - 1e-10,
       "Newton degraded log_lh from {initial_lh} to {final}",
-      final = final_metrics.log_lh,
+      final = final_metrics.log_lh.value(),
     );
   }
 

--- a/packages/treetime/src/optimize/__tests__/test_no_indels.rs
+++ b/packages/treetime/src/optimize/__tests__/test_no_indels.rs
@@ -86,8 +86,8 @@ mod tests {
     assert!(
       result_without.lh_history[0] > result_with.lh_history[0],
       "no_indels=true should produce higher likelihood than with indels: {} vs {}",
-      result_without.lh_history[0],
-      result_with.lh_history[0]
+      result_without.lh_history[0].value(),
+      result_with.lh_history[0].value()
     );
     Ok(())
   }
@@ -111,7 +111,7 @@ mod tests {
       .unwrap()
       .indels = vec![InDel::del((0, 3), Seq::try_from_str("ACG")?)?];
 
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let bl_before: Vec<f64> = graph
       .get_edges()
@@ -175,7 +175,7 @@ mod tests {
       .zip(&result_flag.lh_history)
       .enumerate()
     {
-      assert_abs_diff_eq!(lh_nf, lh_f, epsilon = 1e-10);
+      assert_abs_diff_eq!(lh_nf.value(), lh_f.value(), epsilon = 1e-10);
     }
     Ok(())
   }

--- a/packages/treetime/src/optimize/__tests__/test_optimization_metrics.rs
+++ b/packages/treetime/src/optimize/__tests__/test_optimization_metrics.rs
@@ -2,21 +2,22 @@
 mod tests {
   use crate::optimize::likelihood::OptimizationMetrics;
   use crate::pretty_assert_ulps_eq;
+  use treetime_primitives::LogLh;
 
   #[test]
   fn test_optimization_metrics_default_is_zero() {
     let metrics = OptimizationMetrics::default();
 
-    pretty_assert_ulps_eq!(metrics.log_lh, 0.0, max_ulps = 4);
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), 0.0, max_ulps = 4);
     pretty_assert_ulps_eq!(metrics.derivative, 0.0, max_ulps = 4);
     pretty_assert_ulps_eq!(metrics.second_derivative, 0.0, max_ulps = 4);
   }
 
   #[test]
   fn test_optimization_metrics_new() {
-    let metrics = OptimizationMetrics::new(1.5, -0.3, -2.0);
+    let metrics = OptimizationMetrics::new(LogLh::new(1.5), -0.3, -2.0);
 
-    pretty_assert_ulps_eq!(metrics.log_lh, 1.5, max_ulps = 4);
+    pretty_assert_ulps_eq!(metrics.log_lh.value(), 1.5, max_ulps = 4);
     pretty_assert_ulps_eq!(metrics.derivative, -0.3, max_ulps = 4);
     pretty_assert_ulps_eq!(metrics.second_derivative, -2.0, max_ulps = 4);
   }
@@ -24,11 +25,11 @@ mod tests {
   #[test]
   fn test_optimization_metrics_add_single() {
     let mut total = OptimizationMetrics::default();
-    let other = OptimizationMetrics::new(1.0, 2.0, 3.0);
+    let other = OptimizationMetrics::new(LogLh::new(1.0), 2.0, 3.0);
 
     total.add(&other);
 
-    pretty_assert_ulps_eq!(total.log_lh, 1.0, max_ulps = 4);
+    pretty_assert_ulps_eq!(total.log_lh.value(), 1.0, max_ulps = 4);
     pretty_assert_ulps_eq!(total.derivative, 2.0, max_ulps = 4);
     pretty_assert_ulps_eq!(total.second_derivative, 3.0, max_ulps = 4);
   }
@@ -37,9 +38,9 @@ mod tests {
   fn test_optimization_metrics_add_multiple_partitions() {
     let mut total = OptimizationMetrics::default();
 
-    let partition1 = OptimizationMetrics::new(-10.0, 0.5, -1.0);
-    let partition2 = OptimizationMetrics::new(-15.0, 0.3, -2.0);
-    let partition3 = OptimizationMetrics::new(-5.0, -0.1, -0.5);
+    let partition1 = OptimizationMetrics::new(LogLh::new(-10.0), 0.5, -1.0);
+    let partition2 = OptimizationMetrics::new(LogLh::new(-15.0), 0.3, -2.0);
+    let partition3 = OptimizationMetrics::new(LogLh::new(-5.0), -0.1, -0.5);
 
     total.add(&partition1);
     total.add(&partition2);
@@ -49,19 +50,19 @@ mod tests {
     let expected_derivative = 0.5 + 0.3 + -0.1;
     let expected_second_derivative = -1.0 + -2.0 + -0.5;
 
-    pretty_assert_ulps_eq!(total.log_lh, expected_log_lh, max_ulps = 4);
+    pretty_assert_ulps_eq!(total.log_lh.value(), expected_log_lh, max_ulps = 4);
     pretty_assert_ulps_eq!(total.derivative, expected_derivative, max_ulps = 4);
     pretty_assert_ulps_eq!(total.second_derivative, expected_second_derivative, max_ulps = 4);
   }
 
   #[test]
   fn test_optimization_metrics_add_with_negative_values() {
-    let mut total = OptimizationMetrics::new(-100.0, -5.0, -10.0);
-    let other = OptimizationMetrics::new(-50.0, 3.0, -5.0);
+    let mut total = OptimizationMetrics::new(LogLh::new(-100.0), -5.0, -10.0);
+    let other = OptimizationMetrics::new(LogLh::new(-50.0), 3.0, -5.0);
 
     total.add(&other);
 
-    pretty_assert_ulps_eq!(total.log_lh, -150.0, max_ulps = 4);
+    pretty_assert_ulps_eq!(total.log_lh.value(), -150.0, max_ulps = 4);
     pretty_assert_ulps_eq!(total.derivative, -2.0, max_ulps = 4);
     pretty_assert_ulps_eq!(total.second_derivative, -15.0, max_ulps = 4);
   }
@@ -72,7 +73,7 @@ mod tests {
 
     // Add many small values to test precision preservation
     for i in 0..1000 {
-      let small = OptimizationMetrics::new(0.001, 0.0001 * (i as f64), -0.00001);
+      let small = OptimizationMetrics::new(LogLh::new(0.001), 0.0001 * (i as f64), -0.00001);
       total.add(&small);
     }
 
@@ -81,20 +82,20 @@ mod tests {
     let expected_second_derivative = -0.01;
 
     // Allow more tolerance for 1000 accumulated additions
-    pretty_assert_ulps_eq!(total.log_lh, expected_log_lh, max_ulps = 1000);
+    pretty_assert_ulps_eq!(total.log_lh.value(), expected_log_lh, max_ulps = 1000);
     pretty_assert_ulps_eq!(total.derivative, expected_derivative, max_ulps = 1000);
     pretty_assert_ulps_eq!(total.second_derivative, expected_second_derivative, max_ulps = 1000);
   }
 
   #[test]
   fn test_optimization_metrics_add_zero_is_identity() {
-    let original = OptimizationMetrics::new(-42.5, 1.23, -4.56);
+    let original = OptimizationMetrics::new(LogLh::new(-42.5), 1.23, -4.56);
     let mut total = original.clone();
     let zero = OptimizationMetrics::default();
 
     total.add(&zero);
 
-    pretty_assert_ulps_eq!(total.log_lh, original.log_lh, max_ulps = 4);
+    pretty_assert_ulps_eq!(total.log_lh.value(), original.log_lh.value(), max_ulps = 4);
     pretty_assert_ulps_eq!(total.derivative, original.derivative, max_ulps = 4);
     pretty_assert_ulps_eq!(total.second_derivative, original.second_derivative, max_ulps = 4);
   }

--- a/packages/treetime/src/optimize/__tests__/test_optimize_indel.rs
+++ b/packages/treetime/src/optimize/__tests__/test_optimize_indel.rs
@@ -87,8 +87,8 @@ pub mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, graph)?,
     ))];
-    initialize_marginal(graph, &dense_partitions, &aln)?;
-    update_marginal(graph, &sparse_partitions)?;
+    initialize_marginal(graph, &dense_partitions, &aln)?.value();
+    update_marginal(graph, &sparse_partitions)?.value();
 
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
     initial_guess_mixed(graph, &mixed_partitions, true, false)?;
@@ -146,7 +146,9 @@ pub mod tests {
       .set_branch_length(Some(0.1));
 
     let indel_rate = estimate_indel_rate(&graph, &mixed_partitions);
-    let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate).expect("valid branch lengths");
+    let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate)
+      .expect("valid branch lengths")
+      .value();
 
     let expected_total_lh: f64 = graph
       .get_edges()
@@ -158,6 +160,7 @@ pub mod tests {
         poisson_indel_log_lh(indel_count, indel_rate, branch_length)
           .expect("valid Poisson parameters")
           .log_lh
+          .value()
       })
       .sum();
 
@@ -180,7 +183,9 @@ pub mod tests {
       .set_branch_length(Some(0.0));
 
     let indel_rate = estimate_indel_rate(&graph, &mixed_partitions);
-    let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate).expect("valid branch lengths");
+    let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate)
+      .expect("valid branch lengths")
+      .value();
 
     pretty_assert_neg_inf!(total_lh);
     Ok(())
@@ -199,7 +204,9 @@ pub mod tests {
       .set_branch_length(Some(0.0));
 
     let indel_rate = estimate_indel_rate(&graph, &mixed_partitions);
-    let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate).expect("valid branch lengths");
+    let total_lh = total_indel_log_lh(&graph, &mixed_partitions, indel_rate)
+      .expect("valid branch lengths")
+      .value();
 
     assert!(total_lh.is_finite(), "Expected finite total indel LH, got {total_lh}");
     Ok(())
@@ -417,8 +424,8 @@ pub mod tests {
     );
 
     // Run marginal + optimize
-    update_marginal(&graph, &dense_partitions)?;
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &dense_partitions)?.value();
+    update_marginal(&graph, &sparse_partitions)?.value();
     run_optimize_mixed(&graph, &mixed_partitions, method)?;
 
     let bl_final = graph.get_edges()[0]
@@ -479,8 +486,8 @@ pub mod tests {
     let t_mle = k as f64 / mu;
     let t = t_mle + delta;
     if t > 0.0 {
-      let lh_mle = poisson_indel_log_lh(k, mu, t_mle).expect("valid Poisson parameters").log_lh;
-      let lh = poisson_indel_log_lh(k, mu, t).expect("valid Poisson parameters").log_lh;
+      let lh_mle = poisson_indel_log_lh(k, mu, t_mle).expect("valid Poisson parameters").log_lh.value();
+      let lh = poisson_indel_log_lh(k, mu, t).expect("valid Poisson parameters").log_lh.value();
       assert!(lh <= lh_mle + 1e-14, "log-lh at t={t} ({lh}) should be <= log-lh at MLE ({lh_mle})");
     }
   }
@@ -498,10 +505,12 @@ pub mod tests {
     let h1 = 1e-7;
     let lh_plus = poisson_indel_log_lh(k, mu, t + h1)
       .expect("valid Poisson parameters")
-      .log_lh;
+      .log_lh
+      .value();
     let lh_minus = poisson_indel_log_lh(k, mu, t - h1)
       .expect("valid Poisson parameters")
-      .log_lh;
+      .log_lh
+      .value();
     let numerical_deriv = (lh_plus - lh_minus) / (2.0 * h1);
     assert_abs_diff_eq!(metrics.derivative, numerical_deriv, epsilon = 1e-8);
 
@@ -509,11 +518,16 @@ pub mod tests {
     let h2 = 1e-4;
     let lh_plus2 = poisson_indel_log_lh(k, mu, t + h2)
       .expect("valid Poisson parameters")
-      .log_lh;
-    let lh_center = poisson_indel_log_lh(k, mu, t).expect("valid Poisson parameters").log_lh;
+      .log_lh
+      .value();
+    let lh_center = poisson_indel_log_lh(k, mu, t)
+      .expect("valid Poisson parameters")
+      .log_lh
+      .value();
     let lh_minus2 = poisson_indel_log_lh(k, mu, t - h2)
       .expect("valid Poisson parameters")
-      .log_lh;
+      .log_lh
+      .value();
     let numerical_second = (lh_plus2 - 2.0 * lh_center + lh_minus2) / (h2 * h2);
     assert_abs_diff_eq!(metrics.second_derivative, numerical_second, epsilon = 1e-5);
   }
@@ -547,8 +561,12 @@ pub mod tests {
     let indel_rate = 5.0;
 
     // Bug precondition: substitution-only comparison prefers zero
-    let sub_lh_zero = evaluate_mixed_log_lh_only(&contributions, 0.0).expect("valid branch length");
-    let sub_lh_best = evaluate_mixed_log_lh_only(&contributions, best_positive).expect("valid branch length");
+    let sub_lh_zero = evaluate_mixed_log_lh_only(&contributions, 0.0)
+      .expect("valid branch length")
+      .value();
+    let sub_lh_best = evaluate_mixed_log_lh_only(&contributions, best_positive)
+      .expect("valid branch length")
+      .value();
     assert!(
       sub_lh_zero > sub_lh_best,
       "Bug precondition: subs-only likelihood at zero ({sub_lh_zero}) should exceed positive ({sub_lh_best})"
@@ -557,10 +575,12 @@ pub mod tests {
     // Indel-aware comparison: Poisson log-lh diverges to -infinity near t=0
     let indel_lh_near_zero = poisson_indel_log_lh(indel_count, indel_rate, 1e-15)
       .expect("valid Poisson parameters")
-      .log_lh;
+      .log_lh
+      .value();
     let indel_lh_at_best = poisson_indel_log_lh(indel_count, indel_rate, best_positive)
       .expect("valid Poisson parameters")
-      .log_lh;
+      .log_lh
+      .value();
 
     let combined_near_zero = sub_lh_zero + indel_lh_near_zero;
     let combined_at_best = sub_lh_best + indel_lh_at_best;
@@ -657,8 +677,8 @@ pub mod tests {
       .write_arc()
       .set_branch_length(Some(1e-15));
 
-    update_marginal(&graph, &dense_partitions)?;
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &dense_partitions)?.value();
+    update_marginal(&graph, &sparse_partitions)?.value();
     run_optimize_mixed(&graph, &mixed_partitions, method)?;
 
     let bl = edge_ref.read_arc().payload().read_arc().branch_length().unwrap();
@@ -691,8 +711,8 @@ pub mod tests {
     let contribution = OptimizationContribution::Dense(optimize_dense::PartitionContribution::new(coefficients, gtr));
     let contributions = vec![contribution];
 
-    let sub_only = evaluate_mixed_log_lh_only(&contributions, t).expect("valid branch length");
-    let indel_lh = poisson_indel_log_lh(k, mu, t).expect("valid Poisson parameters").log_lh;
+    let sub_only = evaluate_mixed_log_lh_only(&contributions, t).expect("valid branch length").value();
+    let indel_lh = poisson_indel_log_lh(k, mu, t).expect("valid Poisson parameters").log_lh.value();
     let combined = sub_only + indel_lh;
 
     if k == 0 {
@@ -761,8 +781,8 @@ pub mod tests {
         let h = t * 1e-6;
         prop_assert!(h > 0.0);
         let metrics = poisson_indel_log_lh(k, mu, t).expect("valid Poisson parameters");
-        let lh_plus = poisson_indel_log_lh(k, mu, t + h).expect("valid Poisson parameters").log_lh;
-        let lh_minus = poisson_indel_log_lh(k, mu, t - h).expect("valid Poisson parameters").log_lh;
+        let lh_plus = poisson_indel_log_lh(k, mu, t + h).expect("valid Poisson parameters").log_lh.value();
+        let lh_minus = poisson_indel_log_lh(k, mu, t - h).expect("valid Poisson parameters").log_lh.value();
         let numerical = (lh_plus - lh_minus) / (2.0 * h);
         prop_assert_relative_eq!(metrics.derivative, numerical, max_relative = 1e-4);
       }

--- a/packages/treetime/src/optimize/__tests__/test_optimize_method.rs
+++ b/packages/treetime/src/optimize/__tests__/test_optimize_method.rs
@@ -109,7 +109,7 @@ mod tests {
     let h = u.abs() * 1e-5;
     let eval_u = |uv: f64| {
       let tv = uv.exp();
-      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length") + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh
+      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length").value() + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh.value()
     };
     let dl_du_numerical = (eval_u(u + h) - eval_u(u - h)) / (2.0 * h);
 
@@ -149,7 +149,7 @@ mod tests {
     let h = u.abs() * 1e-4;
     let eval_u = |uv: f64| {
       let tv = uv.exp();
-      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length") + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh
+      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length").value() + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh.value()
     };
     let d2l_du2_numerical = (eval_u(u + h) - 2.0 * eval_u(u) + eval_u(u - h)) / (h * h);
 
@@ -192,7 +192,7 @@ mod tests {
     let h = s * 1e-5;
     let eval_s = |sv: f64| {
       let tv = sv * sv;
-      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length") + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh
+      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length").value() + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh.value()
     };
     let dl_ds_numerical = (eval_s(s + h) - eval_s(s - h)) / (2.0 * h);
 
@@ -232,7 +232,7 @@ mod tests {
     let h = s * 1e-4;
     let eval_s = |sv: f64| {
       let tv = sv * sv;
-      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length") + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh
+      evaluate_mixed_log_lh_only(&contributions, tv).expect("valid branch length").value() + poisson_indel_log_lh(k, mu, tv).expect("valid Poisson parameters").log_lh.value()
     };
     let d2l_ds2_numerical = (eval_s(s + h) - 2.0 * eval_s(s) + eval_s(s - h)) / (h * h);
 
@@ -725,12 +725,16 @@ mod tests {
     );
 
     // Verify local optimality in t-space
-    let lh_opt = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result).expect("valid branch length");
+    let lh_opt = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result)
+      .expect("valid branch length")
+      .value();
     if result > 1e-10 {
-      let lh_below =
-        evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 0.99).expect("valid branch length");
-      let lh_above =
-        evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 1.01).expect("valid branch length");
+      let lh_below = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 0.99)
+        .expect("valid branch length")
+        .value();
+      let lh_above = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 1.01)
+        .expect("valid branch length")
+        .value();
       assert!(
         lh_opt >= lh_below - 1e-10,
         "sqrt: lh at opt ({lh_opt}) < lh below ({lh_below})"
@@ -771,11 +775,15 @@ mod tests {
     );
 
     // Verify local optimality in t-space
-    let lh_opt = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result).expect("valid branch length");
-    let lh_below =
-      evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 0.99).expect("valid branch length");
-    let lh_above =
-      evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 1.01).expect("valid branch length");
+    let lh_opt = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result)
+      .expect("valid branch length")
+      .value();
+    let lh_below = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 0.99)
+      .expect("valid branch length")
+      .value();
+    let lh_above = evaluate_with_indels_log_lh_only(&contributions, 0, 0.0, result * 1.01)
+      .expect("valid branch length")
+      .value();
     assert!(
       lh_opt >= lh_below - 1e-10,
       "log: lh at opt ({lh_opt}) < lh below ({lh_below})"
@@ -1012,10 +1020,13 @@ mod tests {
 
       let indel_count: usize = partitions.iter().map(|p| p.read_arc().edge_indel_count(edge_key)).sum();
 
-      let sub_lh = evaluate_mixed_log_lh_only(&contributions, t).expect("valid branch length");
+      let sub_lh = evaluate_mixed_log_lh_only(&contributions, t)
+        .expect("valid branch length")
+        .value();
       let indel_lh = poisson_indel_log_lh(indel_count, indel_rate, t)
         .expect("valid Poisson parameters")
-        .log_lh;
+        .log_lh
+        .value();
       Ok(sub_lh + indel_lh)
     }
 

--- a/packages/treetime/src/optimize/__tests__/test_root_preservation.rs
+++ b/packages/treetime/src/optimize/__tests__/test_root_preservation.rs
@@ -28,8 +28,8 @@ mod tests {
     let gtr = jc69(JC69Params::default())?;
     let partition = PartitionMarginalDense::new(0, gtr, alphabet, get_common_length(&aln)?);
     let partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![Arc::new(RwLock::new(partition))];
-    initialize_marginal(&graph, &partitions, &aln)?;
-    update_marginal(&graph, &partitions)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
+    update_marginal(&graph, &partitions)?.value();
     let mixed: Vec<Arc<RwLock<dyn PartitionOptimizeOps>>> = partitions
       .into_iter()
       .map(|p| -> Arc<RwLock<dyn PartitionOptimizeOps>> { p })

--- a/packages/treetime/src/optimize/__tests__/test_run_optimize_loop.rs
+++ b/packages/treetime/src/optimize/__tests__/test_run_optimize_loop.rs
@@ -130,8 +130,8 @@ mod tests {
       .unwrap()
       .indels = vec![InDel::del((0, 3), Seq::try_from_str("ACG")?)?];
 
-    let sparse_lh = update_marginal(&graph, &sparse_partitions)?;
-    let dense_lh = update_marginal(&graph, &dense_partitions)?;
+    let sparse_lh = update_marginal(&graph, &sparse_partitions)?.value();
+    let dense_lh = update_marginal(&graph, &dense_partitions)?.value();
     let indel_lh = manual_total_indel_log_lh(&graph, &sparse_partitions);
     let expected_total_lh = sparse_lh + dense_lh + indel_lh;
 
@@ -148,7 +148,7 @@ mod tests {
     )?;
 
     assert_eq!(result.lh_history.len(), 1);
-    assert_abs_diff_eq!(result.lh_history[0], expected_total_lh, epsilon = 1e-10);
+    assert_abs_diff_eq!(result.lh_history[0].value(), expected_total_lh, epsilon = 1e-10);
     Ok(())
   }
 
@@ -231,7 +231,7 @@ mod tests {
       false,
     )?;
 
-    for (i, &lh) in result.lh_history.iter().enumerate() {
+    for (i, lh) in result.lh_history.iter().map(|log_lh| log_lh.value()).enumerate() {
       assert!(lh.is_finite(), "Iteration {i}: log-likelihood must be finite, got {lh}");
     }
     Ok(())
@@ -258,8 +258,8 @@ mod tests {
       .unwrap()
       .indels = vec![InDel::del((0, 3), Seq::try_from_str("ACG")?)?];
 
-    let initial_sparse_lh = update_marginal(&graph, &sparse_partitions)?;
-    let initial_dense_lh = update_marginal(&graph, &dense_partitions)?;
+    let initial_sparse_lh = update_marginal(&graph, &sparse_partitions)?.value();
+    let initial_dense_lh = update_marginal(&graph, &dense_partitions)?.value();
     let initial_lh = initial_sparse_lh + initial_dense_lh + manual_total_indel_log_lh(&graph, &sparse_partitions);
 
     run_optimize_loop(
@@ -274,8 +274,8 @@ mod tests {
       false,
     )?;
 
-    let final_sparse_lh = update_marginal(&graph, &sparse_partitions)?;
-    let final_dense_lh = update_marginal(&graph, &dense_partitions)?;
+    let final_sparse_lh = update_marginal(&graph, &sparse_partitions)?.value();
+    let final_dense_lh = update_marginal(&graph, &dense_partitions)?.value();
     let final_lh = final_sparse_lh + final_dense_lh + manual_total_indel_log_lh(&graph, &sparse_partitions);
 
     assert!(

--- a/packages/treetime/src/optimize/__tests__/test_topology_cleanup.rs
+++ b/packages/treetime/src/optimize/__tests__/test_topology_cleanup.rs
@@ -222,7 +222,7 @@ mod tests {
 
     let fitch = create_fitch_partition(&graph, 0, nuc, &aln)?;
     let sparse_partitions = vec![Arc::new(RwLock::new(fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?))];
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
@@ -234,7 +234,7 @@ mod tests {
     // Run optimize loop with topology cleanup
     let mut lh_prev = f64::MIN;
     for i in 0..10 {
-      let sparse_lh = update_marginal(&graph, &sparse_partitions)?;
+      let sparse_lh = update_marginal(&graph, &sparse_partitions)?.value();
       let total_lh = sparse_lh;
 
       if (total_lh - lh_prev).abs() < 1e-2 {
@@ -300,7 +300,7 @@ mod tests {
 
     let fitch = create_fitch_partition(&graph, 0, nuc, &aln)?;
     let sparse_partitions = vec![Arc::new(RwLock::new(fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?))];
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let dense_partitions: Vec<Arc<RwLock<PartitionMarginalDense>>> = vec![];
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
@@ -311,7 +311,7 @@ mod tests {
 
     let mut lh_prev = f64::MIN;
     for i in 0..10 {
-      let total_lh = update_marginal(&graph, &sparse_partitions)?;
+      let total_lh = update_marginal(&graph, &sparse_partitions)?.value();
       if (total_lh - lh_prev).abs() < 1e-2 {
         break;
       }
@@ -366,7 +366,7 @@ mod tests {
     let sparse_partitions = vec![Arc::new(RwLock::new(
       fitch.into_marginal_sparse(jc69(JC69Params::default())?, &graph)?,
     ))];
-    update_marginal(&graph, &sparse_partitions)?;
+    update_marginal(&graph, &sparse_partitions)?.value();
 
     let initial_node_count = graph.get_nodes().len();
 
@@ -383,7 +383,7 @@ mod tests {
     // The critical test: update_marginal after merge must produce finite log-likelihood.
     // Before the composition fix, the merge-created node had zero composition,
     // causing the backward pass to produce incorrect values.
-    let lh = update_marginal(&graph, &sparse_partitions)?;
+    let lh = update_marginal(&graph, &sparse_partitions)?.value();
     assert!(lh.is_finite(), "log-likelihood must be finite after merge: {lh}");
     assert!(lh < 0.0, "log-likelihood must be negative: {lh}");
 
@@ -452,8 +452,8 @@ mod tests {
 
     let dense_partitions = vec![Arc::new(RwLock::new(PartitionMarginalDense::new(0, jc69(JC69Params::default())?, nuc, get_common_length(&aln)?)))];
 
-    initialize_marginal(&graph, &dense_partitions, &aln)?;
-    update_marginal(&graph, &dense_partitions)?;
+    initialize_marginal(&graph, &dense_partitions, &aln)?.value();
+    update_marginal(&graph, &dense_partitions)?.value();
 
     let sparse_partitions: Vec<Arc<RwLock<PartitionMarginalSparse>>> = vec![];
     let mixed_partitions = collect_optimize_partitions(&dense_partitions, &sparse_partitions);
@@ -464,7 +464,7 @@ mod tests {
 
     let mut lh_prev = f64::MIN;
     for i in 0..10 {
-      let dense_lh = update_marginal(&graph, &dense_partitions)?;
+      let dense_lh = update_marginal(&graph, &dense_partitions)?.value();
       if (dense_lh - lh_prev).abs() < 1e-2 {
         break;
       }

--- a/packages/treetime/src/optimize/eval.rs
+++ b/packages/treetime/src/optimize/eval.rs
@@ -3,6 +3,7 @@ use crate::optimize::likelihood::OptimizationMetrics;
 use eyre::Report;
 use itertools::izip;
 use ndarray::{Array1, ArrayView1};
+use treetime_primitives::LogLh;
 
 /// Unified evaluation of eigenvalue-space site contributions.
 ///
@@ -80,5 +81,9 @@ pub fn evaluate_site_contributions<'a>(
     }
   }
 
-  Ok(OptimizationMetrics::new(log_lh, derivative, second_derivative))
+  Ok(OptimizationMetrics::new(
+    LogLh::new(log_lh),
+    derivative,
+    second_derivative,
+  ))
 }

--- a/packages/treetime/src/optimize/indel.rs
+++ b/packages/treetime/src/optimize/indel.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use treetime_graph::edge::{GraphEdge, HasBranchLength};
 use treetime_graph::graph::Graph;
 use treetime_graph::node::GraphNode;
+use treetime_primitives::LogLh;
 use treetime_utils::{make_error, make_report};
 
 /// Poisson indel log-likelihood contribution for one edge.
@@ -29,13 +30,13 @@ pub fn poisson_indel_log_lh(k: usize, mu: f64, t: f64) -> Result<OptimizationMet
     return Ok(if k == 0 {
       OptimizationMetrics::default()
     } else {
-      OptimizationMetrics::new(f64::NEG_INFINITY, 0.0, 0.0)
+      OptimizationMetrics::new(LogLh::IMPOSSIBLE, 0.0, 0.0)
     });
   }
 
   if k == 0 {
     // Poisson(0 | mu*t) = exp(-mu*t)
-    return Ok(OptimizationMetrics::new(-mu * t, -mu, 0.0));
+    return Ok(OptimizationMetrics::new(LogLh::new(-mu * t), -mu, 0.0));
   }
 
   if t == 0.0 {
@@ -48,7 +49,11 @@ pub fn poisson_indel_log_lh(k: usize, mu: f64, t: f64) -> Result<OptimizationMet
   let derivative = k_f / t - mu;
   let second_derivative = -k_f / (t * t);
 
-  Ok(OptimizationMetrics::new(log_lh, derivative, second_derivative))
+  Ok(OptimizationMetrics::new(
+    LogLh::new(log_lh),
+    derivative,
+    second_derivative,
+  ))
 }
 
 /// Estimate the global indel rate from the tree.
@@ -99,7 +104,7 @@ pub fn total_indel_log_lh<N, E, P>(
   graph: &Graph<N, E, ()>,
   partitions: &[Arc<RwLock<P>>],
   indel_rate: f64,
-) -> Result<f64, Report>
+) -> Result<LogLh, Report>
 where
   N: GraphNode,
   E: GraphEdge + HasBranchLength,
@@ -108,7 +113,7 @@ where
   graph
     .get_edges()
     .par_iter()
-    .map(|edge_ref| -> Result<f64, Report> {
+    .map(|edge_ref| -> Result<LogLh, Report> {
       let edge_key = edge_ref.read_arc().key();
       let edge = edge_ref.read_arc();
       let branch_length = edge.payload().read_arc().branch_length().ok_or_else(|| {
@@ -120,7 +125,7 @@ where
       validate_branch_length_value(branch_length)?;
       let indel_count: usize = partitions.iter().map(|p| p.read_arc().edge_indel_count(edge_key)).sum();
       if indel_count > 0 && branch_length <= 0.0 {
-        Ok(f64::NEG_INFINITY)
+        Ok(LogLh::IMPOSSIBLE)
       } else {
         Ok(poisson_indel_log_lh(indel_count, indel_rate, branch_length)?.log_lh)
       }
@@ -139,7 +144,7 @@ mod tests {
   #[test]
   fn test_optimize_indel_poisson_zero_rate() {
     let metrics = poisson_indel_log_lh(3, 0.0, 0.1).expect("valid Poisson parameters");
-    pretty_assert_neg_inf!(metrics.log_lh);
+    pretty_assert_neg_inf!(metrics.log_lh.value());
     assert_abs_diff_eq!(metrics.derivative, 0.0, epsilon = 1e-15);
     assert_abs_diff_eq!(metrics.second_derivative, 0.0, epsilon = 1e-15);
   }
@@ -149,7 +154,7 @@ mod tests {
     let mu = 5.0;
     let t = 0.1;
     let metrics = poisson_indel_log_lh(0, mu, t).expect("valid Poisson parameters");
-    assert_abs_diff_eq!(metrics.log_lh, -mu * t, epsilon = 1e-15);
+    assert_abs_diff_eq!(metrics.log_lh.value(), -mu * t, epsilon = 1e-15);
     assert_abs_diff_eq!(metrics.derivative, -mu, epsilon = 1e-15);
     assert_abs_diff_eq!(metrics.second_derivative, 0.0, epsilon = 1e-15);
   }
@@ -160,7 +165,7 @@ mod tests {
     // log P(2|1.0) = 2*ln(1) - 1 - ln(2!) = 0 - 1 - ln(2) = -1 - 0.6931...
     let metrics = poisson_indel_log_lh(2, 10.0, 0.1).expect("valid Poisson parameters");
     let expected_log_lh = -1.0 - 2.0_f64.ln();
-    assert_abs_diff_eq!(metrics.log_lh, expected_log_lh, epsilon = 1e-14);
+    assert_abs_diff_eq!(metrics.log_lh.value(), expected_log_lh, epsilon = 1e-14);
   }
 
   #[test]

--- a/packages/treetime/src/optimize/likelihood.rs
+++ b/packages/treetime/src/optimize/likelihood.rs
@@ -3,12 +3,13 @@ use crate::optimize::indel::poisson_indel_log_lh;
 use crate::optimize::sparse_eval::{evaluate_sparse_contribution, evaluate_sparse_contribution_impl};
 use crate::partition::optimization_contribution::OptimizationContribution;
 use eyre::Report;
+use treetime_primitives::LogLh;
 
 /// Metrics computed during branch length optimization
 #[derive(Clone, Debug, Default)]
 pub struct OptimizationMetrics {
   /// Log likelihood value
-  pub log_lh: f64,
+  pub log_lh: LogLh,
   /// First derivative (gradient) of log likelihood with respect to branch length
   pub derivative: f64,
   /// Second derivative (hessian) of log likelihood with respect to branch length
@@ -16,7 +17,7 @@ pub struct OptimizationMetrics {
 }
 
 impl OptimizationMetrics {
-  pub fn new(log_lh: f64, derivative: f64, second_derivative: f64) -> Self {
+  pub fn new(log_lh: LogLh, derivative: f64, second_derivative: f64) -> Self {
     Self {
       log_lh,
       derivative,
@@ -52,7 +53,7 @@ pub fn evaluate_mixed(
 pub fn evaluate_mixed_log_lh_only(
   contributions: &[OptimizationContribution],
   branch_length: f64,
-) -> Result<f64, Report> {
+) -> Result<LogLh, Report> {
   Ok(evaluate_mixed_impl(contributions, branch_length, false)?.log_lh)
 }
 
@@ -90,7 +91,7 @@ pub fn evaluate_with_indels_log_lh_only(
   indel_count: usize,
   indel_rate: f64,
   branch_length: f64,
-) -> Result<f64, Report> {
+) -> Result<LogLh, Report> {
   let sub_lh = evaluate_mixed_log_lh_only(contributions, branch_length)?;
   let indel_lh = poisson_indel_log_lh(indel_count, indel_rate, branch_length)?.log_lh;
   Ok(sub_lh + indel_lh)

--- a/packages/treetime/src/optimize/run_loop.rs
+++ b/packages/treetime/src/optimize/run_loop.rs
@@ -18,6 +18,7 @@ use parking_lot::RwLock;
 use std::sync::Arc;
 use treetime_graph::assign_node_names::assign_node_names;
 use treetime_graph::edge::{GraphEdgeKey, HasBranchLength};
+use treetime_primitives::LogLh;
 use treetime_utils::fmt::float::float_to_significant_digits;
 use treetime_utils::make_error;
 
@@ -75,12 +76,12 @@ pub fn run_optimize_loop(
     estimate_indel_rate(graph, mixed_partitions)
   };
 
-  let mut lh_history: Vec<f64> = Vec::with_capacity(max_iter);
+  let mut lh_history: Vec<LogLh> = Vec::with_capacity(max_iter);
   let mut stopped_at: Option<(usize, ConvergenceReason)> = None;
-  let mut lh_prev = f64::NEG_INFINITY;
-  let mut lh_prev_prev = f64::NEG_INFINITY;
+  let mut lh_prev = LogLh::IMPOSSIBLE;
+  let mut lh_prev_prev = LogLh::IMPOSSIBLE;
 
-  let mut best_lh = f64::NEG_INFINITY;
+  let mut best_lh = LogLh::IMPOSSIBLE;
   let mut best_branch_lengths: Vec<f64> = Vec::new();
 
   for i in 0..max_iter {
@@ -97,14 +98,14 @@ pub fn run_optimize_loop(
     debug!(
       "Iteration {}: likelihood {} (sparse: {}, dense: {}, indel: {}, rate: {})",
       i + 1,
-      float_to_significant_digits(iteration_lh.total_lh, 7),
-      float_to_significant_digits(iteration_lh.sparse_lh, 7),
-      float_to_significant_digits(iteration_lh.dense_lh, 7),
-      float_to_significant_digits(iteration_lh.indel_lh, 7),
+      float_to_significant_digits(iteration_lh.total_lh.value(), 7),
+      float_to_significant_digits(iteration_lh.sparse_lh.value(), 7),
+      float_to_significant_digits(iteration_lh.dense_lh.value(), 7),
+      float_to_significant_digits(iteration_lh.indel_lh.value(), 7),
       float_to_significant_digits(iteration_lh.indel_rate, 7)
     );
 
-    if !iteration_lh.total_lh.is_finite() {
+    if !iteration_lh.total_lh.value().is_finite() {
       if best_branch_lengths.len() == graph.get_edges().len() {
         restore_branch_lengths(graph, &best_branch_lengths);
         update_marginal(graph, sparse_partitions)?;
@@ -146,7 +147,7 @@ pub fn run_optimize_loop(
 
     let topology_changed = prune_and_merge_in_loop(graph, sparse_partitions, dense_partitions, &zero_optimal_edges)?;
     if topology_changed {
-      best_lh = f64::NEG_INFINITY;
+      best_lh = LogLh::IMPOSSIBLE;
     }
 
     lh_prev_prev = lh_prev;
@@ -183,7 +184,7 @@ pub struct OptimizeLoopResult {
   /// branch-length update. Length equals the number of iterations actually executed
   /// (including the final iteration that triggered the convergence break, if any).
   #[allow(dead_code, reason = "read only in test code")]
-  pub lh_history: Vec<f64>,
+  pub lh_history: Vec<LogLh>,
 
   /// Iteration index (0-based) and reason the loop stopped early.
   /// `None` if the loop exhausted `max_iter` without meeting any stopping criterion.
@@ -210,10 +211,10 @@ pub fn collect_optimize_partitions(
 
 #[derive(Clone, Copy, Debug, Default)]
 struct OptimizeIterationLikelihood {
-  sparse_lh: f64,
-  dense_lh: f64,
-  indel_lh: f64,
-  total_lh: f64,
+  sparse_lh: LogLh,
+  dense_lh: LogLh,
+  indel_lh: LogLh,
+  total_lh: LogLh,
   indel_rate: f64,
 }
 
@@ -228,7 +229,7 @@ fn compute_iteration_likelihood(
   let sparse_lh = update_marginal(graph, sparse_partitions)?;
   let dense_lh = update_marginal(graph, dense_partitions)?;
   let indel_lh = if no_indels {
-    0.0
+    LogLh::ZERO
   } else {
     total_indel_log_lh(graph, mixed_partitions, indel_rate)?
   };

--- a/packages/treetime/src/optimize/zero_boundary.rs
+++ b/packages/treetime/src/optimize/zero_boundary.rs
@@ -67,12 +67,9 @@ pub(super) fn grid_search_inner(
     .try_fold(
       None,
       |best, branch_length| -> Result<Option<(f64, OrderedFloat<f64>)>, Report> {
-        let log_lh = OrderedFloat(evaluate_with_indels_log_lh_only(
-          contributions,
-          indel_count,
-          indel_rate,
-          branch_length,
-        )?);
+        let log_lh = OrderedFloat(
+          evaluate_with_indels_log_lh_only(contributions, indel_count, indel_rate, branch_length)?.value(),
+        );
         Ok(match best {
           Some((_, best_log_lh)) if best_log_lh >= log_lh => best,
           _ => Some((branch_length, log_lh)),

--- a/packages/treetime/src/partition/__tests__/test_marginal_core.rs
+++ b/packages/treetime/src/partition/__tests__/test_marginal_core.rs
@@ -6,6 +6,7 @@ mod tests {
   use ndarray::{Array1, array};
   use proptest::prelude::*;
   use rstest::rstest;
+  use treetime_primitives::LogLh;
   use treetime_utils::{pretty_assert_abs_diff_eq, prop_assert_ulps_eq};
 
   /// A matching degenerate scale belongs to the removed child factor and
@@ -13,7 +14,7 @@ mod tests {
   /// https://doi.org/10.1007/s00239-020-09982-w.
   #[test]
   fn test_marginal_core_forward_log_lh_remove_child_cancels_matching_neg_infinity() {
-    let actual = forward_log_lh_remove_child(f64::NEG_INFINITY, f64::NEG_INFINITY);
+    let actual = forward_log_lh_remove_child(LogLh::IMPOSSIBLE, LogLh::IMPOSSIBLE).value();
     pretty_assert_abs_diff_eq!(0.0, actual, epsilon = 1e-12);
   }
 
@@ -22,7 +23,7 @@ mod tests {
   #[test]
   fn test_marginal_core_forward_log_lh_add_normalization_ignores_neg_infinity() {
     let expected = -3.0;
-    let actual = forward_log_lh_add_normalization(expected, f64::NEG_INFINITY);
+    let actual = forward_log_lh_add_normalization(LogLh::new(expected), f64::NEG_INFINITY).value();
     pretty_assert_abs_diff_eq!(expected, actual, epsilon = 1e-12);
   }
 
@@ -30,14 +31,14 @@ mod tests {
   /// the negative-infinity fallback sentinel.
   #[test]
   fn test_marginal_core_forward_log_lh_add_normalization_propagates_nan() {
-    let actual = forward_log_lh_add_normalization(-3.0, f64::NAN);
+    let actual = forward_log_lh_add_normalization(LogLh::new(-3.0), f64::NAN).value();
     assert!(actual.is_nan(), "NaN normalization must propagate, got {actual}");
   }
 
   /// Positive infinity is not the degenerate uniform-fallback sentinel.
   #[test]
   fn test_marginal_core_forward_log_lh_add_normalization_propagates_positive_infinity() {
-    let actual = forward_log_lh_add_normalization(-3.0, f64::INFINITY);
+    let actual = forward_log_lh_add_normalization(LogLh::new(-3.0), f64::INFINITY).value();
     assert!(
       actual.is_infinite() && actual.is_sign_positive(),
       "expected positive infinity, got {actual}"
@@ -47,7 +48,7 @@ mod tests {
   /// A non-matching negative-infinity scale remains an impossible factor.
   #[test]
   fn test_marginal_core_forward_log_lh_remove_child_preserves_unmatched_neg_infinity() {
-    let actual = forward_log_lh_remove_child(f64::NEG_INFINITY, -3.0);
+    let actual = forward_log_lh_remove_child(LogLh::IMPOSSIBLE, LogLh::new(-3.0)).value();
     assert!(
       actual.is_infinite() && actual.is_sign_negative(),
       "expected negative infinity, got {actual}"
@@ -59,7 +60,7 @@ mod tests {
   /// fallback sentinels.
   #[test]
   fn test_marginal_core_forward_log_lh_remove_child_preserves_unmatched_positive_infinity() {
-    let actual = forward_log_lh_remove_child(-3.0, f64::NEG_INFINITY);
+    let actual = forward_log_lh_remove_child(LogLh::new(-3.0), LogLh::IMPOSSIBLE).value();
     assert!(
       actual.is_infinite() && actual.is_sign_positive(),
       "expected positive infinity, got {actual}"
@@ -76,8 +77,8 @@ mod tests {
       child_log_lh in -1e6_f64..0.0,
       normalization in -1e6_f64..0.0,
     ) {
-      let cavity = forward_log_lh_remove_child(node_log_lh, child_log_lh);
-      let actual = forward_log_lh_add_normalization(cavity, normalization);
+      let cavity = forward_log_lh_remove_child(LogLh::new(node_log_lh), LogLh::new(child_log_lh));
+      let actual = forward_log_lh_add_normalization(cavity, normalization).value();
       let expected = node_log_lh - child_log_lh + normalization;
       prop_assert_ulps_eq!(expected, actual, max_ulps = 0);
     }
@@ -86,7 +87,7 @@ mod tests {
     /// forward conditional-message scales.
     #[test]
     fn test_prop_marginal_core_forward_log_lh_neg_infinity_is_neutral(log_lh in -1e6_f64..1e6_f64) {
-      let actual = forward_log_lh_add_normalization(log_lh, f64::NEG_INFINITY);
+      let actual = forward_log_lh_add_normalization(LogLh::new(log_lh), f64::NEG_INFINITY).value();
       prop_assert_ulps_eq!(log_lh, actual, max_ulps = 0);
     }
   }

--- a/packages/treetime/src/partition/__tests__/test_sparse_transition_counting.rs
+++ b/packages/treetime/src/partition/__tests__/test_sparse_transition_counting.rs
@@ -38,7 +38,7 @@ mod tests {
       ..JC69Params::default()
     })?;
     let partition = Arc::new(RwLock::new(fitch.into_marginal_sparse(gtr, &graph)?));
-    update_marginal(&graph, std::slice::from_ref(&partition))?;
+    update_marginal(&graph, std::slice::from_ref(&partition))?.value();
     Ok((graph, partition))
   }
 

--- a/packages/treetime/src/partition/dense.rs
+++ b/packages/treetime/src/partition/dense.rs
@@ -5,7 +5,7 @@ use eyre::Report;
 use ndarray::Array2;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
-use treetime_primitives::Seq;
+use treetime_primitives::{LogLh, Seq};
 use treetime_utils::interval::range_union::range_union;
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
@@ -56,11 +56,11 @@ pub struct DenseSeqDistribution {
   pub dis: Array2<f64>,
 
   /// Total log likelihood
-  pub log_lh: f64,
+  pub log_lh: LogLh,
 }
 
 impl DenseSeqDistribution {
-  pub fn new(dis: Array2<f64>, log_lh: f64) -> Self {
+  pub fn new(dis: Array2<f64>, log_lh: LogLh) -> Self {
     Self { dis, log_lh }
   }
 }

--- a/packages/treetime/src/partition/marginal_core.rs
+++ b/packages/treetime/src/partition/marginal_core.rs
@@ -15,6 +15,7 @@ use treetime_graph::edge::{EdgeOptimizeOps, GraphEdge, GraphEdgeKey, HasBranchLe
 use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
+use treetime_primitives::LogLh;
 use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::array::softmax_with_log_norm::softmax_with_log_norm;
 use treetime_utils::collections::container::get_exactly_one;
@@ -154,7 +155,7 @@ where
       log_dis += &edge.msg_from_child.dis.mapv(f64::ln);
     }
     let (dis, delta_ll) = normalize_from_log(&log_dis);
-    let log_lh = child_edges.iter().map(|edge| edge.msg_from_child.log_lh).sum::<f64>() + delta_ll;
+    let log_lh = child_edges.iter().map(|edge| edge.msg_from_child.log_lh).sum::<LogLh>() + LogLh::new(delta_ll);
     slot.node.profile = DenseSeqDistribution {
       dis: dis.clone(),
       log_lh,
@@ -168,7 +169,7 @@ where
     let delta_ll = normalize_inplace(&mut dis);
     slot.node.profile = DenseSeqDistribution {
       dis,
-      log_lh: msg_to_parent.log_lh + delta_ll,
+      log_lh: msg_to_parent.log_lh + LogLh::new(delta_ll),
     };
   } else {
     let (edge_key, edge) = slot
@@ -269,7 +270,7 @@ where
     let delta_ll = normalize_inplace(&mut dis);
     slot.node.profile = DenseSeqDistribution {
       dis,
-      log_lh: edge.msg_to_parent.log_lh + edge.msg_to_child.log_lh + delta_ll,
+      log_lh: edge.msg_to_parent.log_lh + edge.msg_to_child.log_lh + LogLh::new(delta_ll),
     };
   }
 
@@ -311,7 +312,7 @@ where
     }
 
     let (dis, delta_ll) = normalize_from_log(&log_dis);
-    let log_lh: f64 = node
+    let log_lh: LogLh = node
       .child_keys
       .iter()
       .map(|(_, edge_key)| data.edges[edge_key].msg_from_child.log_lh)
@@ -320,12 +321,12 @@ where
     let node_data = data.nodes.get_mut(&node.key).unwrap();
     node_data.profile = DenseSeqDistribution {
       dis: dis.clone(),
-      log_lh: log_lh + delta_ll,
+      log_lh: log_lh + LogLh::new(delta_ll),
     };
 
     DenseSeqDistribution {
       dis,
-      log_lh: log_lh + delta_ll,
+      log_lh: log_lh + LogLh::new(delta_ll),
     }
   };
 
@@ -337,7 +338,7 @@ where
 
     let node_data = data.nodes.get_mut(&node.key).unwrap();
     node_data.profile.dis = dis;
-    node_data.profile.log_lh = msg_to_parent.log_lh + delta_ll;
+    node_data.profile.log_lh = msg_to_parent.log_lh + LogLh::new(delta_ll);
   } else {
     let edge_key = get_exactly_one(&node.parent_edge_keys).expect("Only nodes with exactly one parent are supported");
     let branch_length = node.parent_edges[0].branch_length().unwrap_or(0.0);
@@ -367,7 +368,7 @@ where
   if !node.is_root {
     let data = partition.marginal_data();
     let mut dis: Option<Array2<f64>> = None;
-    let mut log_lh = 0.0;
+    let mut log_lh = LogLh::ZERO;
     for (_, edge_key) in &node.parent_keys {
       let edge = &data.edges[edge_key];
       let edge_payload = graph.get_edge(*edge_key).unwrap().read_arc().payload().read_arc();
@@ -386,7 +387,7 @@ where
     }
     let mut dis = dis.expect("Non-root node must have at least one parent");
     let delta_ll = normalize_inplace(&mut dis);
-    log_lh += delta_ll;
+    log_lh += LogLh::new(delta_ll);
 
     let data = partition.marginal_data_mut();
     data.nodes.get_mut(&node.key).unwrap().profile = DenseSeqDistribution { dis, log_lh };
@@ -418,11 +419,11 @@ where
 /// `f64::NEG_INFINITY` scale. Matching sentinels refer to the same removed
 /// factor, so they cancel instead of performing the undefined IEEE-754
 /// operation `-inf - (-inf)`.
-pub(crate) fn forward_log_lh_remove_child(node_log_lh: f64, child_log_lh: f64) -> f64 {
-  if node_log_lh == f64::NEG_INFINITY && child_log_lh == f64::NEG_INFINITY {
-    0.0
+pub(crate) fn forward_log_lh_remove_child(node_log_lh: LogLh, child_log_lh: LogLh) -> LogLh {
+  if node_log_lh == LogLh::IMPOSSIBLE && child_log_lh == LogLh::IMPOSSIBLE {
+    LogLh::ZERO
   } else {
-    node_log_lh - child_log_lh
+    LogLh::new(node_log_lh - child_log_lh)
   }
 }
 
@@ -432,11 +433,11 @@ pub(crate) fn forward_log_lh_remove_child(node_log_lh: f64, child_log_lh: f64) -
 /// fallback. It has no finite scale to add to the conditional message. Other
 /// non-finite values still propagate so unexpected NaN and positive infinity
 /// remain observable.
-pub(crate) fn forward_log_lh_add_normalization(log_lh: f64, normalization: f64) -> f64 {
+pub(crate) fn forward_log_lh_add_normalization(log_lh: LogLh, normalization: f64) -> LogLh {
   if normalization == f64::NEG_INFINITY {
     log_lh
   } else {
-    log_lh + normalization
+    log_lh + LogLh::new(normalization)
   }
 }
 

--- a/packages/treetime/src/partition/marginal_dense.rs
+++ b/packages/treetime/src/partition/marginal_dense.rs
@@ -26,7 +26,7 @@ use treetime_graph::graph::Graph;
 use treetime_graph::graph_traverse::{GraphNodeBackward, GraphNodeForward};
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named, NodeAncestralOps};
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::{Seq, seq};
+use treetime_primitives::{LogLh, Seq, seq};
 use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::interval::range::range_contains;
@@ -78,13 +78,17 @@ impl HasGtr for PartitionMarginalDense {
 }
 
 impl HasLogLh for PartitionMarginalDense {
-  fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
-    self.data.nodes.get(&node_key).map_or(0.0, |node| node.profile.log_lh)
+  fn get_log_lh(&self, node_key: GraphNodeKey) -> LogLh {
+    self
+      .data
+      .nodes
+      .get(&node_key)
+      .map_or(LogLh::ZERO, |node| node.profile.log_lh)
   }
 
   fn reset_node_log_likelihoods(&mut self) {
     for node_data in self.data.nodes.values_mut() {
-      node_data.profile.log_lh = 0.0;
+      node_data.profile.log_lh = LogLh::ZERO;
     }
   }
 }
@@ -246,7 +250,7 @@ where
     let seq_info = &self.data.nodes[&node_key];
     Ok(DenseSeqDistribution {
       dis: self.alphabet.seq2prof(&seq_info.seq.sequence)?,
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     })
   }
 
@@ -356,7 +360,7 @@ where
   fn indexed_leaf_profile(&self, node: &DenseNodePartition) -> Result<DenseSeqDistribution, Report> {
     Ok(DenseSeqDistribution {
       dis: self.alphabet.seq2prof(&node.seq.sequence)?,
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     })
   }
 

--- a/packages/treetime/src/partition/marginal_discrete.rs
+++ b/packages/treetime/src/partition/marginal_discrete.rs
@@ -20,6 +20,7 @@ use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_io::nwk::NodeCommentProvider;
+use treetime_primitives::LogLh;
 use treetime_utils::array::ndarray::argmax_first;
 
 #[derive(Clone, Debug, Serialize)]
@@ -78,7 +79,7 @@ impl PartitionMarginalDiscrete {
         leaf_key,
         DenseNodePartition {
           seq: DenseSeqInfo::default(),
-          profile: DenseSeqDistribution::new(profile, 0.0),
+          profile: DenseSeqDistribution::new(profile, LogLh::ZERO),
         },
       );
     }
@@ -119,13 +120,17 @@ impl HasGtr for PartitionMarginalDiscrete {
 }
 
 impl HasLogLh for PartitionMarginalDiscrete {
-  fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
-    self.data.nodes.get(&node_key).map_or(0.0, |node| node.profile.log_lh)
+  fn get_log_lh(&self, node_key: GraphNodeKey) -> LogLh {
+    self
+      .data
+      .nodes
+      .get(&node_key)
+      .map_or(LogLh::ZERO, |node| node.profile.log_lh)
   }
 
   fn reset_node_log_likelihoods(&mut self) {
     for node_data in self.data.nodes.values_mut() {
-      node_data.profile.log_lh = 0.0;
+      node_data.profile.log_lh = LogLh::ZERO;
     }
   }
 }

--- a/packages/treetime/src/partition/marginal_helpers.rs
+++ b/packages/treetime/src/partition/marginal_helpers.rs
@@ -7,7 +7,7 @@ use maplit::btreemap;
 use ndarray::{Array1, Array2};
 use std::collections::{BTreeMap, BTreeSet};
 use std::iter::zip;
-use treetime_primitives::AsciiChar;
+use treetime_primitives::{AsciiChar, LogLh};
 use treetime_utils::array::ndarray::is_max_above;
 use treetime_utils::array::softmax_with_log_norm::softmax_with_log_norm;
 use treetime_utils::interval::range::range_contains;
@@ -62,7 +62,7 @@ pub fn combine_messages(
     }
 
     let (dis, log_norm) = softmax_with_log_norm(log_vec.view());
-    seq_dis.log_lh += log_norm;
+    seq_dis.log_lh += LogLh::new(log_norm);
     if let Some(count) = fixed_counts.get_mut(&state) {
       *count -= 1.0;
     }
@@ -81,7 +81,7 @@ pub fn combine_messages(
     }
 
     let (dis, log_norm) = softmax_with_log_norm(log_vec.view());
-    seq_dis.log_lh += fixed_counts[&state] * log_norm;
+    seq_dis.log_lh += LogLh::new(fixed_counts[&state] * log_norm);
     seq_dis.fixed.insert(state, dis);
   }
   Ok(seq_dis)
@@ -228,7 +228,7 @@ mod tests {
       variable_indel: BTreeSet::new(),
       fixed: btreemap! {},
       fixed_counts: Composition::new(std::iter::empty::<AsciiChar>(), AsciiChar::from_byte_unchecked(b'-')),
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     };
 
     let result = propagate_raw_per_site(&gtr, t, false, &seq_dis, None);
@@ -284,7 +284,7 @@ mod tests {
       variable_indel: BTreeSet::new(),
       fixed: btreemap! {},
       fixed_counts: Composition::new(std::iter::empty::<AsciiChar>(), AsciiChar::from_byte_unchecked(b'-')),
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     };
 
     let result = propagate_raw_per_site(&gtr, t, true, &seq_dis, None);

--- a/packages/treetime/src/partition/marginal_passes.rs
+++ b/packages/treetime/src/partition/marginal_passes.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeSet;
 use treetime_graph::edge::EdgeOptimizeOps;
 use treetime_graph::graph::Graph;
 use treetime_graph::node::{GraphNode, Named};
-use treetime_primitives::AsciiChar;
+use treetime_primitives::{AsciiChar, LogLh};
 use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::interval::range::range_contains;
 
@@ -214,7 +214,7 @@ fn compute_msg_to_child(
     }
   }
 
-  let mut delta_ll = 0.0;
+  let mut delta_ll = LogLh::ZERO;
   for (pos, parent_state) in parent_states {
     let divisor = child_dis
       .variable
@@ -246,7 +246,7 @@ fn compute_msg_to_child(
     delta_ll = forward_log_lh_add_normalization(delta_ll, normalization);
     seq_dis.fixed.insert(*state, dis);
   }
-  seq_dis.log_lh = forward_log_lh_add_normalization(seq_dis.log_lh, delta_ll);
+  seq_dis.log_lh += delta_ll;
   Ok(seq_dis)
 }
 
@@ -321,7 +321,7 @@ where
       variable,
       variable_indel: BTreeSet::new(),
       fixed,
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     }
   } else {
     let mut variable_pos = btreemap! {};

--- a/packages/treetime/src/partition/marginal_sparse.rs
+++ b/packages/treetime/src/partition/marginal_sparse.rs
@@ -23,7 +23,7 @@ use treetime_graph::graph_traverse::GraphNodeForward;
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_graph::reroot::{EdgeMergeInfo, RerootChanges};
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::{AlphabetLike, Seq, seq};
+use treetime_primitives::{AlphabetLike, LogLh, Seq, seq};
 use treetime_utils::array::ndarray::argmax_first;
 use treetime_utils::collections::container::get_exactly_one;
 use treetime_utils::interval::range_union::range_union;
@@ -117,13 +117,16 @@ pub(crate) fn reconstruct_map_seq_sampled(
 }
 
 impl HasLogLh for PartitionMarginalSparse {
-  fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
-    self.nodes.get(&node_key).map_or(0.0, |node| node.profile.log_lh)
+  fn get_log_lh(&self, node_key: GraphNodeKey) -> LogLh {
+    self
+      .nodes
+      .get(&node_key)
+      .map_or(LogLh::ZERO, |node| node.profile.log_lh)
   }
 
   fn reset_node_log_likelihoods(&mut self) {
     for node_data in self.nodes.values_mut() {
-      node_data.profile.log_lh = 0.0;
+      node_data.profile.log_lh = LogLh::ZERO;
     }
   }
 }

--- a/packages/treetime/src/partition/sparse.rs
+++ b/packages/treetime/src/partition/sparse.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;
 use treetime_primitives::AlphabetLike;
-use treetime_primitives::{AsciiChar, Seq, StateSet, seq};
+use treetime_primitives::{AsciiChar, LogLh, Seq, StateSet, seq};
 use treetime_utils::interval::range_union::range_union;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -72,7 +72,7 @@ impl SparseNodePartition {
         variable_indel: BTreeSet::new(),
         fixed: btreemap! {},
         fixed_counts: Composition::new(alphabet.chars(), alphabet.gap()),
-        log_lh: 0.0,
+        log_lh: LogLh::ZERO,
       },
     })
   }
@@ -185,7 +185,7 @@ pub struct SparseSeqDistribution {
   pub fixed_counts: Composition,
 
   /// Total log likelihood
-  pub log_lh: f64,
+  pub log_lh: LogLh,
 }
 
 impl Default for SparseSeqDistribution {
@@ -195,7 +195,7 @@ impl Default for SparseSeqDistribution {
       variable_indel: BTreeSet::new(),
       fixed: btreemap! {},
       fixed_counts: Composition::new(std::iter::empty::<AsciiChar>(), AsciiChar::from_byte_unchecked(b'-')),
-      log_lh: 0.0,
+      log_lh: LogLh::ZERO,
     }
   }
 }

--- a/packages/treetime/src/partition/timetree.rs
+++ b/packages/treetime/src/partition/timetree.rs
@@ -20,7 +20,7 @@ use treetime_graph::graph_traverse::GraphNodeForward;
 use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_graph::reroot::RerootChanges;
 use treetime_io::fasta::FastaRecord;
-use treetime_primitives::Seq;
+use treetime_primitives::{LogLh, Seq};
 
 pub type GraphTimetree<D = ()> = Graph<NodeTimetree, EdgeTimetree, D>;
 pub type PartitionTimetreeRef = Arc<RwLock<PartitionTimetree>>;
@@ -56,7 +56,7 @@ impl HasGtr for PartitionTimetree {
 }
 
 impl HasLogLh for PartitionTimetree {
-  fn get_log_lh(&self, node_key: GraphNodeKey) -> f64 {
+  fn get_log_lh(&self, node_key: GraphNodeKey) -> LogLh {
     match self {
       Self::Dense(partition) => partition.get_log_lh(node_key),
       Self::Sparse(partition) => partition.get_log_lh(node_key),

--- a/packages/treetime/src/partition/traits.rs
+++ b/packages/treetime/src/partition/traits.rs
@@ -22,7 +22,7 @@ use treetime_graph::node::{GraphNode, GraphNodeKey, Named};
 use treetime_graph::reroot::RerootChanges;
 use treetime_io::fasta::FastaRecord;
 use treetime_io::nwk::NodeCommentProvider;
-use treetime_primitives::Seq;
+use treetime_primitives::{LogLh, Seq};
 
 pub trait HasGtr {
   fn gtr(&self) -> &GTR;
@@ -264,7 +264,7 @@ pub trait PartitionCompressed: Sync + Send {
 }
 
 pub trait HasLogLh {
-  fn get_log_lh(&self, node_key: GraphNodeKey) -> f64;
+  fn get_log_lh(&self, node_key: GraphNodeKey) -> LogLh;
 
   fn reset_node_log_likelihoods(&mut self);
 }
@@ -350,7 +350,7 @@ where
 }
 
 /// Calculate the total log likelihood of the graph given the partitions
-pub fn graph_log_lh<P, N, E, D>(graph: &Graph<N, E, D>, partitions: &[Arc<RwLock<P>>]) -> Result<f64, Report>
+pub fn graph_log_lh<P, N, E, D>(graph: &Graph<N, E, D>, partitions: &[Arc<RwLock<P>>]) -> Result<LogLh, Report>
 where
   P: HasLogLh + Send + Sync + ?Sized,
   N: GraphNode,

--- a/packages/treetime/src/test_utils/marginal.rs
+++ b/packages/treetime/src/test_utils/marginal.rs
@@ -21,7 +21,7 @@ pub fn run_dense_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) -> 
   let partition = PartitionMarginalDense::new(0, gtr, alphabet, length);
   let partitions = [Arc::new(RwLock::new(partition))];
 
-  initialize_marginal(&graph, &partitions, &aln)
+  initialize_marginal(&graph, &partitions, &aln).map(|log_lh| log_lh.value())
 }
 
 pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) -> Result<f64, Report> {
@@ -33,5 +33,5 @@ pub fn run_sparse_marginal_with_newick(newick: &str, aln_str: &str, gtr: GTR) ->
   let partition = fitch.into_marginal_sparse(gtr, &graph)?;
   let partitions = [Arc::new(RwLock::new(partition))];
 
-  update_marginal(&graph, &partitions)
+  update_marginal(&graph, &partitions).map(|log_lh| log_lh.value())
 }

--- a/packages/treetime/src/timetree/__tests__/test_refinement.rs
+++ b/packages/treetime/src/timetree/__tests__/test_refinement.rs
@@ -83,7 +83,7 @@ mod tests {
       .sum::<Result<f64, Report>>()?;
 
     // Kingman's node and edge factorizations telescope to the same objective.
-    pretty_assert_abs_diff_eq!(node_lh, edge_lh, epsilon = 1e-10);
+    pretty_assert_abs_diff_eq!(node_lh, edge_lh.value(), epsilon = 1e-10);
 
     let outcome = refine(&mut graph, &partitions, &mut clock_model, Some(&tc))?;
     assert_eq!(TopologyOutcome::Unchanged, outcome.topology);

--- a/packages/treetime/src/timetree/convergence/__tests__/test_likelihood.rs
+++ b/packages/treetime/src/timetree/convergence/__tests__/test_likelihood.rs
@@ -22,6 +22,7 @@ mod tests {
   use treetime_graph::node::GraphNodeKey;
   use treetime_io::dates_csv::DateConstraint;
   use treetime_io::nwk::nwk_read_str;
+  use treetime_primitives::LogLh;
   use treetime_utils::{o, pretty_assert_ulps_eq};
 
   #[test]
@@ -34,7 +35,9 @@ mod tests {
     // Oracle: graph_log_lh() contract in packages/treetime/src/partition/traits.rs.
     let expected = -5.5;
 
-    let actual = compute_sequence_log_lh(&graph, &partitions).expect("sequence log-likelihood must be available");
+    let actual = compute_sequence_log_lh(&graph, &partitions)
+      .expect("sequence log-likelihood must be available")
+      .value();
 
     pretty_assert_ulps_eq!(expected, actual, max_ulps = 10);
     Ok(())
@@ -56,7 +59,9 @@ mod tests {
     // Oracle: one edge with probability 0.25 contributes ln(0.25).
     let expected = 0.25_f64.ln();
 
-    let actual = compute_positional_log_lh(&graph).expect("positional log-likelihood must be available");
+    let actual = compute_positional_log_lh(&graph)
+      .expect("positional log-likelihood must be available")
+      .value();
 
     pretty_assert_ulps_eq!(expected, actual, max_ulps = 10);
     Ok(())
@@ -77,9 +82,11 @@ mod tests {
     let graph = helpers::coalescent_graph()?;
     let tc = Distribution::constant(1.0);
     // Oracle: compute_coalescent_total_lh() is the coalescent model's whole-tree log-likelihood.
-    let expected = compute_coalescent_total_lh(&graph, &tc)?;
+    let expected = compute_coalescent_total_lh(&graph, &tc)?.value();
 
-    let actual = compute_coalescent_log_lh(&graph, Some(&tc)).expect("coalescent log-likelihood must be available");
+    let actual = compute_coalescent_log_lh(&graph, Some(&tc))
+      .expect("coalescent log-likelihood must be available")
+      .value();
 
     pretty_assert_ulps_eq!(expected, actual, max_ulps = 10);
     Ok(())
@@ -110,7 +117,8 @@ mod tests {
       .first()
       .expect("one convergence metric must be recorded")
       .log_lh_total
-      .expect("total log-likelihood must be available");
+      .expect("total log-likelihood must be available")
+      .value();
 
     pretty_assert_ulps_eq!(expected, actual, max_ulps = 10);
     Ok(())
@@ -132,7 +140,7 @@ mod tests {
         root_key,
         DenseNodePartition {
           seq: DenseSeqInfo::default(),
-          profile: DenseSeqDistribution::new(array![[1.0, 0.0, 0.0, 0.0]], log_lh),
+          profile: DenseSeqDistribution::new(array![[1.0, 0.0, 0.0, 0.0]], LogLh::new(log_lh)),
         },
       );
       Ok(Arc::new(RwLock::new(PartitionTimetree::Dense(partition))))

--- a/packages/treetime/src/timetree/convergence/__tests__/test_metrics.rs
+++ b/packages/treetime/src/timetree/convergence/__tests__/test_metrics.rs
@@ -4,6 +4,7 @@ mod tests {
   use eyre::Report;
   use indoc::indoc;
   use pretty_assertions::assert_eq;
+  use treetime_primitives::LogLh;
   use treetime_utils::io::json::{JsonPretty, json_write_str};
 
   #[test]
@@ -11,10 +12,10 @@ mod tests {
     let metrics = ConvergenceMetrics {
       n_diff: 2,
       n_resolved: 1,
-      log_lh_seq: Some(-10.0),
-      log_lh_pos: Some(-20.0),
-      log_lh_coal: Some(-30.0),
-      log_lh_total: Some(-60.0),
+      log_lh_seq: Some(LogLh::new(-10.0)),
+      log_lh_pos: Some(LogLh::new(-20.0)),
+      log_lh_coal: Some(LogLh::new(-30.0)),
+      log_lh_total: Some(LogLh::new(-60.0)),
     };
     let expected = indoc! {r#"{
       "n_diff": 2,

--- a/packages/treetime/src/timetree/convergence/likelihood.rs
+++ b/packages/treetime/src/timetree/convergence/likelihood.rs
@@ -3,9 +3,10 @@ use crate::partition::timetree::{GraphTimetree, PartitionTimetreeRef};
 use crate::partition::traits::graph_log_lh;
 use log::{debug, warn};
 use treetime_distribution::Distribution;
+use treetime_primitives::LogLh;
 
 /// Sum of per-partition root log-likelihoods from marginal reconstruction.
-pub fn compute_sequence_log_lh(graph: &GraphTimetree, partitions: &[PartitionTimetreeRef]) -> Option<f64> {
+pub fn compute_sequence_log_lh(graph: &GraphTimetree, partitions: &[PartitionTimetreeRef]) -> Option<LogLh> {
   if partitions.is_empty() {
     return None;
   }
@@ -26,7 +27,7 @@ pub fn compute_sequence_log_lh(graph: &GraphTimetree, partitions: &[PartitionTim
 /// This is a v1-specific metric. v0's `positional_LH` sums node-level marginal
 /// log-likelihoods from the forward pass. Both metrics trend in the same direction
 /// during convergence but produce different numerical values.
-pub fn compute_positional_log_lh(graph: &GraphTimetree) -> Option<f64> {
+pub fn compute_positional_log_lh(graph: &GraphTimetree) -> Option<LogLh> {
   let mut total = 0.0;
   let mut count = 0_usize;
 
@@ -66,14 +67,14 @@ pub fn compute_positional_log_lh(graph: &GraphTimetree) -> Option<f64> {
     }
   }
 
-  (count > 0).then_some(total)
+  (count > 0).then_some(LogLh::new(total))
 }
 
 /// Total coalescent log-likelihood from the merger model.
 ///
 /// Sums per-edge costs under the Kingman coalescent for the given Tc distribution.
 /// Returns `None` when no coalescent model is active (coalescent_tc is None).
-pub fn compute_coalescent_log_lh(graph: &GraphTimetree, coalescent_tc: Option<&Distribution>) -> Option<f64> {
+pub fn compute_coalescent_log_lh(graph: &GraphTimetree, coalescent_tc: Option<&Distribution>) -> Option<LogLh> {
   let tc = coalescent_tc?;
   match compute_coalescent_total_lh(graph, tc) {
     Ok(lh) => Some(lh),

--- a/packages/treetime/src/timetree/convergence/metrics.rs
+++ b/packages/treetime/src/timetree/convergence/metrics.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use treetime_primitives::LogLh;
 
 /// Tracks convergence metrics across timetree optimization iterations.
 ///
@@ -13,13 +14,13 @@ pub struct ConvergenceMetrics {
   /// Number of polytomies resolved in this iteration
   pub n_resolved: usize,
   /// Sequence log-likelihood (log-probability of sequences given the tree and substitution model)
-  pub log_lh_seq: Option<f64>,
+  pub log_lh_seq: Option<LogLh>,
   /// Positional log-likelihood (log-probability of node positions on the time axis)
-  pub log_lh_pos: Option<f64>,
+  pub log_lh_pos: Option<LogLh>,
   /// Coalescent log-likelihood (population genetic log-prior on node times)
-  pub log_lh_coal: Option<f64>,
+  pub log_lh_coal: Option<LogLh>,
   /// Total log-likelihood (sum of available components; absent components are excluded)
-  pub log_lh_total: Option<f64>,
+  pub log_lh_total: Option<LogLh>,
 }
 
 impl ConvergenceMetrics {

--- a/packages/treetime/src/timetree/convergence/optimizer.rs
+++ b/packages/treetime/src/timetree/convergence/optimizer.rs
@@ -77,10 +77,10 @@ impl TimetreeOptimizer {
     info!(
       "  Iteration {}: n_diff={n_diff}, n_resolved={n_resolved}, log_lh_seq={:.2}, log_lh_pos={:.2}, log_lh_coal={:.2}, log_lh_total={:.2}{}",
       self.i,
-      metric.log_lh_seq.unwrap_or(f64::NAN),
-      metric.log_lh_pos.unwrap_or(f64::NAN),
-      metric.log_lh_coal.unwrap_or(f64::NAN),
-      metric.log_lh_total.unwrap_or(f64::NAN),
+      metric.log_lh_seq.map_or(f64::NAN, |log_lh| log_lh.value()),
+      metric.log_lh_pos.map_or(f64::NAN, |log_lh| log_lh.value()),
+      metric.log_lh_coal.map_or(f64::NAN, |log_lh| log_lh.value()),
+      metric.log_lh_total.map_or(f64::NAN, |log_lh| log_lh.value()),
       if metric.has_converged() { " [converged]" } else { "" }
     );
 

--- a/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs
+++ b/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_dense.rs
@@ -56,7 +56,7 @@ mod tests {
     ))));
 
     let partitions: PartitionTimetreeAllVec = vec![dense_partition];
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
     initialize_node_divergences(&graph)?;
 
     let clock_model = estimate_clock_model_with_reroot(

--- a/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
+++ b/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_gm_runner_marginal_sparse.rs
@@ -60,7 +60,7 @@ mod tests {
     )));
 
     let partitions: PartitionTimetreeAllVec = vec![sparse_partition];
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
     initialize_node_divergences(&graph)?;
 
     let clock_model = estimate_clock_model_with_reroot(

--- a/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
+++ b/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_gm_runner_pre_optimize.rs
@@ -57,7 +57,7 @@ mod tests {
     )));
 
     let partitions: PartitionTimetreeAllVec = vec![sparse_partition];
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
 
     let before = extract_branch_lengths(&graph);
 
@@ -109,7 +109,7 @@ mod tests {
     )));
 
     let partitions: PartitionTimetreeAllVec = vec![sparse_partition];
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
     initialize_node_divergences(&graph)?;
 
     // Pre-optimization step (matching v0 flow)

--- a/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_runner_coalescent.rs
+++ b/packages/treetime/src/timetree/inference/__tests__/test_gm_runner/test_runner_coalescent.rs
@@ -76,7 +76,7 @@ mod tests {
     ))));
 
     let partitions: PartitionTimetreeAllVec = vec![dense_partition];
-    initialize_marginal(&graph, &partitions, &aln)?;
+    initialize_marginal(&graph, &partitions, &aln)?.value();
     initialize_node_divergences(&graph)?;
 
     let clock_model = estimate_clock_model_with_reroot(

--- a/packages/treetime/src/timetree/inference/branch_length_likelihood.rs
+++ b/packages/treetime/src/timetree/inference/branch_length_likelihood.rs
@@ -41,7 +41,9 @@ pub fn compute_branch_length_distribution(
   let log_lh: Array1<f64> = grid
     .iter()
     .copied()
-    .map(|branch_len| evaluate_with_indels_log_lh_only(contributions, indel_count, indel_rate, branch_len))
+    .map(|branch_len| {
+      evaluate_with_indels_log_lh_only(contributions, indel_count, indel_rate, branch_len).map(|log_lh| log_lh.value())
+    })
     .collect::<Result<_, _>>()?;
   let max_log_lh = log_lh.max()?;
 

--- a/packages/treetime/src/timetree/optimization/__tests__/test_reroot.rs
+++ b/packages/treetime/src/timetree/optimization/__tests__/test_reroot.rs
@@ -28,7 +28,7 @@ mod tests {
   use treetime_graph::reroot::RerootChanges;
   use treetime_io::fasta::{FastaRecord, read_many_fasta_str};
   use treetime_io::nwk::nwk_read_str;
-  use treetime_primitives::{AsciiChar, Seq, seq};
+  use treetime_primitives::{AsciiChar, LogLh, Seq, seq};
   use treetime_utils::make_report;
 
   fn c(b: u8) -> AsciiChar {
@@ -207,7 +207,7 @@ mod tests {
         edge_to_a_key => {
           let mut edge = SparseEdgePartition::with_fitch_subs_and_indels(vec![sub_original], vec![indel_original]);
           edge.msg_from_child = SparseSeqDistribution {
-            log_lh: 1.0, // non-default to verify it gets cleared
+            log_lh: LogLh::new(1.0), // non-default to verify it gets cleared
             ..SparseSeqDistribution::default()
           };
           edge
@@ -235,7 +235,7 @@ mod tests {
     assert!(!indel_after.is_deletion(), "Indel direction should be toggled");
 
     // Verify msg_from_child is cleared
-    pretty_assert_ulps_eq!(edge_data.msg_from_child.log_lh, 0.0, max_ulps = 5);
+    pretty_assert_ulps_eq!(edge_data.msg_from_child.log_lh.value(), 0.0, max_ulps = 5);
 
     Ok(())
   }
@@ -497,7 +497,7 @@ mod tests {
     let initial_leaf_count = graph.get_leaves().len();
 
     // Initialize marginal for the sparse partition
-    update_marginal(&graph, &partitions)?;
+    update_marginal(&graph, &partitions)?.value();
 
     // First reroot call (simulating keep_root=false flow)
     let clock_model_1 = reroot_tree(


### PR DESCRIPTION
Aggregate log-likelihoods crossed partition, coalescent, optimization, mugration, and timetree boundaries as raw floats. The compiler could not distinguish them from probabilities, branch lengths, dates, or unrelated optimizer values.

Introduce the transparent `LogLh` scalar and propagate it through aggregate boundaries. [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime-primitives/src/log_lh.rs#L5-L97)] Probability arrays, derivative kernels, distribution grids, and optimizer coordinates retain native `f64`; conversions remain explicit at numerical boundaries. [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime/src/optimize/likelihood.rs#L8-L97)]

The newtype changes compile-time semantics without changing numerical representation. Transparent layout and serialization preserve existing scalar schemas, while domain-directed arithmetic permits aggregation, differences, and optimizer costs without restoring mixed raw-float operations.

### Work items

- [x] Add the transparent scalar, constants, and domain-directed arithmetic [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime-primitives/src/log_lh.rs#L30-L97)]
- [x] Type aggregate partition, inference, coalescent, optimization, mugration, and timetree boundaries [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime/src/partition/traits.rs#L266-L269)] [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime/src/partition/traits.rs#L352-L370)]
- [x] Verify rejected mixed arithmetic, scalar layout, transparent serialization, and numerical behavior [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime-primitives/src/log_lh.rs#L11-L33)] [[src](https://github.com/neherlab/treetime/blob/f5fd968ea8d14f5a0854650166bfbd773b3fce7a/packages/treetime-primitives/src/__tests__/test_log_lh.rs#L8-L75)]