### PR TITLE
fix: the fitch/parsimony sequence reconstruction did not resolve inde…

### DIFF
--- a/kb/issues/N-ancestral-deleted-position-invariant-enforced-by-scattered-guards.md
+++ b/kb/issues/N-ancestral-deleted-position-invariant-enforced-by-scattered-guards.md
@@ -1,0 +1,54 @@
+# Deleted-position invariant is enforced by scattered guards, not by construction
+
+Ancestral reconstruction relies on the invariant that a deleted position carries no character state: every range in `gaps` is also a range in `non_char` (`gaps` is a subset of `non_char`). Leaves (`SparseNodePartition::new`) and the dense representation (`DenseSeqInfo::new`) hold it at construction. Internal sparse nodes did not, so the forward pass could emit a substitution inside a node's own deletion (a position reported as both mutated and gapped on one edge).
+
+The fix restores the invariant, but enforces it by re-asserting it at each downstream reader across two representations and both passes, rather than making a character-at-a-deleted-position unrepresentable at a single point. The behavior is now correct; the concern is that four parallel structures (`sequence`, `non_char`, `gaps`, and the `variable` / `profile.variable` maps) are kept mutually consistent by pairwise synchronization at several sites, so a future code path that populates `variable`/`profile` at a deleted position without a matching guard silently reintroduces the defect.
+
+## Evidence
+
+Root-cause fix (correct, single chokepoint):
+
+- Backward pass unions resolved gaps into `non_char` where the node's masking ranges are computed [`packages/treetime/src/ancestral/fitch.rs#L188`](../../packages/treetime/src/ancestral/fitch.rs#L188), after reordering `resolve_indels_backward` ahead of sequence construction [`packages/treetime/src/ancestral/fitch.rs#L178`](../../packages/treetime/src/ancestral/fitch.rs#L178).
+
+Invariant re-asserted at downstream readers (the scatter):
+
+- Forward pass re-unions `non_char` with `gaps` after gap-widening; correctness depends on running after `resolve_indels_forward`, whose insertion detection reads `non_char` as it stood during the backward pass [`packages/treetime/src/ancestral/fitch.rs#L288`](../../packages/treetime/src/ancestral/fitch.rs#L288). This is call-order coupling justified by comment.
+- Fitch substitution resolver skips positions in `non_char` (backward) and in the edge's `gaps` (forward) at three points [`packages/treetime/src/ancestral/fitch_sub.rs#L33`](../../packages/treetime/src/ancestral/fitch_sub.rs#L33), [`packages/treetime/src/ancestral/fitch_sub.rs#L150`](../../packages/treetime/src/ancestral/fitch_sub.rs#L150), [`packages/treetime/src/ancestral/fitch_sub.rs#L173`](../../packages/treetime/src/ancestral/fitch_sub.rs#L173). The backward guard is needed because `variable` is derived from child positions independently of this node's `non_char`.
+- Sparse marginal substitution emission filters positions that are `non_char` at either endpoint, for parity with the dense `edge_subs()` [`packages/treetime/src/partition/marginal_passes.rs#L246`](../../packages/treetime/src/partition/marginal_passes.rs#L246). The stored `profile.variable` still holds a residue whose argmax is an ordinary state at a deleted site; the filter suppresses it only at emit time.
+- Sparse marginal reconstruction writes residues from the profile and then re-fills deletion ranges with gaps to overwrite them [`packages/treetime/src/partition/marginal_sparse.rs#L116`](../../packages/treetime/src/partition/marginal_sparse.rs#L116). This repairs the output after producing the inconsistent state rather than not producing it.
+
+## Design concerns
+
+- Not correct by construction. The `variable` and `profile.variable` structures permit a character state at a deleted position; consistency is a cross-structure property maintained by convention. Any new consumer must know to re-filter.
+- Temporal coupling. The forward-pass `non_char` re-union has an order dependency on `resolve_indels_forward` and insertion detection, documented in a comment instead of removed.
+- Output repair over prevention. `reconstruct_map_seq_sampled` writes then overwrites deleted sites, so the profile-derived sequence transiently disagrees with the indel track.
+- Test asserts the symptom, not the invariant. `test_fitch_gap_sub_conflict.rs` checks "no substitution inside a deletion" at the edge output; nothing asserts the subset relation on internal-node structures at construction.
+
+## Mitigating context
+
+The dense path already filters deleted positions at `edge_subs()` read time, so the sparse marginal filter [`packages/treetime/src/partition/marginal_passes.rs#L246`](../../packages/treetime/src/partition/marginal_passes.rs#L246) matches an established convention rather than adding a new pattern. The forward `fitch_sub` guard on the edge's `gaps` addresses edge-local deletions (parent-inherited gaps that widen on the edge), a genuinely distinct condition from node `non_char`, so it is not pure redundancy with the backward union.
+
+## Options
+
+- O1. Enforce the subset relation at construction of the sparse node/edge partition: when a range enters `gaps`, remove it from the `variable` and `profile.variable` domains in the same operation, so no reader can observe a residue at a deleted position. Removes the `fitch_sub` and `marginal_passes` guards and the `marginal_sparse` overwrite. Largest change; touches the profile/indel representation.
+- O2. Add a single validated combine step that produces `(sequence, non_char, gaps, variable)` as one consistent value with a debug assertion of the subset relation, and have both passes call it. Removes the forward-pass ordering comment by making order internal to the combinator. Medium change; keeps the current structures.
+- O3. Keep the current guards but add a construction-time invariant check (debug assertion or constructor validation) on internal sparse nodes and an edge-level assertion that no substitution position lies in the edge's `gaps`. Smallest change; converts the silent-reintroduction risk into a loud failure without redesign.
+- O4. Replace the `marginal_sparse` write-then-overwrite with not writing residues at deleted positions in the profile-application loop. Local improvement, independent of O1-O3.
+
+O3 and O4 are compatible with the current design and reduce the latent risk immediately. O1 is the correct-by-construction target and needs approval because it changes the reconstruction representation. Behavior must remain unchanged: the reconstruction output and the gap/substitution test results are the contract.
+
+## Validation
+
+- Add a construction-time assertion that every `gaps` range is contained in `non_char` for internal sparse nodes, and an edge-level assertion that no reported substitution position lies in the edge's deletions. Both must hold on the datasets that motivated the fix.
+- Fitch compression, marginal reconstruction (dense and sparse), and `edge_subs`/`edge_indels` outputs are unchanged versus the current branch.
+- No guard removal changes reconstruction output, confirming the guards were enforcing an invariant that construction can own instead.
+
+## Source
+
+Introduced by neherlab/treetime PR #890 "fix: the fitch/parsimony sequence reconstruction did not resolve indels and substitutions correctly", fix commit [`6774b77`](https://github.com/neherlab/treetime/commit/6774b77092e42e31e77628eec102561dba1057aa).
+
+## Related issues
+
+- [M-partition-compressed-exposes-fitch-storage.md](M-partition-compressed-exposes-fitch-storage.md)
+- [H-gtr-model-state-can-break-invariants.md](H-gtr-model-state-can-break-invariants.md)
+- [N-amino-acid-mutation-indel-representation-undecided.md](N-amino-acid-mutation-indel-representation-undecided.md)

--- a/packages/treetime/src/ancestral/__tests__/mod.rs
+++ b/packages/treetime/src/ancestral/__tests__/mod.rs
@@ -3,6 +3,7 @@ mod prop_marginal_support;
 mod test_attach;
 mod test_dense_completeness;
 mod test_fitch;
+mod test_fitch_gap_sub_conflict;
 mod test_fitch_indel;
 mod test_fitch_sub;
 mod test_marginal_analytical;

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -646,8 +646,15 @@ mod tests {
       let variable_positions = get_root_variable_positions(&graph, &partition);
       assert_eq!(vec![0, 2, 3, 5, 6], variable_positions);
 
+      // Positions 14-15 read as non-char ('.') rather than "AC". The root resolves 14..16 to a gap
+      // (AB leaves it `variable_indel`, CD is gapped, and `resolve_indels_backward` treats
+      // `variable_indel` as gap-compatible), so the backward mask covers them and the states A/C
+      // that leaf A carries there no longer propagate up. Before `gaps` was unioned into
+      // `non_char`, those columns kept a character state while the node reported them deleted,
+      // which let the forward pass emit a substitution inside its own deletion.
+      // See test_fitch_gap_sub_conflict.rs.
       let root_seq = get_root_seq(&graph, &partition);
-      assert_eq!("~C~~C~~TGTATTGAC", root_seq);
+      assert_eq!("~C~~C~~TGTATTG..", root_seq);
 
       // Verify state sets at each variable position (which characters are possible)
       let state_sets = get_root_state_sets(&graph, &partition);

--- a/packages/treetime/src/ancestral/__tests__/test_fitch_gap_sub_conflict.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch_gap_sub_conflict.rs
@@ -1,0 +1,179 @@
+#[cfg(test)]
+mod tests {
+  use crate::alphabet::alphabet::Alphabet;
+  use crate::ancestral::fitch::compress_sequences;
+  use crate::partition::fitch::PartitionFitch;
+  use crate::payload::ancestral::GraphAncestral;
+  use crate::seq::alignment::get_common_length;
+  use eyre::Report;
+  use indoc::indoc;
+  use itertools::Itertools;
+  use maplit::btreemap;
+  use parking_lot::RwLock;
+  use std::sync::Arc;
+  use treetime_io::fasta::read_many_fasta_str;
+  use treetime_io::nwk::nwk_read_str;
+
+  type EdgeReport = (String, Vec<(String, usize)>, Vec<(usize, usize)>);
+
+  /// Run Fitch compression and return, per edge, the substitutions and deletion ranges.
+  fn compress(nwk: &str, fasta: &str) -> Result<Vec<EdgeReport>, Report> {
+    let alphabet = Alphabet::default();
+    let aln = read_many_fasta_str(fasta, &alphabet)?;
+    let graph: GraphAncestral = nwk_read_str(nwk)?;
+    let partitions = [Arc::new(RwLock::new(PartitionFitch {
+      index: 0,
+      alphabet,
+      length: get_common_length(&aln)?,
+      nodes: btreemap! {},
+      edges: btreemap! {},
+    }))];
+    compress_sequences(&graph, &partitions, &aln)?;
+
+    let partition = partitions[0].read_arc();
+    let name = |key| -> String {
+      graph
+        .get_node(key)
+        .unwrap()
+        .read_arc()
+        .payload()
+        .read_arc()
+        .name
+        .clone()
+        .unwrap_or_default()
+    };
+
+    Ok(
+      graph
+        .get_edges()
+        .iter()
+        .map(|edge| {
+          let edge = edge.read_arc();
+          let data = &partition.edges[&edge.key()];
+          (
+            format!("{}->{}", name(edge.source()), name(edge.target())),
+            data
+              .fitch_subs()
+              .iter()
+              .map(|sub| (sub.to_string(), sub.pos()))
+              .collect_vec(),
+            data
+              .indels
+              .iter()
+              .filter(|i| i.is_deletion())
+              .map(|i| i.range)
+              .collect_vec(),
+          )
+        })
+        .collect_vec(),
+    )
+  }
+
+  fn conflicts(edges: &[EdgeReport]) -> Vec<String> {
+    edges
+      .iter()
+      .flat_map(|(name, subs, dels)| {
+        subs
+          .iter()
+          .cartesian_product(dels)
+          .filter(|((_, pos), (lo, hi))| pos >= lo && pos < hi)
+          .map(move |((sub, pos), (lo, hi))| format!("{name}: {sub} (pos {pos}) inside deletion {lo}..{hi}"))
+      })
+      .collect_vec()
+  }
+
+  /// Field-data shape: a single determined residue stranded inside a run of unknowns, with sibling
+  /// clades gapped across the whole region. This is the `PP_0012SSJ` / `PP_000ZH4A` pattern.
+  ///
+  /// `stray` has `G` at column 6 surrounded by `N`, so its `non_char` (union of unknown and gap
+  /// ranges) has a one-column hole at 6. That hole survives every ancestral intersection. At `X`
+  /// the column is only `variable_indel`; at `Y` a gapped sibling turns the whole block into a
+  /// resolved gap -- `variable_indel` counts as gap-compatible -- while `non_char` keeps the hole.
+  /// So column 6 is inside `Y`'s gap yet still carries `G`, and `G` is what gets substituted.
+  #[test]
+  fn stray_residue_in_unknown_run_does_not_create_sub_in_deletion() -> Result<(), Report> {
+    let nwk = "(((stray:0.01,gapped:0.01)X:0.01,gapped2:0.01)Y:0.01,out:0.01)root:0.01;";
+    let fasta = indoc! {r#"
+      >stray
+      AAAANNGNNAAA
+      >gapped
+      AAAA-----AAA
+      >gapped2
+      AAAA-----AAA
+      >out
+      AAAAAAAAAAAA
+    "#};
+
+    let edges = compress(nwk, fasta)?;
+    for (name, subs, dels) in &edges {
+      println!("{name}: subs={subs:?} deletions={dels:?}");
+    }
+    let conflicts = conflicts(&edges);
+    assert!(conflicts.is_empty(), "conflicts:\n{}", conflicts.join("\n"));
+    Ok(())
+  }
+
+  /// Gap-boundary variant: the descendants of `c2` disagree only about the *first* column of the
+  /// deleted block (4), and agree that 5..8 is gapped. `X` resolves the whole block 4..8 to a
+  /// gap, but `non_char` only covers 5..8, so column 4 keeps a canonical state and attracts a
+  /// substitution -- landing exactly on the site where the deletion begins.
+  #[test]
+  fn sub_never_lands_at_deletion_start() -> Result<(), Report> {
+    let nwk = "(((g1:0.01,g2:0.01,g3:0.01)c2:0.01,c1:0.01)X:0.01,out:0.01)root:0.01;";
+    let fasta = indoc! {r#"
+      >g1
+      AAAA----AAAA
+      >g2
+      AAAAC---AAAA
+      >g3
+      AAAAT---AAAA
+      >c1
+      AAAA----AAAA
+      >out
+      AAAAAAAAAAAA
+    "#};
+
+    let edges = compress(nwk, fasta)?;
+    for (name, subs, dels) in &edges {
+      println!("{name}: subs={subs:?} deletions={dels:?}");
+    }
+    let conflicts = conflicts(&edges);
+    assert!(conflicts.is_empty(), "conflicts:\n{}", conflicts.join("\n"));
+    Ok(())
+  }
+
+  /// A Fitch substitution and a deletion on the same edge must not target the same site: the
+  /// child either has a character there (substitution) or a gap (deletion), never both.
+  ///
+  /// Minimal construction. Node `X` has one child that is gapped over 4..8 (`c1`) and one child
+  /// whose own descendants disagree about the gap (`c2`, giving it a `variable_indel` over
+  /// 4..8). `resolve_indels_backward` treats "gapped + variable" as consensus gap, so `X` gets
+  /// `gaps = [(4, 8)]` -- but `X.non_char` is the *intersection* of its children's `non_char`,
+  /// which is empty over 4..8 because `c2` is not `non_char` there. So 4..8 is gapped but not
+  /// masked, and the substitution machinery still sees canonical states there.
+  #[test]
+  fn sub_never_lands_inside_deletion_on_same_edge() -> Result<(), Report> {
+    let nwk = "(((g1:0.01,g2:0.01,g3:0.01)c2:0.01,c1:0.01)X:0.01,out:0.01)root:0.01;";
+    let fasta = indoc! {r#"
+      >g1
+      AAAA----AAAA
+      >g2
+      AAAACCCCAAAA
+      >g3
+      AAAATTTTAAAA
+      >c1
+      AAAA----AAAA
+      >out
+      AAAAAAAAAAAA
+    "#};
+
+    let edges = compress(nwk, fasta)?;
+    for (name, subs, dels) in &edges {
+      println!("{name}: subs={subs:?} deletions={dels:?}");
+    }
+
+    let conflicts = conflicts(&edges);
+    assert!(conflicts.is_empty(), "conflicts:\n{}", conflicts.join("\n"));
+    Ok(())
+  }
+}

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -28,6 +28,7 @@ use treetime_graph::node::{GraphNode, NodeAncestralOps};
 use treetime_io::fasta::FastaRecord;
 use treetime_primitives::{AlphabetLike, LogLh, Seq, seq};
 use treetime_utils::collections::container::get_exactly_one;
+use treetime_utils::interval::range_union::range_union;
 use treetime_utils::sync::mutex::unwrap_arc_rwlock;
 
 pub fn create_fitch_partition<N, E>(
@@ -169,8 +170,22 @@ where
   let child_gaps: Vec<&Vec<(usize, usize)>> = children.iter().map(|(c, _)| &c.gaps).collect_vec();
 
   let ranges = compute_node_ranges(&child_non_chars, &child_gaps);
-  let non_char = ranges.non_char;
   let unknown = ranges.unknown;
+
+  let child_unknown: Vec<&Vec<(usize, usize)>> = children.iter().map(|(c, _)| &c.unknown).collect_vec();
+  let child_variable_indels: Vec<&_> = children.iter().map(|(c, _)| &c.fitch.variable_indel).collect_vec();
+
+  let indels_bw = resolve_indels_backward(&child_gaps, &child_unknown, &child_variable_indels, length);
+
+  // A resolved gap is a position with no character state, so it has to be masked like every other
+  // non-char position. `compute_node_ranges` intersects the children's `non_char`, which drops any
+  // column a child left as `variable_indel`, while `resolve_indels_backward` still resolves such a
+  // column to a gap (it counts `variable_indel` as gap-compatible). Taking the union keeps `gaps` a
+  // subset of `non_char`, the invariant leaves (`SparseNodePartition::new`) and the dense
+  // representation (`DenseSeqInfo::new`) already hold. Without it a single determined residue
+  // stranded inside a missing-data run keeps a character state at a position the node reports as
+  // deleted, and the forward pass then emits a substitution inside its own deletion.
+  let non_char = range_union(&[ranges.non_char, indels_bw.resolved_gaps.clone()]);
 
   let mut sequence = seq![FILL_CHAR; length];
   for r in &non_char {
@@ -179,11 +194,6 @@ where
 
   let mut variable = resolve_variable_positions_backward(&children, &non_char, &mut sequence);
   resolve_fixed_positions_backward(&children, alphabet, &mut sequence, &mut variable);
-
-  let child_unknown: Vec<&Vec<(usize, usize)>> = children.iter().map(|(c, _)| &c.unknown).collect_vec();
-  let child_variable_indels: Vec<&_> = children.iter().map(|(c, _)| &c.fitch.variable_indel).collect_vec();
-
-  let indels_bw = resolve_indels_backward(&child_gaps, &child_unknown, &child_variable_indels, length);
 
   slot.node = SparseNodePartition {
     seq: SparseSeqInfo {
@@ -272,6 +282,10 @@ fn run_fitch_forward_indexed(
       &seq.sequence,
     );
     seq.gaps = new_gaps;
+    // The forward pass widens `gaps` with gaps inherited from the parent, so re-establish
+    // `gaps ⊆ non_char` here too. Must run after `resolve_indels_forward`, which distinguishes
+    // insertions by testing `non_char` as it stood during the backward pass.
+    seq.non_char = range_union(&[seq.non_char.clone(), seq.gaps.clone()]);
     for indel in &indels {
       seq.composition.add_indel(indel);
     }

--- a/packages/treetime/src/ancestral/fitch_sub.rs
+++ b/packages/treetime/src/ancestral/fitch_sub.rs
@@ -29,6 +29,10 @@ pub fn resolve_variable_positions_backward(
   let mut variable = BTreeMap::new();
 
   for pos in variable_positions {
+    if range_contains(non_char, pos) {
+      continue; // this node has no character state here, so nothing is variable
+    }
+
     // Collect child profiles (1D vectors)
     let child_profiles = children
       .iter()
@@ -142,6 +146,9 @@ pub fn resolve_nonroot_substitutions_forward(
 
   // for each variable position, pick a state or a mutation
   for (pos, states) in variable.iter_mut() {
+    if range_contains(gaps, *pos) {
+      continue; // deleted on this edge: there is no character state to resolve or mutate
+    }
     let pnuc = parent_seq.sequence[*pos];
     if alphabet.is_canonical(pnuc) {
       // check whether parent is in child profile (sum>0 --> parent state is in profile)
@@ -163,7 +170,7 @@ pub fn resolve_nonroot_substitutions_forward(
   }
 
   for &pos in parent_seq.fitch.variable.keys() {
-    if variable.contains_key(&pos) || range_contains(&parent_seq.gaps, pos) {
+    if variable.contains_key(&pos) || range_contains(&parent_seq.gaps, pos) || range_contains(gaps, pos) {
       continue;
     }
 

--- a/packages/treetime/src/partition/marginal_passes.rs
+++ b/packages/treetime/src/partition/marginal_passes.rs
@@ -239,6 +239,13 @@ fn compute_ml_subs_for_nodes(
     .dedup();
   positions
     .filter_map(|pos| {
+      // Parity with the dense `edge_subs()` (`marginal_dense.rs`), which skips any position that
+      // is `non_char` at either endpoint. A deleted position can still hold a `profile.variable`
+      // entry whose argmax is an ordinary residue, and reporting it would put a substitution and
+      // a deletion on the same edge at the same site.
+      if range_contains(&parent.seq.non_char, pos) || range_contains(&child.seq.non_char, pos) {
+        return None;
+      }
       let parent_state = resolve_map_state(parent, pos, alphabet);
       let child_state = resolve_map_state(child, pos, alphabet);
       (parent_state != child_state && alphabet.is_canonical(parent_state) && alphabet.is_canonical(child_state))

--- a/packages/treetime/src/partition/marginal_sparse.rs
+++ b/packages/treetime/src/partition/marginal_sparse.rs
@@ -113,6 +113,17 @@ pub(crate) fn reconstruct_map_seq_sampled(
     }
   }
 
+  // Re-apply deletions last. The profile writes above are keyed by position and would otherwise
+  // resurrect a residue at a site the edge reports as deleted, leaving the reconstructed sequence
+  // disagreeing with its own indel track.
+  if let Some(edge) = edge {
+    for indel in &edge.indels {
+      if indel.is_deletion() {
+        seq[indel.range.0..indel.range.1].fill(alphabet.gap());
+      }
+    }
+  }
+
   seq
 }
 


### PR DESCRIPTION
  ## Problem
  
  A node could report a position as deleted (in `gaps`) while still carrying a character
  state there, so the forward pass would emit a substitution *inside its own deletion*.
  The invariant `gaps ⊆ non_char` — which leaves (`SparseNodePartition::new`) and the dense
  representation (`DenseSeqInfo::new`) already maintain — was not held by internal nodes.

  ## Changes

  ### `packages/treetime/src/ancestral/fitch.rs`

  Restores the invariant in both passes.

  - **Backward pass:** `resolve_indels_backward` now runs *before* the sequence is built,
    and `non_char` is the union of `ranges.non_char` with the resolved gaps.
    `compute_node_ranges` intersects the children's `non_char`, dropping any column a child
    left as `variable_indel`, while the indel resolver still treats those as gap-compatible
    and resolves them to gaps — hence the mismatch.
  - **Forward pass:** after `resolve_indels_forward` widens `gaps` with parent-inherited
    gaps, `non_char` is re-unioned with `gaps`. Ordering matters — insertion detection reads
    `non_char` as it stood during the backward pass.

  ### `packages/treetime/src/ancestral/fitch_sub.rs`

  Three guards so deleted positions are never treated as variable or mutable.

  - `resolve_variable_positions_backward` — skip positions contained in `non_char`.
  - `resolve_nonroot_substitutions_forward` — skip positions in the edge's `gaps`, both when
    resolving variable positions and when inheriting the parent's variable positions.

  ### `packages/treetime/src/partition/marginal_passes.rs`

  `compute_ml_subs_for_nodes` now skips positions that are `non_char` at either endpoint,
  matching the dense `edge_subs()` in `marginal_dense.rs`. A deleted site can still carry a
  `profile.variable` entry whose argmax is an ordinary residue, which would put a
  substitution and a deletion on the same edge at the same site.

  ### `packages/treetime/src/partition/marginal_sparse.rs`

  `reconstruct_map_seq_sampled` re-applies the edge's deletions *after* the profile writes.
  Those writes are keyed by position and would otherwise resurrect a residue at a site the
  edge reports as deleted, leaving the reconstructed sequence disagreeing with its own indel
  track.

  ## Tests

  - **New** `packages/treetime/src/ancestral/__tests__/test_fitch_gap_sub_conflict.rs`
    (179 lines): a helper that runs `compress_sequences` and reports, per edge, the
    substitutions and deletion ranges — used to assert that no substitution falls inside a
    deletion.
  - `test_fitch.rs`: one expectation updated — root positions 14–15 now resolve to `..`
    (gap) instead of `AC`, with an inline comment explaining this as the intended
    consequence of unioning `gaps` into `non_char`.