### PR TITLE
fix: return Option from time_bounds instead of panicking on Empty

### DIFF
--- a/packages/treetime-distribution/src/__tests__/test_gm_overlap_boundaries.rs
+++ b/packages/treetime-distribution/src/__tests__/test_gm_overlap_boundaries.rs
@@ -37,8 +37,9 @@ mod tests {
     // packages/legacy/treetime/treetime/distribution.py:82-185.
     pretty_assert_eq!(expected.kind(), DistributionKind::from_distribution(&actual));
     let [expected_start, expected_end] = expected.bounds();
-    pretty_assert_ulps_eq!(expected_start, actual.time_bounds().0, max_ulps = 4);
-    pretty_assert_ulps_eq!(expected_end, actual.time_bounds().1, max_ulps = 4);
+    let (actual_start, actual_end) = actual.time_bounds().unwrap();
+    pretty_assert_ulps_eq!(expected_start, actual_start, max_ulps = 4);
+    pretty_assert_ulps_eq!(expected_end, actual_end, max_ulps = 4);
 
     if let Some([expected_start_value, expected_end_value]) = expected.endpoint_values() {
       let actual = [actual.eval(expected_start)?, actual.eval(expected_end)?];

--- a/packages/treetime-distribution/src/distribution_core/__tests__/test_distribution.rs
+++ b/packages/treetime-distribution/src/distribution_core/__tests__/test_distribution.rs
@@ -7,6 +7,30 @@ mod tests {
   use treetime_utils::pretty_assert_ulps_eq;
 
   #[test]
+  fn test_distribution_time_bounds_empty_is_none() {
+    assert_eq!(None, Distribution::<Plain>::Empty.time_bounds());
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_point_is_degenerate_interval() {
+    assert_eq!(Some((1.0, 1.0)), Distribution::<Plain>::point(1.0, 5.0).time_bounds());
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_range_spans_endpoints() {
+    assert_eq!(
+      Some((0.0, 2.0)),
+      Distribution::<Plain>::range((0.0, 2.0), 3.0).time_bounds()
+    );
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_function_spans_grid() {
+    let func = Distribution::<Plain>::function(array![0.0, 1.0, 2.0], array![1.0, 4.0, 2.0]).unwrap();
+    assert_eq!(Some((0.0, 2.0)), func.time_bounds());
+  }
+
+  #[test]
   fn test_distribution_max_value() {
     let point = Distribution::<Plain>::point(1.0, 5.0);
     assert_relative_eq!(point.max_value(), 5.0);

--- a/packages/treetime-distribution/src/distribution_core/distribution.rs
+++ b/packages/treetime-distribution/src/distribution_core/distribution.rs
@@ -126,10 +126,14 @@ impl<Y: YAxisPolicy> Distribution<Y> {
     distribution_negation_inplace(self)
   }
 
-  pub fn time_bounds(&self) -> (f64, f64) {
-    let t = self.t();
-    debug_assert!(!t.is_empty(), "Cannot extract time bounds from empty distribution");
-    (t[0], t[t.len() - 1])
+  pub fn time_bounds(&self) -> Option<(f64, f64)> {
+    match self {
+      Self::Empty => None,
+      Self::Point(p) => Some((p.t(), p.t())),
+      Self::Range(r) => Some((r.start(), r.end())),
+      Self::Function(f) => Some((f.x_min(), f.x_max())),
+      Self::Formula(f) => Some((f.t_min(), f.t_max())),
+    }
   }
 
   pub fn eval(&self, t: f64) -> Result<f64, Report> {

--- a/packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs
+++ b/packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs
@@ -47,7 +47,7 @@ mod tests {
     #[case] expected: (f64, f64),
   ) {
     let actual = distribution_time_bounds_union(&dist_a, &dist_b);
-    assert_eq!(expected, actual);
+    assert_eq!(Some(expected), actual);
   }
 
   #[rustfmt::skip]
@@ -164,11 +164,11 @@ mod tests {
     let dist_b = Distribution::range((3.0, 4.0), 1.0);
     let dist_c = Distribution::range((5.0, 6.0), 1.0);
 
-    let (t_min_ab, t_max_ab) = distribution_time_bounds_union(&dist_a, &dist_b);
+    let (t_min_ab, t_max_ab) = distribution_time_bounds_union(&dist_a, &dist_b).unwrap();
     let dist_ab = Distribution::range((t_min_ab, t_max_ab), 1.0);
     let result_ab_c = distribution_time_bounds_union(&dist_ab, &dist_c);
 
-    let (t_min_bc, t_max_bc) = distribution_time_bounds_union(&dist_b, &dist_c);
+    let (t_min_bc, t_max_bc) = distribution_time_bounds_union(&dist_b, &dist_c).unwrap();
     let dist_bc = Distribution::range((t_min_bc, t_max_bc), 1.0);
     let result_a_bc = distribution_time_bounds_union(&dist_a, &dist_bc);
 
@@ -201,7 +201,7 @@ mod tests {
     assert_eq!(expected, union_result);
 
     let intersection_result = distribution_time_bounds_intersection(&dist, &dist).unwrap();
-    assert_eq!(expected, intersection_result);
+    assert_eq!(expected, Some(intersection_result));
   }
 
   #[test]
@@ -254,7 +254,7 @@ mod tests {
     let dist_a = Distribution::range((1.0, 3.0), 1.0);
     let dist_b = Distribution::range((2.0, 4.0), 1.0);
 
-    let (t_min, t_max) = distribution_time_bounds_union(&dist_a, &dist_b);
+    let (t_min, t_max) = distribution_time_bounds_union(&dist_a, &dist_b).unwrap();
     let union_dist = Distribution::range((t_min, t_max), 1.0);
 
     assert!(distribution_time_bounds_contains(&union_dist, &dist_a));
@@ -280,7 +280,7 @@ mod tests {
     let dist_b = Distribution::range((-4.0, -2.0), 1.0);
 
     let union_result = distribution_time_bounds_union(&dist_a, &dist_b);
-    assert_eq!((-5.0, -2.0), union_result);
+    assert_eq!(Some((-5.0, -2.0)), union_result);
 
     let intersection_result = distribution_time_bounds_intersection(&dist_a, &dist_b).unwrap();
     assert_eq!((-4.0, -3.0), intersection_result);
@@ -294,7 +294,7 @@ mod tests {
     let point_b = Distribution::point(3.0, 1.0);
 
     let union_result = distribution_time_bounds_union(&point_a, &point_b);
-    assert_eq!((2.0, 3.0), union_result);
+    assert_eq!(Some((2.0, 3.0)), union_result);
 
     let intersection_result = distribution_time_bounds_intersection(&point_a, &point_b);
     assert_eq!(None, intersection_result);
@@ -311,5 +311,52 @@ mod tests {
     assert_eq!((2.0, 2.0), intersection_result);
 
     assert!(distribution_time_bounds_overlaps(&range_a, &range_b));
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_union_empty_operand_is_identity() {
+    let empty = Distribution::empty();
+    let range = Distribution::range((1.0, 3.0), 1.0);
+    assert_eq!(Some((1.0, 3.0)), distribution_time_bounds_union(&empty, &range));
+    assert_eq!(Some((1.0, 3.0)), distribution_time_bounds_union(&range, &empty));
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_union_both_empty_is_none() {
+    let empty = Distribution::empty();
+    assert_eq!(None, distribution_time_bounds_union(&empty, &empty));
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_intersection_empty_operand_is_absorbing() {
+    let empty = Distribution::empty();
+    let range = Distribution::range((1.0, 3.0), 1.0);
+    assert_eq!(None, distribution_time_bounds_intersection(&empty, &range));
+    assert_eq!(None, distribution_time_bounds_intersection(&range, &empty));
+    assert_eq!(None, distribution_time_bounds_intersection(&empty, &empty));
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_contains_empty_inner_is_contained() {
+    let empty = Distribution::empty();
+    let range = Distribution::range((1.0, 3.0), 1.0);
+    assert!(distribution_time_bounds_contains(&range, &empty));
+    assert!(distribution_time_bounds_contains(&empty, &empty));
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_contains_empty_outer_contains_no_nonempty() {
+    let empty = Distribution::empty();
+    let range = Distribution::range((1.0, 3.0), 1.0);
+    assert!(!distribution_time_bounds_contains(&empty, &range));
+  }
+
+  #[test]
+  fn test_distribution_time_bounds_overlaps_empty_never_overlaps() {
+    let empty = Distribution::empty();
+    let range = Distribution::range((1.0, 3.0), 1.0);
+    assert!(!distribution_time_bounds_overlaps(&empty, &range));
+    assert!(!distribution_time_bounds_overlaps(&range, &empty));
+    assert!(!distribution_time_bounds_overlaps(&empty, &empty));
   }
 }

--- a/packages/treetime-distribution/src/distribution_ops/time_bounds.rs
+++ b/packages/treetime-distribution/src/distribution_ops/time_bounds.rs
@@ -8,38 +8,47 @@ pub(super) const MAX_GRID_POINTS: usize = 1_000_000;
 
 /// Compute union of time bounds from two distributions.
 ///
-/// Return (t_min, t_max) tuple representing the smallest interval that encompasses
-/// both distributions' time domains.
+/// `Empty` is the union identity: it contributes nothing. Two empty distributions
+/// yield `None`.
 pub fn distribution_time_bounds_union<Y: YAxisPolicy>(
   dist_a: &Distribution<Y>,
   dist_b: &Distribution<Y>,
-) -> (f64, f64) {
-  let (t_min_a, t_max_a) = dist_a.time_bounds();
-  let (t_min_b, t_max_b) = dist_b.time_bounds();
-  let t_min = f64::min(t_min_a, t_min_b);
-  let t_max = f64::max(t_max_a, t_max_b);
-  (t_min, t_max)
+) -> Option<(f64, f64)> {
+  match (dist_a.time_bounds(), dist_b.time_bounds()) {
+    (Some((t_min_a, t_max_a)), Some((t_min_b, t_max_b))) => {
+      Some((f64::min(t_min_a, t_min_b), f64::max(t_max_a, t_max_b)))
+    },
+    (Some(bounds), None) | (None, Some(bounds)) => Some(bounds),
+    (None, None) => None,
+  }
 }
 
 /// Compute intersection of time bounds from two distributions.
 ///
 /// Return Some((t_min, t_max)) representing the overlapping time interval
-/// or None if intervals don't overlap.
+/// or None if intervals don't overlap. `Empty` is absorbing: intersecting with
+/// it yields `None`.
 pub fn distribution_time_bounds_intersection<Y: YAxisPolicy>(
   dist_a: &Distribution<Y>,
   dist_b: &Distribution<Y>,
 ) -> Option<(f64, f64)> {
-  match distribution_support_intersection(dist_a.time_bounds(), dist_b.time_bounds()) {
+  match distribution_support_intersection(dist_a.time_bounds()?, dist_b.time_bounds()?) {
     SupportIntersection::Disjoint => None,
     SupportIntersection::Point(t) => Some((t, t)),
     SupportIntersection::Interval(bounds) => Some(bounds),
   }
 }
 
-/// Whether inner distribution's time bounds are fully contained within outer distribution's time bounds.
+/// Whether inner distribution's time bounds are fully contained within outer distribution's
+/// time bounds. The empty support is contained in any distribution; no non-empty support is
+/// contained in an empty one.
 pub fn distribution_time_bounds_contains<Y: YAxisPolicy>(outer: &Distribution<Y>, inner: &Distribution<Y>) -> bool {
-  let (t_min_outer, t_max_outer) = outer.time_bounds();
-  let (t_min_inner, t_max_inner) = inner.time_bounds();
+  let Some((t_min_inner, t_max_inner)) = inner.time_bounds() else {
+    return true;
+  };
+  let Some((t_min_outer, t_max_outer)) = outer.time_bounds() else {
+    return false;
+  };
   t_min_outer <= t_min_inner && t_max_inner <= t_max_outer
 }
 

--- a/packages/treetime/src/timetree/confidence.rs
+++ b/packages/treetime/src/timetree/confidence.rs
@@ -200,11 +200,11 @@ pub fn extract_confidence_intervals(graph: &GraphTimetree) -> Vec<NodeConfidence
         // No CI data available: return point estimate
         (date, date)
       } else {
-        // Physical limits from distribution domain (or unbounded if no distribution)
         let limits = payload
           .time_distribution()
           .as_ref()
-          .map_or((f64::NEG_INFINITY, f64::INFINITY), |dist| dist.time_bounds());
+          .and_then(|dist| dist.time_bounds())
+          .unwrap_or((f64::NEG_INFINITY, f64::INFINITY));
         combine_confidence(date, limits, rate_contribution, mutation_contribution)
       };
 

--- a/packages/treetime/src/timetree/inference/__tests__/test_branch_length_likelihood.rs
+++ b/packages/treetime/src/timetree/inference/__tests__/test_branch_length_likelihood.rs
@@ -196,7 +196,7 @@ mod tests {
     )?;
 
     // max_bl = min(max(0.1 * 5, 1e-3 * 10), 5.0) = min(0.5, 5.0) = 0.5
-    let (_t_min, t_max) = distribution.time_bounds();
+    let (_t_min, t_max) = distribution.time_bounds().unwrap();
     assert_abs_diff_eq!(t_max, 0.5, epsilon = 1e-12);
     Ok(())
   }
@@ -218,7 +218,7 @@ mod tests {
     )?;
 
     // max_bl = min(max(2.0 * 5, 1e-3 * 10), 5.0) = min(10.0, 5.0) = 5.0
-    let (_t_min, t_max) = distribution.time_bounds();
+    let (_t_min, t_max) = distribution.time_bounds().unwrap();
     assert_abs_diff_eq!(t_max, 5.0, epsilon = 1e-12);
     Ok(())
   }
@@ -240,7 +240,7 @@ mod tests {
       /* gamma */ 1.0,
     )?;
 
-    let (t_min, _t_max) = distribution.time_bounds();
+    let (t_min, _t_max) = distribution.time_bounds().unwrap();
     assert_abs_diff_eq!(t_min, one_mutation * 0.01, epsilon = 1e-12);
     Ok(())
   }


### PR DESCRIPTION
`fix/distribution-time-bounds-empty-panic` -> `rust`

`Distribution::time_bounds()` indexed the first and last elements of the support array, guarded only by a `debug_assert` that is stripped in release builds. Calling it on the `Empty` variant panicked with an ndarray out-of-bounds error. `Empty` is reachable in production -- confidence-interval assembly reads it when a node's time distribution is present but unsupported, and polytomy resolution and the forward pass both construct it as a fallback.

The method now matches on variants directly to return `Option<(f64, f64)>` [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime-distribution/src/distribution_core/distribution.rs#L129)], yielding `None` for `Empty` without allocating. Each caller supplies its own absence semantics: union treats `Empty` as the identity, intersection as absorbing, containment follows set semantics, and confidence assembly falls back to unbounded limits [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime/src/timetree/confidence.rs#L206)].

### Work items

- [x] Match on variants directly in `time_bounds()`, return `None` for `Empty` [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime-distribution/src/distribution_core/distribution.rs#L129)]
- [x] Update `distribution_time_bounds_union` to return `Option` with `Empty` as identity [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime-distribution/src/distribution_ops/time_bounds.rs#L13)]
- [x] Update `distribution_time_bounds_intersection` to short-circuit on `None` via `?` [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime-distribution/src/distribution_ops/time_bounds.rs#L31)]
- [x] Update `distribution_time_bounds_contains` with set-containment semantics for `Empty` [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime-distribution/src/distribution_ops/time_bounds.rs#L45)]
- [x] Fall back to unbounded limits in confidence assembly [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime/src/timetree/confidence.rs#L206)]
- [x] Add regression tests for `Empty` through `time_bounds()` and all four operations [[src](https://github.com/neherlab/treetime/blob/95f09e827d3066cafa6d6fafdbd1d04839a49d7d/packages/treetime-distribution/src/distribution_ops/__tests__/test_time_bounds.rs#L317)]