### PR TITLE
fix: properly account for polytomies and the multiplicity of states i…

### DIFF
--- a/kb/decisions/ancestral-fitch-plurality-on-multifurcations.md
+++ b/kb/decisions/ancestral-fitch-plurality-on-multifurcations.md
@@ -1,0 +1,125 @@
+# Fitch reconstruction uses the plurality recurrence on multifurcations
+
+v1 resolves a node's parsimony state set by intersecting its children's state sets and, when that
+intersection is empty, retaining the states held by the greatest number of children. v0 retains
+their union instead. On nodes with three or more children the union can keep states that are not of
+minimum cost, so v1 produces different — and strictly more parsimonious — ancestral sequences and
+mutation placements.
+
+**Type**: Intentional scientific-correctness divergence from v0. Approved.
+
+## Why v0's recurrence is wrong here
+
+Let `g_v(x)` be the minimum number of changes in the subtree at `v` given state `x` at `v`, let
+`M_i = min_y g_{c_i}(y)` be child `i`'s own minimum, and let `S_i` be its optimal set. A child
+contributes `M_i` when `x ∈ S_i` and exactly `M_i + 1` otherwise, so
+
+```text
+g_v(x) = Σ_i M_i + k − count(x),   count(x) = #{ i : x ∈ S_i }
+```
+
+Minimising `g_v` therefore maximises `count`, and the node's minimum-cost set is
+`{ x : count(x) = max }`.
+
+Fitch's intersect-or-unite recurrence coincides with this for one or two children — a non-empty
+intersection has `count = k`, and an empty one forces `max count = 1`, making the union the
+plurality — but not beyond. For children `{C}`, `{C}`, `{A}` the union is `{A,C}`, which admits `A`
+at a cost of two changes where `C` costs one.
+
+The defect surfaces at a root polytomy because no parent state constrains the choice there. At
+non-root nodes the forward pass prefers the parent's state whenever it is in the node's set, which
+masks the error whenever the parent happens to be right.
+
+## Measured effect
+
+A 200-leaf root polytomy over real Ebola sequences (197,209 sites), scored over the 43,885
+positions where every leaf is canonical:
+
+| | substitutions |
+| --- | --- |
+| v0 recurrence (union + lowest byte) | 15,477 |
+| plurality | 1,065 |
+
+1,065 is the true optimum, computed independently from the alignment (`Σ_pos k − max_count`), and
+the committed root state is of minimum cost at every one of those positions. The two disagree at
+only 77 positions, but each costs up to `k − 1` extra changes, hence the 93% reduction. Across all
+positions including gaps and ambiguity codes the totals are 58,930 against 4,364.
+
+On a tree with a bifurcating root the output is unchanged: the 967-leaf dataset in `dbg/` produces
+byte-identical mutation sets before and after, because its root has degree 2 and its internal
+polytomies are masked by the parent-state preference.
+
+## Performance
+
+No measurable change. Alternating A/B over seven paired runs of `ancestral --method-anc parsimony`
+on 967 leaves × 197,209 sites: 2.043 s against 2.046 s median, `+0.1%`.
+
+The cost is dominated by the discovery scan, which is unchanged: comparing every child against
+every position is `O(children · length)` and irreducible while nodes store dense sequences.
+Instrumented, `fitch_backward` spent 374 ms of CPU in discovery against 8.7 ms in resolution, over
+3,297 candidate positions across 471 internal nodes. Resolution is `O(children)` per candidate
+rather than `O(1)` per disagreeing child, but candidates are far too few for that to matter.
+
+## Implementation
+
+The recurrence needs each child's optimal set plus a per-state count, not Sankoff cost vectors, so
+the stored representation remains a single `StateSet` bitset and `SparseSeqInfo` is unchanged.
+`StateSet::from_plurality` counts over the union of the input sets, whose width is bounded by the
+alphabet, avoiding both a fixed-width counter array and its per-call zeroing.
+
+The backward pass was reordered into discovery followed by resolution:
+
+- `discover_fixed_disagreements_backward` keeps the child-major loop over whole sequences, writes
+  the agreed state where children agree, and flags a position with `VARIABLE_CHAR` on the first
+  disagreement. It builds no state sets and performs no map lookups.
+- `resolve_variable_positions_backward` then runs over the flagged positions merged with the
+  children's `fitch.variable` keys, recomputing each from every child.
+
+Previously these ran in the opposite order and both folded child states into the same `variable`
+map, because the second had no `VARIABLE_CHAR` guard. That double-counted children at any position
+both observed, which is idempotent under a union and wrong under a count.
+
+Note that leaves do carry `fitch.variable` entries: `SparseNodePartition::new` populates them for
+every position holding a true IUPAC ambiguity code. Only `N` and `-` are excluded, via
+`unknown` / `gaps` / `non_char`.
+
+## Tie-breaking
+
+Where several states remain equally parsimonious, the choice is free with respect to cost. It is
+resolved deterministically, for reproducibility and stable golden masters, by
+`Alphabet::first_canonical`, which orders by the configured alphabet rather than by byte value.
+`StateSet::get_one()` orders by byte and is retained for callers that want that; it is no longer
+used to commit a state to a sequence. For `nuc` the two coincide (`A`, `C`, `G`, `T`), so this part
+changes nothing there. For `aa` they differ: canonical order lists `*` last while its byte (42)
+sorts below `A`, so `get_one()` would commit a stop codon.
+
+The forward pass's preference for the parent's state when it lies in the node's set is unchanged.
+Given a minimal state set that preference is provably optimal rather than heuristic — matching the
+parent avoids a change on the edge while any other member costs exactly one more — and it is what
+pushes mutations toward the tips.
+
+## Consequences
+
+- `--model infer` derives GTR parameters from Fitch parsimony substitution counts, so the inferred
+  model shifts on trees with multifurcations and marginal output shifts with it.
+- Sparse marginal initialisation seeds `state` from `fitch.chosen_state` with a
+  `profile.get_one()` fallback, so both of its inputs change.
+- `test_fitch_polytomy` was rebaselined. At position 4 its `CDE` polytomy has child states
+  `{T}`, `{T}`, `{C}`; the union committed `C` for three changes, the plurality commits `T` for
+  two, which is minimal given that `B`, `C`/`D` and `E` hold three distinct states in separate
+  subtrees.
+
+## Code references
+
+- `packages/treetime-primitives/src/bitset128.rs`: `BitSet128::from_plurality`
+- `packages/treetime/src/alphabet/alphabet.rs`: `Alphabet::first_canonical`
+- `packages/treetime/src/ancestral/fitch_sub.rs`: `discover_fixed_disagreements_backward`,
+  `resolve_variable_positions_backward`, `choose_state`
+- `packages/treetime/src/ancestral/fitch.rs`: discovery-then-resolution ordering
+- `packages/legacy/treetime/treetime/treeanc.py#L638-L655`: v0's intersect-or-unite recurrence
+
+## Related
+
+- Source issue: [kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md](../issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md)
+- Ticket: [kb/tickets/ancestral-fitch-plurality-recurrence-on-multifurcations.md](../tickets/ancestral-fitch-plurality-recurrence-on-multifurcations.md)
+- Hartigan, John A. 1973. "Minimum mutation fits to a given tree." _Biometrics_ 29:53-65. https://doi.org/10.2307/2529676

