### PR TITLE
fix: honor Function tails in point products

### DIFF
--- a/kb/decisions/distribution-tails-and-arithmetic.md
+++ b/kb/decisions/distribution-tails-and-arithmetic.md
@@ -81,6 +81,8 @@ Each operand extends its own domain symmetrically. The extension limit is the ot
 
 When both operands have `Error` or `Zero` tails (the default), the result is identical to strict intersection. When operands carry `Constant` tails -- as backward parent messages do (see [tail assignments](#tail-assignments-in-the-timetree-pipeline)) -- disjoint finite grids overlap via the tails. This prevents the product from collapsing to `Empty` when temporal signals conflict, for example under `--keep-root` where rerooting cannot resolve the tension between subtrees.
 
+Point * Function follows the same per-side rule without constructing a result grid. A point in a `Constant` tail evaluates against the Function's boundary value. A point beyond an `Error` or `Zero` boundary produces `Empty`.
+
 #### Division
 
 The divisor extends its domain; the dividend's bounds are used as-is. This asymmetry reflects the use case: the forward pass divides a parent's time distribution (dividend) by a child's backward message (divisor) to compute the cavity. The divisor's tail metadata determines how far the cavity extends:
@@ -120,7 +122,7 @@ Scientific workflows requiring posterior peak, normalization, or integrated-prob
 
 ### Tail-aware arithmetic
 
-- [packages/treetime-distribution/src/distribution_ops/multiply.rs](../../packages/treetime-distribution/src/distribution_ops/multiply.rs): `fn multiplication_support_intersection()`, `fn multiply_function_function()`, `fn multiply_range_function()`
+- [packages/treetime-distribution/src/distribution_ops/multiply.rs](../../packages/treetime-distribution/src/distribution_ops/multiply.rs): `fn multiplication_support_intersection()`, `fn multiply_point_function()`, `fn multiply_function_function()`, `fn multiply_range_function()`
 - [packages/treetime-distribution/src/distribution_ops/divide.rs](../../packages/treetime-distribution/src/distribution_ops/divide.rs): `fn division_support_intersection()`, `fn divide_function_by_function()`, `fn divide_range_by_function()`
 
 ### Inference pass tail application

--- a/kb/issues/N-distribution-multiply-point-function-tail-blind.md
+++ b/kb/issues/N-distribution-multiply-point-function-tail-blind.md
@@ -1,7 +1,0 @@
-# Point * Function multiplication ignores Function tails
-
-`fn multiply_point_function()` at [packages/treetime-distribution/src/distribution_ops/multiply.rs#L83-L99](../../packages/treetime-distribution/src/distribution_ops/multiply.rs#L83-L99) returns `Empty` when the point falls outside the function's finite grid, even if the function has a `Constant` tail that covers that region.
-
-The product should be `point.amplitude * function.boundary_value` when the point is in the function's tail region, not `Empty`.
-
-Not a production path (inference passes don't produce Point * Function with tails), but inconsistent with the tail-aware contract documented in [kb/decisions/distribution-tails-and-arithmetic.md](../decisions/distribution-tails-and-arithmetic.md).

--- a/packages/treetime-distribution/src/distribution_core/__tests__/test_boundary_behavior.rs
+++ b/packages/treetime-distribution/src/distribution_core/__tests__/test_boundary_behavior.rs
@@ -7,6 +7,7 @@ mod tests {
   use approx::assert_ulps_eq;
   use eyre::Report;
   use ndarray::array;
+  use rstest::rstest;
   use treetime_grid::BoundaryBehavior;
   use treetime_utils::assert_error;
 
@@ -73,13 +74,30 @@ mod tests {
     Ok(())
   }
 
-  #[test]
-  fn test_boundary_multiply_point_outside_function_is_empty() -> Result<(), Report> {
-    let f: DistFnPlain = DistributionFunction::from_range_values((0.0, 2.0), array![1.0, 2.0, 3.0])?;
+  #[rustfmt::skip]
+  #[rstest]
+  #[case::error_left(    (-1.0, BoundaryBehavior::Error,    BoundaryBehavior::Error),    None)]
+  #[case::error_right(   ( 3.0, BoundaryBehavior::Error,    BoundaryBehavior::Error),    None)]
+  #[case::zero_left(     (-1.0, BoundaryBehavior::Zero,     BoundaryBehavior::Error),    None)]
+  #[case::zero_right(    ( 3.0, BoundaryBehavior::Error,    BoundaryBehavior::Zero),     None)]
+  #[case::constant_left( (-1.0, BoundaryBehavior::Constant, BoundaryBehavior::Error),    Some(2.0))]
+  #[case::constant_right(( 3.0, BoundaryBehavior::Error,    BoundaryBehavior::Constant), Some(6.0))]
+  #[trace]
+  fn test_boundary_multiply_point_function_outside_support(
+    #[case] (t, left, right): (f64, BoundaryBehavior, BoundaryBehavior),
+    #[case] expected_amplitude: Option<f64>,
+  ) -> Result<(), Report> {
+    let f: DistFnPlain = DistributionFunction::from_range_values((0.0, 2.0), array![1.0, 2.0, 3.0])?
+      .with_left_extrap(left)?
+      .with_right_extrap(right)?;
     let function = Distribution::Function(f);
-    let point_outside = Distribution::point(5.0, 1.0);
-    let actual = distribution_multiplication(&point_outside, &function)?;
-    assert_eq!(Distribution::empty(), actual);
+    let point = Distribution::point(t, 2.0);
+
+    let actual = distribution_multiplication(&point, &function)?;
+    // Oracle: kb/decisions/distribution-tails-and-arithmetic.md#L74-L84 defines Constant
+    // as evaluable outside the grid and Zero/Error as carrying no product there.
+    let expected = expected_amplitude.map_or_else(Distribution::empty, |amplitude| Distribution::point(t, amplitude));
+    assert_eq!(expected, actual);
     Ok(())
   }
 

--- a/packages/treetime-distribution/src/distribution_ops/multiply.rs
+++ b/packages/treetime-distribution/src/distribution_ops/multiply.rs
@@ -85,11 +85,18 @@ fn multiply_point_function<Y: YAxisPolicy>(
   func: &DistributionFunction<f64, Y>,
 ) -> Result<Distribution<Y>, Report> {
   let t = point.t();
-  // The product with a finite-support function is zero where the point lies outside the
-  // function support, so return an empty distribution rather than evaluating the function
-  // out of support. This matches multiply_point_range and multiply_point_point.
-  if t < func.x_min() || t > func.x_max() {
-    return Ok(Distribution::empty());
+  let tail = if t < func.x_min() {
+    Some(func.left_extrap())
+  } else if t > func.x_max() {
+    Some(func.right_extrap())
+  } else {
+    None
+  };
+  if let Some(tail) = tail {
+    match tail {
+      BoundaryBehavior::Constant => {},
+      BoundaryBehavior::Error | BoundaryBehavior::Zero => return Ok(Distribution::empty()),
+    }
   }
   let func_value = func.interp(t)?;
   let amplitude = Y::multiply(point.amplitude(), func_value);


### PR DESCRIPTION
`fix/distribution-point-function-tails` -> `fix/multiply-honor-tails`

Resolve:

- [kb/issues/N-distribution-multiply-point-function-tail-blind.md](https://github.com/neherlab/treetime/blob/68c5f9960f3f6d92f7a0361149c63e3ee46dcdd7/kb/issues/N-distribution-multiply-point-function-tail-blind.md)

Update:

- [kb/decisions/distribution-tails-and-arithmetic.md](https://github.com/neherlab/treetime/blob/bd1ba318efc7f785bf1f6d4a526dadb9b7280775/kb/decisions/distribution-tails-and-arithmetic.md): define tail behavior for point and Function multiplication

- Depends on: #891

Point multiplication previously treated every location outside a Function's finite grid as empty support. That discarded declared `Constant` tails even though the other multiplication variants already evaluate them.

`fn multiply_point_function()` now selects the boundary behavior for the point's side, evaluates `Constant` tails at the boundary value, and returns `Empty` for `Error` or `Zero` tails. [[src](https://github.com/neherlab/treetime/blob/bd1ba318efc7f785bf1f6d4a526dadb9b7280775/packages/treetime-distribution/src/distribution_ops/multiply.rs#L83-L107)]

This preserves each boundary policy's meaning: `Constant` remains evaluable, `Zero` contributes no product support, and `Error` remains undefined outside the grid. It also makes point products follow the approved per-side multiplication contract. [[src](https://github.com/neherlab/treetime/blob/bd1ba318efc7f785bf1f6d4a526dadb9b7280775/kb/decisions/distribution-tails-and-arithmetic.md#L74-L84)]

### Work items

- [x] Honor left and right Function tails in `fn multiply_point_function()` [[src](https://github.com/neherlab/treetime/blob/bd1ba318efc7f785bf1f6d4a526dadb9b7280775/packages/treetime-distribution/src/distribution_ops/multiply.rs#L83-L107)]
- [x] Cover both sides and every boundary behavior with parameterized tests [[src](https://github.com/neherlab/treetime/blob/bd1ba318efc7f785bf1f6d4a526dadb9b7280775/packages/treetime-distribution/src/distribution_core/__tests__/test_boundary_behavior.rs#L77-L102)]