--- a/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md
+++ b/kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md
@@ -6,6 +6,16 @@ For a root polytomy with child states $C$, $C$, and $A$, the intersection is emp
 
 V0 uses the same intersection-or-union recurrence [packages/legacy/treetime/treetime/treeanc.py#L638-L655](../../packages/legacy/treetime/treetime/treeanc.py#L638-L655). Correcting v1 therefore improves scientific correctness while intentionally diverging from the reference output, which requires explicit approval.
 
+## Second affected site
+
+`resolve_variable_positions_backward` is not the only path. It iterates only positions drawn from the children's `fitch.variable` keys, which covers positions where some child carries a true IUPAC ambiguity code (`SparseNodePartition::new` populates `fitch.variable` whenever `Alphabet::is_ambiguous` holds, so leaves have entries too). Positions where children hold differing canonical fixed states and no child is variable appear in no child's `fitch.variable` and are discovered only by `resolve_fixed_positions_backward` [packages/treetime/src/ancestral/fitch_sub.rs#L86-L110](../../packages/treetime/src/ancestral/fitch_sub.rs#L86-L110), which performs no intersection at all — it accumulates a plain union of differing child states.
+
+The two functions also both fold child states into the same `variable` map, so a position observed by both has its children counted twice. That is idempotent under a bitwise union and unsafe under any count-based rule, which makes merging them a prerequisite for the fix rather than a cleanup.
+
+Measured on a five-leaf star with `l1..l4 = CGTT` and `l5 = AACA`: parsimony root `AACA` (16 changes) against marginal root `CGTT` (4 changes, minimum). With an internal polytomy (`(out,(l1..l5)inner)`, `out = AACA`), `inner` resolves to `AACA` at cost 4 where the minimum is 2, so the defect is not confined to the root — at non-root nodes the parent-state preference in the forward pass masks it whenever the parent happens to be right.
+
+`get_one()` selects by lowest ASCII byte and never consults the alphabet. For `nuc` this coincides with canonical `A,C,G,T`; for `aa` it does not, since canonical order lists `*` last but `*` is ASCII 42, below `A`.
+
 ## Potential solutions
 
 - O1. Use an exact finite-state Sankoff recurrence at nodes with three or more children and retain every minimum-cost parent state; keep the binary Fitch fast path.
@@ -14,7 +24,13 @@ V0 uses the same intersection-or-union recurrence [packages/legacy/treetime/tree
 
 ## Recommendation
 
-Approve O1 as an intentional v0 divergence. Validate it with the explicit $C,C,A$ counterexample, exhaustive finite-state scores on generated multifurcations, and a golden comparison that records the approved difference. No implementation ticket is ready until that scientific-output divergence is approved.
+O1, approved as an intentional v0 divergence. Validate it with the explicit $C,C,A$ counterexample, exhaustive finite-state scores on generated multifurcations, and a golden comparison that records the approved difference.
+
+O1 does not require full Sankoff cost vectors. With unit costs, `g_v(x) = C + k − count(x)` where `count(x)` is the number of children whose optimal set contains $x$ and `C = Σ_i M_i`, because a child contributes `M_i` when $x$ is in its optimal set and exactly `M_i + 1` otherwise. Hence the node's minimum-cost set is `argmax_x count(x)`, which needs only each child's optimal set plus a per-state count. The stored per-node representation remains a single `StateSet` and `SparseSeqInfo` is unchanged. The same identity shows the existing code is already exact when the intersection is non-empty (its members attain `count = k`) and when `k = 2` (an empty intersection forces `max count = 1`, so the union is the plurality set), so new behaviour is confined to `k ≥ 3` with an empty intersection.
+
+A simple majority does not imply a unique minimum: child sets can overlap, so counts can sum above `k`. With `k` children all carrying $\{A,C\}$ both states reach `count = k`, a tie no margin over `k/2` can break. The exact test compares against `max_{y≠x} count(y)`.
+
+Implementation is specified in [kb/tickets/ancestral-fitch-plurality-recurrence-on-multifurcations.md](../tickets/ancestral-fitch-plurality-recurrence-on-multifurcations.md).
 
 ## Related issues
 

--- a/kb/tickets/ancestral-fitch-plurality-recurrence-on-multifurcations.md
+++ b/kb/tickets/ancestral-fitch-plurality-recurrence-on-multifurcations.md
@@ -1,0 +1,152 @@
+# Use the plurality (minimum-cost) Fitch recurrence on multifurcations
+
+The sparse Fitch backward pass discards how many children carry each state. At a node with three or more children whose state sets do not share a common member, the surviving set is the union of the children's states, and the forward pass then resolves it with `StateSet::get_one()`, which returns the lowest ASCII byte. The result is a non-minimum reconstruction whose bias is visible at a root polytomy, where no parent state constrains the choice.
+
+Reproducer: a five-leaf star with `l1..l4 = CGTT` and `l5 = AACA` yields parsimony root `AACA` (16 changes) against marginal root `CGTT` (4 changes, the minimum). With an internal polytomy (`(out,(l1..l5)inner)`, `out = AACA`) the node `inner` resolves to `AACA` at cost 4 where the minimum is 2.
+
+Approved as an intentional divergence from v0, which uses the same intersection-or-union recurrence.
+
+## Correctness argument
+
+Let `g_v(x)` be the minimum number of changes in the subtree at `v` given state `x` at `v`, let `M_i = min_y g_{c_i}(y)`, and let `S_i = argmin_y g_{c_i}(y)` be child `i`'s optimal set. Then
+
+```text
+g_v(x) = Σ_i min( g_{c_i}(x), min_{y≠x} g_{c_i}(y) + 1 )
+```
+
+Under unit costs with integer `g`, the inner minimum is `M_i` when `x ∈ S_i` and exactly `M_i + 1` when `x ∉ S_i`. Therefore
+
+```text
+g_v(x) = C + k − count(x),    count(x) = #{ i : x ∈ S_i },   C = Σ_i M_i
+```
+
+so `argmin_x g_v(x) = argmax_x count(x)` and the node's optimal set is
+
+```text
+V(v) = { x : count(x) = max_y count(y) }
+```
+
+Three consequences that bound the work:
+
+1. Only each child's **optimal set** and a per-state **count** are needed. No Sankoff cost vectors. The per-node stored representation stays a single `StateSet`; `SparseSeqInfo` does not change.
+2. The existing intersection branch is **already exact**: members of a non-empty intersection have `count = k`, the maximum attainable, so `V(v) = intersection`.
+3. `k = 2` is **already exact**: an empty intersection implies `max count = 1`, so `V(v) = union`.
+
+New behaviour is therefore required only when `k ≥ 3` and the intersection is empty. `k` is the number of children carrying a character state at that position, not the node's degree.
+
+## Prerequisite: invert the pass order, split discovery from resolution
+
+The count is only well defined if each child contributes exactly once. Today it does not, because two functions both write `variable` and both fold in child states:
+
+- `resolve_variable_positions_backward` (`fitch_sub.rs:18-79`) iterates positions drawn from the children's `fitch.variable` keys and folds in **every** child's state at those positions, using `StateSet::from_char(child.sequence[pos])` for children that are not variable there.
+- `resolve_fixed_positions_backward` (`fitch_sub.rs:86-110`) then rescans **all children over the full sequence** and ORs each canonical child state into the same `variable` map.
+
+The second function has no `VARIABLE_CHAR` guard — its only skips are `parent_state == child_state` and `parent_state == NON_CHAR` — so a position already promoted by the first function falls through and has its children folded in a second time. Under a bitwise union that is idempotent and harmless; under a count it is not.
+
+The double-processing is confined to `VARIABLE_CHAR` positions. In the first function's `Unambiguous` case the second cannot re-widen: the intersection is a subset of every child's set, so a child fixed at `s` forces the resolved state to `s`, and the child that was variable carries `VARIABLE_CHAR` in its own sequence and fails `is_canonical`.
+
+Both discovery sources must survive:
+
+- Positions where some child carries a true IUPAC ambiguity code. `SparseNodePartition::new` (`partition/sparse.rs:43-49`) populates `fitch.variable` for every position where `Alphabet::is_ambiguous` holds, so **leaves do have `fitch.variable` entries**. `N` and `-` are excluded — they go to `unknown` / `gaps` / `non_char`.
+- Positions where children hold differing canonical fixed states and no child is variable. These appear in no child's `fitch.variable` and are discovered only by comparing child sequences.
+
+### Do not merge the two functions into one pass
+
+`O(L·k)` byte comparisons are irreducible while each node stores a dense `sequence: Seq` of length `L`; discovering which positions differ requires touching every byte of every child. Only a sparse per-node diff representation would beat that, which is out of scope here.
+
+The existing split exists so that the `O(L·k)` work iterates vectors and performs no position lookups. A single merged pass would have to consult `child.fitch.variable` per child per position — a `BTreeMap` lookup with poor locality inside the hot loop. Do not do this. Instead invert the order and separate discovery from resolution:
+
+**Pass A — discovery** (`resolve_fixed_positions_backward`, runs **first**). Keep the child-major vector iteration exactly as it is: two streams per pass, no map operations. Detecting a disagreement does not require all children simultaneously, only that some child differs, so the cheap incremental loop suffices. On disagreement, write `VARIABLE_CHAR` and move on. **Do not construct a `StateSet` and do not touch the `variable` map.** This removes the `variable.entry(pos).or_insert_with(...)` `BTreeMap` operations that currently sit inside the `O(L·k)` loop.
+
+**Collect.** One linear `O(L)` scan gathers `VARIABLE_CHAR` positions into a sorted `Vec<usize>`. No map, and sorted, so it merges cleanly against the children's already-sorted `fitch.variable` keys.
+
+**Pass B — resolution** (`resolve_variable_positions_backward`, runs **second**) over discovered positions ∪ children's `fitch.variable` keys. It already re-collects every child's state set from scratch at each position it visits, so it is authoritative and counts each child exactly once. The plurality rule goes here and nowhere else.
+
+Pass B visits more positions than today, but those are exactly the positions Pass A previously did map work for. Treat the net cost as unknown and measure it (see Validation); do not assume a speedup.
+
+### Landmine to remove
+
+`or_insert_with(|| stateset! {*parent_state})` (`fitch_sub.rs:104`) builds a state set from the sentinel when `*parent_state == VARIABLE_CHAR`, inserting `~` (ASCII 126) as a phantom state. It is unreachable today only because the first function always writes `VARIABLE_CHAR` and inserts into `variable` in the same step. It becomes reachable as soon as Pass A writes `VARIABLE_CHAR` without inserting, and a phantom state would then be counted. Removing this line is part of the fix.
+
+## Implementation
+
+### 1. Plurality primitive
+
+Add a function that takes a slice of `StateSet` and returns the argmax-count set.
+
+- Use a fixed-size counter array indexed by canonical alphabet index (`Alphabet::char`, `index_to_char`). Chosen over bit-sliced counting for readability and maintainability; revisit only if profiling shows it matters.
+- No heap allocation on the hot path.
+- Single pass to accumulate counts, single pass over the alphabet to select the maximum.
+- Return the set of all states attaining the maximum, so downstream tie-break policy stays in one place.
+- Assert or error on an empty input slice: at least one child is informative wherever the node is not itself `non_char`.
+
+### 2. Pass A: discovery only
+
+Reduce `resolve_fixed_positions_backward` to detection and reorder it to run before `resolve_variable_positions_backward`:
+
+- Keep the child-major loop over `sequence.iter_mut().enumerate()` and the existing `parent_state == child_state` / `NON_CHAR` / `is_canonical(child_state)` conditions.
+- `FILL_CHAR` still takes the child's state, as now.
+- On any other disagreement, set `*parent_state = VARIABLE_CHAR` and nothing else. Drop the `variable.entry(...)` line entirely; the function no longer takes or returns a `variable` map.
+- Add a `VARIABLE_CHAR` skip so an already-flagged position is not revisited by later children.
+
+Then collect flagged positions with one linear scan of `sequence` for `VARIABLE_CHAR` into a sorted `Vec<usize>`.
+
+### 3. Pass B: authoritative resolution
+
+Extend `resolve_variable_positions_backward` to take the discovered positions in addition to the children's `fitch.variable` keys, and merge the two sorted sources into its position list. Per position it already does the right thing; only the empty-intersection branch changes:
+
+1. Skip the position when the node is `non_char` there.
+2. Collect each informative child's state set exactly once — `fitch.variable` entry when present, otherwise `StateSet::from_char(child.sequence[pos])` — skipping children that are `non_char` there, and preserving the existing `edge.transmission` skip.
+3. Compute the intersection. If non-empty, use it (`Unambiguous` writes the state into `sequence`; `Ambiguous` records the set and writes `VARIABLE_CHAR`).
+4. Empty intersection with `k == 2`: use the union (identical to the plurality result; keep as a fast path).
+5. Empty intersection with `k ≥ 3`: use the plurality set.
+
+Because Pass B recomputes from all children at every position it visits, it overwrites whatever Pass A left in `sequence`, so a flagged position gets exactly one count per child. Preserve the existing outputs unchanged: the returned `variable` map, `VARIABLE_CHAR` markers in `sequence`, and `FILL_CHAR` handling.
+
+### 4. Tie-break policy
+
+Apply one policy at all three sites that currently call `get_one()`:
+
+- `resolve_root_forward` (`fitch_sub.rs:117-127`) — the root has no parent, so every member of `V(root)` is equally parsimonious.
+- `resolve_nonroot_substitutions_forward` (`fitch_sub.rs:158` and `fitch_sub.rs:167`) — reached only when the parent state is not in the node's set.
+
+Rules:
+
+- **Keep the parent-state preference exactly as it is.** Given correct downpass sets, choosing the parent's state when it is in `V(v)` is provably optimal, not a heuristic: the child contributes `M_c` for `y = p ∈ S_c` and `M_c + 1` for any other choice. This is what pushes mutations toward the tips; do not alter it.
+- **Remain deterministic.** Do not introduce randomised tie-breaking as the default; it would make output irreproducible between runs and destabilise golden masters without reducing cost.
+- **Break remaining ties by canonical alphabet order, not ASCII order.** `StateSet::get_one()` is `bits.trailing_zeros()` (`bitset128.rs:155-168`) and never consults the alphabet. For `nuc` the two coincide (canonical `A,C,G,T`). For `aa` they do not: canonical lists `*` last but `*` is ASCII 42, below `A`, so any set containing a stop codon resolves to `*`. Either add an alphabet-aware selector for these call sites or give `Alphabet` a `first_canonical(StateSet)` helper. Leave `get_one()` itself alone if other callers depend on its current meaning.
+
+## Validation
+
+- Unit: the `C, C, A` three-child case returns `{C}`, not `{A, C}`.
+- Unit: four children `{C}` and one `{A}` returns `{C}`; the reproducers above yield root `CGTT` and `inner` `CGTT`.
+- Unit: genuine ties are preserved as sets — two children `{C}` and two `{A}` returns `{A, C}` — and the tie-break then selects deterministically.
+- Unit: overlapping child sets are counted correctly — `k` children all `{A, C}` returns `{A, C}` with `count = k` for both, confirming that a simple majority over `k/2` does not imply uniqueness.
+- Unit: a leaf carrying an IUPAC ambiguity code contributes its full state set once and not twice. Construct a position that both discovery sources would have found under the old code, so a double count would change the result.
+- Unit: a position flagged by Pass A and also present in a child's `fitch.variable` appears exactly once in Pass B's merged position list.
+- Unit: no `StateSet` ever contains a sentinel (`~`, `.`, or `' '`); assert over the returned `variable` map on inputs that promote positions in both passes.
+- Benchmark: compare before and after on a tree with a large polytomy. The cost change is unknown by construction — Pass A loses its in-loop `BTreeMap` operations while Pass B gains positions — so record the measurement rather than assuming a direction. Measure by alternating the two binaries within one run; measuring the two sets minutes apart gives a spurious 30% regression from machine state alone.
+- Unit: `k == 2` results are unchanged from the current implementation across intersecting and disjoint inputs.
+- Unit: `aa` alphabet, a state set containing `*`, resolves to the lowest **canonical** state rather than `*`.
+- Property: exhaustive brute-force minimum-change scoring over generated small multifurcations (degrees 3–6, alphabet size 4) confirms the returned set equals the true minimum-cost set at every node.
+- Regression: confirm each new test fails against the current implementation before the change.
+
+## Expected output changes
+
+Recorded divergences to expect and approve, not defects:
+
+- Golden-master ancestral outputs move on any tree containing a multifurcation.
+- `--model infer` derives GTR parameters from Fitch parsimony substitution counts, so the inferred model changes and marginal output shifts with it. The probabilistic path will not stay byte-identical.
+- Sparse marginal initialisation seeds `state` from `fitch.chosen_state` with a `profile.get_one()` fallback (`partition/marginal_passes.rs:283-293`); both inputs change.
+- `fitch_cleanup` clears `variable` for internal nodes, so `run_fitch_reconstruction`'s `set_to_char` loop touches leaves only and is structurally unaffected.
+
+Record the approved divergence in `kb/decisions/` once implemented, and un-ignore or re-baseline the affected golden masters.
+
+## Status
+
+Implemented. Outcome, measurements and the approved divergence are recorded in
+[kb/decisions/ancestral-fitch-plurality-on-multifurcations.md](../decisions/ancestral-fitch-plurality-on-multifurcations.md).
+
+## Related issues
+
+- Source: [kb/issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md](../issues/M-ancestral-fitch-polytomy-recurrence-not-minimum.md) — note that this issue locates the defect only in `resolve_variable_positions_backward`; the polytomy-of-leaves path also runs through `resolve_fixed_positions_backward`, and both must change together.

--- a/packages/treetime-primitives/src/__tests__/test_bitset128.rs
+++ b/packages/treetime-primitives/src/__tests__/test_bitset128.rs
@@ -171,6 +171,169 @@ mod tests {
   }
 
   #[test]
+  fn test_bitset128_from_plurality_breaks_fitch_union_tie() {
+    // The canonical counterexample: Fitch's union fallback yields {A,C} and admits root A at a
+    // cost of two changes, while only C is minimal at one.
+    let sets = [bitset128! {'C'}, bitset128! {'C'}, bitset128! {'A'}];
+    let actual = BitSet128::from_plurality(&sets);
+    let expected = bitset128! {'C'};
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_large_majority() {
+    let sets = [
+      bitset128! {'C'},
+      bitset128! {'C'},
+      bitset128! {'C'},
+      bitset128! {'C'},
+      bitset128! {'A'},
+    ];
+    let actual = BitSet128::from_plurality(&sets);
+    let expected = bitset128! {'C'};
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_retains_genuine_tie() {
+    let sets = [bitset128! {'C'}, bitset128! {'C'}, bitset128! {'A'}, bitset128! {'A'}];
+    let actual = BitSet128::from_plurality(&sets);
+    let expected = bitset128! {'A', 'C'};
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_overlapping_sets_tie_above_half() {
+    // Overlapping sets let counts sum above the number of sets, so both states reach count = 5.
+    // A simple majority over half the sets therefore cannot imply a unique result.
+    let sets = [bitset128! {'A', 'C'}; 5];
+    let actual = BitSet128::from_plurality(&sets);
+    let expected = bitset128! {'A', 'C'};
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_partial_overlap() {
+    // count(A) = 3, count(C) = 2, count(G) = 1.
+    let sets = [bitset128! {'A', 'C'}, bitset128! {'A', 'C'}, bitset128! {'A', 'G'}];
+    let actual = BitSet128::from_plurality(&sets);
+    let expected = bitset128! {'A'};
+    assert_eq!(actual, expected);
+  }
+
+  #[rstest]
+  #[case(bitset128! {'A', 'C'}, bitset128! {'G', 'T'}, bitset128! {'A', 'C', 'G', 'T'})]
+  #[case(bitset128! {'A', 'C'}, bitset128! {'C', 'G'}, bitset128! {'C'})]
+  #[case(bitset128! {'A'}, bitset128! {'A'}, bitset128! {'A'})]
+  #[case(bitset128! {'A'}, bitset128! {'C'}, bitset128! {'A', 'C'})]
+  fn test_bitset128_from_plurality_two_sets_matches_fitch(
+    #[case] a: BitSet128,
+    #[case] b: BitSet128,
+    #[case] expected: BitSet128,
+  ) {
+    // With one or two sets the plurality coincides with intersect-or-unite, so the existing
+    // bifurcating behaviour is preserved exactly.
+    let sets = [a, b];
+    let intersection = BitSet128::from_intersection(sets);
+    let fitch = if intersection.is_empty() {
+      BitSet128::from_union(sets)
+    } else {
+      intersection
+    };
+    assert_eq!(BitSet128::from_plurality(&sets), expected);
+    assert_eq!(BitSet128::from_plurality(&sets), fitch);
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_single_set() {
+    let sets = [bitset128! {'A', 'G'}];
+    let actual = BitSet128::from_plurality(&sets);
+    let expected = bitset128! {'A', 'G'};
+    assert_eq!(actual, expected);
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_empty_input() {
+    let actual = BitSet128::from_plurality(&[]);
+    assert_eq!(actual, bitset128! {});
+  }
+
+  #[test]
+  fn test_bitset128_from_plurality_all_empty_sets() {
+    let sets = [bitset128! {}; 3];
+    let actual = BitSet128::from_plurality(&sets);
+    assert_eq!(actual, bitset128! {});
+  }
+
+  /// Exhaustive check against a brute-force minimisation of the parsimony cost.
+  ///
+  /// For a star tree whose children have optimal sets `S_i`, the cost of assigning state `x` to
+  /// the parent is `Σ_i [x ∉ S_i]`. This enumerates every combination of non-empty subsets of a
+  /// four-letter alphabet, computes the true minimum-cost state set directly from that
+  /// definition, and requires `from_plurality` to return exactly it.
+  #[rstest]
+  #[case(3)]
+  #[case(4)]
+  fn test_bitset128_from_plurality_matches_brute_force_minimum(#[case] n_children: usize) {
+    const STATES: [char; 4] = ['A', 'C', 'G', 'T'];
+
+    // All 15 non-empty subsets of a four-letter alphabet.
+    let subsets: Vec<BitSet128> = (1_u8..16)
+      .map(|mask| {
+        let mut set = BitSet128::new();
+        for (i, state) in STATES.iter().enumerate() {
+          if mask & (1 << i) != 0 {
+            set.insert(*state);
+          }
+        }
+        set
+      })
+      .collect();
+
+    let mut n_cases = 0_usize;
+    let mut indices = vec![0_usize; n_children];
+    loop {
+      let sets: Vec<BitSet128> = indices.iter().map(|&i| subsets[i]).collect();
+
+      // Brute force: cost of each state, then every state attaining the minimum.
+      let costs: Vec<usize> = STATES
+        .iter()
+        .map(|state| sets.iter().filter(|set| !set.contains(*state)).count())
+        .collect();
+      let min_cost = *costs.iter().min().unwrap();
+      let mut expected = BitSet128::new();
+      for (i, state) in STATES.iter().enumerate() {
+        if costs[i] == min_cost {
+          expected.insert(*state);
+        }
+      }
+
+      assert_eq!(
+        BitSet128::from_plurality(&sets),
+        expected,
+        "plurality disagrees with brute-force minimum for sets {sets:?}"
+      );
+      n_cases += 1;
+
+      // Odometer over subset indices.
+      let mut d = 0;
+      while d < n_children {
+        indices[d] += 1;
+        if indices[d] < subsets.len() {
+          break;
+        }
+        indices[d] = 0;
+        d += 1;
+      }
+      if d == n_children {
+        break;
+      }
+    }
+
+    assert_eq!(n_cases, subsets.len().pow(n_children as u32), "enumerated every case");
+  }
+
+  #[test]
   fn test_bitset128_difference() {
     let a = bitset128! {'a', 'b', 'c'};
     let b = bitset128! {'b', 'c', 'x'};

--- a/packages/treetime-primitives/src/bitset128.rs
+++ b/packages/treetime-primitives/src/bitset128.rs
@@ -120,6 +120,43 @@ impl BitSet128 {
       .map_or_else(Self::new, |bits| Self { bits })
   }
 
+  /// States contained in the greatest number of the given sets.
+  ///
+  /// Under unit-cost parsimony this is the minimum-change state set of a node whose children
+  /// have the given optimal sets. Writing `g(x)` for the minimum number of changes in the
+  /// subtree given state `x` at the node, `M_i` for child `i`'s own minimum and `S_i` for its
+  /// optimal set, a child contributes `M_i` when `x ∈ S_i` and exactly `M_i + 1` otherwise, so
+  ///
+  /// ```text
+  /// g(x) = Σ_i M_i + k − count(x),   count(x) = #{ i : x ∈ S_i }
+  /// ```
+  ///
+  /// Minimising `g` therefore maximises `count`. Fitch's intersect-or-unite recurrence agrees
+  /// with this for one or two sets, but for three or more it can retain states that are not of
+  /// minimum cost: for `{C}`, `{C}`, `{A}` the union is `{A,C}` while only `{C}` is minimal.
+  ///
+  /// Note that a simple majority does not imply a unique result. Sets may overlap, so counts can
+  /// sum above `k`: given `k` sets all equal to `{A,C}`, both states reach `count = k`.
+  ///
+  /// Returns the empty set when `sets` is empty or all its members are empty.
+  pub fn from_plurality(sets: &[Self]) -> Self {
+    // Only states present in at least one set can attain the maximum, and there are at most as
+    // many of those as the alphabet is wide, so counting over the union avoids both a
+    // fixed-width counter array and its per-call zeroing.
+    let mut best = Self::new();
+    let mut best_count = 0_usize;
+    for state in Self::from_union(sets).iter() {
+      let count = sets.iter().filter(|set| set.contains(state)).count();
+      if count > best_count {
+        best_count = count;
+        best = Self::from_char(state);
+      } else if count == best_count {
+        best.insert(state);
+      }
+    }
+    best
+  }
+
   pub fn is_disjoint(&self, other: &Self) -> bool {
     (self.bits & other.bits) == 0
   }

--- a/packages/treetime/src/alphabet/alphabet.rs
+++ b/packages/treetime/src/alphabet/alphabet.rs
@@ -265,6 +265,20 @@ impl Alphabet {
     self.canonical.iter()
   }
 
+  /// First state of `set` in canonical alphabet order, or `None` if `set` holds no canonical state.
+  ///
+  /// Use this, rather than `StateSet::get_one()`, whenever an arbitrary member of a state set has
+  /// to be committed to a sequence. `get_one()` returns the lowest ASCII byte and never consults
+  /// the alphabet: for `nuc` that happens to coincide with canonical order (`A`, `C`, `G`, `T`),
+  /// but for `aa` it does not, since canonical order lists `*` last while its byte (42) sorts
+  /// below `A`.
+  pub fn first_canonical(&self, set: StateSet) -> Option<AsciiChar> {
+    // Iterates `index_to_char`, which is built from `config.canonical` and so preserves the
+    // configured order. `canonical()` cannot be used here: it iterates a `StateSet`, which yields
+    // ascending byte order and would reproduce exactly the behaviour this method exists to avoid.
+    self.index_to_char.iter().copied().find(|c| set.contains(*c))
+  }
+
   /// Check is character is canonical
   pub fn is_canonical(&self, c: AsciiChar) -> bool {
     self.canonical.contains(c)

--- a/packages/treetime/src/ancestral/__tests__/test_fitch.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch.rs
@@ -559,15 +559,23 @@ mod tests {
     let partition = partitions[0].read_arc();
 
     // Verify substitutions on edges
+    //
+    // Position 4 exercises the multifurcation recurrence. C and D read `T` there while E reads
+    // `C`, so the child state sets are {T}, {T}, {C}: no state is shared by all three. Fitch's
+    // union fallback would retain {T,C} and commit `C`, charging one substitution to each of
+    // `CDE->C` and `CDE->D` plus `A4C` on `root->CDE`, for three changes. The plurality is {T},
+    // which commits `T` and charges only `CDE->E` plus `A4T` on `root->CDE`, for two. Two is
+    // minimal: B reads `A`, C and D read `T`, and E reads `C`, three distinct states in separate
+    // subtrees, so at least two changes are unavoidable.
     let actual_subs = collect_edge_subs(&graph, &partition);
     let expected_subs = btreemap! {
       o!("AB->A")     => vec![],
       o!("AB->B")     => vec![],
       o!("root->AB")  => vec![],
-      o!("CDE->C")    => vec![o!("C4T")],
-      o!("CDE->D")    => vec![o!("C4T")],
-      o!("CDE->E")    => vec![],
-      o!("root->CDE") => vec![o!("C2G"), o!("A4C")],
+      o!("CDE->C")    => vec![],
+      o!("CDE->D")    => vec![],
+      o!("CDE->E")    => vec![o!("T4C")],
+      o!("root->CDE") => vec![o!("C2G"), o!("A4T")],
     };
     assert_eq!(expected_subs, actual_subs);
 

--- a/packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs
+++ b/packages/treetime/src/ancestral/__tests__/test_fitch_sub.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-  use crate::alphabet::alphabet::{Alphabet, FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
+  use crate::alphabet::alphabet::{Alphabet, AlphabetName, FILL_CHAR, NON_CHAR, VARIABLE_CHAR};
   use crate::ancestral::fitch_sub::{
-    finalize_sequence_forward, resolve_fixed_positions_backward, resolve_nonroot_substitutions_forward,
+    discover_fixed_disagreements_backward, finalize_sequence_forward, resolve_nonroot_substitutions_forward,
     resolve_root_forward, resolve_variable_positions_backward,
   };
   use crate::partition::sparse::{FitchSeqDistribution, SparseEdgePartition, SparseSeqInfo};
@@ -47,7 +47,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     assert!(variable.is_empty(), "No variable positions when children agree");
   }
@@ -61,7 +61,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     assert!(variable.is_empty(), "Fixed-position disagreement is not handled here");
     assert_eq!(sequence[1], FILL_CHAR, "Position 1 unchanged by variable pass");
@@ -78,7 +78,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     // intersection {A,G} ∩ {A,C} = {A} is a singleton: resolved immediately, not stored as variable
     assert!(variable.is_empty());
@@ -96,7 +96,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     // intersection {A,G,C} ∩ {A,C} = {A,C}: ambiguous, stored as variable
     assert_eq!(variable.len(), 1);
@@ -117,7 +117,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     assert_eq!(variable.len(), 1);
     assert!(variable[&0].contains(b'A'));
@@ -136,7 +136,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     assert!(variable.is_empty(), "Singleton intersection resolved immediately");
     assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'A'));
@@ -154,7 +154,7 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let variable = resolve_variable_positions_backward(&children, &[], &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &[], &[], &mut sequence);
 
     // child1 is in non_char at pos 0, so only child0's {A,G} contributes
     assert_eq!(variable.len(), 1);
@@ -162,24 +162,23 @@ mod tests {
     assert!(variable[&0].contains(b'G'));
   }
 
-  // --- resolve_fixed_positions_backward ---
+  // --- discover_fixed_disagreements_backward ---
 
   #[test]
-  fn test_fitch_sub_fixed_backward_sets_fill_char() {
+  fn test_fitch_sub_discover_sets_fill_char() {
     let child0 = make_seq_info("ACGT");
     let edge0 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let mut variable = BTreeMap::new();
-    resolve_fixed_positions_backward(&children, &NUC_ALPHABET, &mut sequence, &mut variable);
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
 
     assert_eq!(sequence.as_str(), "ACGT");
-    assert!(variable.is_empty());
+    assert!(discovered.is_empty());
   }
 
   #[test]
-  fn test_fitch_sub_fixed_backward_promotes_to_variable() {
+  fn test_fitch_sub_discover_flags_disagreement() {
     let child0 = make_seq_info("ACGT");
     let child1 = make_seq_info("GCGT");
     let edge0 = make_edge();
@@ -187,28 +186,191 @@ mod tests {
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0), (&child1, &edge1)];
 
     let mut sequence = seq![FILL_CHAR; 4];
-    let mut variable = BTreeMap::new();
-    resolve_fixed_positions_backward(&children, &NUC_ALPHABET, &mut sequence, &mut variable);
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
 
-    assert_eq!(variable.len(), 1);
-    assert!(variable[&0].contains(b'A'));
-    assert!(variable[&0].contains(b'G'));
+    assert_eq!(discovered, vec![0], "only the disagreeing position is reported");
     assert_eq!(sequence[0], VARIABLE_CHAR);
     assert_eq!(sequence[1], AsciiChar::from_byte_unchecked(b'C'));
   }
 
   #[test]
-  fn test_fitch_sub_fixed_backward_skips_non_char() {
+  fn test_fitch_sub_discover_skips_non_char() {
     let child0 = make_seq_info("ACGT");
     let edge0 = make_edge();
     let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![(&child0, &edge0)];
 
     let mut sequence = seq![NON_CHAR; 4];
-    let mut variable = BTreeMap::new();
-    resolve_fixed_positions_backward(&children, &NUC_ALPHABET, &mut sequence, &mut variable);
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
 
     assert_eq!(sequence[0], NON_CHAR, "NON_CHAR positions are skipped");
-    assert!(variable.is_empty());
+    assert!(discovered.is_empty());
+  }
+
+  #[test]
+  fn test_fitch_sub_discover_reports_position_once_for_many_children() {
+    // A position is flagged on the first disagreement and skipped by every later child, so it is
+    // reported exactly once however many children differ.
+    let child0 = make_seq_info("A");
+    let child1 = make_seq_info("C");
+    let child2 = make_seq_info("G");
+    let child3 = make_seq_info("T");
+    let edges = [make_edge(), make_edge(), make_edge(), make_edge()];
+    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> = vec![
+      (&child0, &edges[0]),
+      (&child1, &edges[1]),
+      (&child2, &edges[2]),
+      (&child3, &edges[3]),
+    ];
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+
+    assert_eq!(discovered, vec![0]);
+  }
+
+  // --- plurality resolution on multifurcations ---
+
+  /// Builds `n` single-position children, each fixed at the given state.
+  fn fixed_children(states: &[&str]) -> Vec<SparseSeqInfo> {
+    states.iter().map(|s| make_seq_info(s)).collect()
+  }
+
+  fn as_children<'a>(
+    infos: &'a [SparseSeqInfo],
+    edges: &'a [SparseEdgePartition],
+  ) -> Vec<(&'a SparseSeqInfo, &'a SparseEdgePartition)> {
+    infos.iter().zip(edges.iter()).collect()
+  }
+
+  #[test]
+  fn test_fitch_sub_plurality_three_children_c_c_a() {
+    // Fitch's union fallback would give {A,C}, which admits the non-minimal root state A.
+    let infos = fixed_children(&["C", "C", "A"]);
+    let edges = vec![make_edge(), make_edge(), make_edge()];
+    let children = as_children(&infos, &edges);
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    assert_eq!(variable[&0], stateset! {b'C'}, "only C is of minimum cost");
+    assert_eq!(sequence[0], VARIABLE_CHAR);
+  }
+
+  #[test]
+  fn test_fitch_sub_plurality_five_children_four_to_one() {
+    let infos = fixed_children(&["C", "C", "C", "C", "A"]);
+    let edges = vec![make_edge(), make_edge(), make_edge(), make_edge(), make_edge()];
+    let children = as_children(&infos, &edges);
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    assert_eq!(variable[&0], stateset! {b'C'});
+  }
+
+  #[test]
+  fn test_fitch_sub_plurality_retains_genuine_tie() {
+    let infos = fixed_children(&["C", "C", "A", "A"]);
+    let edges = vec![make_edge(), make_edge(), make_edge(), make_edge()];
+    let children = as_children(&infos, &edges);
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    assert_eq!(variable[&0], stateset! {b'A', b'C'}, "an even split stays ambiguous");
+  }
+
+  #[test]
+  fn test_fitch_sub_plurality_two_children_unchanged() {
+    // Bifurcations must keep the intersect-or-unite result exactly.
+    let infos = fixed_children(&["C", "A"]);
+    let edges = vec![make_edge(), make_edge()];
+    let children = as_children(&infos, &edges);
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    assert_eq!(variable[&0], stateset! {b'A', b'C'});
+  }
+
+  #[test]
+  fn test_fitch_sub_plurality_counts_ambiguous_leaf_exactly_once() {
+    // Position 0 is reachable from both discovery sources: child2 carries an IUPAC code, so the
+    // position is in its `fitch.variable`, and the canonical states of child0 and child1 differ,
+    // so the discovery pass also flags it. Counting child0 twice would make count(C) = 2 beat
+    // count(A) = count(G) = 1 and wrongly collapse the result to {C}.
+    let mut child0 = make_seq_info("C");
+    let mut child1 = make_seq_info("A");
+    let mut child2 = make_seq_info("R");
+    child2
+      .fitch
+      .variable
+      .insert(0, NUC_ALPHABET.char_to_set(AsciiChar::from_byte_unchecked(b'R'))); // R = {A, G}
+    child0.fitch.variable.clear();
+    child1.fitch.variable.clear();
+    let edges = [make_edge(), make_edge(), make_edge()];
+    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> =
+      vec![(&child0, &edges[0]), (&child1, &edges[1]), (&child2, &edges[2])];
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    assert_eq!(discovered, vec![0], "the fixed disagreement is discovered");
+
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    // count(C) = 1 (child0), count(A) = 2 (child1, child2), count(G) = 1 (child2).
+    assert_eq!(variable[&0], stateset! {b'A'});
+  }
+
+  #[test]
+  fn test_fitch_sub_plurality_position_from_both_sources_resolved_once() {
+    let mut child0 = make_seq_info("C");
+    child0.fitch.variable.insert(0, stateset! {b'C'});
+    let child1 = make_seq_info("A");
+    let child2 = make_seq_info("A");
+    let edges = [make_edge(), make_edge(), make_edge()];
+    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> =
+      vec![(&child0, &edges[0]), (&child1, &edges[1]), (&child2, &edges[2])];
+
+    let mut sequence = seq![FILL_CHAR; 1];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    assert_eq!(variable.len(), 1, "the position appears once in the merged list");
+    assert_eq!(variable[&0], stateset! {b'A'}, "count(A) = 2 beats count(C) = 1");
+  }
+
+  #[test]
+  fn test_fitch_sub_resolution_never_stores_sentinel_states() {
+    // The discovery pass writes VARIABLE_CHAR into `sequence`; no sentinel may ever reach a
+    // StateSet, whether from that marker or from a gap or fill byte.
+    let mut child0 = make_seq_info("CA");
+    child0.fitch.variable.insert(1, stateset! {b'A', b'G'});
+    let child1 = make_seq_info("AA");
+    let child2 = make_seq_info("GA");
+    let edges = [make_edge(), make_edge(), make_edge()];
+    let children: Vec<(&SparseSeqInfo, &SparseEdgePartition)> =
+      vec![(&child0, &edges[0]), (&child1, &edges[1]), (&child2, &edges[2])];
+
+    let mut sequence = seq![FILL_CHAR; 2];
+    let discovered = discover_fixed_disagreements_backward(&children, &NUC_ALPHABET, &mut sequence);
+    let variable = resolve_variable_positions_backward(&children, &discovered, &[], &mut sequence);
+
+    for (pos, states) in &variable {
+      for state in states.chars() {
+        assert!(
+          NUC_ALPHABET.is_canonical(state) || NUC_ALPHABET.is_ambiguous(state),
+          "position {pos} holds non-alphabet state {state:?}"
+        );
+        assert_ne!(state, VARIABLE_CHAR);
+        assert_ne!(state, FILL_CHAR);
+        assert_ne!(state, NON_CHAR);
+      }
+    }
   }
 
   // --- resolve_root_forward ---
@@ -219,14 +381,45 @@ mod tests {
     let variable = btreemap! { 0_usize => stateset! {b'A', b'G'} };
     let mut chosen_state = BTreeMap::new();
 
-    resolve_root_forward(&mut sequence, &variable, &mut chosen_state);
+    resolve_root_forward(&mut sequence, &variable, &mut chosen_state, &NUC_ALPHABET);
 
     assert_eq!(
       sequence[0],
       AsciiChar::from_byte_unchecked(b'A'),
-      "get_one picks alphabetically first"
+      "ties break to the first canonical state"
     );
     assert_eq!(chosen_state[&0], AsciiChar::from_byte_unchecked(b'A'));
+  }
+
+  #[test]
+  fn test_fitch_sub_root_forward_tie_break_uses_canonical_order_not_ascii() {
+    // In the amino-acid alphabet canonical order lists `*` last, but its byte (42) sorts below
+    // `A` (65). Selecting by byte would commit the stop codon; canonical order gives `A`.
+    let aa = Alphabet::new(AlphabetName::Aa).unwrap();
+    let mut sequence = Seq::try_from_str("~").unwrap();
+    let variable = btreemap! { 0_usize => stateset! {b'*', b'A', b'C'} };
+    let mut chosen_state = BTreeMap::new();
+
+    resolve_root_forward(&mut sequence, &variable, &mut chosen_state, &aa);
+
+    assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'A'));
+    assert_eq!(chosen_state[&0], AsciiChar::from_byte_unchecked(b'A'));
+    assert_eq!(
+      variable[&0].get_one(),
+      AsciiChar::from_byte_unchecked(b'*'),
+      "get_one would have selected the stop codon"
+    );
+  }
+
+  #[test]
+  fn test_fitch_sub_root_forward_tie_break_is_deterministic() {
+    let variable = btreemap! { 0_usize => stateset! {b'A', b'C', b'G', b'T'} };
+    for _ in 0..16 {
+      let mut sequence = Seq::try_from_str("~").unwrap();
+      let mut chosen_state = BTreeMap::new();
+      resolve_root_forward(&mut sequence, &variable, &mut chosen_state, &NUC_ALPHABET);
+      assert_eq!(sequence[0], AsciiChar::from_byte_unchecked(b'A'));
+    }
   }
 
   #[test]
@@ -237,7 +430,7 @@ mod tests {
     let variable = BTreeMap::new();
     let mut chosen_state = BTreeMap::new();
 
-    resolve_root_forward(&mut sequence, &variable, &mut chosen_state);
+    resolve_root_forward(&mut sequence, &variable, &mut chosen_state, &NUC_ALPHABET);
 
     assert!(chosen_state.is_empty(), "No variable substitutions to resolve");
     assert_eq!(sequence, Seq::try_from_str("ACGT").unwrap(), "Sequence unchanged");

--- a/packages/treetime/src/ancestral/fitch.rs
+++ b/packages/treetime/src/ancestral/fitch.rs
@@ -1,7 +1,7 @@
 use crate::alphabet::alphabet::{Alphabet, FILL_CHAR, NON_CHAR};
 use crate::ancestral::fitch_indel::{compute_node_ranges, resolve_indels_backward, resolve_indels_forward};
 use crate::ancestral::fitch_sub::{
-  finalize_sequence_forward, resolve_fixed_positions_backward, resolve_nonroot_substitutions_forward,
+  discover_fixed_disagreements_backward, finalize_sequence_forward, resolve_nonroot_substitutions_forward,
   resolve_root_forward, resolve_variable_positions_backward,
 };
 use crate::make_report;
@@ -192,8 +192,13 @@ where
     sequence[r.0..r.1].fill(NON_CHAR);
   }
 
-  let mut variable = resolve_variable_positions_backward(&children, &non_char, &mut sequence);
-  resolve_fixed_positions_backward(&children, alphabet, &mut sequence, &mut variable);
+  // Discovery first, resolution second. The discovery pass only flags positions where children
+  // hold differing canonical states; the resolution pass then recomputes every candidate position
+  // from all children, so each child is counted exactly once. Running them the other way round
+  // let both passes fold child states into the same map, which is harmless for a union but not
+  // for the plurality rule.
+  let discovered = discover_fixed_disagreements_backward(&children, alphabet, &mut sequence);
+  let variable = resolve_variable_positions_backward(&children, &discovered, &non_char, &mut sequence);
 
   slot.node = SparseNodePartition {
     seq: SparseSeqInfo {
@@ -302,7 +307,12 @@ fn run_fitch_forward_indexed(
     edge.indels.extend(indels);
   } else {
     let seq = &mut node_data.seq;
-    resolve_root_forward(&mut seq.sequence, &seq.fitch.variable, &mut seq.fitch.chosen_state);
+    resolve_root_forward(
+      &mut seq.sequence,
+      &seq.fitch.variable,
+      &mut seq.fitch.chosen_state,
+      alphabet,
+    );
   }
 
   let seq = &mut node_data.seq;

--- a/packages/treetime/src/ancestral/fitch_sub.rs
+++ b/packages/treetime/src/ancestral/fitch_sub.rs
@@ -5,24 +5,39 @@ use crate::seq::mutation::Sub;
 use eyre::Report;
 use itertools::Itertools;
 use std::collections::BTreeMap;
-use treetime_primitives::{AlphabetLike, AsciiChar, BitSet128, Seq, StateSet, StateSetStatus, stateset};
+use treetime_primitives::{AlphabetLike, AsciiChar, Seq, StateSet, StateSetStatus};
 use treetime_utils::interval::range::range_contains;
 
-/// Backward pass: resolve variable positions using Fitch parsimony.
+/// Backward pass: resolve candidate positions using minimum-change parsimony.
 ///
-/// For each position that is variable in at least one child, collects the child
-/// state sets, computes the intersection (or union when the intersection is
-/// empty), and writes the result into `sequence` and the returned variable map.
+/// This is the authoritative resolution pass. For every candidate position it collects each
+/// informative child's state set exactly once and combines them, writing the result into
+/// `sequence` and the returned variable map.
+///
+/// Candidate positions come from two sources, which must both be supplied:
+///
+/// - positions that are variable in at least one child, i.e. where a child carries an IUPAC
+///   ambiguity code or was itself left ambiguous by its own backward pass;
+/// - `discovered`, the positions where children hold differing canonical states, found by
+///   [`discover_fixed_disagreements_backward`]. These appear in no child's `fitch.variable`.
+///
+/// The combination rule is the intersection of the child state sets when that is non-empty, and
+/// otherwise the plurality: the states held by the greatest number of children. Intersection is
+/// already minimal when non-empty, since its members are contained in every child and so attain
+/// the largest possible count. See [`StateSet::from_plurality`] for why the plurality, rather
+/// than Fitch's union fallback, is required once a node has three or more children.
 ///
 /// Positions transmitted along an edge or in `non_char` ranges are skipped.
 pub fn resolve_variable_positions_backward(
   children: &[(&SparseSeqInfo, &SparseEdgePartition)],
+  discovered: &[usize],
   non_char: &[(usize, usize)],
   sequence: &mut Seq,
 ) -> BTreeMap<usize, StateSet> {
   let variable_positions = children
     .iter()
     .flat_map(|(c, _)| c.fitch.variable.keys().copied())
+    .chain(discovered.iter().copied())
     .unique()
     .collect_vec();
 
@@ -53,7 +68,14 @@ pub fn resolve_variable_positions_backward(
       })
       .collect_vec();
 
-    // Calculate Fitch parsimony.
+    if child_profiles.is_empty() {
+      // No child carries character state here. The node's `non_char` is derived from the
+      // children's, so this is unreachable via that route; guard rather than fall through and
+      // store an empty state set, which no consumer can resolve.
+      continue;
+    }
+
+    // Calculate minimum-change parsimony.
     // If we save the states of the children for each position that is variable in the node,
     // then we would not need the full sequences in the forward pass.
     let intersection = StateSet::from_intersection(&child_profiles);
@@ -69,8 +91,15 @@ pub fn resolve_variable_positions_backward(
         sequence[pos] = VARIABLE_CHAR;
       },
       StateSetStatus::Empty => {
-        let union = StateSet::from_union(&child_profiles);
-        variable.insert(pos, union);
+        // No state is shared by every child, so retain those shared by the most. With one or
+        // two children the plurality is exactly the union, which is Fitch's fallback; with three
+        // or more the union can retain non-minimal states.
+        let resolved = if child_profiles.len() <= 2 {
+          StateSet::from_union(&child_profiles)
+        } else {
+          StateSet::from_plurality(&child_profiles)
+        };
+        variable.insert(pos, resolved);
         sequence[pos] = VARIABLE_CHAR;
       },
     }
@@ -79,38 +108,69 @@ pub fn resolve_variable_positions_backward(
   variable
 }
 
-/// Backward pass: resolve fixed positions where children disagree with current parent state.
+/// Backward pass: find positions where children hold differing canonical states.
 ///
-/// Scans each child's fixed sequence positions. When a child has a canonical state
-/// that differs from the current parent state, either sets the parent (if still
-/// FILL_CHAR) or promotes the position to variable.
-pub fn resolve_fixed_positions_backward(
+/// This is a discovery pass only. It writes the agreed state into `sequence` where all children
+/// agree, and marks a position with `VARIABLE_CHAR` as soon as any child disagrees. It does not
+/// combine state sets: resolution belongs to [`resolve_variable_positions_backward`], which runs
+/// afterwards and recomputes each candidate position from every child.
+///
+/// The returned positions are those marked `VARIABLE_CHAR`, in ascending order.
+///
+/// Detecting a disagreement only requires noticing that *some* child differs, never all children
+/// at once, so this keeps the child-major loop over whole sequences. Comparing every child against
+/// every position is `O(children · length)` and irreducible while nodes store dense sequences, so
+/// the loop deliberately performs no map lookups or state-set construction. Positions are recorded
+/// as they are flagged rather than by rescanning `sequence` afterwards, which would add another
+/// full-length pass per node; the `VARIABLE_CHAR` skip guarantees each is recorded at most once.
+pub fn discover_fixed_disagreements_backward(
   children: &[(&SparseSeqInfo, &SparseEdgePartition)],
   alphabet: &Alphabet,
   sequence: &mut Seq,
-  variable: &mut BTreeMap<usize, StateSet>,
-) {
+) -> Vec<usize> {
+  let mut discovered = vec![];
   for &(child, _) in children {
     for (pos, parent_state) in sequence.iter_mut().enumerate() {
       let child_state = child.sequence[pos];
-      if *parent_state == child_state || *parent_state == NON_CHAR {
-        continue; // if parent is equal to child state or we know it's a non-char, skip
+      if *parent_state == child_state || *parent_state == NON_CHAR || *parent_state == VARIABLE_CHAR {
+        continue; // agrees with the parent, known non-char, or already flagged as disagreeing
       }
       if alphabet.is_canonical(child_state) {
         if *parent_state == FILL_CHAR {
-          // if child state is canonical and parent is still FILL_CHAR, set parent_state
+          // first child to claim this position: adopt its state as the provisional agreement
           *parent_state = child_state;
         } else {
-          // otherwise set or update the variable state
-          *variable.entry(pos).or_insert_with(|| stateset! {*parent_state}) += child_state;
+          // a canonical state differing from the provisional agreement: flag for resolution
           *parent_state = VARIABLE_CHAR;
+          discovered.push(pos);
         }
       }
     }
   }
+
+  // Flags are emitted in ascending order within each child but interleaved across children.
+  // Sorting keeps the returned contract stable for callers and tests; it is over the handful of
+  // disagreeing positions, not the sequence length.
+  discovered.sort_unstable();
+  discovered
+}
+
+/// Commit one state from a set of equally parsimonious alternatives.
+///
+/// Every member of a resolved state set yields the same subtree cost, so this choice is free with
+/// respect to parsimony. It is kept deterministic so that output is reproducible between runs, and
+/// ordered by the alphabet rather than by byte value; see [`Alphabet::first_canonical`].
+///
+/// Falls back to the lowest byte if the set holds no canonical state, which preserves the previous
+/// behaviour for sets that consumers cannot interpret anyway.
+fn choose_state(states: StateSet, alphabet: &Alphabet) -> AsciiChar {
+  alphabet.first_canonical(states).unwrap_or_else(|| states.get_one())
 }
 
 /// Forward pass: resolve variable substitution states at the root.
+///
+/// The root has no parent to inherit from, so each variable position is committed by the
+/// tie-break policy in [`choose_state`].
 ///
 /// Variable indels at the root default to present (no gap). Direction is
 /// resolved in the forward pass on children via parent state.
@@ -118,9 +178,10 @@ pub fn resolve_root_forward(
   sequence: &mut Seq,
   variable: &BTreeMap<usize, StateSet>,
   chosen_state: &mut BTreeMap<usize, AsciiChar>,
+  alphabet: &Alphabet,
 ) {
   for (pos, states) in variable {
-    let chosen = states.get_one();
+    let chosen = choose_state(*states, alphabet);
     sequence[*pos] = chosen;
     chosen_state.insert(*pos, chosen);
   }
@@ -153,9 +214,13 @@ pub fn resolve_nonroot_substitutions_forward(
     if alphabet.is_canonical(pnuc) {
       // check whether parent is in child profile (sum>0 --> parent state is in profile)
       if states.contains(pnuc) {
+        // Preferring the parent's state is not a tie-break heuristic: given a minimal state set it
+        // is provably optimal, since matching the parent avoids a change on this edge while any
+        // other member of the set costs exactly one more. This is what pushes mutations toward the
+        // tips.
         sequence[*pos] = pnuc;
       } else {
-        let cnuc = states.get_one();
+        let cnuc = choose_state(*states, alphabet);
         sequence[*pos] = cnuc;
         let m = Sub::new(pnuc, *pos, cnuc)?;
         m.check_determined(alphabet)?;
@@ -164,7 +229,7 @@ pub fn resolve_nonroot_substitutions_forward(
       }
     } else if alphabet.is_gap(pnuc) && !range_contains(gaps, *pos) {
       // if parent is gap, but child isn't, we need to resolve variable states
-      sequence[*pos] = states.get_one();
+      sequence[*pos] = choose_state(*states, alphabet);
     }
     chosen_state.insert(*pos, sequence[*pos]);
   }


### PR DESCRIPTION
This PR implements Fitch in a way that actually minimizes the number of mutations. In our previous implementation the root state always too precedence. That was intended. But the implementation led to strange very non-parsimonious solutions when the root was a polytomy. Instead of only applying this multiplicity based resolution at the root, it is now applied everywhere. 

